### PR TITLE
fix(generator): improve jetbrains font fallback stack

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -20,7 +20,7 @@
 #   Generate new token (classic)
 #   Required scope: read:user
 # ------------------------------------------------------------
-GITHUB_TOKEN=ghp_your_personal_access_token_here
+# GITHUB_TOKEN=ghp_your_personal_access_token_here
 
 
 # ------------------------------------------------------------

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -33,7 +33,7 @@ const TOWER_ANIMATION_CSS = `
   }`;
 
 const FONT_MAP: Record<string, string> = {
-  jetbrains: '"JetBrains Mono", monospace',
+  jetbrains: '"JetBrains Mono", "Fira Code", "Courier New", monospace',
   fira: '"Fira Code", monospace',
   roboto: '"Roboto", sans-serif',
 };


### PR DESCRIPTION
## Description
Improved the fallback font stack for the jetbrains font option in the SVG generator.

The renderer already imports JetBrains Mono via Google Fonts, but some platforms (notably iOS/Safari) may not consistently apply external font imports inside inline SVG rendering. This change improves graceful fallback behavior and prevents serif fallback rendering by using a stronger monospace fallback chain.

Updated fallback stack:
`JetBrains Mono` `Fira Code` `Courier New` `monospace`

Fixes #76 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [x] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
Tested locally on desktop browsers using the `/api/streak` endpoint with `font=jetbrains`.

The updated fallback stack improves graceful degradation when JetBrains Mono is unavailable, reducing the chance of serif fallback rendering on unsupported platforms/browsers.

<img width="749" height="580" alt="Screenshot 2026-05-23 221819" src="https://github.com/user-attachments/assets/63e59d68-1e80-408b-9b7f-78a56c72caf3" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
