### PR TITLE
fix(ui): add custom text selection color to match site theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -78,3 +78,8 @@ body {
   background: #333;
   border-radius: 3px;
 }
+/* Custom text selection color to match site theme */
+::selection {
+  background-color: #00ffaa;
+  color: #0d1117;
+}


### PR DESCRIPTION
## Description
The default browser text selection color (bright blue) looked out of place 
on CommitPulse's dark premium design. This PR adds a `::selection` CSS rule 
in `globals.css` so highlighted text uses the site's green accent color instead.

Closes #60

## Pillar
Frontend / UI Enhancement

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My change is minimal and focused on the issue
- [x] No new dependencies added
- [x] Visual preview attached below

## Visual Preview

<img width="1600" height="823" alt="WhatsApp Image 2026-05-21 at 11 07 05" src="https://github.com/user-attachments/assets/072f9fbe-59f6-41bf-a636-00a3fa435e5b" />
<img width="1600" height="879" alt="WhatsApp Image 2026-05-21 at 11 07 05 (1)" src="https://github.com/user-attachments/assets/254ccb33-7a84-44bd-a0b7-1a3d7f613e5c" />

