### PR TITLE
fix(validation): enforce year >= 2008 with consistent error message in zod schema

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -260,7 +260,7 @@ describe('GET /api/streak', () => {
       const body = await response.json();
 
       expect(response.status).toBe(400);
-      expect(body.details.fieldErrors.year[0]).toContain('Invalid "year" parameter');
+      expect(body.details.fieldErrors.year[0]).toContain('GitHub was founded in 2008');
     });
 
     it('returns 400 for malformed numeric year', async () => {
@@ -268,7 +268,7 @@ describe('GET /api/streak', () => {
       const body = await response.json();
 
       expect(response.status).toBe(400);
-      expect(body.details.fieldErrors.year[0]).toContain('Invalid "year" parameter');
+      expect(body.details.fieldErrors.year[0]).toContain('GitHub was founded in 2008');
     });
 
     it('returns 400 for years before GitHub existed', async () => {
@@ -276,7 +276,7 @@ describe('GET /api/streak', () => {
       const body = await response.json();
 
       expect(response.status).toBe(400);
-      expect(body.details.fieldErrors.year[0]).toContain('Invalid "year" parameter');
+      expect(body.details.fieldErrors.year[0]).toContain('GitHub was founded in 2008');
     });
 
     it('returns 400 for future years', async () => {
@@ -286,7 +286,7 @@ describe('GET /api/streak', () => {
       const body = await response.json();
 
       expect(response.status).toBe(400);
-      expect(body.details.fieldErrors.year[0]).toContain('Invalid "year" parameter');
+      expect(body.details.fieldErrors.year[0]).toContain('GitHub was founded in 2008');
     });
   });
 

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -34,21 +34,18 @@ export const streakParamsSchema = z.object({
   font: z.string().optional(),
   year: z
     .string()
-    .regex(/^\d{4}$/, {
-      message: 'Invalid "year" parameter. Use YYYY format, e.g. 2024.',
-    })
+    .optional()
     .refine(
-      (year) => {
-        const yearNum = parseInt(year, 10);
+      (val) => {
+        if (!val) return true;
+        const yearNum = parseInt(val, 10);
         const currentYear = new Date().getFullYear();
-
-        return yearNum >= 2005 && yearNum <= currentYear;
+        return /^\d{4}$/.test(val) && yearNum >= 2008 && yearNum <= currentYear;
       },
       {
-        message: 'Invalid "year" parameter. Use YYYY format, e.g. 2024.',
+        message: 'GitHub was founded in 2008. Please provide a year of 2008 or later.',
       }
-    )
-    .optional(),
+    ),
   refresh: z
     .string()
     .optional()


### PR DESCRIPTION
## Description

Fixes #146 
- `lib/validations.ts` — updated the `year` field in `streakParamsSchema` to reject any year before 2008 using a single refine check, returning a consistent "GitHub was founded in 2008. Please provide a year of 2008 or later." error message for all invalid year inputs including `non-numeric`, `out-of-range`, and `pre-2008 values`.
 - `app/api/streak/route.test.ts` — updated 4 test assertions to expect the new consistent error message instead of the previous 'Invalid "year" parameter' string.

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
https://collection.cloudinary.com/dqvm8dce2/8a46b6e30ac67c2ca9344f3b72beb8fc

## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME&year=....`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.
