### PR TITLE
feat:added mobile responsiveness to home and dashboard page

### DIFF
--- a/app/components/FeatureCard.tsx
+++ b/app/components/FeatureCard.tsx
@@ -14,10 +14,10 @@ export function FeatureCard({ icon, title, desc, accent }: FeatureCardProps) {
   return (
     <motion.div
       whileHover={{ y: -5 }}
-      className="p-10 bg-[#0f0f0f] border border-white/5 rounded-[2rem] hover:border-white/20 transition-all group"
+      className="p-10 bg-[#0f0f0f] border border-white/5 rounded-4xl hover:border-white/20 transition-all group"
     >
       <div className={`mb-6 p-3 w-fit rounded-xl bg-white/5 ${accent}`}>{icon}</div>
-      <h3 className="text-xl font-bold mb-3 group-hover:text-emerald-400 transition-colors uppercase tracking-widest text-sm">
+      <h3 className="text-xl font-bold mb-3 group-hover:text-emerald-400 transition-colors uppercase tracking-widest max-md:text-sm">
         {title}
       </h3>
       <p className="text-gray-500 leading-relaxed font-medium">{desc}</p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -156,7 +156,7 @@ export default function LandingPage() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.15 }}
           >
-            <h1 className="mb-8 bg-gradient-to-b from-white to-white/30 bg-clip-text text-5xl font-extrabold tracking-tight text-transparent md:text-8xl">
+            <h1 className="mb-8 bg-linear-to-b from-white to-white/30 bg-clip-text text-4xl sm:text-5xl font-extrabold tracking-tight text-transparent md:text-8xl ">
               Elevate Your <br /> Contribution Story.
             </h1>
           </motion.div>
@@ -165,7 +165,7 @@ export default function LandingPage() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.3 }}
-            className="mx-auto max-w-2xl text-lg leading-relaxed text-gray-400 md:text-xl"
+            className="mx-auto max-w-2xl text-md sm:text-lg leading-relaxed text-gray-400 md:text-xl "
           >
             Stop settling for flat grids. Generate high-fidelity, 3D isometric monoliths that
             visualize your coding rhythm with professional precision.

--- a/components/dashboard/AIInsights.tsx
+++ b/components/dashboard/AIInsights.tsx
@@ -36,7 +36,7 @@ export default function AIInsights({ insights }: { insights: AIInsight[] }) {
                 size={14}
                 className="text-[#A1A1AA] mt-0.5 shrink-0 group-hover:text-white transition-colors duration-200"
               />
-              <p className="text-sm text-[#A1A1AA] leading-relaxed group-hover:text-white/80 transition-colors duration-200">
+              <p className="text-sm  text-[#A1A1AA] leading-relaxed group-hover:text-white/80 transition-colors duration-200">
                 {insight.text}
               </p>
             </motion.div>

--- a/components/dashboard/Heatmap.tsx
+++ b/components/dashboard/Heatmap.tsx
@@ -78,7 +78,7 @@ export default function Heatmap({ data }: { data: ActivityData[] }) {
         {/* Header */}
         <div className="flex justify-between items-end mb-4">
           <div>
-            <h3 className="text-sm font-semibold text-white tracking-tight">
+            <h3 className=" text-sm font-semibold text-white tracking-tight">
               Contribution Heatmap
             </h3>
             <p className="text-xs text-[#A1A1AA] mt-0.5">Last 365 days</p>
@@ -104,7 +104,7 @@ export default function Heatmap({ data }: { data: ActivityData[] }) {
               height: (7 * (CELL + GAP) - GAP) * scale,
             }}
           >
-            <div className="flex" style={{ gap: GAP }}>
+            <div className="flex " style={{ gap: GAP }}>
               {weeks.map((week, wIndex) => (
                 <div key={wIndex} className="flex flex-col" style={{ gap: GAP }}>
                   {week.map((day, dIndex) => (


### PR DESCRIPTION
## Description
- added mobile responsiveness for home page and dashboard so the design is better and more alligned for even smaller devices

Fixes #53 

## Pillar

- [x] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
### previously
<img width="211" height="469" alt="image" src="https://github.com/user-attachments/assets/6c9feab3-8b40-44c9-974f-c4e8a474d0a8" />
<img width="200" height="406" alt="image" src="https://github.com/user-attachments/assets/ca05b175-4593-4c1a-9c4d-5ea8c31548e7" />
<img width="200" height="302" alt="image" src="https://github.com/user-attachments/assets/02b86317-f079-44b1-82c3-2775900f89cc" />

fix:-
<img width="182" height="407" alt="image" src="https://github.com/user-attachments/assets/7ac64ab6-7b30-4bca-9c1f-34e3e4531d06" />
<img width="182" height="233" alt="image" src="https://github.com/user-attachments/assets/e1c346ee-2379-421b-866f-01a1fc33e8e0" />
<img width="176" height="298" alt="image" src="https://github.com/user-attachments/assets/f16cc516-f935-44ef-987c-709c91355820" />
<img width="176" height="404" alt="image" src="https://github.com/user-attachments/assets/6f33e1db-8303-4da7-a1ed-a65c4b316712" />
<img width="182" height="403" alt="image" src="https://github.com/user-attachments/assets/54b82007-b8cf-4806-981d-d4fd9e23c18c" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
