### PR TITLE
ui: add custom indigo selection highlight color matching dark theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -78,3 +78,15 @@ body {
   background: #333;
   border-radius: 3px;
 }
+
+
+/* Custom text selection color matching dark theme */
+::selection {
+  background: rgba(99, 102, 241, 0.4);
+  color: #ffffff;
+}
+
+::-moz-selection {
+  background: rgba(99, 102, 241, 0.4);
+  color: #ffffff;
+}


### PR DESCRIPTION
Replace the browser's default bright blue text selection color with a custom indigo highlight (rgba(99, 102, 241, 0.4)) that matches the dark premium aesthetic of CommitPulse.

Changes:
- Added ::selection with indigo background matching the existing accent color
- Added ::-moz-selection for Firefox compatibility
- Keeps text white for contrast against dark background

Closes #60