### PR TITLE
feat(seo): update layout metadata and open graph tags (#57)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,32 +3,62 @@ import { Inter } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/next';
 import Navbar from './components/navbar';
 import CherryBlossom from '@/components/CherryBlossom';
+import type { Metadata } from 'next';
 
 const inter = Inter({ subsets: ['latin'] });
 
-export const metadata = {
-  title: 'CommitPulse | Visualize Your Rhythm',
-  description: 'Premium GitHub streak monoliths',
+export const metadata: Metadata = {
+  metadataBase: new URL('https://commitpulse.vercel.app'),
+  title: 'CommitPulse | 3D Isometric GitHub Contribution Graph',
+  description:
+    'Transform your GitHub contribution history into a cinematic, 3D isometric SVG monolith. Drop it into your README and visualize your developer rhythm with real-time accuracy.',
+  keywords: [
+    'GitHub',
+    'contribution graph',
+    'isometric',
+    '3D SVG',
+    'GitHub stats',
+    'README widget',
+    'developer portfolio',
+    'CommitPulse',
+  ],
+  authors: [{ name: 'Sourav Jha', url: 'https://github.com/JhaSourav07' }],
+  creator: 'Sourav Jha',
   openGraph: {
-    title: 'CommitPulse | Visualize Your Rhythm',
-    description: 'Your GitHub contributions as a cinematic SVG monolith.',
-    url: 'https://commitpulse.vercel.app',
+    type: 'website',
+    locale: 'en_US',
+    url: 'https://commitpulse.vercel.app/',
+    title: 'CommitPulse | 3D Isometric GitHub Contribution Graph',
+    description:
+      'Generate a cinematic, isometric 3D SVG of your GitHub contributions for your README. Stop being boring and visualize your grind.',
     siteName: 'CommitPulse',
     images: [
       {
-        url: '/api/og?user=jhasourav07',
+        url: 'https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=neon',
         width: 1200,
         height: 630,
-        alt: 'CommitPulse Preview',
+        alt: 'CommitPulse 3D GitHub Contribution Graph Preview',
       },
     ],
-    type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'CommitPulse | Visualize Your Rhythm',
-    description: 'Your GitHub contributions as a cinematic SVG monolith.',
-    images: ['/api/og?user=jhasourav07'],
+    title: 'CommitPulse | Elevate Your GitHub README',
+    description:
+      'Generate a cinematic, isometric 3D SVG of your GitHub contributions for your README.',
+    images: ['https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=neon'],
+    // creator: '@your_twitter_handle', // Uncomment and add your Twitter handle here
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
   },
 };
 


### PR DESCRIPTION
### Replaces the default Next.js boilerplate metadata with a fully optimized SEO configuration in `app/layout.tsx`. This includes professional title/description tags, Open Graph configurations, and Twitter Card setups so the project generates rich, clickable previews when shared on platforms like Discord, Twitter, and LinkedIn.

Fixes #57 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

*Since metadata does not alter the UI, here is a screenshot of the DOM `<head>` rendering the new Open Graph and Twitter tags on the local dev server:*

<img width="1395" height="368" alt="image" src="https://github.com/user-attachments/assets/190bec49-1e3d-4e28-b4e8-1a2e73609738" />

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter. *(N/A)*
- [x] I have started the repo.
- [ ] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). *(N/A)*

### ⚠️ Note to Maintainers Regarding Local Tests
I wanted to flag that `npm run test` is currently failing on a fresh clone of `main` due to a module resolution error (`Cannot find module '@testing-library/react' imported from vitest/dist/module-evaluator.js`). I attempted a clean re-clone and forced module installations, but the Vitest environment seems to be missing dependencies in the core setup. 

Since my changes only touch static Next.js metadata in `layout.tsx`, I am opening this PR so the SEO improvements aren't blocked, but wanted to let you know about the local test suite bug!
