### PR TITLE
feat(svg): add compact monthly stats view mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ URL Parameter > Theme Default > System Fallback
 | `hide_stats`      | `boolean` | No         | `false`                        | Hides the bottom row displaying Current Streak, Annual Sync Total, and Peak Streak stats when set to `true` or `1`.                                                       |
 | `tz`              | `string`  | No         | Omitted = UTC                  | IANA timezone (e.g. `Asia/Kolkata`, `America/New_York`) — aligns "today" with the user local midnight. Note: `?tz=UTC` is valid but cached separately from omitting `tz`. |
 | `lang`            | `string`  | No         | `en`                           | Language code for labels (`en`, `es`, `hi`, `fr`)                                                                                                                         |
+| `view`            | `string`  | No         | `default`                      | Rendering mode: `default` (3D Monolith) or `monthly` (Compact monthly stats)                                                                                              |
+| `delta_format`    | `string`  | No         | `percent`                      | Format for month-over-month delta in monthly view: `percent` (e.g. +12%), `absolute` (e.g. +15 commits), or `both`                                                        |
+| `width`           | `number`  | No         | `300`                          | Custom width for the SVG canvas (currently only applies to `view=monthly`)                                                                                                |
+| `height`          | `number`  | No         | `120`                          | Custom height for the SVG canvas (currently only applies to `view=monthly`)                                                                                               |
 
 ### Theme Presets
 
@@ -203,6 +207,14 @@ URL Parameter > Theme Default > System Fallback
 <!-- View contributions for a specific past year -->
 
 ![](https://commitpulse.vercel.app/api/streak?user=jhasourav07&year=2023)
+
+<!-- Compact Monthly Stats View -->
+
+![](https://commitpulse.vercel.app/api/streak?user=jhasourav07&view=monthly)
+
+<!-- Monthly View with Absolute Delta and Custom Dimensions -->
+
+![](https://commitpulse.vercel.app/api/streak?user=jhasourav07&view=monthly&delta_format=absolute&width=400&height=150)
 
 <!-- Hide GitHub username/title -->
 

--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -411,4 +411,23 @@ describe('GET /api/streak', () => {
       expect(getSecondsUntilMidnightInTimezone).not.toHaveBeenCalled();
     });
   });
+
+  describe('monthly view parameter', () => {
+    it('returns 200 when view=monthly is given', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', view: 'monthly' }));
+
+      expect(response.status).toBe(200);
+      const body = await response.text();
+      expect(body).toContain('COMMITS THIS MONTH');
+    });
+
+    it('defaults to default view when an unknown view is given', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', view: 'invalid' }));
+
+      expect(response.status).toBe(200);
+      const body = await response.text();
+      // It should generate the default streak SVG and have "CURRENT_STREAK"
+      expect(body).toContain('CURRENT_STREAK');
+    });
+  });
 });

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -1,8 +1,13 @@
 // app/api/streak/route.ts
 import { NextResponse } from 'next/server';
 import { fetchGitHubContributions } from '../../../lib/github';
-import { calculateStreak } from '../../../lib/calculate';
-import { generateNotFoundSVG, generateSVG, escapeXML } from '../../../lib/svg/generator';
+import { calculateStreak, calculateMonthlyStats } from '../../../lib/calculate';
+import {
+  generateNotFoundSVG,
+  generateSVG,
+  generateMonthlySVG,
+  escapeXML,
+} from '../../../lib/svg/generator';
 import { getSecondsUntilUTCMidnight, getSecondsUntilMidnightInTimezone } from '../../../utils/time';
 import type { BadgeParams } from '../../../types';
 import { themes } from '../../../lib/svg/themes';
@@ -40,6 +45,10 @@ export async function GET(request: Request) {
       hide_background,
       hide_stats,
       lang,
+      view,
+      delta_format,
+      width,
+      height,
     } = parseResult.data;
 
     const themeName = theme || 'dark';
@@ -83,6 +92,10 @@ export async function GET(request: Request) {
       hideBackground: hide_background,
       hide_stats,
       lang,
+      view,
+      delta_format,
+      width: width ? parseInt(width, 10) : undefined,
+      height: height ? parseInt(height, 10) : undefined,
       size,
     };
 
@@ -91,8 +104,15 @@ export async function GET(request: Request) {
       from,
       to,
     });
-    const stats = calculateStreak(calendar, timezone);
-    const svg = generateSVG(stats, params, calendar);
+
+    let svg = '';
+    if (view === 'monthly') {
+      const stats = calculateMonthlyStats(calendar, timezone);
+      svg = generateMonthlySVG(stats, params);
+    } else {
+      const stats = calculateStreak(calendar, timezone);
+      svg = generateSVG(stats, params, calendar);
+    }
 
     const secondsToMidnight = tzParam
       ? getSecondsUntilMidnightInTimezone(timezone)

--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateStreak } from './calculate';
+import { calculateStreak, calculateMonthlyStats } from './calculate';
 import type { ContributionCalendar } from '../types';
 
 // Turns a flat array of daily counts into the ContributionCalendar shape,
@@ -256,6 +256,105 @@ describe('calculateStreak — timezone awareness', () => {
     // nowUTC = 2024-06-16T07:00Z → UTC date = 2024-06-16
     const result = calculateStreak(tzCalendar, 'UTC', nowUTC);
     expect(result.todayDate).toBe('2024-06-16');
+  });
+});
+
+describe('calculateMonthlyStats', () => {
+  it('calculates monthly stats correctly when both months have commits', () => {
+    const calendar = {
+      totalContributions: 15,
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 5, date: '2024-05-15' },
+            { contributionCount: 10, date: '2024-06-10' },
+          ],
+        },
+      ],
+    };
+    const now = new Date('2024-06-15T12:00:00Z');
+    const result = calculateMonthlyStats(calendar, 'UTC', now);
+
+    expect(result.currentMonthTotal).toBe(10);
+    expect(result.previousMonthTotal).toBe(5);
+    expect(result.deltaAbsolute).toBe(5);
+    expect(result.deltaPercentage).toBe(100);
+    expect(result.currentMonthName).toBe('June');
+  });
+
+  it('handles zero previous month contributions', () => {
+    const calendar = {
+      totalContributions: 10,
+      weeks: [
+        {
+          contributionDays: [{ contributionCount: 10, date: '2024-06-10' }],
+        },
+      ],
+    };
+    const now = new Date('2024-06-15T12:00:00Z');
+    const result = calculateMonthlyStats(calendar, 'UTC', now);
+
+    expect(result.previousMonthTotal).toBe(0);
+    expect(result.currentMonthTotal).toBe(10);
+    expect(result.deltaPercentage).toBe(100);
+  });
+
+  it('handles zero current month contributions', () => {
+    const calendar = {
+      totalContributions: 5,
+      weeks: [
+        {
+          contributionDays: [{ contributionCount: 5, date: '2024-05-10' }],
+        },
+      ],
+    };
+    const now = new Date('2024-06-15T12:00:00Z');
+    const result = calculateMonthlyStats(calendar, 'UTC', now);
+
+    expect(result.previousMonthTotal).toBe(5);
+    expect(result.currentMonthTotal).toBe(0);
+    expect(result.deltaPercentage).toBe(-100);
+  });
+
+  it('handles negative delta correctly', () => {
+    const calendar = {
+      totalContributions: 15,
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 10, date: '2024-05-10' },
+            { contributionCount: 5, date: '2024-06-10' },
+          ],
+        },
+      ],
+    };
+    const now = new Date('2024-06-15T12:00:00Z');
+    const result = calculateMonthlyStats(calendar, 'UTC', now);
+
+    expect(result.previousMonthTotal).toBe(10);
+    expect(result.currentMonthTotal).toBe(5);
+    expect(result.deltaPercentage).toBe(-50);
+    expect(result.deltaAbsolute).toBe(-5);
+  });
+
+  it('handles year boundary correctly (Jan vs Dec)', () => {
+    const calendar = {
+      totalContributions: 15,
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 10, date: '2023-12-15' },
+            { contributionCount: 5, date: '2024-01-15' },
+          ],
+        },
+      ],
+    };
+    const now = new Date('2024-01-15T12:00:00Z');
+    const result = calculateMonthlyStats(calendar, 'UTC', now);
+
+    expect(result.previousMonthTotal).toBe(10);
+    expect(result.currentMonthTotal).toBe(5);
+    expect(result.currentMonthName).toBe('January');
   });
 });
 

--- a/lib/calculate.ts
+++ b/lib/calculate.ts
@@ -1,5 +1,5 @@
 // lib/calculate.ts
-import type { ContributionCalendar, StreakStats } from '../types';
+import type { ContributionCalendar, StreakStats, MonthlyStats } from '../types';
 
 export function calculateStreak(
   calendar: ContributionCalendar,
@@ -74,5 +74,64 @@ export function calculateStreak(
     longestStreak,
     totalContributions: calendar.totalContributions,
     todayDate,
+  };
+}
+
+export function calculateMonthlyStats(
+  calendar: ContributionCalendar,
+  timezone: string = 'UTC',
+  now: Date = new Date()
+): MonthlyStats {
+  const days = calendar.weeks.flatMap((week) => week.contributionDays);
+
+  const localTodayStr = new Intl.DateTimeFormat('en-CA', { timeZone: timezone }).format(now);
+  const [currentYearStr, currentMonthStr] = localTodayStr.split('-');
+  const currentYear = parseInt(currentYearStr, 10);
+  const currentMonth = parseInt(currentMonthStr, 10);
+
+  let prevMonth = currentMonth - 1;
+  let prevYear = currentYear;
+  if (prevMonth === 0) {
+    prevMonth = 12;
+    prevYear -= 1;
+  }
+
+  const currentMonthPrefix = `${currentYear}-${currentMonth.toString().padStart(2, '0')}`;
+  const prevMonthPrefix = `${prevYear}-${prevMonth.toString().padStart(2, '0')}`;
+
+  let currentMonthTotal = 0;
+  let previousMonthTotal = 0;
+
+  for (const day of days) {
+    if (day.date.startsWith(currentMonthPrefix)) {
+      currentMonthTotal += day.contributionCount;
+    } else if (day.date.startsWith(prevMonthPrefix)) {
+      previousMonthTotal += day.contributionCount;
+    }
+  }
+
+  const currentMonthName = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    month: 'long',
+  }).format(now);
+
+  const deltaAbsolute = currentMonthTotal - previousMonthTotal;
+  let deltaPercentage = 0;
+
+  if (previousMonthTotal === 0) {
+    if (currentMonthTotal > 0) {
+      deltaPercentage = 100;
+    }
+  } else {
+    deltaPercentage = Math.round((deltaAbsolute / previousMonthTotal) * 100);
+    if (deltaPercentage === -0) deltaPercentage = 0;
+  }
+
+  return {
+    currentMonthTotal,
+    previousMonthTotal,
+    deltaPercentage,
+    deltaAbsolute,
+    currentMonthName,
   };
 }

--- a/lib/i18n/badgeLabels.ts
+++ b/lib/i18n/badgeLabels.ts
@@ -2,6 +2,8 @@ export interface BadgeLabels {
   CURRENT_STREAK: string;
   ANNUAL_SYNC_TOTAL: string;
   PEAK_STREAK: string;
+  COMMITS_THIS_MONTH: string;
+  VS_LAST_MONTH: string;
 }
 
 export const labels: Record<string, BadgeLabels> = {
@@ -9,21 +11,29 @@ export const labels: Record<string, BadgeLabels> = {
     CURRENT_STREAK: 'CURRENT_STREAK',
     ANNUAL_SYNC_TOTAL: 'ANNUAL_SYNC_TOTAL',
     PEAK_STREAK: 'PEAK_STREAK',
+    COMMITS_THIS_MONTH: 'COMMITS THIS MONTH',
+    VS_LAST_MONTH: 'vs last month',
   },
   es: {
     CURRENT_STREAK: 'RACHA_ACTUAL',
     ANNUAL_SYNC_TOTAL: 'TOTAL_ANUAL',
     PEAK_STREAK: 'RACHA_MÁXIMA',
+    COMMITS_THIS_MONTH: 'COMMITS ESTE MES',
+    VS_LAST_MONTH: 'vs mes anterior',
   },
   hi: {
     CURRENT_STREAK: 'वर्तमान_स्ट्रीक',
     ANNUAL_SYNC_TOTAL: 'वार्षिक_कुल',
     PEAK_STREAK: 'अधिकतम_स्ट्रीक',
+    COMMITS_THIS_MONTH: 'इस महीने के कमिट्स',
+    VS_LAST_MONTH: 'पिछले महीने की तुलना में',
   },
   fr: {
     CURRENT_STREAK: 'SÉRIE_ACTUELLE',
     ANNUAL_SYNC_TOTAL: 'TOTAL_ANNUEL',
     PEAK_STREAK: 'SÉRIE_MAXIMALE',
+    COMMITS_THIS_MONTH: 'COMMITS CE MOIS',
+    VS_LAST_MONTH: 'vs mois dernier',
   },
 };
 

--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { generateSVG } from './generator';
-import type { BadgeParams, ContributionCalendar, StreakStats } from '../../types';
+import { generateSVG, generateMonthlySVG } from './generator';
+import type { BadgeParams, ContributionCalendar, StreakStats, MonthlyStats } from '../../types';
 
 describe('generateSVG', () => {
   const mockStats: StreakStats = {
@@ -376,5 +376,51 @@ describe('generateSVG', () => {
 
       expect(svg).not.toContain('attributeName="opacity" values="1;0.4;1"');
     });
+  });
+});
+
+describe('generateMonthlySVG', () => {
+  const mockMonthlyStats: MonthlyStats = {
+    currentMonthTotal: 42,
+    previousMonthTotal: 30,
+    deltaPercentage: 40,
+    deltaAbsolute: 12,
+    currentMonthName: 'June',
+  };
+
+  it('renders monthly stats correctly with absolute delta', () => {
+    const svg = generateMonthlySVG(mockMonthlyStats, {
+      user: 'octocat',
+      delta_format: 'absolute',
+    } as unknown as BadgeParams);
+    expect(svg).toContain('JUNE');
+    expect(svg).toContain('42');
+    expect(svg).toContain('+12 commits');
+  });
+
+  it('renders monthly stats correctly with percentage delta', () => {
+    const svg = generateMonthlySVG(mockMonthlyStats, {
+      user: 'octocat',
+      delta_format: 'percent',
+    } as unknown as BadgeParams);
+    expect(svg).toContain('+40%');
+  });
+
+  it('renders monthly stats correctly with both delta formats', () => {
+    const svg = generateMonthlySVG(mockMonthlyStats, {
+      user: 'octocat',
+      delta_format: 'both',
+    } as unknown as BadgeParams);
+    expect(svg).toContain('+40% (+12)');
+  });
+
+  it('respects custom width and height parameters', () => {
+    const svg = generateMonthlySVG(mockMonthlyStats, {
+      user: 'octocat',
+      width: 400,
+      height: 200,
+    } as unknown as BadgeParams);
+    expect(svg).toContain('width="400"');
+    expect(svg).toContain('height="200"');
   });
 });

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -1,4 +1,4 @@
-import type { BadgeParams, ContributionCalendar, StreakStats } from '../../types';
+import type { BadgeParams, ContributionCalendar, StreakStats, MonthlyStats } from '../../types';
 import { getLabels } from '../i18n/badgeLabels';
 import { AUTO_DARK_THEME, AUTO_LIGHT_THEME } from './themes';
 import { TOWER_ANIMATION_CSS } from './animations';
@@ -350,6 +350,182 @@ ${
   <rect x="${s(100)}" y="${s(60)}" width="${s(400)}" height="${sf}" class="cp-accent-fill" fill-opacity="0.3">
     <animate attributeName="y" values="${s(80)};${s(320)};${s(80)}" dur="${params.speed || '8s'}" repeatCount="indefinite" />
   </rect>
+</svg>
+`;
+}
+
+export function generateMonthlySVG(stats: MonthlyStats, params: BadgeParams): string {
+  if (params.autoTheme) {
+    return generateAutoThemeMonthlySVG(stats, params);
+  }
+
+  const safeUser = escapeXML(params.user || 'GitHub User');
+  const bg = `#${(params.bg || '0d1117').replace('#', '')}`;
+  const accent = `#${(params.accent || '00ffaa').replace('#', '')}`;
+  const text = `#${(params.text || 'ffffff').replace('#', '')}`;
+
+  const sanitizeFont = (name: string) => name.replace(/[^a-zA-Z0-9\s-]/g, '').trim();
+  const sanitizedFont = params.font ? sanitizeFont(params.font) : null;
+  const predefinedFont = sanitizedFont ? FONT_MAP[sanitizedFont.toLowerCase()] : null;
+  const isPredefinedFont = Boolean(predefinedFont);
+  const selectedFont = isPredefinedFont
+    ? predefinedFont
+    : sanitizedFont
+      ? `"${sanitizedFont}", sans-serif`
+      : null;
+
+  const statsFont = selectedFont || '"Space Grotesk", sans-serif';
+  const parsedRadius = Number(params.radius);
+  const radius = Math.max(0, Math.min(Number.isNaN(parsedRadius) ? 8 : parsedRadius, 50));
+  const labels = getLabels(params.lang);
+
+  const width = params.width || 300;
+  const height = params.height || 120;
+
+  const googleFontsImport =
+    sanitizedFont && !isPredefinedFont
+      ? `@import url('https://fonts.googleapis.com/css2?family=${encodeURIComponent(sanitizedFont).replace(/%20/g, '+')}&amp;display=swap');`
+      : '';
+
+  let deltaText = '';
+  if (params.delta_format === 'absolute') {
+    deltaText =
+      stats.deltaAbsolute > 0
+        ? `+${stats.deltaAbsolute} commits`
+        : stats.deltaAbsolute === 0
+          ? `0 commits`
+          : `${stats.deltaAbsolute} commits`;
+  } else if (params.delta_format === 'both') {
+    deltaText =
+      stats.deltaPercentage > 0
+        ? `+${stats.deltaPercentage}% (+${stats.deltaAbsolute})`
+        : stats.deltaPercentage < 0
+          ? `${stats.deltaPercentage}% (${stats.deltaAbsolute})`
+          : `0% (${stats.deltaAbsolute > 0 ? '+' : ''}${stats.deltaAbsolute})`;
+  } else {
+    deltaText =
+      stats.deltaPercentage > 0
+        ? `+${stats.deltaPercentage}%`
+        : stats.deltaPercentage < 0
+          ? `${stats.deltaPercentage}%`
+          : `0%`;
+  }
+  const deltaColor = stats.deltaAbsolute >= 0 ? accent : '#ff4444';
+
+  return `
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="${width}"
+  height="${height}"
+  viewBox="0 0 ${width} ${height}"
+  fill="none"
+  role="img"
+>
+  <title>Monthly Stats for ${safeUser}</title>
+  <style>
+  @import url('https://fonts.googleapis.com/css2?family=Fira+Code&amp;family=JetBrains+Mono&amp;family=Roboto&amp;display=swap');
+  ${googleFontsImport}
+
+  .title { font-family: ${selectedFont || '"Syncopate", sans-serif'}; fill: ${text}; font-size: 14px; letter-spacing: 2px; font-weight: 400; opacity: 0.8; }
+  .stats { font-family: ${statsFont}; fill: ${accent}; font-size: 36px; font-weight: 600; letter-spacing: 0; }
+  .label { font-family: "Roboto", sans-serif; fill: ${text}; font-size: 10px; font-weight: 400; letter-spacing: 1px; opacity: 0.7; }
+  .delta { font-family: "Roboto", sans-serif; fill: ${deltaColor}; font-size: 12px; font-weight: 500; }
+  </style>
+
+  <rect width="${width}" height="${height}" rx="${radius}" fill="${params.hideBackground ? 'transparent' : bg}" />
+
+  <text x="20" y="40" class="title">${stats.currentMonthName.toUpperCase()}</text>
+  <text x="20" y="85" class="stats">${stats.currentMonthTotal}</text>
+  <text x="20" y="105" class="label">${labels.COMMITS_THIS_MONTH}</text>
+
+  <g transform="translate(${width - 20}, 80)" text-anchor="end">
+    <text class="delta">${deltaText}</text>
+    <text y="20" class="label">${labels.VS_LAST_MONTH}</text>
+  </g>
+</svg>
+`;
+}
+
+function generateAutoThemeMonthlySVG(stats: MonthlyStats, params: BadgeParams): string {
+  const light = AUTO_LIGHT_THEME;
+  const dark = AUTO_DARK_THEME;
+  const safeUser = escapeXML(params.user || 'GitHub User');
+  const sanitizeFont = (name: string) => name.replace(/[^a-zA-Z0-9\s-]/g, '').trim();
+  const sanitizedFont = params.font ? sanitizeFont(params.font) : null;
+  const predefinedFont = sanitizedFont ? FONT_MAP[sanitizedFont.toLowerCase()] : null;
+  const isPredefinedFont = Boolean(predefinedFont);
+  const selectedFont = isPredefinedFont
+    ? predefinedFont
+    : sanitizedFont
+      ? `"${sanitizedFont}", sans-serif`
+      : null;
+  const statsFont = selectedFont || '"Space Grotesk", sans-serif';
+  const parsedRadius = Number(params.radius);
+  const radius = Math.max(0, Math.min(Number.isNaN(parsedRadius) ? 8 : parsedRadius, 50));
+  const labels = getLabels(params.lang);
+
+  const width = params.width || 300;
+  const height = params.height || 120;
+
+  let deltaText = '';
+  if (params.delta_format === 'absolute') {
+    deltaText =
+      stats.deltaAbsolute > 0
+        ? `+${stats.deltaAbsolute} commits`
+        : stats.deltaAbsolute === 0
+          ? `0 commits`
+          : `${stats.deltaAbsolute} commits`;
+  } else if (params.delta_format === 'both') {
+    deltaText =
+      stats.deltaPercentage > 0
+        ? `+${stats.deltaPercentage}% (+${stats.deltaAbsolute})`
+        : stats.deltaPercentage < 0
+          ? `${stats.deltaPercentage}% (${stats.deltaAbsolute})`
+          : `0% (${stats.deltaAbsolute > 0 ? '+' : ''}${stats.deltaAbsolute})`;
+  } else {
+    deltaText =
+      stats.deltaPercentage > 0
+        ? `+${stats.deltaPercentage}%`
+        : stats.deltaPercentage < 0
+          ? `${stats.deltaPercentage}%`
+          : `0%`;
+  }
+
+  return `
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="${width}"
+  height="${height}"
+  viewBox="0 0 ${width} ${height}"
+  fill="none"
+  role="img"
+>
+  <title>Monthly Stats for ${safeUser}</title>
+  <style>
+  @import url('https://fonts.googleapis.com/css2?family=Fira+Code&amp;family=JetBrains+Mono&amp;family=Roboto&amp;display=swap');
+  :root { --cp-bg: #${light.bg}; --cp-text: #${light.text}; --cp-accent: #${light.accent}; --cp-negative: #ff4444; }
+  @media (prefers-color-scheme: dark) { :root { --cp-bg: #${dark.bg}; --cp-text: #${dark.text}; --cp-accent: #${dark.accent}; --cp-negative: #ff6666; } }
+  .cp-bg-fill { fill: var(--cp-bg); } 
+  .cp-text-fill { fill: var(--cp-text); color: var(--cp-text); } 
+  .cp-accent-fill { fill: var(--cp-accent); color: var(--cp-accent); }
+  .cp-delta-fill { fill: ${stats.deltaAbsolute >= 0 ? 'var(--cp-accent)' : 'var(--cp-negative)'}; }
+  
+  .title { font-family: ${selectedFont || '"Syncopate", sans-serif'}; fill: var(--cp-text); font-size: 14px; letter-spacing: 2px; font-weight: 400; opacity: 0.8; }
+  .stats { font-family: ${statsFont}; fill: var(--cp-accent); font-size: 36px; font-weight: 600; letter-spacing: 0; }
+  .label { font-family: "Roboto", sans-serif; fill: var(--cp-text); font-size: 10px; font-weight: 400; letter-spacing: 1px; opacity: 0.7; }
+  .delta { font-family: "Roboto", sans-serif; font-size: 12px; font-weight: 500; }
+  </style>
+
+  <rect width="${width}" height="${height}" rx="${radius}" ${params.hideBackground ? 'fill="transparent"' : 'class="cp-bg-fill"'} />
+
+  <text x="20" y="40" class="title">${stats.currentMonthName.toUpperCase()}</text>
+  <text x="20" y="85" class="stats">${stats.currentMonthTotal}</text>
+  <text x="20" y="105" class="label">${labels.COMMITS_THIS_MONTH}</text>
+
+  <g transform="translate(${width - 20}, 80)" text-anchor="end">
+    <text class="delta cp-delta-fill">${deltaText}</text>
+    <text y="20" class="label">${labels.VS_LAST_MONTH}</text>
+  </g>
 </svg>
 `;
 }

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -71,6 +71,10 @@ export const streakParamsSchema = z.object({
     .optional()
     .transform((val) => val === 'true' || val === '1'),
   lang: z.string().optional().default('en'),
+  view: z.enum(['default', 'monthly']).catch('default').default('default'),
+  delta_format: z.enum(['percent', 'absolute', 'both']).catch('percent').default('percent'),
+  width: z.string().optional(),
+  height: z.string().optional(),
 });
 
 export const githubParamsSchema = z.object({

--- a/types/index.ts
+++ b/types/index.ts
@@ -25,6 +25,14 @@ export interface ContributionCalendar {
   weeks: ContributionWeek[];
 }
 
+export interface MonthlyStats {
+  currentMonthTotal: number;
+  previousMonthTotal: number;
+  deltaPercentage: number;
+  deltaAbsolute: number;
+  currentMonthName: string;
+}
+
 export interface BadgeParams {
   user: string;
   bg: string;
@@ -39,5 +47,9 @@ export interface BadgeParams {
   hideBackground?: boolean;
   hide_stats?: boolean;
   lang?: string;
+  view?: 'default' | 'monthly';
+  delta_format?: 'percent' | 'absolute' | 'both';
+  width?: number;
+  height?: number;
   size?: 'small' | 'medium' | 'large';
 }


### PR DESCRIPTION
## Description

This PR introduces a new `view=monthly` mode that renders a compact, text-focused monthly stats view instead of the default 3D isometric monolith.

**Key features:**
- **Monthly view mode:** Passing `view=monthly` to the endpoint switches the SVG rendering engine to the new compact view.
- **Month-over-month Delta:** Added `delta_format` parameter (`percent`, `absolute`, or `both`) to display a comparison against the previous calendar month.
- **Configurable Dimensions:** Added `width` and `height` parameters for custom SVG canvas sizing.
- **Timezone-aware Math:** Core logic correctly handles timezone offsets and year boundaries when isolating the current and previous month's contribution counts.
- **Testing:** Comprehensive unit tests added for stats calculation, SVG generation, and Zod parameter validation routing.

Fixex #160 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [x] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Feature addition, docs)

## Visual Preview
<img width="311" height="136" alt="2026-05-23_14-51-36" src="https://github.com/user-attachments/assets/88274460-ea25-4f4f-b192-b1e0d177f81a" />



## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR. *(Note: you may need to squash your commits if you have more than one!)*
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
