### PR TITLE
feat: add empty states for dashboard components

### DIFF
--- a/components/dashboard/ActivityLandscape.test.tsx
+++ b/components/dashboard/ActivityLandscape.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ActivityLandscape from './ActivityLandscape';
+
+// Mock framer-motion
+vi.mock('framer-motion', () => {
+  const React = require('react');
+  return {
+    motion: {
+      div: React.forwardRef((props: any, ref: any) => {
+        const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props;
+        return <div ref={ref} {...rest} />;
+      }),
+    },
+  };
+});
+
+describe('ActivityLandscape', () => {
+  it('renders a fallback UI when data is empty', () => {
+    render(<ActivityLandscape data={[]} />);
+    
+    // Check for the header
+    expect(screen.getByText('Activity Landscape')).toBeDefined();
+    
+    // Check for the fallback text
+    expect(screen.getByText('No recent activity to display.')).toBeDefined();
+  });
+});

--- a/components/dashboard/ActivityLandscape.test.tsx
+++ b/components/dashboard/ActivityLandscape.test.tsx
@@ -3,25 +3,27 @@ import { describe, it, expect, vi } from 'vitest';
 import ActivityLandscape from './ActivityLandscape';
 
 // Mock framer-motion
-vi.mock('framer-motion', () => {
-  const React = require('react');
+vi.mock('framer-motion', async () => {
+  const React = await import('react');
+  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+    const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props as any;
+    return <div ref={ref} {...rest} />;
+  });
+  MotionDiv.displayName = 'MotionDiv';
+
   return {
-    motion: {
-      div: React.forwardRef((props: any, ref: any) => {
-        const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props;
-        return <div ref={ref} {...rest} />;
-      }),
-    },
+    motion: { div: MotionDiv },
   };
 });
 
 describe('ActivityLandscape', () => {
   it('renders a fallback UI when data is empty', () => {
     render(<ActivityLandscape data={[]} />);
-    
+
     // Check for the header
     expect(screen.getByText('Activity Landscape')).toBeDefined();
-    
+
     // Check for the fallback text
     expect(screen.getByText('No recent activity to display.')).toBeDefined();
   });

--- a/components/dashboard/ActivityLandscape.test.tsx
+++ b/components/dashboard/ActivityLandscape.test.tsx
@@ -5,11 +5,13 @@ import ActivityLandscape from './ActivityLandscape';
 // Mock framer-motion
 vi.mock('framer-motion', async () => {
   const React = await import('react');
-  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
-    const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props as any;
-    return <div ref={ref} {...rest} />;
-  });
+  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    (props, ref) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+      const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props as any;
+      return <div ref={ref} {...rest} />;
+    }
+  );
   MotionDiv.displayName = 'MotionDiv';
 
   return {

--- a/components/dashboard/ActivityLandscape.tsx
+++ b/components/dashboard/ActivityLandscape.tsx
@@ -23,6 +23,7 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
   };
 
   const displayData = getFilteredData();
+  const isEmpty = !data || data.length === 0;
   const maxCount = Math.max(...displayData.map((d) => d.count), 1);
 
   return (
@@ -58,36 +59,42 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
       </div>
 
       {/* Graph */}
-      <div className="h-[200px] w-full flex items-end justify-between gap-[2px] relative">
-        {displayData.map((day, i) => {
-          const heightPercent = Math.max((day.count / maxCount) * 100, 3);
-          const isHigh = day.intensity >= 3;
+      {isEmpty ? (
+        <div className="flex items-center justify-center h-[200px] text-sm text-[#A1A1AA]">
+          No recent activity to display.
+        </div>
+      ) : (
+        <div className="h-[200px] w-full flex items-end justify-between gap-[2px] relative">
+          {displayData.map((day, i) => {
+            const heightPercent = Math.max((day.count / maxCount) * 100, 3);
+            const isHigh = day.intensity >= 3;
 
-          return (
-            <div key={i} className="relative flex-1 flex items-end group/bar h-full">
-              {/* Tooltip */}
-              <div className="absolute -top-11 left-1/2 -translate-x-1/2 bg-[#111] border border-[rgba(255,255,255,0.1)] px-2.5 py-1.5 rounded-md opacity-0 group-hover/bar:opacity-100 transition-opacity duration-150 pointer-events-none z-20 flex flex-col items-center whitespace-nowrap shadow-xl">
-                <span className="text-[10px] text-[#A1A1AA]">{day.date}</span>
-                <span className="text-xs font-semibold text-white">{day.count}</span>
+            return (
+              <div key={i} className="relative flex-1 flex items-end group/bar h-full">
+                {/* Tooltip */}
+                <div className="absolute -top-11 left-1/2 -translate-x-1/2 bg-[#111] border border-[rgba(255,255,255,0.1)] px-2.5 py-1.5 rounded-md opacity-0 group-hover/bar:opacity-100 transition-opacity duration-150 pointer-events-none z-20 flex flex-col items-center whitespace-nowrap shadow-xl">
+                  <span className="text-[10px] text-[#A1A1AA]">{day.date}</span>
+                  <span className="text-xs font-semibold text-white">{day.count}</span>
+                </div>
+
+                {/* Bar */}
+                <motion.div
+                  initial={{ height: 0 }}
+                  animate={{ height: `${heightPercent}%` }}
+                  transition={{ duration: 0.6, delay: i * 0.008, ease: [0.16, 1, 0.3, 1] }}
+                  className={`w-full rounded-t-[2px] transition-all duration-200 ${
+                    isHigh
+                      ? 'bg-white group-hover/bar:bg-white'
+                      : day.intensity > 0
+                        ? 'bg-zinc-600 group-hover/bar:bg-zinc-400'
+                        : 'bg-zinc-800 group-hover/bar:bg-zinc-700'
+                  }`}
+                />
               </div>
-
-              {/* Bar */}
-              <motion.div
-                initial={{ height: 0 }}
-                animate={{ height: `${heightPercent}%` }}
-                transition={{ duration: 0.6, delay: i * 0.008, ease: [0.16, 1, 0.3, 1] }}
-                className={`w-full rounded-t-[2px] transition-all duration-200 ${
-                  isHigh
-                    ? 'bg-white group-hover/bar:bg-white'
-                    : day.intensity > 0
-                      ? 'bg-zinc-600 group-hover/bar:bg-zinc-400'
-                      : 'bg-zinc-800 group-hover/bar:bg-zinc-700'
-                }`}
-              />
-            </div>
-          );
-        })}
-      </div>
+            );
+          })}
+        </div>
+      )}
 
       {/* X axis */}
       <div className="w-full h-px bg-[rgba(255,255,255,0.06)] mt-3" />

--- a/components/dashboard/CommitClock.test.tsx
+++ b/components/dashboard/CommitClock.test.tsx
@@ -5,11 +5,13 @@ import CommitClock from './CommitClock';
 // Mock framer-motion
 vi.mock('framer-motion', async () => {
   const React = await import('react');
-  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
-    const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props as any;
-    return <div ref={ref} {...rest} />;
-  });
+  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    (props, ref) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+      const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props as any;
+      return <div ref={ref} {...rest} />;
+    }
+  );
   MotionDiv.displayName = 'MotionDiv';
 
   const MotionG = React.forwardRef<SVGGElement, React.SVGAttributes<SVGGElement>>((props, ref) => {

--- a/components/dashboard/CommitClock.test.tsx
+++ b/components/dashboard/CommitClock.test.tsx
@@ -3,29 +3,34 @@ import { describe, it, expect, vi } from 'vitest';
 import CommitClock from './CommitClock';
 
 // Mock framer-motion
-vi.mock('framer-motion', () => {
-  const React = require('react');
+vi.mock('framer-motion', async () => {
+  const React = await import('react');
+  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+    const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props as any;
+    return <div ref={ref} {...rest} />;
+  });
+  MotionDiv.displayName = 'MotionDiv';
+
+  const MotionG = React.forwardRef<SVGGElement, React.SVGAttributes<SVGGElement>>((props, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+    const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props as any;
+    return <g ref={ref} {...rest} />;
+  });
+  MotionG.displayName = 'MotionG';
+
   return {
-    motion: {
-      div: React.forwardRef((props: any, ref: any) => {
-        const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props;
-        return <div ref={ref} {...rest} />;
-      }),
-      g: React.forwardRef((props: any, ref: any) => {
-        const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props;
-        return <g ref={ref} {...rest} />;
-      }),
-    },
+    motion: { div: MotionDiv, g: MotionG },
   };
 });
 
 describe('CommitClock', () => {
   it('renders a fallback UI when data is empty array', () => {
     render(<CommitClock data={[]} />);
-    
+
     // Check for the header
     expect(screen.getByText('Commit Clock')).toBeDefined();
-    
+
     // Check for the fallback text
     expect(screen.getByText('No commit activity yet.')).toBeDefined();
   });
@@ -33,7 +38,7 @@ describe('CommitClock', () => {
   it('renders a fallback UI when all commits are 0', () => {
     const emptyData = Array.from({ length: 24 }, (_, i) => ({ hour: i, commits: 0 }));
     render(<CommitClock data={emptyData} />);
-    
+
     expect(screen.getByText('No commit activity yet.')).toBeDefined();
   });
 });

--- a/components/dashboard/CommitClock.test.tsx
+++ b/components/dashboard/CommitClock.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import CommitClock from './CommitClock';
+
+// Mock framer-motion
+vi.mock('framer-motion', () => {
+  const React = require('react');
+  return {
+    motion: {
+      div: React.forwardRef((props: any, ref: any) => {
+        const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props;
+        return <div ref={ref} {...rest} />;
+      }),
+      g: React.forwardRef((props: any, ref: any) => {
+        const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props;
+        return <g ref={ref} {...rest} />;
+      }),
+    },
+  };
+});
+
+describe('CommitClock', () => {
+  it('renders a fallback UI when data is empty array', () => {
+    render(<CommitClock data={[]} />);
+    
+    // Check for the header
+    expect(screen.getByText('Commit Clock')).toBeDefined();
+    
+    // Check for the fallback text
+    expect(screen.getByText('No commit activity yet.')).toBeDefined();
+  });
+
+  it('renders a fallback UI when all commits are 0', () => {
+    const emptyData = Array.from({ length: 24 }, (_, i) => ({ hour: i, commits: 0 }));
+    render(<CommitClock data={emptyData} />);
+    
+    expect(screen.getByText('No commit activity yet.')).toBeDefined();
+  });
+});

--- a/components/dashboard/CommitClock.tsx
+++ b/components/dashboard/CommitClock.tsx
@@ -5,6 +5,7 @@ import { CommitClockData } from '@/types/dashboard';
 
 export default function CommitClock({ data }: { data: CommitClockData[] }) {
   const maxCommits = Math.max(...data.map((d) => d.commits), 1);
+  const isEmpty = !data || data.length === 0 || data.every((d) => d.commits === 0);
   const radius = 80;
   const cx = 150;
   const cy = 150;
@@ -23,75 +24,81 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
         <p className="text-xs text-[#A1A1AA] mt-1">24-hour activity cycle</p>
       </div>
 
-      <div className="relative w-[280px] h-[280px] flex items-center justify-center mt-4">
-        <svg width="280" height="280" className="rotate-[-90deg]">
-          {/* Base ring */}
-          <circle
-            cx={cx - 10}
-            cy={cy - 10}
-            r={radius}
-            fill="none"
-            stroke="rgba(255,255,255,0.04)"
-            strokeWidth="18"
-          />
-
-          {/* Spokes */}
-          {data.map((d, i) => {
-            const angle = (i * 360) / 24;
-            const length = Math.max((d.commits / maxCommits) * 38, 4);
-            const isHigh = d.commits > maxCommits * 0.7;
-            const rad = (angle * Math.PI) / 180;
-
-            return (
-              <motion.g
-                key={i}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ delay: i * 0.04, duration: 0.2 }}
-              >
-                <line
-                  x1={r4(cx - 10 + radius * Math.cos(rad))}
-                  y1={r4(cy - 10 + radius * Math.sin(rad))}
-                  x2={r4(cx - 10 + (radius + length) * Math.cos(rad))}
-                  y2={r4(cy - 10 + (radius + length) * Math.sin(rad))}
-                  stroke={isHigh ? '#ffffff' : 'rgba(255,255,255,0.2)'}
-                  strokeWidth="5"
-                  strokeLinecap="round"
-                />
-              </motion.g>
-            );
-          })}
-
-          {/* Hour labels */}
-          {(['6h', '12h', '18h', '24h'] as const).map((label, i) => {
-            const positions = [
-              { x: cx - 10 + radius - 14, y: cy - 10 + 4 },
-              { x: cx - 10, y: cy - 10 + radius - 8 },
-              { x: cx - 10 - radius + 14, y: cy - 10 + 4 },
-              { x: cx - 10, y: cy - 10 - radius + 14 },
-            ];
-            const p = positions[i];
-            return (
-              <text
-                key={label}
-                x={p.x}
-                y={p.y}
-                fill="rgba(255,255,255,0.25)"
-                fontSize="9"
-                textAnchor="middle"
-                transform={`rotate(90, ${p.x}, ${p.y})`}
-              >
-                {label}
-              </text>
-            );
-          })}
-        </svg>
-
-        {/* Center label */}
-        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-          <span className="text-xl font-semibold text-white/60">24h</span>
+      {isEmpty ? (
+        <div className="flex items-center justify-center h-[280px] mt-4 text-sm text-[#A1A1AA]">
+          No commit activity yet.
         </div>
-      </div>
+      ) : (
+        <div className="relative w-[280px] h-[280px] flex items-center justify-center mt-4">
+          <svg width="280" height="280" className="rotate-[-90deg]">
+            {/* Base ring */}
+            <circle
+              cx={cx - 10}
+              cy={cy - 10}
+              r={radius}
+              fill="none"
+              stroke="rgba(255,255,255,0.04)"
+              strokeWidth="18"
+            />
+
+            {/* Spokes */}
+            {data.map((d, i) => {
+              const angle = (i * 360) / 24;
+              const length = Math.max((d.commits / maxCommits) * 38, 4);
+              const isHigh = d.commits > maxCommits * 0.7;
+              const rad = (angle * Math.PI) / 180;
+
+              return (
+                <motion.g
+                  key={i}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={{ delay: i * 0.04, duration: 0.2 }}
+                >
+                  <line
+                    x1={r4(cx - 10 + radius * Math.cos(rad))}
+                    y1={r4(cy - 10 + radius * Math.sin(rad))}
+                    x2={r4(cx - 10 + (radius + length) * Math.cos(rad))}
+                    y2={r4(cy - 10 + (radius + length) * Math.sin(rad))}
+                    stroke={isHigh ? '#ffffff' : 'rgba(255,255,255,0.2)'}
+                    strokeWidth="5"
+                    strokeLinecap="round"
+                  />
+                </motion.g>
+              );
+            })}
+
+            {/* Hour labels */}
+            {(['6h', '12h', '18h', '24h'] as const).map((label, i) => {
+              const positions = [
+                { x: cx - 10 + radius - 14, y: cy - 10 + 4 },
+                { x: cx - 10, y: cy - 10 + radius - 8 },
+                { x: cx - 10 - radius + 14, y: cy - 10 + 4 },
+                { x: cx - 10, y: cy - 10 - radius + 14 },
+              ];
+              const p = positions[i];
+              return (
+                <text
+                  key={label}
+                  x={p.x}
+                  y={p.y}
+                  fill="rgba(255,255,255,0.25)"
+                  fontSize="9"
+                  textAnchor="middle"
+                  transform={`rotate(90, ${p.x}, ${p.y})`}
+                >
+                  {label}
+                </text>
+              );
+            })}
+          </svg>
+
+          {/* Center label */}
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+            <span className="text-xl font-semibold text-white/60">24h</span>
+          </div>
+        </div>
+      )}
     </motion.div>
   );
 }

--- a/components/dashboard/Heatmap.test.tsx
+++ b/components/dashboard/Heatmap.test.tsx
@@ -10,26 +10,28 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
 }));
 
 // Mock framer-motion to avoid animation issues in tests
-vi.mock('framer-motion', () => {
-  const React = require('react');
+vi.mock('framer-motion', async () => {
+  const React = await import('react');
+  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+    const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props as any;
+    return <div ref={ref} {...rest} />;
+  });
+  MotionDiv.displayName = 'MotionDiv';
+
   return {
-    motion: {
-      div: React.forwardRef((props: any, ref: any) => {
-        const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props;
-        return <div ref={ref} {...rest} />;
-      }),
-    },
-    AnimatePresence: ({ children }: any) => <>{children}</>,
+    motion: { div: MotionDiv },
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   };
 });
 
 describe('Heatmap', () => {
   it('renders a fallback UI when data is empty', () => {
     render(<Heatmap data={[]} />);
-    
+
     // Check for the header
     expect(screen.getByText('Contribution Heatmap')).toBeDefined();
-    
+
     // Check for the fallback text
     expect(screen.getByText('No recent activity to display.')).toBeDefined();
   });

--- a/components/dashboard/Heatmap.test.tsx
+++ b/components/dashboard/Heatmap.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Heatmap from './Heatmap';
+
+// Mock ResizeObserver
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// Mock framer-motion to avoid animation issues in tests
+vi.mock('framer-motion', () => {
+  const React = require('react');
+  return {
+    motion: {
+      div: React.forwardRef((props: any, ref: any) => {
+        const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props;
+        return <div ref={ref} {...rest} />;
+      }),
+    },
+    AnimatePresence: ({ children }: any) => <>{children}</>,
+  };
+});
+
+describe('Heatmap', () => {
+  it('renders a fallback UI when data is empty', () => {
+    render(<Heatmap data={[]} />);
+    
+    // Check for the header
+    expect(screen.getByText('Contribution Heatmap')).toBeDefined();
+    
+    // Check for the fallback text
+    expect(screen.getByText('No recent activity to display.')).toBeDefined();
+  });
+});

--- a/components/dashboard/Heatmap.test.tsx
+++ b/components/dashboard/Heatmap.test.tsx
@@ -12,11 +12,13 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
 // Mock framer-motion to avoid animation issues in tests
 vi.mock('framer-motion', async () => {
   const React = await import('react');
-  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
-    const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props as any;
-    return <div ref={ref} {...rest} />;
-  });
+  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    (props, ref) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+      const { viewport, whileInView, initial, animate, exit, transition, ...rest } = props as any;
+      return <div ref={ref} {...rest} />;
+    }
+  );
   MotionDiv.displayName = 'MotionDiv';
 
   return {

--- a/components/dashboard/Heatmap.tsx
+++ b/components/dashboard/Heatmap.tsx
@@ -18,10 +18,14 @@ export default function Heatmap({ data }: { data: ActivityData[] }) {
   const [scale, setScale] = useState(1);
   const [tooltip, setTooltip] = useState<TooltipState | null>(null);
 
+  const isEmpty = !data || data.length === 0;
+
   // Group into 7-day columns
   const weeks: ActivityData[][] = [];
-  for (let i = 0; i < data.length; i += 7) {
-    weeks.push(data.slice(i, i + 7));
+  if (!isEmpty) {
+    for (let i = 0; i < data.length; i += 7) {
+      weeks.push(data.slice(i, i + 7));
+    }
   }
 
   const naturalWidth = weeks.length * (CELL + GAP) - GAP;
@@ -95,32 +99,38 @@ export default function Heatmap({ data }: { data: ActivityData[] }) {
         </div>
 
         {/* Scale wrapper */}
-        <div ref={containerRef} className="w-full overflow-hidden">
-          <div
-            style={{
-              width: naturalWidth,
-              transformOrigin: 'top left',
-              transform: `scale(${scale})`,
-              height: (7 * (CELL + GAP) - GAP) * scale,
-            }}
-          >
-            <div className="flex" style={{ gap: GAP }}>
-              {weeks.map((week, wIndex) => (
-                <div key={wIndex} className="flex flex-col" style={{ gap: GAP }}>
-                  {week.map((day, dIndex) => (
-                    <div
-                      key={dIndex}
-                      onMouseEnter={(e) => handleMouseEnter(e, day)}
-                      onMouseLeave={handleMouseLeave}
-                      className={`rounded-sm cursor-pointer transition-all duration-150 hover:brightness-125 hover:scale-125 ${getIntensityColor(day.intensity)}`}
-                      style={{ width: CELL, height: CELL }}
-                    />
-                  ))}
-                </div>
-              ))}
+        {isEmpty ? (
+          <div className="flex items-center justify-center py-12 text-sm text-[#A1A1AA]">
+            No recent activity to display.
+          </div>
+        ) : (
+          <div ref={containerRef} className="w-full overflow-hidden">
+            <div
+              style={{
+                width: naturalWidth,
+                transformOrigin: 'top left',
+                transform: `scale(${scale})`,
+                height: (7 * (CELL + GAP) - GAP) * scale,
+              }}
+            >
+              <div className="flex" style={{ gap: GAP }}>
+                {weeks.map((week, wIndex) => (
+                  <div key={wIndex} className="flex flex-col" style={{ gap: GAP }}>
+                    {week.map((day, dIndex) => (
+                      <div
+                        key={dIndex}
+                        onMouseEnter={(e) => handleMouseEnter(e, day)}
+                        onMouseLeave={handleMouseLeave}
+                        className={`rounded-sm cursor-pointer transition-all duration-150 hover:brightness-125 hover:scale-125 ${getIntensityColor(day.intensity)}`}
+                        style={{ width: CELL, height: CELL }}
+                      />
+                    ))}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </motion.div>
 
       {/* Tooltip rendered at viewport level — unaffected by scale/overflow */}


### PR DESCRIPTION
## Description

This PR introduces graceful degradation for the dashboard components when no activity data is available. Previously, these components could look broken or render awkwardly with empty datasets. The components now detect missing data and display polished, dark-theme-compatible fallback UIs (e.g., "No recent activity to display.").

Fixes #165

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

*(Optional: Feel free to drop a screenshot of the new empty state here before submitting!)*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [ ] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.