### PR TITLE
feat: add customizable border color parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,25 +137,27 @@ URL Parameter > Theme Default > System Fallback
 
 ### Parameter Reference
 
-| Parameter         | Type      | Required   | Default                        | Description                                                                                                                                                               |
-| ----------------- | --------- | ---------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `user`            | `string`  | ✅ **Yes** | —                              | GitHub username to render                                                                                                                                                 |
-| `theme`           | `string`  | No         | `dark`                         | Preset theme name (see below)                                                                                                                                             |
-| `bg`              | `hex`     | No         | Theme default                  | Background color — **without** `#`                                                                                                                                        |
-| `accent`          | `hex`     | No         | Theme default                  | Tower & glow color — **without** `#`                                                                                                                                      |
-| `text`            | `hex`     | No         | Theme default                  | Label & stat text color — **without** `#`                                                                                                                                 |
-| `radius`          | `number`  | No         | `8`                            | Border corner radius in pixels                                                                                                                                            |
-| `speed`           | `string`  | No         | `8s`                           | Radar scan duration (`2s`–`20s`, default `8s`)                                                                                                                            |
-| `scale`           | `string`  | No         | `linear`                       | Tower height scaling: `linear` or `log` (logarithmic)                                                                                                                     |
-| `size`            | `string`  | No         | `medium`                       | Badge dimensions: `small` (400×280), `medium` (600×420), `large` (800×560)                                                                                                |
-| `font`            | `string`  | No         | CommitPulse default typography | Any **Google Font** name (e.g. `Orbitron`, `Inter`)                                                                                                                       |
-| `refresh`         | `boolean` | No         | `false`                        | Bypass cache for real-time data                                                                                                                                           |
-| `year`            | `string`  | No         | —                              | Calendar year to render (e.g. `2023`, `2024`)                                                                                                                             |
-| `hide_title`      | `boolean` | No         | `false`                        | Hide GitHub username/title from the SVG badge                                                                                                                             |
-| `hide_background` | `boolean` | No         | `false`                        | Remove the background rect, letting the monolith float on the page                                                                                                        |
-| `hide_stats`      | `boolean` | No         | `false`                        | Hides the bottom row displaying Current Streak, Annual Sync Total, and Peak Streak stats when set to `true` or `1`.                                                       |
-| `tz`              | `string`  | No         | Omitted = UTC                  | IANA timezone (e.g. `Asia/Kolkata`, `America/New_York`) — aligns "today" with the user local midnight. Note: `?tz=UTC` is valid but cached separately from omitting `tz`. |
-| `lang`            | `string`  | No         | `en`                           | Language code for labels (`en`, `es`, `hi`, `fr`)                                                                                                                         |
+| Parameter | Type     | Required   | Default       | Description                                          |
+| --------- | -------- | ---------- | ------------- | ---------------------------------------------------- |
+| `user`    | `string` | ✅ **Yes** | —             | GitHub username to render                            |
+| `theme`   | `string` | No         | `dark`        | Preset theme name (see below)                        |
+| `bg`      | `hex`    | No         | Theme default | Background color — **without** `#`                   |
+| `accent`  | `hex`    | No         | Theme default | Tower & glow color — **without** `#`                 |
+| `border`  | `hex`    | No         | —             | Border color for the SVG container — **without** `#` |
+
+| `text` | `hex` | No | Theme default | Label & stat text color — **without** `#` |
+| `radius` | `number` | No | `8` | Border corner radius in pixels |
+| `speed` | `string` | No | `8s` | Radar scan duration (`2s`–`20s`, default `8s`) |
+| `scale` | `string` | No | `linear` | Tower height scaling: `linear` or `log` (logarithmic) |
+| `size` | `string` | No | `medium` | Badge dimensions: `small` (400×280), `medium` (600×420), `large` (800×560) |
+| `font` | `string` | No | CommitPulse default typography | Any **Google Font** name (e.g. `Orbitron`, `Inter`) |
+| `refresh` | `boolean` | No | `false` | Bypass cache for real-time data |
+| `year` | `string` | No | — | Calendar year to render (e.g. `2023`, `2024`) |
+| `hide_title` | `boolean` | No | `false` | Hide GitHub username/title from the SVG badge |
+| `hide_background` | `boolean` | No | `false` | Remove the background rect, letting the monolith float on the page |
+| `hide_stats` | `boolean` | No | `false` | Hides the bottom row displaying Current Streak, Annual Sync Total, and Peak Streak stats when set to `true` or `1`. |
+| `tz` | `string` | No | Omitted = UTC | IANA timezone (e.g. `Asia/Kolkata`, `America/New_York`) — aligns "today" with the user local midnight. Note: `?tz=UTC` is valid but cached separately from omitting `tz`. |
+| `lang` | `string` | No | `en` | Language code for labels (`en`, `es`, `hi`, `fr`) |
 
 ### Theme Presets
 

--- a/README.md
+++ b/README.md
@@ -158,29 +158,29 @@ URL Parameter > Theme Default > System Fallback
 | `hide_stats` | `boolean` | No | `false` | Hides the bottom row displaying Current Streak, Annual Sync Total, and Peak Streak stats when set to `true` or `1`. |
 | `tz` | `string` | No | Omitted = UTC | IANA timezone (e.g. `Asia/Kolkata`, `America/New_York`) — aligns "today" with the user local midnight. Note: `?tz=UTC` is valid but cached separately from omitting `tz`. |
 | `lang` | `string` | No | `en` | Language code for labels (`en`, `es`, `hi`, `fr`) |
-| Parameter         | Type      | Required   | Default                        | Description                                                                                                                                                               |
+| Parameter | Type | Required | Default | Description |
 | ----------------- | --------- | ---------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `user`            | `string`  | ✅ **Yes** | —                              | GitHub username to render                                                                                                                                                 |
-| `theme`           | `string`  | No         | `dark`                         | Preset theme name (see below)                                                                                                                                             |
-| `bg`              | `hex`     | No         | Theme default                  | Background color — **without** `#`                                                                                                                                        |
-| `accent`          | `hex`     | No         | Theme default                  | Tower & glow color — **without** `#`                                                                                                                                      |
-| `text`            | `hex`     | No         | Theme default                  | Label & stat text color — **without** `#`                                                                                                                                 |
-| `radius`          | `number`  | No         | `8`                            | Border corner radius in pixels                                                                                                                                            |
-| `speed`           | `string`  | No         | `8s`                           | Radar scan duration (`2s`–`20s`, default `8s`)                                                                                                                            |
-| `scale`           | `string`  | No         | `linear`                       | Tower height scaling: `linear` or `log` (logarithmic)                                                                                                                     |
-| `size`            | `string`  | No         | `medium`                       | Badge dimensions: `small` (400×280), `medium` (600×420), `large` (800×560)                                                                                                |
-| `font`            | `string`  | No         | CommitPulse default typography | Any **Google Font** name (e.g. `Orbitron`, `Inter`)                                                                                                                       |
-| `refresh`         | `boolean` | No         | `false`                        | Bypass cache for real-time data                                                                                                                                           |
-| `year`            | `string`  | No         | —                              | Calendar year to render (e.g. `2023`, `2024`)                                                                                                                             |
-| `hide_title`      | `boolean` | No         | `false`                        | Hide GitHub username/title from the SVG badge                                                                                                                             |
-| `hide_background` | `boolean` | No         | `false`                        | Remove the background rect, letting the monolith float on the page                                                                                                        |
-| `hide_stats`      | `boolean` | No         | `false`                        | Hides the bottom row displaying Current Streak, Annual Sync Total, and Peak Streak stats when set to `true` or `1`.                                                       |
-| `tz`              | `string`  | No         | Omitted = UTC                  | IANA timezone (e.g. `Asia/Kolkata`, `America/New_York`) — aligns "today" with the user local midnight. Note: `?tz=UTC` is valid but cached separately from omitting `tz`. |
-| `lang`            | `string`  | No         | `en`                           | Language code for labels (`en`, `es`, `hi`, `fr`)                                                                                                                         |
-| `view`            | `string`  | No         | `default`                      | Rendering mode: `default` (3D Monolith) or `monthly` (Compact monthly stats)                                                                                              |
-| `delta_format`    | `string`  | No         | `percent`                      | Format for month-over-month delta in monthly view: `percent` (e.g. +12%), `absolute` (e.g. +15 commits), or `both`                                                        |
-| `width`           | `number`  | No         | `300`                          | Custom width for the SVG canvas (currently only applies to `view=monthly`)                                                                                                |
-| `height`          | `number`  | No         | `120`                          | Custom height for the SVG canvas (currently only applies to `view=monthly`)                                                                                               |
+| `user` | `string` | ✅ **Yes** | — | GitHub username to render |
+| `theme` | `string` | No | `dark` | Preset theme name (see below) |
+| `bg` | `hex` | No | Theme default | Background color — **without** `#` |
+| `accent` | `hex` | No | Theme default | Tower & glow color — **without** `#` |
+| `text` | `hex` | No | Theme default | Label & stat text color — **without** `#` |
+| `radius` | `number` | No | `8` | Border corner radius in pixels |
+| `speed` | `string` | No | `8s` | Radar scan duration (`2s`–`20s`, default `8s`) |
+| `scale` | `string` | No | `linear` | Tower height scaling: `linear` or `log` (logarithmic) |
+| `size` | `string` | No | `medium` | Badge dimensions: `small` (400×280), `medium` (600×420), `large` (800×560) |
+| `font` | `string` | No | CommitPulse default typography | Any **Google Font** name (e.g. `Orbitron`, `Inter`) |
+| `refresh` | `boolean` | No | `false` | Bypass cache for real-time data |
+| `year` | `string` | No | — | Calendar year to render (e.g. `2023`, `2024`) |
+| `hide_title` | `boolean` | No | `false` | Hide GitHub username/title from the SVG badge |
+| `hide_background` | `boolean` | No | `false` | Remove the background rect, letting the monolith float on the page |
+| `hide_stats` | `boolean` | No | `false` | Hides the bottom row displaying Current Streak, Annual Sync Total, and Peak Streak stats when set to `true` or `1`. |
+| `tz` | `string` | No | Omitted = UTC | IANA timezone (e.g. `Asia/Kolkata`, `America/New_York`) — aligns "today" with the user local midnight. Note: `?tz=UTC` is valid but cached separately from omitting `tz`. |
+| `lang` | `string` | No | `en` | Language code for labels (`en`, `es`, `hi`, `fr`) |
+| `view` | `string` | No | `default` | Rendering mode: `default` (3D Monolith) or `monthly` (Compact monthly stats) |
+| `delta_format` | `string` | No | `percent` | Format for month-over-month delta in monthly view: `percent` (e.g. +12%), `absolute` (e.g. +15 commits), or `both` |
+| `width` | `number` | No | `300` | Custom width for the SVG canvas (currently only applies to `view=monthly`) |
+| `height` | `number` | No | `120` | Custom height for the SVG canvas (currently only applies to `view=monthly`) |
 
 ### Theme Presets
 

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -30,6 +30,7 @@ export async function GET(request: Request) {
       bg,
       text,
       accent,
+      border,
       scale,
       size,
       speed,
@@ -79,6 +80,7 @@ export async function GET(request: Request) {
       bg: isAutoTheme ? selectedTheme.bg : bg || selectedTheme.bg,
       text: isAutoTheme ? selectedTheme.text : text || selectedTheme.text,
       accent: isAutoTheme ? selectedTheme.accent : accent || selectedTheme.accent,
+      border,
 
       radius,
       speed,

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -196,7 +196,13 @@ export function generateSVG(
   @media (prefers-reduced-motion: reduce) { .heat-particles { display: none; } }
   </style>
 
-  <rect width="${W}" height="${H}" rx="${radius}" fill="${params.hideBackground ? 'transparent' : bg}" />
+  <rect
+   width="${W}"
+   height="${H}"
+   rx="${radius}"
+   fill="${params.hideBackground ? 'transparent' : bg}"
+   ${params.border ? `stroke="#${params.border}" stroke-width="2"` : ''}
+  />
 
   <g transform="translate(0, ${s(20)})">${towers}</g>
   ${

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -169,45 +169,8 @@ function renderFooter(
   sf: number
 ): string {
   const s = (n: number) => Math.round(n * sf);
+
   return `
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="${W}"
-  height="${H}"
-  viewBox="0 0 ${W} ${H}"
-  fill="none"
-  role="img"
->
-  <title>CommitPulse Stats for ${safeUser}</title>
-  <desc>
-    ${params.user || 'This user'} has ${stats.totalContributions} total contributions and a longest streak of ${stats.longestStreak} days.
-  </desc>
-  <defs>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%"><feGaussianBlur stdDeviation="${fs(5)}" result="blur" /><feComposite in="SourceGraphic" in2="blur" operator="over" /></filter>
-  </defs>
-
-  <style>
-  @import url('https://fonts.googleapis.com/css2?family=Fira+Code&amp;family=JetBrains+Mono&amp;family=Roboto&amp;display=swap');
-  ${googleFontsImport}
-  ${TOWER_ANIMATION_CSS}
-
-  .title { font-family: ${selectedFont || '"Syncopate", sans-serif'}; fill: ${text}; font-size: ${fs(18)}px; letter-spacing: ${fs(6)}px; font-weight: 400; opacity: 0.8; }
-  .stats { font-family: ${statsFont}; fill: ${text}; font-size: ${fs(42)}px; font-weight: 500; letter-spacing: 0; }
-  .total-val { font-family: ${statsFont}; fill: ${accent}; font-size: ${fs(24)}px; font-weight: 500; }
-  .label { font-family: "Roboto", sans-serif; fill: ${accent}; font-size: ${fs(11)}px; font-weight: 400; letter-spacing: ${fs(2)}px; opacity: 0.7; }
-
-  @media (prefers-reduced-motion: reduce) { .heat-particles { display: none; } }
-  </style>
-
-  <rect
-   width="${W}"
-   height="${H}"
-   rx="${radius}"
-   fill="${params.hideBackground ? 'transparent' : bg}"
-   ${params.border ? `stroke="#${params.border}" stroke-width="2"` : ''}
-  />
-
-  <g transform="translate(0, ${s(20)})">${towers}</g>
   ${
     !params.hide_stats
       ? `
@@ -215,19 +178,39 @@ function renderFooter(
     <text class="label">${labels.CURRENT_STREAK}</text>
     <text y="${s(40)}" class="stats" filter="url(#glow)">${stats.currentStreak}</text>
   </g>
+
   <g transform="translate(${s(300)}, ${s(340)})" text-anchor="middle">
     <text class="label">${labels.ANNUAL_SYNC_TOTAL}</text>
     <text y="${s(40)}" class="total-val" filter="url(#glow)">${stats.totalContributions}</text>
   </g>
+
   <g transform="translate(${s(560)}, ${s(340)})" text-anchor="end">
     <text class="label">${labels.PEAK_STREAK}</text>
     <text y="${s(40)}" class="stats">${stats.longestStreak}</text>
   </g>`
       : ''
   }
-  ${!params.hide_title ? `<text x="${s(300)}" y="${s(50)}" text-anchor="middle" class="title">${safeUser.toUpperCase()}</text>` : ''}
-  <rect x="${s(100)}" y="${s(60)}" width="${s(400)}" height="${sf}" fill="${accent}" fill-opacity="0.3">
-    <animate attributeName="y" values="${s(80)};${s(320)};${s(80)}" dur="${params.speed || '8s'}" repeatCount="indefinite" />
+
+  ${
+    !params.hide_title
+      ? `<text x="${s(300)}" y="${s(50)}" text-anchor="middle" class="title">${safeUser.toUpperCase()}</text>`
+      : ''
+  }
+
+  <rect
+    x="${s(100)}"
+    y="${s(60)}"
+    width="${s(400)}"
+    height="${sf}"
+    fill="${accent}"
+    fill-opacity="0.3"
+  >
+    <animate
+      attributeName="y"
+      values="${s(80)};${s(320)};${s(80)}"
+      dur="${params.speed || '8s'}"
+      repeatCount="indefinite"
+    />
   </rect>`;
 }
 

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -18,6 +18,10 @@ export const streakParamsSchema = z.object({
     .string()
     .optional()
     .transform((val) => (val ? sanitizeHexColor(val, '00ffaa') : undefined)),
+  border: z
+    .string()
+    .optional()
+    .transform((val) => (val ? sanitizeHexColor(val, 'ffffff') : undefined)),
 
   // Silently fall back to 'linear' for unknown values (matches old behavior)
   scale: z.enum(['linear', 'log']).catch('linear').default('linear'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9990,24 +9990,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",

--- a/types/index.ts
+++ b/types/index.ts
@@ -30,6 +30,7 @@ export interface BadgeParams {
   bg: string;
   text: string;
   accent: string;
+  border?: string;
   speed: string;
   scale: 'linear' | 'log';
   font?: string;


### PR DESCRIPTION
Fixes #151

## Description
Adds a customizable `border` URL parameter for the SVG streak card container.

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [x] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕰️ Pillar 3 — Timezone Logic Optimization
- [ ] 🛠 Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` for the new URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit in this PR.
- [x] The SVG output matches the CommitPulse aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord server.

## Changes
- Added `border` parameter support in SVG generator
- Passed `border` parameter through API route
- Updated README parameter documentation