### PR TITLE
refactor(hooks): export MAX and STORAGE_KEY constants from useRecentSearches

### DIFF
--- a/hooks/useRecentSearches.test.ts
+++ b/hooks/useRecentSearches.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useRecentSearches } from './useRecentSearches';
+import { MAX, useRecentSearches } from './useRecentSearches';
 
 const store: Record<string, string> = {};
 
@@ -49,14 +49,14 @@ describe('useRecentSearches', () => {
     expect(result.current.searches.length).toBe(2);
   });
 
-  it('caps at 5 entries', () => {
+  it(`caps at ${MAX} entries`, () => {
     const { result } = renderHook(() => useRecentSearches());
     ['a', 'b', 'c', 'd', 'e', 'f'].forEach((u) => {
       act(() => {
         result.current.addSearch(u);
       });
     });
-    expect(result.current.searches.length).toBe(5);
+    expect(result.current.searches.length).toBe(MAX);
   });
 
   it('clears all searches', () => {

--- a/hooks/useRecentSearches.ts
+++ b/hooks/useRecentSearches.ts
@@ -2,13 +2,13 @@
 
 import { useState } from 'react';
 
-const KEY = 'recentSearches';
-const MAX = 5;
+export const STORAGE_KEY = 'recentSearches';
+export const MAX = 5;
 
 function loadFromStorage(): string[] {
   if (typeof window === 'undefined') return [];
   try {
-    const stored = localStorage.getItem(KEY);
+    const stored = localStorage.getItem(STORAGE_KEY);
     return stored ? (JSON.parse(stored) as string[]) : [];
   } catch {
     return [];
@@ -23,7 +23,7 @@ export function useRecentSearches() {
     setSearches((prev) => {
       const deduped = [query, ...prev.filter((s) => s !== query)].slice(0, MAX);
       try {
-        localStorage.setItem(KEY, JSON.stringify(deduped));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(deduped));
       } catch {}
       return deduped;
     });
@@ -32,7 +32,7 @@ export function useRecentSearches() {
   const clearSearches = () => {
     setSearches([]);
     try {
-      localStorage.removeItem(KEY);
+      localStorage.removeItem(STORAGE_KEY);
     } catch {}
   };
 


### PR DESCRIPTION
Closes #394

Exports MAX and STORAGE_KEY so tests can reference them without hardcoding.