### PR TITLE
test(api): strengthen validation tests for speed and scale query params

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -195,6 +195,13 @@ describe('GET /api/streak', () => {
       // "5" doesn't match /^\d+(\.\d+)?s$/, so the default kicks in.
       expect(body).toContain('8s');
     });
+
+    it('falls back to 8s when speed=10 is provided', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', speed: '10' }));
+      const body = await response.text();
+
+      expect(body).toContain('8s');
+    });
   });
 
   describe('scale parameter', () => {
@@ -208,6 +215,12 @@ describe('GET /api/streak', () => {
       // The route only accepts "log" — anything else is treated as "linear".
       // A 200 response confirms no crash; the generator silently uses the default.
       const response = await GET(makeRequest({ user: 'octocat', scale: 'exponential' }));
+
+      expect(response.status).toBe(200);
+    });
+
+    it('defaults to linear scale when scale=foo is given', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', scale: 'foo' }));
 
       expect(response.status).toBe(200);
     });


### PR DESCRIPTION
## Description

Fixes #158
Added additional validation test coverage for invalid speed and scale query parameter values.

Included tests for:

- speed=10
- scale=foo

Also verified fallback/default behavior continues to work correctly for invalid inputs.
## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
