### PR TITLE
docs: add Contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,13 @@ _Built with obsession, shipped with precision._
 ### This project is an official participant in Nexus Spring of Code (NSoC) 2026.
 
 </div>
+
+---
+
+## 💖 Contributors
+
+Thanks to all contributors who have helped make CommitPulse better!
+
+<a href="https://github.com/JhaSourav07/commitpulse/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=JhaSourav07/commitpulse" alt="Contributors" />
+</a>


### PR DESCRIPTION
## What does this PR do?

Adds a `## 💖 Contributors` section at the bottom of `README.md` using [contrib.rocks](https://contrib.rocks) to automatically display contributor profile pictures.

## Pillar

- [ ] New Theme Design
- [ ] Geometric SVG Improvement
- [ ] Timezone Logic Optimization
- [x] Other — Documentation: add Contributors section to README

## Visual Preview

The contrib.rocks widget auto-renders at:
```
https://contrib.rocks/image?repo=JhaSourav07/commitpulse
```
It shows avatar thumbnails of all GitHub contributors, updating automatically as new contributors merge PRs.

## Checklist

- [x] I've tested this locally
- [x] All new logic/features have accompanying Vitest tests
- [x] `npm run test` passes locally
- [x] The SVG output matches the CommitPulse aesthetic standard
- [x] I've updated README.md if I added a new parameter or theme
- [x] My commits follow the Conventional Commits format