### PR TITLE
refactor(github): validate GitHub username format before making API calls

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -6,6 +6,7 @@ import {
   fetchUserRepos,
   getFullDashboardData,
   generateAchievements,
+  validateGitHubUsername,
   clearGitHubApiCacheForTests,
   GITHUB_CACHE_TTL_MS,
 } from './github';
@@ -37,6 +38,24 @@ beforeEach(() => {
 
 afterEach(() => {
   clearGitHubApiCacheForTests();
+});
+
+describe('validateGitHubUsername', () => {
+  it('returns true for a valid username', () => {
+    expect(validateGitHubUsername('octocat')).toBe(true);
+  });
+
+  it('throws for a username longer than 39 characters', () => {
+    expect(() => validateGitHubUsername('a'.repeat(40))).toThrow('Invalid GitHub username format');
+  });
+
+  it('throws for a username with underscore', () => {
+    expect(() => validateGitHubUsername('invalid_user')).toThrow('Invalid GitHub username format');
+  });
+
+  it('throws for a username with space', () => {
+    expect(() => validateGitHubUsername('user name')).toThrow('Invalid GitHub username format');
+  });
 });
 
 describe('fetchGitHubContributions', () => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -9,6 +9,13 @@ interface GitHubRepo {
   language: string | null;
 }
 
+export function validateGitHubUsername(username: string): boolean {
+  if (!/^[a-zA-Z0-9-]{1,39}$/.test(username)) {
+    throw new Error('Invalid GitHub username format');
+  }
+  return true;
+}
+
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 500;
 const CONTRIBUTION_MILESTONES = [1, 10, 100, 250, 500, 1000];
@@ -106,6 +113,7 @@ export async function fetchGitHubContributions(
   username: string,
   options: FetchOptions = {}
 ): Promise<ContributionCalendar> {
+  validateGitHubUsername(username);
   const key = cacheKey('contributions', username, options.from?.substring(0, 4));
 
   if (!options.bypassCache) {


### PR DESCRIPTION
Closes #407

Adds validateGitHubUsername helper for early validation. Invalid usernames fail fast with a clear message.