### PR TITLE
feat: support ?theme=random parameter

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -18,9 +18,8 @@ export async function GET(request: Request) {
 
     const rawTheme = searchParams.get('theme') || 'dark';
     const themeKeys = Object.keys(themes);
-    const themeName = rawTheme === 'random'
-      ? themeKeys[Math.floor(Math.random() * themeKeys.length)]
-      : rawTheme;
+    const themeName =
+      rawTheme === 'random' ? themeKeys[Math.floor(Math.random() * themeKeys.length)] : rawTheme;
     const selectedTheme = themes[themeName] || themes.dark;
 
     const rawSpeed = searchParams.get('speed') || '8s';

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -16,7 +16,11 @@ export async function GET(request: Request) {
       return new NextResponse('Missing "user" parameter', { status: 400 });
     }
 
-    const themeName = searchParams.get('theme') || 'dark';
+    const rawTheme = searchParams.get('theme') || 'dark';
+    const themeKeys = Object.keys(themes);
+    const themeName = rawTheme === 'random'
+      ? themeKeys[Math.floor(Math.random() * themeKeys.length)]
+      : rawTheme;
     const selectedTheme = themes[themeName] || themes.dark;
 
     const rawSpeed = searchParams.get('speed') || '8s';


### PR DESCRIPTION
## Summary

Closes #66

Passing `?theme=random` now picks a random theme from the `themes` object on every request, so users get a surprise color palette.

## Changes

**`app/api/streak/route.ts`**
- Read raw theme param into `rawTheme`
- If `rawTheme === 'random'`, pick a random key from `Object.keys(themes)`
- Otherwise behave exactly as before (falls back to `dark` for unknown themes)

## Example

```
/api/streak?user=jhasourav07&theme=random
```

Each request returns a different color scheme. Works with any valid theme in `themes.ts`; no crash possible since `themes[randomKey]` is always defined.