### PR TITLE
fix(og): remove refresh=true from internal streak fetch to prevent unnecessary GitHub API calls

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -16,7 +16,7 @@ export async function GET(req: NextRequest) {
   try {
     const baseUrl = req.nextUrl.origin;
 
-    const res = await fetch(`${baseUrl}/api/streak?user=${user}&refresh=true`, {
+    const res = await fetch(`${baseUrl}/api/streak?user=${user}`, {
       cache: 'no-store',
     });
 


### PR DESCRIPTION
## Description

Fixes #138 
- `app/api/og/route.tsx` — removed `&refresh=true` from the internal `/api/streak` fetch call so social crawlers (Twitterbot, LinkedInBot, Slackbot) hitting `/api/og` use the default cached response instead of forcing a fresh GitHub API call on every request, preventing unnecessary API calls and rate-limit exhaustion.

## Pillar
🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Notice difference in `Cache-Control` values in the 2 cases: 

Without `&refresh=true`:
<img width="1470" height="626" alt="Screenshot 2026-05-23 at 11 44 56 PM" src="https://github.com/user-attachments/assets/c1822cbb-17bc-453c-aea9-45fe2c73bb3c" />

With `&refresh=true`:
<img width="1470" height="629" alt="Screenshot 2026-05-23 at 11 45 18 PM" src="https://github.com/user-attachments/assets/d7899c65-3038-42aa-8ff8-be71cf4b99d4" />

- That difference in the `Cache-Control` header is the proof that removing refresh=true from the OG route makes the OG image use the cached response instead of bypassing it every time.


## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME&refresh=true`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.
