### PR TITLE
fix: remove incorrect public repo fallback from isPro logic

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -263,7 +263,7 @@ export async function getFullDashboardData(username: string, options: FetchOptio
       username: profileData.login,
       name: profileData.name || profileData.login,
       avatarUrl: profileData.avatar_url,
-      isPro: profileData.plan?.name === 'pro' || profileData.public_repos > 50,
+      isPro: profileData.plan?.name === 'pro',
       bio: profileData.bio || 'No bio available',
       location: profileData.location || 'Earth',
       joinedDate: new Date(profileData.created_at).toLocaleDateString('en-US', {


### PR DESCRIPTION
## Description

This PR fixes the incorrect `isPro` badge logic where users with more than 50 public repositories were incorrectly marked as GitHub Pro users.

The fallback condition based on repository count has been removed so that the PRO badge only appears when GitHub explicitly confirms a Pro plan.

Fixes #143

---

## Changes Made

* Removed:

```ts id="m8p1ke"
|| profileData.public_repos > 50
```

* Updated `isPro` logic in:

```txt id="s6v3ta"
lib/github.ts
```

---

## Pillar

Bug Fix

---

## Checklist

* [x] Code follows project conventions
* [x] Changes tested locally
* [x] No unrelated files modified
* [x] Linked the related issue properly
