### PR TITLE
fix(dashboard): correct copy markdown URL generation in ShareSheet

### DIFF
--- a/components/dashboard/ShareSheet.test.tsx
+++ b/components/dashboard/ShareSheet.test.tsx
@@ -116,6 +116,27 @@ describe('ShareSheet', () => {
     });
   });
 
+  it('handles Copy Markdown action', async () => {
+    render(<ShareSheet {...defaultProps} />);
+    const copyButton = screen.getByText('Copy Markdown').closest('button');
+
+    fireEvent.click(copyButton!);
+
+    // Wait for the async clipboard write to be called
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        expect.stringContaining('![CommitPulse](')
+      );
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining('/api/streak?user=octocat')
+    );
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalledWith(
+      expect.stringContaining('/dashboard/')
+    );
+  });
+
   it('handles Share on X action', () => {
     render(<ShareSheet {...defaultProps} />);
     const twitterButton = screen.getByText('Share on X').closest('button');

--- a/components/dashboard/ShareSheet.tsx
+++ b/components/dashboard/ShareSheet.tsx
@@ -149,7 +149,7 @@ export default function ShareSheet({ username, isOpen, onClose, exportData }: Sh
   const handleCopyMarkdown = async () => {
     setOptionState('markdown', 'loading');
     try {
-      const markdown = `![CommitPulse](${PROFILE_URL(username).replace(username, `api/streak?user=${username}`)})`;
+      const markdown = `![CommitPulse](${window.location.origin}/api/streak?user=${encodeURIComponent(username)})`;
       await navigator.clipboard.writeText(markdown);
       setOptionState('markdown', 'success');
       setTimeout(() => onClose(), 800);


### PR DESCRIPTION
## Description
This PR fixes a bug in the dashboard's ShareSheet where clicking the "Copy Markdown" button would generate a broken image URL. The PROFILE_URL helper was appending /dashboard/ to the origin, which caused the string replacement logic to retain the /dashboard path segment, resulting in a 404 Not Found error when the markdown snippet was embedded in a README.

Fixes #249 

Fix Details:

```
- const markdown = `![CommitPulse](${PROFILE_URL(username).replace(username, `api/streak?user=${username}`)})`;
+ const markdown = `![CommitPulse](${window.location.origin}/api/streak?user=${username})`;
```

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
