### PR TITLE
feat(customize): add font selector for streak badge preview

### DIFF
--- a/app/customize/components/ControlsPanel.tsx
+++ b/app/customize/components/ControlsPanel.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from 'react';
-import { SPEEDS, type Scale } from '../types';
+import { FONTS, SIZES, SPEEDS, type BadgeSize, type Scale } from '../types';
 import { isValidHex, stripHash } from '../utils';
 import { SectionLabel } from './SectionLabel';
 import { StyledSelect, ThemeSelector } from './ThemeSelector';
@@ -85,7 +85,11 @@ export function ControlsPanel({
   textHex,
   scale,
   speed,
+  year,
+  font,
+  onFontChange,
   radius,
+  size,
   onUsernameChange,
   onThemeChange,
   onBgHexChange,
@@ -93,6 +97,8 @@ export function ControlsPanel({
   onTextHexChange,
   onScaleChange,
   onSpeedChange,
+  onYearChange,
+  onSizeChange,
   onClearOverrides,
   onRadiusChange,
 }: {
@@ -103,7 +109,11 @@ export function ControlsPanel({
   textHex: string;
   scale: Scale;
   speed: string;
+  year: string;
+  font: string;
+  onFontChange: (value: string) => void;
   radius: number;
+  size: BadgeSize;
   onUsernameChange: (value: string) => void;
   onThemeChange: (value: string) => void;
   onBgHexChange: (value: string) => void;
@@ -111,10 +121,13 @@ export function ControlsPanel({
   onTextHexChange: (value: string) => void;
   onScaleChange: (value: Scale) => void;
   onSpeedChange: (value: string) => void;
+  onYearChange: (value: string) => void;
+  onSizeChange: (value: BadgeSize) => void;
   onClearOverrides: () => void;
   onRadiusChange: (value: number) => void;
 }): ReactElement {
   const hasOverrides = Boolean(bgHex || accentHex || textHex);
+  const currentYear = new Date().getFullYear();
   const isAutoTheme = theme === 'auto';
 
   return (
@@ -135,14 +148,32 @@ export function ControlsPanel({
           />
         </ControlRow>
 
-        <div className="h-px bg-white/5" />
-
         <ThemeSelector theme={theme} onThemeChange={onThemeChange} />
+
+        <div className="h-px bg-white/5" />
+        <ControlRow label="Year">
+          <div className="relative">
+            <StyledSelect id="year-select" value={year} onChange={(value) => onYearChange(value)}>
+              <option value="">{currentYear} (current)</option>
+
+              {Array.from({ length: currentYear - 2019 }, (_, i) => {
+                const yearOption = currentYear - i - 1;
+
+                return (
+                  <option key={yearOption} value={yearOption.toString()}>
+                    {yearOption}
+                  </option>
+                );
+              })}
+            </StyledSelect>
+          </div>
+        </ControlRow>
 
         <div className="h-px bg-white/5" />
 
         <div>
           <SectionLabel>Custom Color Overrides</SectionLabel>
+
           {isAutoTheme ? (
             <p className="text-[11px] text-white/30 mt-2 leading-relaxed">
               Custom colors are disabled for the <strong className="text-white/50">Auto</strong>{' '}
@@ -155,6 +186,7 @@ export function ControlsPanel({
                 These override the theme preset above. Enter HEX values without&nbsp;
                 <code className="text-white/40">#</code>.
               </p>
+
               <div className="flex flex-col gap-3">
                 <HexInput
                   id="bg-hex-input"
@@ -178,6 +210,7 @@ export function ControlsPanel({
                   placeholder="e.g. ffffff"
                 />
               </div>
+
               {hasOverrides && (
                 <button
                   id="clear-overrides-btn"
@@ -229,9 +262,21 @@ export function ControlsPanel({
           </div>
         </ControlRow>
 
+        <ControlRow label="Font">
+          <div className="relative">
+            <StyledSelect id="font-select" value={font} onChange={onFontChange}>
+              {FONTS.map((fontOption) => (
+                <option key={fontOption.value} value={fontOption.value}>
+                  {fontOption.label}
+                </option>
+              ))}
+            </StyledSelect>
+          </div>
+        </ControlRow>
+
         <ControlRow label="Border Radius">
           <div className="relative flex items-center">
-            <div className="absolute inset-x-0 h-0.75  rounded-full  bg-white/6 " />
+            <div className="absolute inset-x-0 h-0.75 rounded-full bg-white/6" />
             <input
               type="range"
               min="0"
@@ -242,10 +287,27 @@ export function ControlsPanel({
               className="w-full relative bg-transparent appearance-none outline-none slider"
             />
           </div>
-          <div className="flex justify-between text-sm text-white/20 ">
+
+          <div className="flex justify-between text-sm text-white/20">
             <span>0</span>
             <span className="text-emerald-300/60 font-mono text-[11px]">{radius}</span>
             <span>50</span>
+          </div>
+        </ControlRow>
+
+        <ControlRow label="Badge Size">
+          <div className="relative">
+            <StyledSelect
+              id="size-select"
+              value={size}
+              onChange={(v) => onSizeChange(v as BadgeSize)}
+            >
+              {SIZES.map((sizeOption) => (
+                <option key={sizeOption.value} value={sizeOption.value}>
+                  {sizeOption.label}
+                </option>
+              ))}
+            </StyledSelect>
           </div>
         </ControlRow>
       </div>

--- a/app/customize/page.tsx
+++ b/app/customize/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { ControlsPanel } from './components/ControlsPanel';
 import { ExportPanel } from './components/ExportPanel';
-import type { ExportFormat, Scale } from './types';
+import type { ExportFormat, Scale, BadgeSize } from './types';
 import { getExportSnippet, stripHash } from './utils';
 
 // ─── Main Page ────────────────────────────────────────────────────────────────
@@ -18,7 +18,10 @@ export default function CustomizePage(): ReactElement {
   const [textHex, setTextHex] = useState('');
   const [scale, setScale] = useState<Scale>('linear');
   const [speed, setSpeed] = useState('8s');
+  const [year, setYear] = useState('');
   const [radius, setRadius] = useState(8);
+  const [size, setSize] = useState<BadgeSize>('medium');
+  const [font, setFont] = useState('');
   const [exportFormat, setExportFormat] = useState<ExportFormat>('markdown');
   const [copied, setCopied] = useState(false);
   const trimmedUsername = username.trim();
@@ -62,8 +65,10 @@ export default function CustomizePage(): ReactElement {
 
     if (scale !== 'linear') params.set('scale', scale);
     if (speed !== '8s') params.set('speed', speed);
+    if (year) params.set('year', year);
     if (radius !== 8) params.set('radius', radius.toString());
-
+    if (size !== 'medium') params.set('size', size);
+    if (font !== '') params.set('font', font);
     return params.toString();
   }, [
     hasUsername,
@@ -75,7 +80,10 @@ export default function CustomizePage(): ReactElement {
     textHex,
     scale,
     speed,
+    year,
     radius,
+    size,
+    font,
   ]);
 
   const queryString = buildQueryParams();
@@ -170,7 +178,10 @@ export default function CustomizePage(): ReactElement {
               textHex={textHex}
               scale={scale}
               speed={speed}
+              year={year}
               radius={radius}
+              size={size}
+              font={font}
               onUsernameChange={setUsername}
               onThemeChange={handleThemeChange}
               onBgHexChange={setBgHex}
@@ -178,7 +189,10 @@ export default function CustomizePage(): ReactElement {
               onTextHexChange={setTextHex}
               onScaleChange={setScale}
               onSpeedChange={setSpeed}
+              onYearChange={setYear}
               onRadiusChange={setRadius}
+              onSizeChange={setSize}
+              onFontChange={setFont}
               onClearOverrides={() => {
                 setBgHex('');
                 setAccentHex('');

--- a/app/customize/types.ts
+++ b/app/customize/types.ts
@@ -17,3 +17,19 @@ export const SPEEDS = [
   { value: '12s', label: 'Slow  (12s)' },
   { value: '20s', label: 'Ultra-slow (20s)' },
 ] as const;
+
+export type BadgeSize = 'small' | 'medium' | 'large';
+
+export const SIZES = [
+  { value: 'small', label: 'Small' },
+  { value: 'medium', label: 'Medium (Default)' },
+  { value: 'large', label: 'Large' },
+] as const;
+export type Font = '' | 'jetbrains' | 'fira' | 'roboto';
+
+export const FONTS = [
+  { value: '', label: 'Default' },
+  { value: 'jetbrains', label: 'JetBrains Mono' },
+  { value: 'fira', label: 'Fira Code' },
+  { value: 'roboto', label: 'Roboto' },
+] as const;


### PR DESCRIPTION
## Description

Fixes #139 

Added a Font selector in the Customization Studio allowing users to choose between predefined fonts for the `/api/streak` badge preview. The selected font is passed as a query parameter and updates both the live preview and export snippet in real time.

## Pillar

- [x] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="1920" height="1019" alt="Screenshot (96)" src="https://github.com/user-attachments/assets/a02b5a29-02e8-47d4-8517-19ff83419416" />
<img width="1920" height="1025" alt="Screenshot (94)" src="https://github.com/user-attachments/assets/ee23119a-e839-4824-8086-5a0b1b39ceed" />
<img width="1920" height="891" alt="Screenshot (99)" src="https://github.com/user-attachments/assets/7b368b70-bcf2-4846-ad65-57566d34fc14" />
<img width="1920" height="846" alt="Screenshot (98)" src="https://github.com/user-attachments/assets/ed1e7d9b-a244-4c58-ba54-08d1fddb5c8c" />

## Checklist:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME&font=fira`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo locally and verified it runs correctly.
- [x] I have made sure that I have only one commit in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.