### PR TITLE
refactor: separate sticky header components for improved layout

### DIFF
--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -135,10 +135,10 @@ export default function Navbar() {
 
   return (
     <header className="fixed inset-x-0 top-0 z-50 px-4 pt-4 sm:px-6">
-      <div className="mx-auto max-w-6xl">
+      <div className="flex w-full items-center justify-between gap-3">
         <div
           ref={shellRef}
-          className="relative overflow-hidden rounded-2xl border border-white/25 bg-black/45 backdrop-blur-xl shadow-[0_14px_40px_rgba(0,0,0,0.45)]"
+          className="relative overflow-hidden rounded-2xl border border-white/25 bg-black/45 backdrop-blur-xl shadow-[0_14px_40px_rgba(0,0,0,0.45)] w-auto"
           style={shellVars}
           onMouseEnter={updateRect}
           onMouseMove={(event) => {
@@ -183,7 +183,7 @@ export default function Navbar() {
               maskComposite: 'exclude',
             }}
           />
-          <nav className="relative flex items-center justify-between px-4 py-3 sm:px-6">
+          <nav className="relative flex flex-wrap items-center justify-between gap-3 px-4 py-3 sm:px-6">
             <Link
               href="/"
               aria-label="Go to home"
@@ -197,21 +197,6 @@ export default function Navbar() {
                 CommitPulse
               </span>
             </Link>
-
-            <div className="hidden items-center gap-3 md:flex">
-              {NAV_LINKS.map((link) => (
-                <a
-                  key={link.href}
-                  href={link.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 rounded-xl border border-white/15 bg-white/5 px-4 py-2 text-sm font-medium text-white/90 transition hover:border-white/45 hover:bg-white/10"
-                >
-                  <GithubMark />
-                  {link.label}
-                </a>
-              ))}
-            </div>
 
             <button
               type="button"
@@ -244,6 +229,25 @@ export default function Navbar() {
               </ul>
             </div>
           ) : null}
+        </div>
+
+        <div className="hidden md:block">
+          <div className="relative overflow-hidden rounded-2xl border border-white/25 bg-black/45 backdrop-blur-xl shadow-[0_14px_40px_rgba(0,0,0,0.45)] p-3 md:p-4">
+            <div className="flex items-center gap-3">
+              {NAV_LINKS.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 rounded-xl border border-white/15 bg-white/5 px-4 py-2 text-sm font-medium text-white/90 transition hover:border-white/45 hover:bg-white/10"
+                >
+                  <GithubMark />
+                  {link.label}
+                </a>
+              ))}
+            </div>
+          </div>
         </div>
       </div>
     </header>

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -138,7 +138,7 @@ export default function Navbar() {
       <div className="flex w-full items-center justify-between gap-3">
         <div
           ref={shellRef}
-          className="relative overflow-hidden rounded-2xl border border-white/25 bg-black/45 backdrop-blur-xl shadow-[0_14px_40px_rgba(0,0,0,0.45)] w-auto"
+          className="relative w-full overflow-hidden rounded-2xl border border-white/25 bg-black/45 backdrop-blur-xl shadow-[0_14px_40px_rgba(0,0,0,0.45)] md:w-auto"
           style={shellVars}
           onMouseEnter={updateRect}
           onMouseMove={(event) => {

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -19,6 +19,9 @@ const NAV_LINKS = [
   },
 ];
 
+const shellCardClasses =
+  'relative overflow-hidden rounded-2xl border border-white/25 bg-black/45 backdrop-blur-xl shadow-[0_14px_40px_rgba(0,0,0,0.45)]';
+
 export default function Navbar() {
   const [open, setOpen] = useState(false);
   const shellRef = useRef<HTMLDivElement>(null);
@@ -135,10 +138,10 @@ export default function Navbar() {
 
   return (
     <header className="fixed inset-x-0 top-0 z-50 px-4 pt-4 sm:px-6">
-      <div className="flex w-full items-center justify-between gap-3">
+      <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-3">
         <div
           ref={shellRef}
-          className="relative w-full overflow-hidden rounded-2xl border border-white/25 bg-black/45 backdrop-blur-xl shadow-[0_14px_40px_rgba(0,0,0,0.45)] md:w-auto"
+          className={`${shellCardClasses} w-auto`}
           style={shellVars}
           onMouseEnter={updateRect}
           onMouseMove={(event) => {
@@ -231,8 +234,8 @@ export default function Navbar() {
           ) : null}
         </div>
 
-        <div className="hidden md:block">
-          <div className="relative overflow-hidden rounded-2xl border border-white/25 bg-black/45 backdrop-blur-xl shadow-[0_14px_40px_rgba(0,0,0,0.45)] p-3 md:p-4">
+        <nav aria-label="External repository" className="hidden md:block">
+          <div className={`${shellCardClasses} p-3 md:p-4`}>
             <div className="flex items-center gap-3">
               {NAV_LINKS.map((link) => (
                 <a
@@ -248,7 +251,7 @@ export default function Navbar() {
               ))}
             </div>
           </div>
-        </div>
+        </nav>
       </div>
     </header>
   );


### PR DESCRIPTION
## Description

Refactors the sticky header/navbar layout to improve visual hierarchy and scrolling experience.

Previously, branding ("CommitPulse") and actions ("GitHub Repo") were grouped inside a single elongated sticky container, which made the interface appear visually heavy while scrolling.

This PR separates these elements into independent compact components to improve spacing, readability, and overall layout balance **without changing any existing functionality or logic**.

Fixes #275 

### Changes made

- Separated branding and action elements into independent components
- Reduced visual clutter caused by the long sticky header
- Improved spacing and layout hierarchy
- Preserved sticky behavior where applicable
- Maintained responsiveness across screen sizes
- Kept navigation/actions/functionality unchanged
- Scoped changes only to frontend UI

---

## Pillar

UI/UX Improvement

Reason:

This contribution improves dashboard usability, layout hierarchy, and scrolling experience without modifying backend logic or application behavior.

---

## Checklist

- [x] Linked issue in description
- [x] Changes are scoped only to assigned issue
- [x] No logic or functionality modified
- [x] No API/authentication/state changes introduced
- [x] Responsive layout tested
- [x] Existing navigation/actions verified
- [x] Self-reviewed changes
- [x] No unrelated files modified
- [x] Project builds successfully

---

## Screenshorts Attached 

## Before
<img width="1919" height="957" alt="Screenshot 2026-05-23 173235" src="https://github.com/user-attachments/assets/7ad77b8e-394a-478b-8df7-38d242960016" />

## After
<img width="1919" height="915" alt="Screenshot 2026-05-23 185827" src="https://github.com/user-attachments/assets/c9451f4b-bf34-471e-bad2-4b9f0a8b8174" />


## How to Test

1. Run the application:

```bash
npm run dev