### PR TITLE
fix(github): expand language color mapping

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -306,6 +306,7 @@ export async function getFullDashboardData(username: string, options: FetchOptio
     });
 
     // Fixed color mapping for common languages to avoid random colors
+    // Fixed color mapping for common languages to avoid random colors
     const languageColors: Record<string, string> = {
       TypeScript: '#3178c6',
       JavaScript: '#f1e05a',
@@ -316,6 +317,22 @@ export async function getFullDashboardData(username: string, options: FetchOptio
       CSS: '#563d7c',
       Go: '#00ADD8',
       Rust: '#dea584',
+
+      C: '#555555',
+      'C#': '#178600',
+      PHP: '#4F5D95',
+      Ruby: '#701516',
+      Swift: '#F05138',
+      Kotlin: '#A97BFF',
+      Dart: '#00B4AB',
+      Lua: '#000080',
+      R: '#198CE7',
+      Scala: '#c22d40',
+      Perl: '#0298c3',
+      Haskell: '#5e5086',
+      Elixir: '#6e4a7e',
+      Vue: '#41b883',
+      Svelte: '#ff3e00',
     };
 
     const totalLangs = Object.values(langCounts).reduce((a, b) => a + b, 0);


### PR DESCRIPTION
## Description

Fixes #133 

Expanded the `languageColors` mapping in `lib/github.ts` by adding more popular programming languages and their corresponding colors. This improves dashboard chart accuracy by reducing fallback usage of the default purple color for commonly used languages.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — this PR only updates the language color mapping used for dashboard charts and does not directly modify SVG layout, themes, or rendering logic.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_GITHUB_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.