### PR TITLE
feat: exponential backoff retry for GitHub API calls

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -9,6 +9,39 @@ interface GitHubRepo {
   language: string | null;
 }
 
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 500;
+
+/**
+ * Wraps fetch with exponential backoff retry logic.
+ * Retries ONLY on network errors, 429 Too Many Requests, and 5xx server errors.
+ * Returns immediately for all other statuses (2xx success, 3xx redirects, 4xx client errors).
+ */
+export async function fetchWithRetry(
+  url: string,
+  options: RequestInit,
+  attempt = 0
+): Promise<Response> {
+  let res: Response | null = null;
+  try {
+    res = await fetch(url, options);
+  } catch (err) {
+    // Network error — retry if attempts remain, otherwise rethrow
+    if (attempt >= MAX_RETRIES) throw err;
+    const delay = BASE_DELAY_MS * Math.pow(2, attempt);
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    return fetchWithRetry(url, options, attempt + 1);
+  }
+
+  // Only retry on 429 or 5xx — all other statuses are returned immediately
+  const shouldRetry = res.status === 429 || res.status >= 500;
+  if (!shouldRetry || attempt >= MAX_RETRIES) return res;
+
+  const delay = BASE_DELAY_MS * Math.pow(2, attempt);
+  await new Promise((resolve) => setTimeout(resolve, delay));
+  return fetchWithRetry(url, options, attempt + 1);
+}
+
 const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql';
 const GITHUB_REST_URL = 'https://api.github.com';
 
@@ -91,7 +124,7 @@ export async function fetchGitHubContributions(
     }
   `;
 
-  const res = await fetch(GITHUB_GRAPHQL_URL, {
+  const res = await fetchWithRetry(GITHUB_GRAPHQL_URL, {
     method: 'POST',
     headers: getHeaders(),
     body: JSON.stringify({ query, variables: { login: username } }),
@@ -133,7 +166,7 @@ export async function fetchUserProfile(
     if (cached) return cached;
   }
 
-  const res = await fetch(`${GITHUB_REST_URL}/users/${username}`, {
+  const res = await fetchWithRetry(`${GITHUB_REST_URL}/users/${username}`, {
     headers: getHeaders(),
     cache: 'no-store',
   });
@@ -163,10 +196,13 @@ export async function fetchUserRepos(
     if (cached) return cached;
   }
 
-  const res = await fetch(`${GITHUB_REST_URL}/users/${username}/repos?per_page=100&sort=pushed`, {
-    headers: getHeaders(),
-    cache: 'no-store',
-  });
+  const res = await fetchWithRetry(
+    `${GITHUB_REST_URL}/users/${username}/repos?per_page=100&sort=pushed`,
+    {
+      headers: getHeaders(),
+      cache: 'no-store',
+    }
+  );
 
   if (!res.ok) {
     throw new Error(`GitHub REST API error: ${res.status}`);


### PR DESCRIPTION
## Description

Fixes #50

Adds a `fetchWithRetry` utility that wraps all GitHub API `fetch` calls with exponential backoff. Retries only on network errors, 429 (rate limit), and 5xx server errors — up to 3 times with 500ms → 1s → 2s delays. All 4xx client errors (401, 403, 404, 422, etc.) return immediately without retrying to avoid duplicate requests on non-transient failures.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No SVG visual changes — this is a backend reliability improvement. The badge output is identical; the fix improves resilience when GitHub API returns transient 502/503 errors or drops connections.

**Retry behaviour:**

| Condition | Action |
|---|---|
| Network error | Retry with backoff (500ms → 1s → 2s) |
| 5xx server error | Retry with backoff |
| 429 Too Many Requests | Retry with backoff |
| 4xx client error (401, 403, 404, 422 …) | Return immediately — no retry |
| 2xx success | Return immediately |

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).