### PR TITLE
refactor(github): validate username format before GraphQL calls

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -8,6 +8,7 @@ import {
   generateAchievements,
   clearGitHubApiCacheForTests,
   GITHUB_CACHE_TTL_MS,
+  validateGitHubUsername,
 } from './github';
 import type { ContributionCalendar } from '../types';
 
@@ -37,6 +38,23 @@ beforeEach(() => {
 
 afterEach(() => {
   clearGitHubApiCacheForTests();
+});
+
+describe('validateGitHubUsername', () => {
+  it('accepts valid GitHub usernames', () => {
+    expect(validateGitHubUsername('octocat')).toBe(true);
+    expect(validateGitHubUsername('github-actions')).toBe(true);
+    expect(validateGitHubUsername('user123')).toBe(true);
+  });
+
+  it('rejects invalid GitHub usernames', () => {
+    expect(validateGitHubUsername('a'.repeat(40))).toBe(false);
+    expect(validateGitHubUsername('octo_cat')).toBe(false);
+    expect(validateGitHubUsername('octo cat')).toBe(false);
+    expect(validateGitHubUsername('-octocat')).toBe(false);
+    expect(validateGitHubUsername('octocat-')).toBe(false);
+    expect(validateGitHubUsername('octo--cat')).toBe(false);
+  });
 });
 
 describe('fetchGitHubContributions', () => {
@@ -99,6 +117,14 @@ describe('fetchGitHubContributions', () => {
     const result = await fetchGitHubContributions('new-user');
 
     expect(result).toEqual(emptyCalendar);
+  });
+
+  it('throws before fetching when the username format is invalid', async () => {
+    await expect(fetchGitHubContributions('octo_cat')).rejects.toThrow(
+      'Invalid GitHub username format'
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it('throws with the status code when the server returns 500', async () => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -66,6 +66,10 @@ type FetchOptions = {
 
 export const GITHUB_CACHE_TTL_MS = 5 * 60 * 1000;
 
+export function validateGitHubUsername(username: string): boolean {
+  return /^(?!-)(?!.*--)[A-Za-z0-9-]{1,39}(?<!-)$/.test(username);
+}
+
 interface GitHubUserProfile {
   login: string;
   name: string | null;
@@ -106,6 +110,10 @@ export async function fetchGitHubContributions(
   username: string,
   options: FetchOptions = {}
 ): Promise<ContributionCalendar> {
+  if (!validateGitHubUsername(username)) {
+    throw new Error('Invalid GitHub username format');
+  }
+
   const key = cacheKey('contributions', username, options.from?.substring(0, 4));
 
   if (!options.bypassCache) {


### PR DESCRIPTION
## Summary
- Add `validateGitHubUsername` to enforce GitHub username format before contribution GraphQL requests
- Throw `Invalid GitHub username format` before hitting the API for invalid usernames
- Add validator coverage for valid names, too-long names, underscores, spaces, leading/trailing hyphens, and consecutive hyphens

Closes #407

## Verification
- `npm test -- lib/github.test.ts`
- `npm run lint -- lib/github.ts lib/github.test.ts`
- `npm run typecheck`
- `git diff --check`