### PR TITLE
fix(api): validate year query param format in /api/streak

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -242,6 +242,54 @@ describe('GET /api/streak', () => {
     });
   });
 
+  describe('year parameter', () => {
+    it('accepts a valid 4-digit year', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', year: '2024' }));
+
+      expect(response.status).toBe(200);
+    });
+
+    it('functions normally when the year parameter is missing', async () => {
+      const response = await GET(makeRequest({ user: 'octocat' }));
+
+      expect(response.status).toBe(200);
+    });
+
+    it('returns 400 for invalid year format', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', year: 'abcd' }));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.details.fieldErrors.year[0]).toContain('Invalid "year" parameter');
+    });
+
+    it('returns 400 for malformed numeric year', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', year: '100000' }));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.details.fieldErrors.year[0]).toContain('Invalid "year" parameter');
+    });
+
+    it('returns 400 for years before GitHub existed', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', year: '1999' }));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.details.fieldErrors.year[0]).toContain('Invalid "year" parameter');
+    });
+
+    it('returns 400 for future years', async () => {
+      const futureYear = (new Date().getFullYear() + 1).toString();
+
+      const response = await GET(makeRequest({ user: 'octocat', year: futureYear }));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.details.fieldErrors.year[0]).toContain('Invalid "year" parameter');
+    });
+  });
+
   describe('theme parameter', () => {
     it('returns 200 for a valid known theme like "neon"', async () => {
       const response = await GET(makeRequest({ user: 'octocat', theme: 'neon' }));

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -30,7 +30,23 @@ export const streakParamsSchema = z.object({
 
   radius: z.string().default('8'),
   font: z.string().optional(),
-  year: z.string().optional(),
+  year: z
+    .string()
+    .regex(/^\d{4}$/, {
+      message: 'Invalid "year" parameter. Use YYYY format, e.g. 2024.',
+    })
+    .refine(
+      (year) => {
+        const yearNum = parseInt(year, 10);
+        const currentYear = new Date().getFullYear();
+
+        return yearNum >= 2005 && yearNum <= currentYear;
+      },
+      {
+        message: 'Invalid "year" parameter. Use YYYY format, e.g. 2024.',
+      }
+    )
+    .optional(),
   refresh: z
     .string()
     .optional()


### PR DESCRIPTION
## Description

Fixes #155 
Added validation for the year query parameter in /api/streak.

## Changes made
- Added centralized Zod validation for the year query parameter
- Restricted accepted values to valid 4-digit GitHub-era years (2005 → current year)
- Added structured 400 validation responses for invalid input
- Preserved existing behavior when the year parameter is not provided
- Updated tests to match the repository’s newer validation architecture
- Added test coverage for:
  - valid years
  - missing year parameter
  - invalid formats
  - malformed numeric years
  - years before GitHub existed
  - future years
 
## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
