### PR TITLE
feat: add year filter to customization studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We render your contribution data as a **3D Isometric City** — a grid of glowin
 
 **Ghost City Architecture:** In this mode, zero-contribution days aren't just empty space. They are rendered as thin, wireframe-style **blueprint foundations** (4px high). This gives your commit landscape a structured, architectural "work-in-progress" look even during rest days, maintaining the premium 3D aesthetic across the entire calendar.
 
-This is not decoration. This is a **live, animated data visualization** that makes your dedication impossible to ignore.
+This is not decoration. This is a **live , animated data visualization** that makes your dedication impossible to ignore.
 
 ### Why Isometric > Flat
 

--- a/app/customize/components/ControlsPanel.tsx
+++ b/app/customize/components/ControlsPanel.tsx
@@ -141,19 +141,16 @@ export function ControlsPanel({
             <StyledSelect id="year-select" value={year} onChange={(value) => onYearChange(value)}>
               <option value="">Current Year</option>
 
-              {Array.from(
-                { length: new Date().getFullYear() - 2019 },
-                (_, i) => {
-                  const currentYear = new Date().getFullYear();
-                  const yearOption = currentYear - i-1;
+              {Array.from({ length: new Date().getFullYear() - 2019 }, (_, i) => {
+                const currentYear = new Date().getFullYear();
+                const yearOption = currentYear - i - 1;
 
-                  return (
-                    <option key={yearOption} value={yearOption.toString()}>
-                      {yearOption}
-                    </option>
-                  );
-                }
-              )}
+                return (
+                  <option key={yearOption} value={yearOption.toString()}>
+                    {yearOption}
+                  </option>
+                );
+              })}
             </StyledSelect>
           </div>
         </ControlRow>

--- a/app/customize/components/ControlsPanel.tsx
+++ b/app/customize/components/ControlsPanel.tsx
@@ -115,6 +115,7 @@ export function ControlsPanel({
   onClearOverrides: () => void;
 }): ReactElement {
   const hasOverrides = Boolean(bgHex || accentHex || textHex);
+  const currentYear = new Date().getFullYear();
   const isAutoTheme = theme === 'auto';
 
   return (
@@ -135,14 +136,15 @@ export function ControlsPanel({
           />
         </ControlRow>
 
+        <ThemeSelector theme={theme} onThemeChange={onThemeChange} />
+
         <div className="h-px bg-white/5" />
         <ControlRow label="Year">
           <div className="relative">
             <StyledSelect id="year-select" value={year} onChange={(value) => onYearChange(value)}>
-              <option value="">Current Year</option>
+              <option value="">{currentYear} (current)</option>
 
-              {Array.from({ length: new Date().getFullYear() - 2019 }, (_, i) => {
-                const currentYear = new Date().getFullYear();
+              {Array.from({ length: currentYear - 2019 }, (_, i) => {
                 const yearOption = currentYear - i - 1;
 
                 return (
@@ -156,8 +158,6 @@ export function ControlsPanel({
         </ControlRow>
 
         <div className="h-px bg-white/5" />
-
-        <ThemeSelector theme={theme} onThemeChange={onThemeChange} />
 
         <div className="h-px bg-white/5" />
 

--- a/app/customize/components/ControlsPanel.tsx
+++ b/app/customize/components/ControlsPanel.tsx
@@ -85,6 +85,7 @@ export function ControlsPanel({
   textHex,
   scale,
   speed,
+  year,
   onUsernameChange,
   onThemeChange,
   onBgHexChange,
@@ -92,6 +93,7 @@ export function ControlsPanel({
   onTextHexChange,
   onScaleChange,
   onSpeedChange,
+  onYearChange,
   onClearOverrides,
 }: {
   username: string;
@@ -101,6 +103,7 @@ export function ControlsPanel({
   textHex: string;
   scale: Scale;
   speed: string;
+  year: string;
   onUsernameChange: (value: string) => void;
   onThemeChange: (value: string) => void;
   onBgHexChange: (value: string) => void;
@@ -108,6 +111,7 @@ export function ControlsPanel({
   onTextHexChange: (value: string) => void;
   onScaleChange: (value: Scale) => void;
   onSpeedChange: (value: string) => void;
+  onYearChange: (value: string) => void;
   onClearOverrides: () => void;
 }): ReactElement {
   const hasOverrides = Boolean(bgHex || accentHex || textHex);
@@ -129,6 +133,29 @@ export function ControlsPanel({
             placeholder="jhasourav07"
             className="w-full bg-black border border-white/10 rounded-xl px-4 py-2.5 text-sm font-mono text-emerald-300 placeholder:text-white/20 outline-none focus:border-emerald-500/50 transition-colors"
           />
+        </ControlRow>
+
+        <div className="h-px bg-white/5" />
+        <ControlRow label="Year">
+          <div className="relative">
+            <StyledSelect id="year-select" value={year} onChange={(value) => onYearChange(value)}>
+              <option value="">Current Year</option>
+
+              {Array.from(
+                { length: new Date().getFullYear() - 2019 },
+                (_, i) => {
+                  const currentYear = new Date().getFullYear();
+                  const yearOption = currentYear - i-1;
+
+                  return (
+                    <option key={yearOption} value={yearOption.toString()}>
+                      {yearOption}
+                    </option>
+                  );
+                }
+              )}
+            </StyledSelect>
+          </div>
         </ControlRow>
 
         <div className="h-px bg-white/5" />

--- a/app/customize/page.tsx
+++ b/app/customize/page.tsx
@@ -64,7 +64,18 @@ export default function CustomizePage(): ReactElement {
     if (speed !== '8s') params.set('speed', speed);
     if (year) params.set('year', year);
     return params.toString();
-  }, [hasUsername, trimmedUsername, theme, isAutoTheme, bgHex, accentHex, textHex, scale, speed, year]);
+  }, [
+    hasUsername,
+    trimmedUsername,
+    theme,
+    isAutoTheme,
+    bgHex,
+    accentHex,
+    textHex,
+    scale,
+    speed,
+    year,
+  ]);
 
   const queryString = buildQueryParams();
   const previewSrc = `/api/streak?${queryString}`;

--- a/app/customize/page.tsx
+++ b/app/customize/page.tsx
@@ -18,6 +18,7 @@ export default function CustomizePage(): ReactElement {
   const [textHex, setTextHex] = useState('');
   const [scale, setScale] = useState<Scale>('linear');
   const [speed, setSpeed] = useState('8s');
+  const [year, setYear] = useState('');
   const [exportFormat, setExportFormat] = useState<ExportFormat>('markdown');
   const [copied, setCopied] = useState(false);
   const trimmedUsername = username.trim();
@@ -61,9 +62,9 @@ export default function CustomizePage(): ReactElement {
 
     if (scale !== 'linear') params.set('scale', scale);
     if (speed !== '8s') params.set('speed', speed);
-
+    if (year) params.set('year', year);
     return params.toString();
-  }, [hasUsername, trimmedUsername, theme, isAutoTheme, bgHex, accentHex, textHex, scale, speed]);
+  }, [hasUsername, trimmedUsername, theme, isAutoTheme, bgHex, accentHex, textHex, scale, speed, year]);
 
   const queryString = buildQueryParams();
   const previewSrc = `/api/streak?${queryString}`;
@@ -157,6 +158,7 @@ export default function CustomizePage(): ReactElement {
               textHex={textHex}
               scale={scale}
               speed={speed}
+              year={year}
               onUsernameChange={setUsername}
               onThemeChange={handleThemeChange}
               onBgHexChange={setBgHex}
@@ -164,6 +166,7 @@ export default function CustomizePage(): ReactElement {
               onTextHexChange={setTextHex}
               onScaleChange={setScale}
               onSpeedChange={setSpeed}
+              onYearChange={setYear}
               onClearOverrides={() => {
                 setBgHex('');
                 setAccentHex('');


### PR DESCRIPTION
## Description

Added a dynamic Year filter to the Customization Studio.

Fixes #142

### Changes Made

* Added a Year dropdown for selecting contribution years
* Implemented dynamic year generation based on the current year
* Added year state handling in `page.tsx`
* Updated query parameter generation to append `&year=` only when a specific year is selected
* Ensured selecting Current Year removes the year query parameter
* Updated live preview and export snippet generation accordingly
* Optimized current year calculation by moving it outside the loop
* Added `(current)` label for better UX consistency
* Repositioned the Year selector below Theme Presets

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

### Before

#### Old Year Dropdown

<img width="389" height="518" alt="img1" src="https://github.com/user-attachments/assets/64ac5c54-1d97-41dd-a7b7-566abb6b3df7" />


#### Old Placement

<img width="1533" height="732" alt="img2" src="https://github.com/user-attachments/assets/502bd108-739a-49a9-b234-c6e95410a5eb" />


---

### After

#### Improved Year Selector UI

<img width="1529" height="679" alt="img3" src="https://github.com/user-attachments/assets/cb212318-4a9c-476a-8aea-edb24c72eaf9" />


## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/customize`).
* [x] I have run `npm run format` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable for this UI-only change).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
