### PR TITLE
fix(api): sanitize font param to prevent CSS injection and handle blank input

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -41,6 +41,15 @@ export async function GET(request: Request) {
       hide_stats: hideStatsParam,
     } = parseResult.data;
 
+    //sanitizing font
+    const sanitizedFont = ((): string | undefined => {
+      if (!font) return undefined;
+      const trimmed = font.trim();
+      if (!trimmed) return undefined;
+      const cleaned = trimmed.replace(/[^a-zA-Z0-9\s\-']/g, '').trim();
+      return cleaned || undefined;
+    })();
+
     const hide_stats = hideStatsParam === 'true' || hideStatsParam === '1';
 
     const themeName = theme || 'dark';
@@ -86,8 +95,7 @@ export async function GET(request: Request) {
       radius: safeRadius,
       speed,
       scale,
-      font,
-
+      font: sanitizedFont,
       autoTheme: isAutoTheme,
       hideBackground: hide_background,
       hide_stats: hide_stats,

--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -116,6 +116,34 @@ describe('generateSVG', () => {
     expect(svg).toContain('font-family: "Space Grotesk", sans-serif');
   });
 
+  it('uses default font when font param is an empty string', () => {
+    const svg = generateSVG(
+      mockStats,
+      { user: 'avi', font: '' } as unknown as BadgeParams,
+      mockCalendar
+    );
+    expect(svg).toContain('Space Grotesk');
+    expect(svg).not.toContain('family=&amp;display=swap');
+  });
+
+  it('uses default font when font param is whitespace only', () => {
+    const svg = generateSVG(
+      mockStats,
+      { user: 'avi', font: '   ' } as unknown as BadgeParams,
+      mockCalendar
+    );
+    expect(svg).toContain('Space Grotesk');
+    expect(svg).not.toContain('family=+&amp;display=swap');
+  });
+
+  it('allows apostrophes in font names like Times New Roman', () => {
+    const svg = generateSVG(
+      mockStats,
+      { user: 'avi', font: 'Gill Sans' } as unknown as BadgeParams,
+      mockCalendar
+    );
+    expect(svg).toContain('Gill Sans');
+  });
   it('emits tower-raising CSS animations and staggered delays', () => {
     const svg = generateSVG(mockStats, { user: 'avi' } as unknown as BadgeParams, mockCalendar);
 

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -231,7 +231,7 @@ export function generateSVG(
   const accent = `#${(params.accent || '00ffaa').replace('#', '')}`;
   const text = `#${(params.text || 'ffffff').replace('#', '')}`;
 
-  const sanitizeFont = (name: string) => name.replace(/[^a-zA-Z0-9\s-]/g, '').trim();
+  const sanitizeFont = (name: string): string => name.replace(/[^a-zA-Z0-9\s\-']/g, '').trim();
   const sanitizedFont = params.font ? sanitizeFont(params.font) : null;
   const predefinedFont = sanitizedFont ? FONT_MAP[sanitizedFont.toLowerCase()] : null;
   const isPredefinedFont = Boolean(predefinedFont);
@@ -359,9 +359,10 @@ function generateAutoThemeSVG(
   const light = AUTO_LIGHT_THEME;
   const dark = AUTO_DARK_THEME;
   const safeUser = escapeXML(params.user || 'GitHub User');
-  const selectedFont = params.font
-    ? FONT_MAP[params.font.toLowerCase()] || '"JetBrains Mono", monospace'
-    : null;
+  const sanitizeFont = (name: string): string => name.replace(/[^a-zA-Z0-9\s\-']/g, '').trim();
+  const sanitizedFont = params.font ? sanitizeFont(params.font) : null;
+  const predefinedFont = sanitizedFont ? FONT_MAP[sanitizedFont.toLowerCase()] : null;
+  const selectedFont = predefinedFont || (sanitizedFont ? `"${sanitizedFont}", sans-serif` : null);
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const parsedRadius = Number(params.radius);
   const radius = Math.max(0, Math.min(Number.isNaN(parsedRadius) ? 8 : parsedRadius, 50));


### PR DESCRIPTION
## Description

Fixes #164 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
**Test 1 — Valid font works normally**
`?font=Orbitron` → renders with Orbitron font applied correctly
<img width="1919" height="790" alt="Screenshot 2026-05-21 153816" src="https://github.com/user-attachments/assets/975ce392-022d-474d-aaeb-b251dc882515" />

**Test 2 — Empty font falls back to default**
`?font=` → renders with default Space Grotesk font, no crash
<img width="1905" height="769" alt="Screenshot 2026-05-21 153837" src="https://github.com/user-attachments/assets/4a55fffc-83f0-4b47-8700-5f9b6a7cb57d" />

**Test 3 — Whitespace-only falls back to default**
`?font=+++` → renders with default Space Grotesk font, no crash
<img width="1919" height="772" alt="Screenshot 2026-05-21 153856" src="https://github.com/user-attachments/assets/07d7f372-2c1d-4344-81cf-d3d196081073" />

**Test 4 — Malicious input is stripped safely**
`?font=Arial<script>alert(1)</script>` → script tags removed, renders as Arial
<img width="1919" height="793" alt="Screenshot 2026-05-21 153913" src="https://github.com/user-attachments/assets/e48802f8-2195-401a-81b2-0438f0b34618" />

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=varsha-lab2028`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
