### PR TITLE
feat:added mobile responsiveness to home and dashboard page

### DIFF
--- a/app/components/CustomizeCTA.tsx
+++ b/app/components/CustomizeCTA.tsx
@@ -35,7 +35,7 @@ export function CustomizeCTA() {
 
           <div className="shrink-0">
             <Link href="/customize" id="open-customization-studio-cta">
-              <span className="relative inline-flex items-center gap-2 px-7 py-4 rounded-2xl font-bold text-sm text-black bg-white hover:scale-[1.03] active:scale-[0.97] transition-transform duration-200 shadow-[0_0_30px_-4px_rgba(255,255,255,0.25)] cursor-pointer select-none">
+              <span className="relative inline-flex items-center gap-2 px-4 md:px-7 py-4 rounded-2xl font-bold text-sm text-black bg-white hover:scale-[1.03] active:scale-[0.97] transition-transform duration-200 shadow-[0_0_30px_-4px_rgba(255,255,255,0.25)] cursor-pointer select-none">
                 {/* Button shimmer */}
                 <span
                   aria-hidden="true"

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,7 @@
 
 @theme {
   --font-sans: 'Inter', ui-sans-serif, system-ui;
+  --breakpoint-xs: 26rem;
 }
 
 @layer utilities {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -165,7 +165,7 @@ export default function LandingPage() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.3 }}
-            className="mx-auto max-w-2xl text-md sm:text-lg leading-relaxed text-gray-400 md:text-xl "
+            className="mx-auto max-w-2xl text-sm sm:text-lg leading-relaxed text-gray-400 md:text-xl "
           >
             Stop settling for flat grids. Generate high-fidelity, 3D isometric monoliths that
             visualize your coding rhythm with professional precision.
@@ -266,10 +266,10 @@ export default function LandingPage() {
                     <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.04] text-white/60">
                       <Icons.Github />
                     </div>
-                    <p className="text-lg font-semibold tracking-tight text-white">
+                    <p className="md:text-lg text-md font-semibold tracking-tight text-white">
                       Enter a GitHub username to preview
                     </p>
-                    <p className="mt-2 max-w-md text-sm leading-relaxed text-[#A1A1AA]">
+                    <p className="mt-2 max-w-md text-xs xs:text-sm leading-relaxed text-[#A1A1AA]">
                       Your 3D contribution monolith will appear here as soon as you add a username.
                     </p>
                   </div>

--- a/components/dashboard/AIInsights.tsx
+++ b/components/dashboard/AIInsights.tsx
@@ -36,7 +36,7 @@ export default function AIInsights({ insights }: { insights: AIInsight[] }) {
                 size={14}
                 className="text-[#A1A1AA] mt-0.5 shrink-0 group-hover:text-white transition-colors duration-200"
               />
-              <p className="text-sm  text-[#A1A1AA] leading-relaxed group-hover:text-white/80 transition-colors duration-200">
+              <p className="text-xs xs:text-sm  text-[#A1A1AA] leading-relaxed group-hover:text-white/80 transition-colors duration-200">
                 {insight.text}
               </p>
             </motion.div>

--- a/components/dashboard/Heatmap.tsx
+++ b/components/dashboard/Heatmap.tsx
@@ -76,18 +76,21 @@ export default function Heatmap({ data }: { data: ActivityData[] }) {
         className="p-6 rounded-xl bg-[#0a0a0a] border border-[rgba(255,255,255,0.08)]"
       >
         {/* Header */}
+        <h3 className=" text-sm font-semibold text-white tracking-tight my-1">
+          Contribution Heatmap
+        </h3>
         <div className="flex justify-between items-end mb-4">
           <div>
-            <h3 className=" text-sm font-semibold text-white tracking-tight">
-              Contribution Heatmap
-            </h3>
             <p className="text-xs text-[#A1A1AA] mt-0.5">Last 365 days</p>
           </div>
           <div className="flex items-center gap-2 text-xs text-[#A1A1AA]">
             <span>Less</span>
             <div className="flex gap-1">
               {[0, 1, 2, 3, 4].map((level) => (
-                <div key={level} className={`w-3 h-3 rounded-sm ${getIntensityColor(level)}`} />
+                <div
+                  key={level}
+                  className={` h-2 w-2 xs:w-3 xs:h-3 rounded-sm ${getIntensityColor(level)}`}
+                />
               ))}
             </div>
             <span>More</span>

--- a/components/dashboard/ProfileCard.tsx
+++ b/components/dashboard/ProfileCard.tsx
@@ -38,10 +38,12 @@ export default function ProfileCard({ user, exportData }: ProfileCardProps) {
 
           <h2 className="text-lg font-semibold text-white mb-0.5">{user.name}</h2>
           <p className="text-sm text-[#A1A1AA] mb-4">@{user.username}</p>
-          <p className="text-sm text-[#A1A1AA] leading-relaxed mb-5 max-w-[220px]">{user.bio}</p>
+          <p className=" text-xs xs:text-sm text-[#A1A1AA] leading-relaxed mb-5 max-w-[220px]">
+            {user.bio}
+          </p>
 
           {/* Meta */}
-          <div className="flex flex-col gap-1.5 w-full mb-6">
+          <div className="flex md:flex-col justify-around gap-1.5 w-full mb-6">
             <div className="flex items-center justify-center gap-1.5 text-[#A1A1AA] text-xs">
               <MapPin size={12} />
               <span>{user.location}</span>


### PR DESCRIPTION
## Description

- Made more changes to #53 and added responsiveness
- added responsiveness as asked to home and dashboard and added new size xs as reposive design


Fixes #225 

## Pillar

- [x] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

### previously
<img width="211" height="469" alt="image" src="https://github.com/user-attachments/assets/6c9feab3-8b40-44c9-974f-c4e8a474d0a8" />
<img width="200" height="406" alt="image" src="https://github.com/user-attachments/assets/ca05b175-4593-4c1a-9c4d-5ea8c31548e7" />
<img width="200" height="302" alt="image" src="https://github.com/user-attachments/assets/02b86317-f079-44b1-82c3-2775900f89cc" />

## fix:-
<img width="182" height="407" alt="image" src="https://github.com/user-attachments/assets/7ac64ab6-7b30-4bca-9c1f-34e3e4531d06" />
<img width="182" height="233" alt="image" src="https://github.com/user-attachments/assets/e1c346ee-2379-421b-866f-01a1fc33e8e0" />
<img width="176" height="298" alt="image" src="https://github.com/user-attachments/assets/f16cc516-f935-44ef-987c-709c91355820" />
<img width="176" height="404" alt="image" src="https://github.com/user-attachments/assets/6f33e1db-8303-4da7-a1ed-a65c4b316712" />
<img width="182" height="403" alt="image" src="https://github.com/user-attachments/assets/54b82007-b8cf-4806-981d-d4fd9e23c18c" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
