### PR TITLE
feat: inject semantic title and desc into generated SVGs

### DIFF
--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -126,7 +126,9 @@ export function generateSVG(
   });
 
   return `
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="420" viewBox="0 0 600 420" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="420" viewBox="0 0 600 420" fill="none" role="img" aria-labelledby="commitpulse-title commitpulse-desc">
+  <title id="commitpulse-title">CommitPulse Stats for ${params.user || 'user'}</title>
+  <desc id="commitpulse-desc">${params.user || 'user'} has ${stats.totalContributions} total contributions and a longest streak of ${stats.longestStreak} days.</desc>
   <defs>
     <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="5" result="blur" />


### PR DESCRIPTION
## Summary

Closes #70

Screen readers couldn't read CommitPulse SVGs embedded in GitHub READMEs. Added `<title>` and `<desc>` tags with dynamic stats so the data is accessible to visually impaired developers.

## Changes

**`lib/svg/generator.ts`**
- Added `role="img"` + `aria-labelledby` to `<svg>` tag
- Injected `<title id="commitpulse-title">CommitPulse Stats for {user}</title>`
- Injected `<desc id="commitpulse-desc">{user} has {totalContributions} total contributions and a longest streak of {longestStreak} days.</desc>`

## Example output

```svg
<svg ... role="img" aria-labelledby="commitpulse-title commitpulse-desc">
  <title id="commitpulse-title">CommitPulse Stats for jhasourav07</title>
  <desc id="commitpulse-desc">jhasourav07 has 1240 total contributions and a longest streak of 45 days.</desc>
  ...
```

Visual rendering is unchanged — `<title>` and `<desc>` are non-visual SVG metadata elements.