### PR TITLE
fix(calculate): handle single-day and empty calendars safely in streak calculations

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -164,4 +164,20 @@ describe('calculateStreak', () => {
     expect(result.totalContributions).toBe(1);
     expect(result.longestStreak).toBe(1);
   });
+
+  it('handles a single inactive day safely (0 contributions)', () => {
+    const calendar = buildCalendar([0]);
+    expect(() => calculateStreak(calendar)).not.toThrow();
+    const result = calculateStreak(calendar);
+    expect(result.currentStreak).toBe(0);
+    expect(result.longestStreak).toBe(0);
+  });
+
+  it('handles an empty contribution calendar safely without crashing', () => {
+    const calendar = buildCalendar([]);
+    expect(() => calculateStreak(calendar)).not.toThrow();
+    const result = calculateStreak(calendar);
+    expect(result.currentStreak).toBe(0);
+    expect(result.longestStreak).toBe(0);
+  });
 });

--- a/lib/calculate.ts
+++ b/lib/calculate.ts
@@ -22,13 +22,22 @@ export function calculateStreak(calendar: ContributionCalendar): StreakStats {
   // 2. Calculate Current Streak (Backwards loop with Grace Period)
   // We look at the very last day in the array (Today in UTC)
   const todayIndex = days.length - 1;
+  if (todayIndex < 0) {
+    return {
+      currentStreak: 0,
+      longestStreak: 0,
+      totalContributions: calendar.totalContributions,
+    };
+  }
+
   const today = days[todayIndex];
-  const yesterday = days[todayIndex - 1];
+  const yesterday = todayIndex > 0 ? days[todayIndex - 1] : null;
 
   // If I committed today, the streak is alive.
   // If I haven't committed today, but I committed yesterday,
   // the streak is STILL alive (Grace Period).
-  const isStreakAlive = today.contributionCount > 0 || yesterday.contributionCount > 0;
+  const isStreakAlive =
+    today.contributionCount > 0 || (yesterday ? yesterday.contributionCount > 0 : false);
 
   if (isStreakAlive) {
     // Count backwards from the first day that has a contribution


### PR DESCRIPTION
## Description
When calculating the user's current streak with the grace-period logic in lib/calculate.ts, the function resolves yesterday relative to the last index of the contribution days:

```
const todayIndex = days.length - 1;
const today = days[todayIndex];
const yesterday = days[todayIndex - 1];
```
If a user has a contribution calendar containing only 1 day (e.g. a brand-new user account, or dynamic range filters):

- todayIndex is 0.
- yesterday evaluates to days[-1], which is undefined.
- If today.contributionCount is 0, the logic attempts to check if the streak is alive by checking yesterday.contributionCount > 0.
- Since yesterday is undefined, accessing .contributionCount throws TypeError: Cannot read properties of undefined (reading 'contributionCount') and crashes the API server, returning a 500 Internal Server Error.

A similar crash occurs if days.length is 0 (empty list) because today is also undefined.

**Solution**

- Safety Boundary Guard: Introduced an early-return check if todayIndex < 0 to safely handle empty calendars by returning baseline stats.
- Defensive Resolution: Safely resolved yesterday with a ternary boundary check: todayIndex > 0 ? days[todayIndex - 1] : null.
- Optional Grace Check: Safely evaluated yesterday inside the isStreakAlive boolean expression:

`const isStreakAlive = today.contributionCount > 0 || (yesterday ? yesterday.contributionCount > 0 : false);`

Fixes #220 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x ] I have read the `CONTRIBUTING.md` file.
- [x ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x ] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x ] I have updated `README.md` if I added a new theme or URL parameter.
- [ x] I have started the repo.
- [ x] I have made sure that i have only one commit to merge in this PR.
- [ x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
