### PR TITLE
feat: add shuffle button for theme presets

### DIFF
--- a/app/customize/components/ThemeSelector.tsx
+++ b/app/customize/components/ThemeSelector.tsx
@@ -124,16 +124,13 @@ export function ThemeSelector({
 }): ReactElement {
   const isAuto = theme === 'auto';
 
- const handleRandomTheme = (): void => {
-  const availableThemes = THEME_KEYS.filter(
-    (key) => key !== 'auto' && key !== theme
-  );
+  const handleRandomTheme = (): void => {
+    const availableThemes = THEME_KEYS.filter((key) => key !== 'auto' && key !== theme);
 
-  const randomTheme =
-    availableThemes[Math.floor(Math.random() * availableThemes.length)];
+    const randomTheme = availableThemes[Math.floor(Math.random() * availableThemes.length)];
 
-  onThemeChange(randomTheme);
-};
+    onThemeChange(randomTheme);
+  };
 
   return (
     <div className="flex flex-col gap-1.5">
@@ -143,16 +140,10 @@ export function ThemeSelector({
         {/* Select + Shuffle Button */}
         <div className="flex items-center gap-2">
           <div className="flex-1">
-            <StyledSelect
-              id="theme-select"
-              value={theme}
-              onChange={onThemeChange}
-            >
+            <StyledSelect id="theme-select" value={theme} onChange={onThemeChange}>
               {THEME_KEYS.map((key) => (
                 <option key={key} value={key}>
-                  {key === 'auto'
-                    ? 'Auto (System)'
-                    : key.charAt(0).toUpperCase() + key.slice(1)}
+                  {key === 'auto' ? 'Auto (System)' : key.charAt(0).toUpperCase() + key.slice(1)}
                 </option>
               ))}
             </StyledSelect>
@@ -162,7 +153,7 @@ export function ThemeSelector({
             type="button"
             onClick={handleRandomTheme}
             title="Shuffle Theme"
-          className="h-10 w-10 cursor-pointer flex items-center justify-center rounded-xl border border-white/10 bg-white/5 text-white/70 transition-all duration-200 hover:bg-white/15 hover:border-white/20 hover:text-white hover:scale-105 active:scale-95"
+            className="h-10 w-10 cursor-pointer flex items-center justify-center rounded-xl border border-white/10 bg-white/5 text-white/70 transition-all duration-200 hover:bg-white/15 hover:border-white/20 hover:text-white hover:scale-105 active:scale-95"
           >
             <Shuffle className="w-4 h-4" />
           </button>
@@ -176,14 +167,8 @@ export function ThemeSelector({
                 title="Light → Dark (auto)"
                 className="w-5 h-5 rounded-md border border-white/10 overflow-hidden flex"
               >
-                <span
-                  className="w-1/2 h-full"
-                  style={{ backgroundColor: `#${themes.light.bg}` }}
-                />
-                <span
-                  className="w-1/2 h-full"
-                  style={{ backgroundColor: `#${themes.dark.bg}` }}
-                />
+                <span className="w-1/2 h-full" style={{ backgroundColor: `#${themes.light.bg}` }} />
+                <span className="w-1/2 h-full" style={{ backgroundColor: `#${themes.dark.bg}` }} />
               </span>
 
               <span className="text-[11px] text-white/25 ml-1 self-center">
@@ -205,9 +190,7 @@ export function ThemeSelector({
                 ) : null;
               })}
 
-              <span className="text-[11px] text-white/25 ml-1 self-center">
-                bg · accent · text
-              </span>
+              <span className="text-[11px] text-white/25 ml-1 self-center">bg · accent · text</span>
             </>
           )}
         </div>

--- a/app/customize/components/ThemeSelector.tsx
+++ b/app/customize/components/ThemeSelector.tsx
@@ -1,4 +1,93 @@
+// import type { ReactElement, ReactNode } from 'react';
+// import { themes } from '../../../lib/svg/themes';
+// import { THEME_KEYS, type ThemeKey } from '../types';
+// import { SectionLabel } from './SectionLabel';
+
+// function StyledSelect({
+//   id,
+//   value,
+//   onChange,
+//   children,
+// }: {
+//   id: string;
+//   value: string;
+//   onChange: (v: string) => void;
+//   children: ReactNode;
+// }): ReactElement {
+//   return (
+//     <select
+//       id={id}
+//       value={value}
+//       onChange={(e) => onChange(e.target.value)}
+//       className="w-full bg-black border border-white/10 rounded-xl px-4 py-2.5 text-sm text-white outline-none focus:border-emerald-500/50 transition-colors appearance-none cursor-pointer"
+//     >
+//       {children}
+//     </select>
+//   );
+// }
+
+// export function ThemeSelector({
+//   theme,
+//   onThemeChange,
+// }: {
+//   theme: string;
+//   onThemeChange: (theme: string) => void;
+// }): ReactElement {
+//   const isAuto = theme === 'auto';
+
+//   return (
+//     <div className="flex flex-col gap-1.5">
+//       <SectionLabel>Theme Preset</SectionLabel>
+//       <div className="relative">
+//         <StyledSelect id="theme-select" value={theme} onChange={onThemeChange}>
+//           {THEME_KEYS.map((key) => (
+//             <option key={key} value={key}>
+//               {key === 'auto' ? 'Auto (System)' : key.charAt(0).toUpperCase() + key.slice(1)}
+//             </option>
+//           ))}
+//         </StyledSelect>
+
+//         <div className="mt-2 flex gap-1.5">
+//           {isAuto ? (
+//             <>
+//               {/* Split swatch: left half = light bg, right half = dark bg */}
+//               <span
+//                 title="Light → Dark (auto)"
+//                 className="w-5 h-5 rounded-md border border-white/10 overflow-hidden flex"
+//               >
+//                 <span className="w-1/2 h-full" style={{ backgroundColor: `#${themes.light.bg}` }} />
+//                 <span className="w-1/2 h-full" style={{ backgroundColor: `#${themes.dark.bg}` }} />
+//               </span>
+//               <span className="text-[11px] text-white/25 ml-1 self-center">
+//                 switches with OS theme
+//               </span>
+//             </>
+//           ) : (
+//             <>
+//               {(['bg', 'accent', 'text'] as const).map((prop) => {
+//                 const color = themes[theme as ThemeKey]?.[prop];
+//                 return color ? (
+//                   <span
+//                     key={prop}
+//                     title={`${prop}: #${color}`}
+//                     className="w-5 h-5 rounded-md border border-white/10"
+//                     style={{ backgroundColor: `#${color}` }}
+//                   />
+//                 ) : null;
+//               })}
+//               <span className="text-[11px] text-white/25 ml-1 self-center">bg · accent · text</span>
+//             </>
+//           )}
+//         </div>
+//       </div>
+//     </div>
+//   );
+// }
+
+// export { StyledSelect };
 import type { ReactElement, ReactNode } from 'react';
+import { Shuffle } from 'lucide-react';
+
 import { themes } from '../../../lib/svg/themes';
 import { THEME_KEYS, type ThemeKey } from '../types';
 import { SectionLabel } from './SectionLabel';
@@ -35,17 +124,49 @@ export function ThemeSelector({
 }): ReactElement {
   const isAuto = theme === 'auto';
 
+ const handleRandomTheme = (): void => {
+  const availableThemes = THEME_KEYS.filter(
+    (key) => key !== 'auto' && key !== theme
+  );
+
+  const randomTheme =
+    availableThemes[Math.floor(Math.random() * availableThemes.length)];
+
+  onThemeChange(randomTheme);
+};
+
   return (
     <div className="flex flex-col gap-1.5">
       <SectionLabel>Theme Preset</SectionLabel>
+
       <div className="relative">
-        <StyledSelect id="theme-select" value={theme} onChange={onThemeChange}>
-          {THEME_KEYS.map((key) => (
-            <option key={key} value={key}>
-              {key === 'auto' ? 'Auto (System)' : key.charAt(0).toUpperCase() + key.slice(1)}
-            </option>
-          ))}
-        </StyledSelect>
+        {/* Select + Shuffle Button */}
+        <div className="flex items-center gap-2">
+          <div className="flex-1">
+            <StyledSelect
+              id="theme-select"
+              value={theme}
+              onChange={onThemeChange}
+            >
+              {THEME_KEYS.map((key) => (
+                <option key={key} value={key}>
+                  {key === 'auto'
+                    ? 'Auto (System)'
+                    : key.charAt(0).toUpperCase() + key.slice(1)}
+                </option>
+              ))}
+            </StyledSelect>
+          </div>
+
+          <button
+            type="button"
+            onClick={handleRandomTheme}
+            title="Shuffle Theme"
+          className="h-10 w-10 cursor-pointer flex items-center justify-center rounded-xl border border-white/10 bg-white/5 text-white/70 transition-all duration-200 hover:bg-white/15 hover:border-white/20 hover:text-white hover:scale-105 active:scale-95"
+          >
+            <Shuffle className="w-4 h-4" />
+          </button>
+        </div>
 
         <div className="mt-2 flex gap-1.5">
           {isAuto ? (
@@ -55,9 +176,16 @@ export function ThemeSelector({
                 title="Light → Dark (auto)"
                 className="w-5 h-5 rounded-md border border-white/10 overflow-hidden flex"
               >
-                <span className="w-1/2 h-full" style={{ backgroundColor: `#${themes.light.bg}` }} />
-                <span className="w-1/2 h-full" style={{ backgroundColor: `#${themes.dark.bg}` }} />
+                <span
+                  className="w-1/2 h-full"
+                  style={{ backgroundColor: `#${themes.light.bg}` }}
+                />
+                <span
+                  className="w-1/2 h-full"
+                  style={{ backgroundColor: `#${themes.dark.bg}` }}
+                />
               </span>
+
               <span className="text-[11px] text-white/25 ml-1 self-center">
                 switches with OS theme
               </span>
@@ -66,6 +194,7 @@ export function ThemeSelector({
             <>
               {(['bg', 'accent', 'text'] as const).map((prop) => {
                 const color = themes[theme as ThemeKey]?.[prop];
+
                 return color ? (
                   <span
                     key={prop}
@@ -75,7 +204,10 @@ export function ThemeSelector({
                   />
                 ) : null;
               })}
-              <span className="text-[11px] text-white/25 ml-1 self-center">bg · accent · text</span>
+
+              <span className="text-[11px] text-white/25 ml-1 self-center">
+                bg · accent · text
+              </span>
             </>
           )}
         </div>


### PR DESCRIPTION
## Description
Adds a Shuffle Theme button to the customize page so users can quickly preview random preset themes without manually cycling through the dropdown.

Fixes #136

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

##Changes Made
-[x]Added a Shuffle icon button using lucide-react
-[x]Implemented handleRandomTheme for random preset selection
-[x]Excluded the auto theme from shuffle behavior
-[x]Prevented immediate repetition of the currently active theme
-[x]Added hover, scale, and active click animations

## Visual Preview
Added a shuffle button beside the theme selector for quick random theme discovery.
<img width="465" height="463" alt="Screenshot 2026-05-19 124435" src="https://github.com/user-attachments/assets/c943b94c-58eb-444a-8015-90b3bc8b96fb" />

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.

