### PR TITLE
fix: escape XML in SVG error response to prevent malformed output

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -2,7 +2,7 @@
 import { NextResponse } from 'next/server';
 import { fetchGitHubContributions } from '../../../lib/github';
 import { calculateStreak } from '../../../lib/calculate';
-import { generateSVG } from '../../../lib/svg/generator';
+import { generateSVG, escapeXML } from '../../../lib/svg/generator';
 import { getSecondsUntilUTCMidnight, getSecondsUntilMidnightInTimezone } from '../../../utils/time';
 import type { BadgeParams } from '../../../types';
 import { themes } from '../../../lib/svg/themes';
@@ -127,7 +127,7 @@ export async function GET(request: Request) {
       <svg xmlns="http://www.w3.org/2000/svg" width="400" height="150">
         <rect width="100%" height="100%" fill="#2d0000" rx="8"/>
         <text x="50%" y="50%" text-anchor="middle" fill="#ffcccc">
-          Error: ${message}
+          Error: ${escapeXML(message)}
         </text>
       </svg>
     `;

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -2,7 +2,6 @@
 import { NextResponse } from 'next/server';
 import { fetchGitHubContributions } from '../../../lib/github';
 import { calculateStreak } from '../../../lib/calculate';
-import { generateSVG, escapeXML } from '../../../lib/svg/generator';
 import { generateNotFoundSVG, generateSVG, escapeXML } from '../../../lib/svg/generator';
 import { getSecondsUntilUTCMidnight, getSecondsUntilMidnightInTimezone } from '../../../utils/time';
 import type { BadgeParams } from '../../../types';

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -162,7 +162,7 @@ function computeTowers(
   return towers;
 }
 
-function escapeXML(str: string): string {
+export function escapeXML(str: string): string {
   return str
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')


### PR DESCRIPTION
## Description

Fixes #250 

This PR fixes a bug where error messages in the `/api/streak` SVG error response were not XML-escaped. If an error message contained characters like `<`, `>`, or `&`, the SVG output would be malformed. Now uses the existing `escapeXML` function from `lib/svg/generator.ts` to properly escape error messages before rendering.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — this is a backend fix with no visual change. The SVG error response now properly escapes special characters in error messages.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

### Requested Labels

GSSoC 2026 , gssoc:approved , level:beginner , quality:clean ,  type:refactor