### PR TITLE
fix(ui): move *:focus-visible rule into @layer base to allow brand ring override

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -60,9 +60,11 @@ body {
 }
 
 /* Vercel-style focus ring */
-*:focus-visible {
-  outline: 2px solid rgba(99, 102, 241, 0.6);
-  outline-offset: 2px;
+@layer base {
+  *:focus-visible {
+    outline: 2px solid rgba(99, 102, 241, 0.6);
+    outline-offset: 2px;
+  }
 }
 
 /* Smooth scrollbar on dark bg */


### PR DESCRIPTION
## Description

Fixes #61

**Root Cause**

- globals.css had a global *:focus-visible rule outside any CSS layer. In Tailwind v4, all utility classes live in @layer utilities, but un-layered CSS always wins the cascade regardless of specificity, so the blue ring bled through no matter what utility classes were on the input.

**Fix**

- Moved the *:focus-visible rule in globals.css into @layer base, so Tailwind utilities can properly override it. No changes were needed to the input's className. The existing outline-none utility class already suppresses the outline through Tailwind v4's layer cascade.

**Result**

- The input now shows only CommitPulse's primary brand accent color (#00ffaa) as the focus ring with a smooth transition-all duration-200, consistent with the dark theme aesthetic.


## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
