### PR TITLE
Feat/recent searches

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -47,6 +47,14 @@ vi.mock('framer-motion', () => ({
   AnimatePresence: ({ children }: any) => <>{children}</>,
 }));
 
+vi.mock('@/hooks/useRecentSearches', () => ({
+  useRecentSearches: () => ({
+    searches: [],
+    addSearch: vi.fn(),
+    clearSearches: vi.fn(),
+  }),
+}));
+
 describe('LandingPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import { X } from 'lucide-react';
 
 import { CommitPulseLogo } from '@/components/commitpulse-logo';
 import { CustomizeCTA } from './components/CustomizeCTA';
+import { useRecentSearches } from '@/hooks/useRecentSearches';
 
 const Icons = {
   Github: () => (
@@ -83,6 +84,7 @@ export default function LandingPage() {
   const [username, setUsername] = useState('');
   const [copied, setCopied] = useState(false);
   const guideRef = useRef<HTMLDivElement>(null);
+  const { searches, addSearch, clearSearches } = useRecentSearches();
   const trimmedUsername = username.trim();
   const hasUsername = trimmedUsername.length > 0;
 
@@ -93,6 +95,7 @@ export default function LandingPage() {
     if (!hasUsername) return;
 
     trackUser(trimmedUsername);
+    addSearch(trimmedUsername);
 
     navigator.clipboard.writeText(markdown);
     setCopied(true);
@@ -234,6 +237,7 @@ export default function LandingPage() {
                       e.preventDefault();
                     } else {
                       trackUser(trimmedUsername);
+                      addSearch(trimmedUsername);
                     }
                   }}
                   className={`relative flex min-w-[160px] items-center justify-center gap-2 overflow-hidden rounded-xl border px-6 py-3.5 text-sm font-semibold transition-all duration-200 active:scale-[0.98] ${
@@ -246,6 +250,27 @@ export default function LandingPage() {
                 </Link>
               </div>
             </div>
+
+            {searches.length > 0 && (
+              <div className="flex flex-wrap items-center gap-2 mb-6 mt-3">
+                <span className="text-xs text-[#A1A1AA]">Recent:</span>
+                {searches.map((s) => (
+                  <button
+                    key={s}
+                    onClick={() => setUsername(s)}
+                    className="rounded-full border border-[rgba(255,255,255,0.08)] bg-[#111] px-3 py-1 text-xs text-white/70 transition-all hover:border-[rgba(255,255,255,0.2)] hover:text-white"
+                  >
+                    {s}
+                  </button>
+                ))}
+                <button
+                  onClick={clearSearches}
+                  className="text-xs text-[#A1A1AA] underline hover:text-white transition-colors"
+                >
+                  Clear
+                </button>
+              </div>
+            )}
 
             <div className="group relative">
               <div className="absolute -inset-1 rounded-[2rem] bg-white/5 opacity-50 blur-xl transition duration-1000 group-hover:opacity-100" />

--- a/hooks/useRecentSearches.test.ts
+++ b/hooks/useRecentSearches.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRecentSearches } from './useRecentSearches';
+
+const store: Record<string, string> = {};
+
+beforeEach(() => {
+  Object.keys(store).forEach((k) => delete store[k]);
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+    },
+    writable: true,
+  });
+});
+
+describe('useRecentSearches', () => {
+  it('starts empty', () => {
+    const { result } = renderHook(() => useRecentSearches());
+    expect(result.current.searches).toEqual([]);
+  });
+
+  it('adds a search', () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.addSearch('torvalds');
+    });
+    expect(result.current.searches[0]).toBe('torvalds');
+  });
+
+  it('deduplicates — moves existing to front', () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.addSearch('torvalds');
+    });
+    act(() => {
+      result.current.addSearch('gaearon');
+    });
+    act(() => {
+      result.current.addSearch('torvalds');
+    });
+    expect(result.current.searches[0]).toBe('torvalds');
+    expect(result.current.searches.length).toBe(2);
+  });
+
+  it('caps at 5 entries', () => {
+    const { result } = renderHook(() => useRecentSearches());
+    ['a', 'b', 'c', 'd', 'e', 'f'].forEach((u) => {
+      act(() => {
+        result.current.addSearch(u);
+      });
+    });
+    expect(result.current.searches.length).toBe(5);
+  });
+
+  it('clears all searches', () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.addSearch('torvalds');
+    });
+    act(() => {
+      result.current.clearSearches();
+    });
+    expect(result.current.searches).toEqual([]);
+  });
+});

--- a/hooks/useRecentSearches.ts
+++ b/hooks/useRecentSearches.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState } from 'react';
+
+const KEY = 'recentSearches';
+const MAX = 5;
+
+function loadFromStorage(): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const stored = localStorage.getItem(KEY);
+    return stored ? (JSON.parse(stored) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function useRecentSearches() {
+  const [searches, setSearches] = useState<string[]>(loadFromStorage);
+
+  const addSearch = (query: string) => {
+    if (!query.trim()) return;
+    setSearches((prev) => {
+      const deduped = [query, ...prev.filter((s) => s !== query)].slice(0, MAX);
+      try {
+        localStorage.setItem(KEY, JSON.stringify(deduped));
+      } catch {}
+      return deduped;
+    });
+  };
+
+  const clearSearches = () => {
+    setSearches([]);
+    try {
+      localStorage.removeItem(KEY);
+    } catch {}
+  };
+
+  return { searches, addSearch, clearSearches };
+}


### PR DESCRIPTION
## Description

Adds a "Recent Searches" history below the search input using localStorage so users can quickly re-visit previously searched GitHub profiles without retyping.

Closes #73

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] ✨ Other — UX enhancement (recent searches history)

## Visual Preview

### Recent Searches chips (homepage)
<img width="1440" height="772" alt="Screenshot 2026-05-21 at 4 35 46 PM" src="https://github.com/user-attachments/assets/2cb08154-d187-48a4-9192-4f8c7d1cd79f" />

### Watch Dashboard (navigated from chip click)
<img width="1440" height="722" alt="Screenshot 2026-05-21 at 4 36 58 PM" src="https://github.com/user-attachments/assets/fef554a8-24d3-4139-a59a-387668535846" />




## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.