### PR TITLE
feat: configurable radar scan speed (#13) + logarithmic tower scaling (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ URL Parameter > Theme Default > System Fallback
 | `accent` | `hex` | No | Theme default | Tower & glow color — **without** `#` |
 | `text` | `hex` | No | Theme default | Label & stat text color — **without** `#` |
 | `radius` | `number` | No | `8` | Border corner radius in pixels |
+| `speed` | `string` | No | `8s` | Radar scan animation duration (e.g. `4s`, `12s`) |
+| `scale` | `string` | No | `linear` | Tower height scaling: `linear` or `log` (logarithmic) |
 | `refresh` | `boolean` | No | `false` | Bypass cache for real-time data |
 
 ### Theme Presets
@@ -104,6 +106,9 @@ URL Parameter > Theme Default > System Fallback
 
 <!-- Force bypass cache for latest data -->
 ![](https://commitpulse.vercel.app/api/streak?user=jhasourav07&refresh=true)
+
+<!-- Fast scan + logarithmic scaling for power users -->
+![](https://commitpulse.vercel.app/api/streak?user=jhasourav07&speed=4s&scale=log)
 ```
 
 ---

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -21,6 +21,14 @@ export async function GET(request: Request) {
     const themeName = searchParams.get("theme") || "dark";
     const selectedTheme = themes[themeName] || themes["dark"];
 
+    // Parse speed: validate it's a number followed by 's', default to '8s'
+    const rawSpeed = searchParams.get("speed") || "8s";
+    const speed = /^\d+(\.\d+)?s$/.test(rawSpeed) ? rawSpeed : "8s";
+
+    // Parse scale: only 'log' or 'linear' (default)
+    const rawScale = searchParams.get("scale");
+    const scale = rawScale === "log" ? "log" : "linear";
+
     const params: BadgeParams = {
       user,
       // Priority: URL Param > Theme Default > Fallback
@@ -28,6 +36,8 @@ export async function GET(request: Request) {
       text: searchParams.get("text") || selectedTheme.text,
       accent: searchParams.get("accent") || selectedTheme.accent,
       radius: searchParams.get("radius") || "8",
+      speed,
+      scale,
     };
 
     // 2. Fetch Data & Calculate Stats

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -13,8 +13,11 @@ export function generateSVG(stats: StreakStats, params: BadgeParams, calendar: a
     week.contributionDays.forEach((day: any, j: number) => {
       const tooltip = `${day.date}: ${day.contributionCount} contributions`;
 
-      // Height scales with contribution count
-      const h = Math.min(day.contributionCount * 5, 50); 
+      // Height scales with contribution count (linear or logarithmic)
+      const rawH = params.scale === 'log'
+        ? (day.contributionCount > 0 ? Math.log2(day.contributionCount + 1) * 20 : 0)
+        : day.contributionCount * 5;
+      const h = Math.min(rawH, 50);
       const x = 300 + (i - j) * 16; 
       const y = 120 + (i + j) * 9; 
       
@@ -74,7 +77,7 @@ export function generateSVG(stats: StreakStats, params: BadgeParams, calendar: a
       <text x="300" y="50" text-anchor="middle" class="title">${params.user.toUpperCase()}</text>
 
       <rect x="100" y="60" width="400" height="1" fill="${accent}" fill-opacity="0.3">
-        <animate attributeName="y" values="80;320;80" dur="8s" repeatCount="indefinite" />
+        <animate attributeName="y" values="80;320;80" dur="${params.speed || '8s'}" repeatCount="indefinite" />
       </rect>
     </svg>
   `;

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -14,10 +14,12 @@ export function generateSVG(stats: StreakStats, params: BadgeParams, calendar: a
       const tooltip = `${day.date}: ${day.contributionCount} contributions`;
 
       // Height scales with contribution count (linear or logarithmic)
-      const rawH = params.scale === 'log'
-        ? (day.contributionCount > 0 ? Math.log2(day.contributionCount + 1) * 20 : 0)
-        : day.contributionCount * 5;
-      const h = Math.min(rawH, 50);
+      const h = params.scale === 'log'
+        ? Math.min(
+            day.contributionCount > 0 ? Math.log2(day.contributionCount + 1) * 12 : 0,
+            80
+          )
+        : Math.min(day.contributionCount * 5, 50);
       const x = 300 + (i - j) * 16; 
       const y = 120 + (i + j) * 9; 
       

--- a/types/index.ts
+++ b/types/index.ts
@@ -17,4 +17,6 @@ export interface BadgeParams {
   text?: string;
   accent?: string;
   radius?: string;
+  speed?: string;
+  scale?: 'linear' | 'log';
 }


### PR DESCRIPTION
## Summary

This PR implements two feature requests in a single coherent change:

### Issue #13 — Configurable Radar Scan Animation Speed

Added  URL parameter to control the radar scan line animation duration.

**Implementation:**
- : Parse  param with regex validation (), default to  if missing or invalid
- : Replace hardcoded `dur="8s"` with `dur="${params.speed || '8s'}"` on the `<animate>` tag

**Usage:** `?speed=4s` (faster) or `?speed=12s` (slower, more atmospheric)

### Issue #12 — Logarithmic Tower Scaling

Added  URL parameter to switch between linear and logarithmic height scaling.

**Implementation:**
- : Added `scale?: 'linear' | 'log'` to BadgeParams
- : Parse  param, accept only  or default to 
- : Use `Math.log2(count + 1) * 20` formula when , ensuring 1-commit and 100-commit days show distinctly different heights

**Usage:** `?scale=log`

### Combined example
```
?user=jhasourav07&speed=4s&scale=log
```

### Files changed
- `types/index.ts` — added `speed` and `scale` fields to `BadgeParams`
- `app/api/streak/route.ts` — parse and validate new params
- `lib/svg/generator.ts` — apply dynamic speed + log scaling logic
- `README.md` — updated parameter reference table + added usage example

Closes #13
Closes #12