### PR TITLE
Add milestone achievements to dashboard

### DIFF
--- a/app/(root)/dashboard/[username]/page.test.tsx
+++ b/app/(root)/dashboard/[username]/page.test.tsx
@@ -59,6 +59,7 @@ describe('DashboardPage', () => {
     languages: [{ name: 'TypeScript', percentage: 100, color: '#3178c6' }],
     activity: [],
     insights: [],
+    achievements: [],
     commitClock: [],
   };
 

--- a/app/(root)/dashboard/[username]/page.tsx
+++ b/app/(root)/dashboard/[username]/page.tsx
@@ -94,40 +94,8 @@ export default async function DashboardPage({ params }: { params: Promise<{ user
             exportData={{ stats: data.stats, languages: data.languages }}
           />
           {/* We omit real achievements data generation for now and just show a placeholder based on streaks */}
-          <Achievements
-            achievements={[
-              {
-                id: '1',
-                title: 'Streak Master',
-                description: 'Reached a 7 day streak',
-                icon: 'Flame',
-                isUnlocked: data.stats.currentStreak >= 7,
-              },
-              {
-                id: '2',
-                title: 'Consistent',
-                description: 'Over 100 contributions',
-                icon: 'GitCommit',
-                isUnlocked: data.stats.totalContributions >= 100,
-              },
-              {
-                id: '3',
-                title: 'Polyglot',
-                description: 'Uses multiple languages',
-                icon: 'Code',
-                isUnlocked: data.languages.length >= 2,
-              },
-              {
-                id: '4',
-                title: 'Night Owl',
-                description: 'Commits late at night',
-                icon: 'Moon',
-                isUnlocked: true,
-              },
-            ]}
-          />
+          <Achievements achievements={data.achievements} />
         </aside>
-
         {/* Main Content */}
         <div className="flex flex-col gap-6 lg:gap-8 min-w-0">
           <section>

--- a/components/dashboard/Achievements.tsx
+++ b/components/dashboard/Achievements.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { Trophy, Moon, Flame, Code, Sun, LucideIcon } from 'lucide-react';
+import { useState } from 'react';
+import { Trophy, Flame } from 'lucide-react';
 import { Achievement } from '@/types/dashboard';
 
-const iconMap: Record<string, LucideIcon> = { Moon, Flame, Code, Sun, Trophy };
-
 export default function Achievements({ achievements }: { achievements: Achievement[] }) {
+  const [showAll, setShowAll] = useState(false);
+  const visibleAchievements = showAll ? achievements : achievements.slice(0, 4);
   return (
     <motion.div
       initial={{ opacity: 0, y: 12 }}
@@ -21,8 +22,8 @@ export default function Achievements({ achievements }: { achievements: Achieveme
       </div>
 
       <div className="grid grid-cols-2 gap-2">
-        {achievements.map((achievement, i) => {
-          const Icon = iconMap[achievement.icon] || Trophy;
+        {visibleAchievements.map((achievement, i) => {
+          const Icon = achievement.type === 'streak' ? Flame : Trophy;
           return (
             <motion.div
               key={achievement.id}
@@ -40,16 +41,29 @@ export default function Achievements({ achievements }: { achievements: Achieveme
                 size={18}
                 className={`mb-2.5 ${achievement.isUnlocked ? 'text-[#A1A1AA]' : 'text-[#555]'}`}
               />
-              <h4 className="text-[11px] font-semibold text-white mb-1 line-clamp-1 w-full leading-snug">
+              <h4 className="text-[11px] font-semibold text-white mb-1 text-center w-full leading-snug">
                 {achievement.title}
               </h4>
               <p className="text-[10px] text-[#A1A1AA] line-clamp-2 w-full leading-relaxed">
                 {achievement.description}
               </p>
+              {achievement.progress !== undefined && !achievement.isUnlocked && (
+                <p className="text-[10px] text-[#777] mt-2">
+                  {achievement.currentValue}/{achievement.threshold}
+                </p>
+              )}
             </motion.div>
           );
         })}
       </div>
+      {achievements.length > 4 && (
+        <button
+          onClick={() => setShowAll(!showAll)}
+          className="mt-4 w-full rounded-lg border border-[rgba(255,255,255,0.08)] bg-[#111] py-2 text-xs font-medium text-white transition-all hover:bg-[#161616]"
+        >
+          {showAll ? 'Show Less' : 'See All Achievements'}
+        </button>
+      )}
     </motion.div>
   );
 }

--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -5,6 +5,7 @@ import {
   fetchUserProfile,
   fetchUserRepos,
   getFullDashboardData,
+  generateAchievements,
   clearGitHubApiCacheForTests,
   GITHUB_CACHE_TTL_MS,
 } from './github';
@@ -321,5 +322,26 @@ describe('GitHub API cache behavior', () => {
     await fetchGitHubContributions('octocat');
 
     expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});
+describe('generateAchievements', () => {
+  it('marks contribution milestones correctly', () => {
+    const achievements = generateAchievements(600, 10);
+
+    const unlocked = achievements.filter((a) => a.isUnlocked);
+
+    expect(unlocked.some((a) => a.title === '500 Contributions')).toBe(true);
+
+    expect(unlocked.some((a) => a.title === '1000 Contributions')).toBe(false);
+  });
+
+  it('marks streak milestones correctly', () => {
+    const achievements = generateAchievements(50, 35);
+
+    const unlocked = achievements.filter((a) => a.isUnlocked);
+
+    expect(unlocked.some((a) => a.title === '30 Day Streak')).toBe(true);
+
+    expect(unlocked.some((a) => a.title === '100 Day Streak')).toBe(false);
   });
 });

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -11,6 +11,8 @@ interface GitHubRepo {
 
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 500;
+const CONTRIBUTION_MILESTONES = [1, 10, 100, 250, 500, 1000];
+const STREAK_MILESTONES = [3, 7, 30, 100];
 
 /**
  * Wraps fetch with exponential backoff retry logic.
@@ -226,6 +228,50 @@ export async function fetchUserRepos(
   return repos;
 }
 
+export function generateAchievements(totalContributions: number, currentStreak: number) {
+  const achievements = [];
+
+  // Contribution milestones
+  for (const threshold of CONTRIBUTION_MILESTONES) {
+    achievements.push({
+      id: `contrib-${threshold}`,
+      title:
+        threshold === 1
+          ? 'First Contribution'
+          : threshold === 10
+            ? 'Contributor'
+            : `${threshold} Contributions`,
+      description: `Reached ${threshold} total contributions`,
+      icon: '🏆',
+      isUnlocked: totalContributions >= threshold,
+      type: 'contributions' as const,
+      threshold,
+      currentValue: totalContributions,
+      progress: Math.min(100, Math.round((totalContributions / threshold) * 100)),
+    });
+  }
+
+  // Streak milestones
+  for (const threshold of STREAK_MILESTONES) {
+    achievements.push({
+      id: `streak-${threshold}`,
+      title: threshold === 3 ? 'Getting Started' : `${threshold} Day Streak`,
+      description:
+        threshold === 3
+          ? 'Maintained a 3-day coding streak'
+          : `Maintained a ${threshold}-day coding streak`,
+      icon: '🔥',
+      isUnlocked: currentStreak >= threshold,
+      type: 'streak' as const,
+      threshold,
+      currentValue: currentStreak,
+      progress: Math.min(100, Math.round((currentStreak / threshold) * 100)),
+    });
+  }
+
+  return achievements;
+}
+
 export async function getFullDashboardData(username: string, options: FetchOptions = {}) {
   try {
     const [profileData, reposData, calendarData] = await Promise.all([
@@ -328,6 +374,11 @@ export async function getFullDashboardData(username: string, options: FetchOptio
       .sort((a, b) => b.percentage - a.percentage)
       .slice(0, 5); // top 5
 
+    const achievements = generateAchievements(
+      streakStats.totalContributions,
+      streakStats.currentStreak
+    );
+
     // 4. Insights Generation
     const insights = [
       {
@@ -363,6 +414,7 @@ export async function getFullDashboardData(username: string, options: FetchOptio
       languages,
       activity,
       insights,
+      achievements,
       commitClock,
     };
   } catch (error: unknown) {

--- a/types/dashboard.ts
+++ b/types/dashboard.ts
@@ -43,8 +43,13 @@ export interface Achievement {
   id: string;
   title: string;
   description: string;
-  icon: string; // e.g. lucide icon name or emoji
+  icon: string;
   isUnlocked: boolean;
+
+  type?: 'contributions' | 'streak';
+  threshold?: number;
+  currentValue?: number;
+  progress?: number;
 }
 
 export interface CommitClockData {


### PR DESCRIPTION
## Description

Fixes #162 

Added milestone-based achievements for contribution totals and streak lengths in the dashboard.

### Changes Made

* Added milestone generation logic for:

  * Contributions (100, 250, 500, 1000)
  * Streaks (7, 30, 100)
* Added achievement progress tracking
* Integrated achievements into dashboard response data
* Replaced placeholder achievements with dynamic milestone achievements
* Updated Achievements UI to display milestone progress
* Added tests for milestone generation logic

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Added dynamic milestone achievement cards with:

* contribution milestones
* streak milestones
* locked/unlocked states
* progress indicators

<img width="1912" height="907" alt="image" src="https://github.com/user-attachments/assets/fdb90a55-a8df-4b34-a339-c7fd491df4bd" />
<img width="1918" height="905" alt="image" src="https://github.com/user-attachments/assets/7ac8e512-724c-42b4-a7ed-b68cf418ce8a" />
<img width="1912" height="632" alt="image" src="https://github.com/user-attachments/assets/84e64674-0616-49b6-aa23-e39009dccb54" />


## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [x] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
