### PR TITLE
refactor: split customize studio components

### DIFF
--- a/app/customize/components/ControlsPanel.tsx
+++ b/app/customize/components/ControlsPanel.tsx
@@ -1,0 +1,219 @@
+import type { ReactElement, ReactNode } from 'react';
+import { SPEEDS, type Scale } from '../types';
+import { isValidHex, stripHash } from '../utils';
+import { SectionLabel } from './SectionLabel';
+import { StyledSelect, ThemeSelector } from './ThemeSelector';
+
+function ControlRow({ label, children }: { label: string; children: ReactNode }): ReactElement {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <SectionLabel>{label}</SectionLabel>
+      {children}
+    </div>
+  );
+}
+
+function HexInput({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+}): ReactElement {
+  const pickerValue = isValidHex(value) ? `#${stripHash(value)}` : '#000000';
+  const swatchColor = isValidHex(value) ? pickerValue : null;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <SectionLabel>{label}</SectionLabel>
+      <div className="relative flex items-center gap-2">
+        <label
+          htmlFor={`${id}-picker`}
+          title="Open color picker"
+          className="relative shrink-0 w-9 h-9 rounded-xl border border-white/10 overflow-hidden cursor-pointer hover:border-emerald-500/50 transition-colors"
+          style={{ backgroundColor: swatchColor ?? '#1a1a1a' }}
+        >
+          {!swatchColor && (
+            <span
+              className="absolute inset-0"
+              style={{
+                backgroundImage: 'repeating-conic-gradient(#333 0% 25%, #1a1a1a 0% 50%)',
+                backgroundSize: '8px 8px',
+              }}
+            />
+          )}
+          <input
+            id={`${id}-picker`}
+            type="color"
+            value={pickerValue}
+            onChange={(e) => onChange(stripHash(e.target.value))}
+            className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+            aria-label={`Color picker for ${label}`}
+          />
+        </label>
+
+        <div className="relative flex-1 flex items-center">
+          <span className="absolute left-3 text-white/30 text-sm select-none pointer-events-none">
+            #
+          </span>
+          <input
+            id={id}
+            type="text"
+            value={value}
+            onChange={(e) => onChange(e.target.value.replace(/^#/, ''))}
+            placeholder={placeholder.replace(/^#/, '')}
+            maxLength={6}
+            className="w-full bg-black border border-white/10 rounded-xl pl-7 pr-4 py-2.5 text-sm font-mono text-emerald-300 placeholder:text-white/20 outline-none focus:border-emerald-500/50 transition-colors"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ControlsPanel({
+  username,
+  theme,
+  bgHex,
+  accentHex,
+  textHex,
+  scale,
+  speed,
+  onUsernameChange,
+  onThemeChange,
+  onBgHexChange,
+  onAccentHexChange,
+  onTextHexChange,
+  onScaleChange,
+  onSpeedChange,
+  onClearOverrides,
+}: {
+  username: string;
+  theme: string;
+  bgHex: string;
+  accentHex: string;
+  textHex: string;
+  scale: Scale;
+  speed: string;
+  onUsernameChange: (value: string) => void;
+  onThemeChange: (value: string) => void;
+  onBgHexChange: (value: string) => void;
+  onAccentHexChange: (value: string) => void;
+  onTextHexChange: (value: string) => void;
+  onScaleChange: (value: Scale) => void;
+  onSpeedChange: (value: string) => void;
+  onClearOverrides: () => void;
+}): ReactElement {
+  const hasOverrides = Boolean(bgHex || accentHex || textHex);
+
+  return (
+    <div>
+      <p className="text-xs font-bold uppercase tracking-[0.22em] text-emerald-400 mb-4">
+        Controls
+      </p>
+
+      <div className="flex flex-col gap-5">
+        <ControlRow label="GitHub Username">
+          <input
+            id="username-input"
+            type="text"
+            value={username}
+            onChange={(e) => onUsernameChange(e.target.value)}
+            placeholder="jhasourav07"
+            className="w-full bg-black border border-white/10 rounded-xl px-4 py-2.5 text-sm font-mono text-emerald-300 placeholder:text-white/20 outline-none focus:border-emerald-500/50 transition-colors"
+          />
+        </ControlRow>
+
+        <div className="h-px bg-white/5" />
+
+        <ThemeSelector theme={theme} onThemeChange={onThemeChange} />
+
+        <div className="h-px bg-white/5" />
+
+        <div>
+          <SectionLabel>Custom Color Overrides</SectionLabel>
+          <p className="text-[11px] text-white/25 mb-3 leading-relaxed">
+            These override the theme preset above. Enter HEX values without&nbsp;
+            <code className="text-white/40">#</code>.
+          </p>
+          <div className="flex flex-col gap-3">
+            <HexInput
+              id="bg-hex-input"
+              label="Background"
+              value={bgHex}
+              onChange={onBgHexChange}
+              placeholder="e.g. 0a0a0a"
+            />
+            <HexInput
+              id="accent-hex-input"
+              label="Accent / Tower Color"
+              value={accentHex}
+              onChange={onAccentHexChange}
+              placeholder="e.g. 00ffaa"
+            />
+            <HexInput
+              id="text-hex-input"
+              label="Text / Label Color"
+              value={textHex}
+              onChange={onTextHexChange}
+              placeholder="e.g. ffffff"
+            />
+          </div>
+          {hasOverrides && (
+            <button
+              id="clear-overrides-btn"
+              onClick={onClearOverrides}
+              className="mt-3 text-[11px] text-red-400/60 hover:text-red-400 transition-colors"
+            >
+              Clear overrides
+            </button>
+          )}
+        </div>
+
+        <div className="h-px bg-white/5" />
+
+        <ControlRow label="Tower Height Scaling">
+          <div className="grid grid-cols-2 gap-2">
+            {(['linear', 'log'] as Scale[]).map((currentScale) => (
+              <button
+                key={currentScale}
+                id={`scale-${currentScale}-btn`}
+                onClick={() => onScaleChange(currentScale)}
+                className={`py-2.5 rounded-xl text-sm font-bold transition-all ${
+                  scale === currentScale
+                    ? 'bg-emerald-500/15 border border-emerald-500/30 text-emerald-400'
+                    : 'bg-black border border-white/8 text-white/30 hover:text-white/60 hover:border-white/20'
+                }`}
+              >
+                {currentScale === 'linear' ? 'Linear' : 'Logarithmic'}
+              </button>
+            ))}
+          </div>
+          <p className="text-[11px] text-white/25 mt-1.5 leading-relaxed">
+            {scale === 'log'
+              ? 'Log mode compresses extreme outliers. Great for power committers.'
+              : 'Linear mode shows raw commit counts as tower heights.'}
+          </p>
+        </ControlRow>
+
+        <ControlRow label="Radar Scan Speed">
+          <div className="relative">
+            <StyledSelect id="speed-select" value={speed} onChange={onSpeedChange}>
+              {SPEEDS.map((speedOption) => (
+                <option key={speedOption.value} value={speedOption.value}>
+                  {speedOption.label}
+                </option>
+              ))}
+            </StyledSelect>
+          </div>
+        </ControlRow>
+      </div>
+    </div>
+  );
+}

--- a/app/customize/components/ExportPanel.tsx
+++ b/app/customize/components/ExportPanel.tsx
@@ -1,0 +1,126 @@
+import type { ReactElement } from 'react';
+import type { ExportFormat } from '../types';
+import { getPlaceholderSnippet } from '../utils';
+
+const EXPORT_FORMATS: { value: ExportFormat; label: string }[] = [
+  { value: 'markdown', label: 'Markdown' },
+  { value: 'html', label: 'HTML' },
+];
+
+export function ExportPanel({
+  format,
+  snippet,
+  copied,
+  hasUsername,
+  onFormatChange,
+  onCopy,
+}: {
+  format: ExportFormat;
+  snippet: string;
+  copied: boolean;
+  hasUsername: boolean;
+  onFormatChange: (format: ExportFormat) => void;
+  onCopy: () => void;
+}): ReactElement {
+  const activeSnippet = hasUsername ? snippet : getPlaceholderSnippet(format);
+  const formatLabel = format === 'markdown' ? 'Markdown' : 'HTML';
+
+  return (
+    <div className="bg-[#0a0a0a] border border-white/5 rounded-[1.75rem] p-6">
+      <div className="flex flex-col gap-4 mb-5 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-[0.22em] text-emerald-400">
+            {formatLabel} Export Snippet
+          </p>
+          <p className="mt-1 text-[11px] text-white/25">
+            Switch formats without changing the live badge configuration.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <div
+            className="inline-flex rounded-xl border border-white/10 bg-black p-1"
+            aria-label="Export format"
+          >
+            {EXPORT_FORMATS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => onFormatChange(option.value)}
+                aria-pressed={format === option.value}
+                className={`rounded-lg px-3 py-1.5 text-xs font-bold transition-all ${
+                  format === option.value
+                    ? 'bg-emerald-500/15 text-emerald-300 shadow-[0_0_24px_rgba(16,185,129,0.16)]'
+                    : 'text-white/35 hover:text-white/70'
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+
+          <button
+            id="copy-markdown-btn"
+            onClick={onCopy}
+            disabled={!hasUsername}
+            className={`relative inline-flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-bold transition-all duration-200 ${
+              !hasUsername
+                ? 'bg-white/[0.04] border border-white/8 text-white/30'
+                : copied
+                  ? 'bg-emerald-500/15 border border-emerald-500/30 text-emerald-400'
+                  : 'bg-white text-black hover:scale-[1.03] active:scale-[0.97]'
+            }`}
+          >
+            {copied ? (
+              <>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="w-3.5 h-3.5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+                Copied!
+              </>
+            ) : (
+              <>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="w-3.5 h-3.5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                </svg>
+                Copy {formatLabel}
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      <div className="bg-black/60 border border-white/8 rounded-xl px-5 py-4 overflow-x-auto">
+        <code className="text-emerald-300 text-xs font-mono leading-relaxed break-all whitespace-pre-wrap">
+          {activeSnippet}
+        </code>
+      </div>
+
+      <p className="mt-4 text-[11px] text-white/20 leading-relaxed">
+        Paste this into your GitHub profile&apos;s <code className="text-white/35">README.md</code>.
+        The badge renders server-side, no script required.
+      </p>
+    </div>
+  );
+}

--- a/app/customize/components/SectionLabel.tsx
+++ b/app/customize/components/SectionLabel.tsx
@@ -1,0 +1,9 @@
+import type { ReactElement, ReactNode } from 'react';
+
+export function SectionLabel({ children }: { children: ReactNode }): ReactElement {
+  return (
+    <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/30 mb-2">
+      {children}
+    </p>
+  );
+}

--- a/app/customize/components/ThemeSelector.tsx
+++ b/app/customize/components/ThemeSelector.tsx
@@ -1,0 +1,67 @@
+import type { ReactElement, ReactNode } from 'react';
+import { themes } from '../../../lib/svg/themes';
+import { THEME_KEYS, type ThemeKey } from '../types';
+import { SectionLabel } from './SectionLabel';
+
+function StyledSelect({
+  id,
+  value,
+  onChange,
+  children,
+}: {
+  id: string;
+  value: string;
+  onChange: (v: string) => void;
+  children: ReactNode;
+}): ReactElement {
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full bg-black border border-white/10 rounded-xl px-4 py-2.5 text-sm text-white outline-none focus:border-emerald-500/50 transition-colors appearance-none cursor-pointer"
+    >
+      {children}
+    </select>
+  );
+}
+
+export function ThemeSelector({
+  theme,
+  onThemeChange,
+}: {
+  theme: string;
+  onThemeChange: (theme: string) => void;
+}): ReactElement {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <SectionLabel>Theme Preset</SectionLabel>
+      <div className="relative">
+        <StyledSelect id="theme-select" value={theme} onChange={onThemeChange}>
+          {THEME_KEYS.map((key) => (
+            <option key={key} value={key}>
+              {key.charAt(0).toUpperCase() + key.slice(1)}
+            </option>
+          ))}
+        </StyledSelect>
+
+        <div className="mt-2 flex gap-1.5">
+          {(['bg', 'accent', 'text'] as const).map((prop) => {
+            const color = themes[theme as ThemeKey]?.[prop];
+            return color ? (
+              <span
+                key={prop}
+                title={`${prop}: #${color}`}
+                className="w-5 h-5 rounded-md border border-white/10"
+                style={{ backgroundColor: `#${color}` }}
+              />
+            ) : null;
+          })}
+          <span className="text-[11px] text-white/25 ml-1 self-center">bg · accent · text</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { StyledSelect };

--- a/app/customize/page.tsx
+++ b/app/customize/page.tsx
@@ -1,144 +1,16 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useCallback, useState, type ReactElement } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { themes } from '../../lib/svg/themes';
-
-// ─── Types ────────────────────────────────────────────────────────────────────
-
-type Scale = 'linear' | 'log';
-
-// Theme options are derived dynamically from lib/svg/themes.ts
-const THEME_KEYS = Object.keys(themes);
-
-const SPEEDS = [
-  { value: '4s', label: 'Fast  (4s)' },
-  { value: '8s', label: 'Default (8s)' },
-  { value: '12s', label: 'Slow  (12s)' },
-  { value: '20s', label: 'Ultra-slow (20s)' },
-] as const;
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function stripHash(val: string) {
-  return val.replace(/^#/, '');
-}
-
-// ─── Sub-components ───────────────────────────────────────────────────────────
-
-function SectionLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-white/30 mb-2">
-      {children}
-    </p>
-  );
-}
-
-function ControlRow({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <SectionLabel>{label}</SectionLabel>
-      {children}
-    </div>
-  );
-}
-
-function StyledSelect({
-  id,
-  value,
-  onChange,
-  children,
-}: {
-  id: string;
-  value: string;
-  onChange: (v: string) => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <select
-      id={id}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      className="w-full bg-black border border-white/10 rounded-xl px-4 py-2.5 text-sm text-white outline-none focus:border-emerald-500/50 transition-colors appearance-none cursor-pointer"
-    >
-      {children}
-    </select>
-  );
-}
-
-function HexInput({
-  id,
-  label,
-  value,
-  onChange,
-  placeholder,
-}: {
-  id: string;
-  label: string;
-  value: string;
-  onChange: (v: string) => void;
-  placeholder: string;
-}) {
-  // Normalise to a valid 6-char hex for the color picker (falls back to #000000)
-  const isValidHex = /^[0-9a-fA-F]{6}$/.test(stripHash(value));
-  const pickerValue = isValidHex ? `#${stripHash(value)}` : '#000000';
-  const swatchColor = isValidHex ? pickerValue : null;
-
-  return (
-    <div className="flex flex-col gap-1.5">
-      <SectionLabel>{label}</SectionLabel>
-      <div className="relative flex items-center gap-2">
-        {/* ── Color picker trigger ── */}
-        <label
-          htmlFor={`${id}-picker`}
-          title="Open color picker"
-          className="relative shrink-0 w-9 h-9 rounded-xl border border-white/10 overflow-hidden cursor-pointer hover:border-emerald-500/50 transition-colors"
-          style={{ backgroundColor: swatchColor ?? '#1a1a1a' }}
-        >
-          {/* Checkerboard shown when no color is set */}
-          {!swatchColor && (
-            <span
-              className="absolute inset-0"
-              style={{
-                backgroundImage: 'repeating-conic-gradient(#333 0% 25%, #1a1a1a 0% 50%)',
-                backgroundSize: '8px 8px',
-              }}
-            />
-          )}
-          <input
-            id={`${id}-picker`}
-            type="color"
-            value={pickerValue}
-            onChange={(e) => onChange(stripHash(e.target.value))}
-            className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
-            aria-label={`Color picker for ${label}`}
-          />
-        </label>
-
-        {/* ── Text input ── */}
-        <div className="relative flex-1 flex items-center">
-          <span className="absolute left-3 text-white/30 text-sm select-none pointer-events-none">
-            #
-          </span>
-          <input
-            id={id}
-            type="text"
-            value={value}
-            onChange={(e) => onChange(e.target.value.replace(/^#/, ''))}
-            placeholder={placeholder.replace(/^#/, '')}
-            maxLength={6}
-            className="w-full bg-black border border-white/10 rounded-xl pl-7 pr-4 py-2.5 text-sm font-mono text-emerald-300 placeholder:text-white/20 outline-none focus:border-emerald-500/50 transition-colors"
-          />
-        </div>
-      </div>
-    </div>
-  );
-}
+import { ControlsPanel } from './components/ControlsPanel';
+import { ExportPanel } from './components/ExportPanel';
+import type { ExportFormat, Scale } from './types';
+import { getExportSnippet, stripHash } from './utils';
 
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
-export default function CustomizePage() {
+export default function CustomizePage(): ReactElement {
   const [username, setUsername] = useState('');
   const [theme, setTheme] = useState('dark');
   const [bgHex, setBgHex] = useState('');
@@ -146,13 +18,14 @@ export default function CustomizePage() {
   const [textHex, setTextHex] = useState('');
   const [scale, setScale] = useState<Scale>('linear');
   const [speed, setSpeed] = useState('8s');
+  const [exportFormat, setExportFormat] = useState<ExportFormat>('markdown');
   const [copied, setCopied] = useState(false);
   const trimmedUsername = username.trim();
   const hasUsername = trimmedUsername.length > 0;
 
   // ── buildQueryParams ──────────────────────────────────────────────────────
 
-  const buildQueryParams = useCallback(() => {
+  const buildQueryParams = useCallback((): string => {
     const params = new URLSearchParams();
 
     if (hasUsername) {
@@ -177,12 +50,12 @@ export default function CustomizePage() {
 
   const queryString = buildQueryParams();
   const previewSrc = `/api/streak?${queryString}`;
-  const markdownSnippet = `![CommitPulse](https://commitpulse.vercel.app/api/streak?${queryString})`;
+  const exportSnippet = getExportSnippet(exportFormat, queryString);
 
-  const copyMarkdown = () => {
+  const copyExportSnippet = (): void => {
     if (!hasUsername) return;
 
-    navigator.clipboard.writeText(markdownSnippet);
+    navigator.clipboard.writeText(exportSnippet);
     setCopied(true);
     setTimeout(() => setCopied(false), 3000);
   };
@@ -245,8 +118,8 @@ export default function CustomizePage() {
             Fine-tune your monolith.
           </h1>
           <p className="text-gray-500 text-sm max-w-xl">
-            Every change below updates the preview in real-time. Copy the Markdown snippet when
-            you&apos;re done — no extra steps required.
+            Every change below updates the preview in real-time. Copy the export snippet when
+            you&apos;re done. No extra steps required.
           </p>
         </motion.div>
 
@@ -259,147 +132,27 @@ export default function CustomizePage() {
             transition={{ duration: 0.5, delay: 0.1 }}
             className="bg-[#0a0a0a] border border-white/5 rounded-[1.75rem] p-6 flex flex-col gap-6 sticky top-6"
           >
-            <div>
-              <p className="text-xs font-bold uppercase tracking-[0.22em] text-emerald-400 mb-4">
-                Controls
-              </p>
-
-              <div className="flex flex-col gap-5">
-                {/* Username */}
-                <ControlRow label="GitHub Username">
-                  <input
-                    id="username-input"
-                    type="text"
-                    value={username}
-                    onChange={(e) => setUsername(e.target.value)}
-                    placeholder="jhasourav07"
-                    className="w-full bg-black border border-white/10 rounded-xl px-4 py-2.5 text-sm font-mono text-emerald-300 placeholder:text-white/20 outline-none focus:border-emerald-500/50 transition-colors"
-                  />
-                </ControlRow>
-
-                {/* Divider */}
-                <div className="h-px bg-white/5" />
-
-                {/* Theme */}
-                <ControlRow label="Theme Preset">
-                  <div className="relative">
-                    <StyledSelect id="theme-select" value={theme} onChange={setTheme}>
-                      {THEME_KEYS.map((key) => (
-                        <option key={key} value={key}>
-                          {key.charAt(0).toUpperCase() + key.slice(1)}
-                        </option>
-                      ))}
-                    </StyledSelect>
-                    {/* Theme color swatches — driven from the imported themes object */}
-                    <div className="mt-2 flex gap-1.5">
-                      {(['bg', 'accent', 'text'] as const).map((prop) => {
-                        const color = themes[theme]?.[prop];
-                        return color ? (
-                          <span
-                            key={prop}
-                            title={`${prop}: #${color}`}
-                            className="w-5 h-5 rounded-md border border-white/10"
-                            style={{ backgroundColor: `#${color}` }}
-                          />
-                        ) : null;
-                      })}
-                      <span className="text-[11px] text-white/25 ml-1 self-center">
-                        bg · accent · text
-                      </span>
-                    </div>
-                  </div>
-                </ControlRow>
-
-                {/* Divider */}
-                <div className="h-px bg-white/5" />
-
-                {/* Custom hex overrides */}
-                <div>
-                  <SectionLabel>Custom Color Overrides</SectionLabel>
-                  <p className="text-[11px] text-white/25 mb-3 leading-relaxed">
-                    These override the theme preset above. Enter HEX values without&nbsp;
-                    <code className="text-white/40">#</code>.
-                  </p>
-                  <div className="flex flex-col gap-3">
-                    <HexInput
-                      id="bg-hex-input"
-                      label="Background"
-                      value={bgHex}
-                      onChange={setBgHex}
-                      placeholder="e.g. 0a0a0a"
-                    />
-                    <HexInput
-                      id="accent-hex-input"
-                      label="Accent / Tower Color"
-                      value={accentHex}
-                      onChange={setAccentHex}
-                      placeholder="e.g. 00ffaa"
-                    />
-                    <HexInput
-                      id="text-hex-input"
-                      label="Text / Label Color"
-                      value={textHex}
-                      onChange={setTextHex}
-                      placeholder="e.g. ffffff"
-                    />
-                  </div>
-                  {(bgHex || accentHex || textHex) && (
-                    <button
-                      id="clear-overrides-btn"
-                      onClick={() => {
-                        setBgHex('');
-                        setAccentHex('');
-                        setTextHex('');
-                      }}
-                      className="mt-3 text-[11px] text-red-400/60 hover:text-red-400 transition-colors"
-                    >
-                      ✕ Clear overrides
-                    </button>
-                  )}
-                </div>
-
-                {/* Divider */}
-                <div className="h-px bg-white/5" />
-
-                {/* Scale */}
-                <ControlRow label="Tower Height Scaling">
-                  <div className="grid grid-cols-2 gap-2">
-                    {(['linear', 'log'] as Scale[]).map((s) => (
-                      <button
-                        key={s}
-                        id={`scale-${s}-btn`}
-                        onClick={() => setScale(s)}
-                        className={`py-2.5 rounded-xl text-sm font-bold transition-all ${
-                          scale === s
-                            ? 'bg-emerald-500/15 border border-emerald-500/30 text-emerald-400'
-                            : 'bg-black border border-white/8 text-white/30 hover:text-white/60 hover:border-white/20'
-                        }`}
-                      >
-                        {s === 'linear' ? 'Linear' : 'Logarithmic'}
-                      </button>
-                    ))}
-                  </div>
-                  <p className="text-[11px] text-white/25 mt-1.5 leading-relaxed">
-                    {scale === 'log'
-                      ? 'Log mode compresses extreme outliers — great for power committers.'
-                      : 'Linear mode shows raw commit counts as tower heights.'}
-                  </p>
-                </ControlRow>
-
-                {/* Scan speed */}
-                <ControlRow label="Radar Scan Speed">
-                  <div className="relative">
-                    <StyledSelect id="speed-select" value={speed} onChange={setSpeed}>
-                      {SPEEDS.map((s) => (
-                        <option key={s.value} value={s.value}>
-                          {s.label}
-                        </option>
-                      ))}
-                    </StyledSelect>
-                  </div>
-                </ControlRow>
-              </div>
-            </div>
+            <ControlsPanel
+              username={username}
+              theme={theme}
+              bgHex={bgHex}
+              accentHex={accentHex}
+              textHex={textHex}
+              scale={scale}
+              speed={speed}
+              onUsernameChange={setUsername}
+              onThemeChange={setTheme}
+              onBgHexChange={setBgHex}
+              onAccentHexChange={setAccentHex}
+              onTextHexChange={setTextHex}
+              onScaleChange={setScale}
+              onSpeedChange={setSpeed}
+              onClearOverrides={() => {
+                setBgHex('');
+                setAccentHex('');
+                setTextHex('');
+              }}
+            />
           </motion.aside>
 
           {/* ════ RIGHT: Preview + Export ════════════════════════════════════ */}
@@ -466,82 +219,19 @@ export default function CustomizePage() {
 
               <p className="mt-3 text-[11px] text-white/20 text-center">
                 {hasUsername
-                  ? 'Preview updates on every change · Hosted badge is cached at UTC midnight'
-                  : 'Add a username to enable live preview and Markdown export'}
+                  ? 'Preview updates on every change. Hosted badge is cached at UTC midnight'
+                  : 'Add a username to enable live preview and export snippets'}
               </p>
             </div>
 
-            {/* Export */}
-            <div className="bg-[#0a0a0a] border border-white/5 rounded-[1.75rem] p-6">
-              <div className="flex items-center justify-between mb-5">
-                <p className="text-xs font-bold uppercase tracking-[0.22em] text-emerald-400">
-                  Markdown Export
-                </p>
-                <button
-                  id="copy-markdown-btn"
-                  onClick={copyMarkdown}
-                  disabled={!hasUsername}
-                  className={`relative inline-flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-bold transition-all duration-200 ${
-                    !hasUsername
-                      ? 'bg-white/[0.04] border border-white/8 text-white/30'
-                      : copied
-                        ? 'bg-emerald-500/15 border border-emerald-500/30 text-emerald-400'
-                        : 'bg-white text-black hover:scale-[1.03] active:scale-[0.97]'
-                  }`}
-                >
-                  {copied ? (
-                    <>
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="w-3.5 h-3.5"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="3"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        aria-hidden="true"
-                      >
-                        <polyline points="20 6 9 17 4 12" />
-                      </svg>
-                      Copied!
-                    </>
-                  ) : (
-                    <>
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="w-3.5 h-3.5"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        aria-hidden="true"
-                      >
-                        <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-                        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-                      </svg>
-                      Copy Markdown
-                    </>
-                  )}
-                </button>
-              </div>
-
-              <div className="bg-black/60 border border-white/8 rounded-xl px-5 py-4 overflow-x-auto">
-                <code className="text-emerald-300 text-xs font-mono leading-relaxed break-all whitespace-pre-wrap">
-                  {hasUsername
-                    ? markdownSnippet
-                    : '![CommitPulse](https://commitpulse.vercel.app/api/streak?user=your-github-username)'}
-                </code>
-              </div>
-
-              <p className="mt-4 text-[11px] text-white/20 leading-relaxed">
-                Paste this into your GitHub profile&apos;s{' '}
-                <code className="text-white/35">README.md</code> — the badge renders server-side, no
-                script required.
-              </p>
-            </div>
+            <ExportPanel
+              format={exportFormat}
+              snippet={exportSnippet}
+              copied={copied}
+              hasUsername={hasUsername}
+              onFormatChange={setExportFormat}
+              onCopy={copyExportSnippet}
+            />
 
             {/* URL breakdown */}
             <div className="bg-[#0a0a0a] border border-white/5 rounded-[1.75rem] p-6">

--- a/app/customize/types.ts
+++ b/app/customize/types.ts
@@ -1,0 +1,16 @@
+import { themes } from '../../lib/svg/themes';
+
+export type Scale = 'linear' | 'log';
+
+export type ExportFormat = 'markdown' | 'html';
+
+export type ThemeKey = Extract<keyof typeof themes, string>;
+
+export const THEME_KEYS = Object.keys(themes) as ThemeKey[];
+
+export const SPEEDS = [
+  { value: '4s', label: 'Fast  (4s)' },
+  { value: '8s', label: 'Default (8s)' },
+  { value: '12s', label: 'Slow  (12s)' },
+  { value: '20s', label: 'Ultra-slow (20s)' },
+] as const;

--- a/app/customize/utils.ts
+++ b/app/customize/utils.ts
@@ -1,0 +1,29 @@
+import type { ExportFormat } from './types';
+
+const BADGE_BASE_URL = 'https://commitpulse.vercel.app/api/streak';
+
+export function stripHash(val: string): string {
+  return val.replace(/^#/, '');
+}
+
+export function isValidHex(value: string): boolean {
+  return /^[0-9a-fA-F]{6}$/.test(stripHash(value));
+}
+
+export function getBadgeUrl(queryString: string): string {
+  return `${BADGE_BASE_URL}?${queryString}`;
+}
+
+export function getExportSnippet(format: ExportFormat, queryString: string): string {
+  const badgeUrl = getBadgeUrl(queryString);
+
+  if (format === 'html') {
+    return `<img src="${badgeUrl}" alt="CommitPulse" />`;
+  }
+
+  return `![CommitPulse](${badgeUrl})`;
+}
+
+export function getPlaceholderSnippet(format: ExportFormat): string {
+  return getExportSnippet(format, 'user=your-github-username');
+}


### PR DESCRIPTION
## Description

Fixes #93

Refactors the Customize Studio page so `app/customize/page.tsx` acts as the state/orchestration layer while internal types, helpers, and UI pieces live in dedicated files. This also adds a clean Markdown/HTML export toggle so users can copy the active snippet format from the export panel.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

This PR does not change the generated SVG output. It updates the Customize Studio UI by replacing the old Markdown-only export block with an export panel that can switch between:

- Markdown snippet: `![CommitPulse](...)`
- HTML snippet: `<img src="..." alt="CommitPulse" />`

The live badge preview and active parameters panel remain unchanged.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).

Validation run:

- `prettier --check` on touched Customize Studio files
- `npm run typecheck`
- `npm run lint`
- `npm run test` (10 files, 111 tests passed)
- `npm run build`