### PR TITLE
feat(streak): add hide_background parameter to make SVG background transparent

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,19 +82,20 @@ URL Parameter > Theme Default > System Fallback
 
 ### Parameter Reference
 
-| Parameter | Type      | Required   | Default                        | Description                                           |
-| --------- | --------- | ---------- | ------------------------------ | ----------------------------------------------------- |
-| `user`    | `string`  | ✅ **Yes** | —                              | GitHub username to render                             |
-| `theme`   | `string`  | No         | `dark`                         | Preset theme name (see below)                         |
-| `bg`      | `hex`     | No         | Theme default                  | Background color — **without** `#`                    |
-| `accent`  | `hex`     | No         | Theme default                  | Tower & glow color — **without** `#`                  |
-| `text`    | `hex`     | No         | Theme default                  | Label & stat text color — **without** `#`             |
-| `radius`  | `number`  | No         | `8`                            | Border corner radius in pixels                        |
-| `speed`   | `string`  | No         | `8s`                           | Radar scan animation duration (e.g. `4s`, `12s`)      |
-| `scale`   | `string`  | No         | `linear`                       | Tower height scaling: `linear` or `log` (logarithmic) |
-| `font`    | `string`  | No         | CommitPulse default typography | Any **Google Font** name (e.g., `Orbitron`, `Inter`)  |
-| `refresh` | `boolean` | No         | `false`                        | Bypass cache for real-time data                       |
-| `year`    | `string`  | No         | —                              | Calendar year to render (e.g. `2023`, `2024`)         |
+| Parameter         | Type      | Required   | Default                        | Description                                                        |
+| ----------------- | --------- | ---------- | ------------------------------ | ------------------------------------------------------------------ |
+| `user`            | `string`  | ✅ **Yes** | —                              | GitHub username to render                                          |
+| `theme`           | `string`  | No         | `dark`                         | Preset theme name (see below)                                      |
+| `bg`              | `hex`     | No         | Theme default                  | Background color — **without** `#`                                 |
+| `accent`          | `hex`     | No         | Theme default                  | Tower & glow color — **without** `#`                               |
+| `text`            | `hex`     | No         | Theme default                  | Label & stat text color — **without** `#`                          |
+| `radius`          | `number`  | No         | `8`                            | Border corner radius in pixels                                     |
+| `speed`           | `string`  | No         | `8s`                           | Radar scan animation duration (e.g. `4s`, `12s`)                   |
+| `scale`           | `string`  | No         | `linear`                       | Tower height scaling: `linear` or `log` (logarithmic)              |
+| `font`            | `string`  | No         | CommitPulse default typography | Any **Google Font** name (e.g., `Orbitron`, `Inter`)               |
+| `refresh`         | `boolean` | No         | `false`                        | Bypass cache for real-time data                                    |
+| `year`            | `string`  | No         | —                              | Calendar year to render (e.g. `2023`, `2024`)                      |
+| `hide_background` | `boolean` | No         | `false`                        | Remove the background rect, letting the monolith float on the page |
 
 ### Theme Presets
 

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -22,8 +22,20 @@ export async function GET(request: Request) {
       );
     }
 
-    const { user, theme, bg, text, accent, scale, speed, radius, font, year, refresh } =
-      parseResult.data;
+    const {
+      user,
+      theme,
+      bg,
+      text,
+      accent,
+      scale,
+      speed,
+      radius,
+      font,
+      year,
+      refresh,
+      hide_background,
+    } = parseResult.data;
 
     const from = year ? `${year}-01-01T00:00:00Z` : undefined;
     const to = year ? `${year}-12-31T23:59:59Z` : undefined;
@@ -54,6 +66,7 @@ export async function GET(request: Request) {
       scale,
       font,
       autoTheme: isAutoTheme,
+      hideBackground: hide_background,
     };
 
     const calendar = await fetchGitHubContributions(user, { bypassCache: refresh, from, to });

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -295,7 +295,7 @@ export function generateSVG(
   @media (prefers-reduced-motion: reduce) { .heat-particles { display: none; } }
   </style>
 
-  <rect width="600" height="420" rx="${radius}" fill="${bg}" />
+  <rect width="600" height="420" rx="${radius}" fill="${params.hideBackground ? 'transparent' : bg}" />
 
   <g transform="translate(0, 20)">${towers}</g>
 
@@ -410,7 +410,7 @@ function generateAutoThemeSVG(
   @media (prefers-reduced-motion: reduce) { .heat-particles { display: none; } }
   </style>
 
-  <rect width="600" height="420" rx="${radius}" class="cp-bg-fill" />
+  <rect width="600" height="420" rx="${radius}" ${params.hideBackground ? 'fill="transparent"' : 'class="cp-bg-fill"'} />
   <g transform="translate(0, 20)">
     ${towers}
   </g>

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -26,6 +26,10 @@ export const streakParamsSchema = z.object({
     .string()
     .optional()
     .transform((val) => val === 'true'),
+  hide_background: z
+    .string()
+    .optional()
+    .transform((val) => val === 'true'),
 });
 
 export const githubParamsSchema = z.object({

--- a/types/index.ts
+++ b/types/index.ts
@@ -34,4 +34,5 @@ export interface BadgeParams {
   font?: string;
   radius?: string;
   autoTheme?: boolean;
+  hideBackground?: boolean;
 }


### PR DESCRIPTION
## Description

Fixes #131 
Adds a `hide_background=true` URL parameter that makes the base <rect> of the SVG transparent, allowing the monolith to float naturally on a README page without a solid background box.

Changes made:
- `lib/validations.ts` — Added `hide_background` field to `streakParamsSchema` as an optional boolean-transformed string
- `app/api/streak/route.ts` — Destructured `hide_background` from parsed params and passed it into `BadgeParams` as `hideBackground`
- `types/index.ts` — added `hideBackground?:` boolean to the `BadgeParams` interface
- `lib/svg/generator.ts` — updated both `generateSVG` and `generateAutoThemeSVG` to conditionally set the background <rect> fill to transparent when `hideBackground` is true
- `README.md` — added `hide_background` to the Parameter Reference table

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
https://collection.cloudinary.com/dqvm8dce2/ce54209a1a00e816516d85178dbd53c7

Hitting `/api/streak?user=YOUR_USERNAME&hide_background=true` returns a valid SVG with a transparent background, letting the monolith float on the page.

## Checklist

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME&hide_background=true`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- I have updated `README.md` if I added a new theme or URL parameter.
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.
- The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
