### PR TITLE
feat(github): add AbortController timeout to fetchWithRetry with per-endpoint defaults

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -13,27 +13,43 @@ const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 500;
 const CONTRIBUTION_MILESTONES = [1, 10, 100, 250, 500, 1000];
 const STREAK_MILESTONES = [3, 7, 30, 100];
+const GRAPHQL_TIMEOUT_MS = 8000; // 8s for GraphQL endpoint
+const REST_TIMEOUT_MS = 5000; // 5s for REST endpoints
 
-/**
- * Wraps fetch with exponential backoff retry logic.
- * Retries ONLY on network errors, 429 Too Many Requests, and 5xx server errors.
- * Returns immediately for all other statuses (2xx success, 3xx redirects, 4xx client errors).
- */
 export async function fetchWithRetry(
   url: string,
   options: RequestInit,
-  attempt = 0
+  attempt = 0,
+  timeoutMs?: number
 ): Promise<Response> {
+  // Determine default timeout based on endpoint type if not explicitly provided.
+  // GraphQL calls carry a larger payload and need a slightly longer window.
+  const resolvedTimeout =
+    timeoutMs ?? (url.includes('graphql') ? GRAPHQL_TIMEOUT_MS : REST_TIMEOUT_MS);
+
+  // Each retry attempt gets a fresh AbortController so the timeout window
+  // resets per attempt — not cumulative across the entire retry chain.
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), resolvedTimeout);
+
   let res: Response | null = null;
   try {
-    res = await fetch(url, options);
+    res = await fetch(url, { ...options, signal: controller.signal });
   } catch (err) {
+    clearTimeout(timeoutId);
+    // AbortError means the timeout fired — throw a clear typed message.
+    if (err instanceof Error && err.name === 'AbortError') {
+      const seconds = resolvedTimeout / 1000;
+      throw new Error(`GitHub API request timed out after ${seconds}s`);
+    }
     // Network error — retry if attempts remain, otherwise rethrow
     if (attempt >= MAX_RETRIES) throw err;
     const delay = BASE_DELAY_MS * Math.pow(2, attempt);
     await new Promise((resolve) => setTimeout(resolve, delay));
-    return fetchWithRetry(url, options, attempt + 1);
+    return fetchWithRetry(url, options, attempt + 1, timeoutMs);
   }
+
+  clearTimeout(timeoutId);
 
   // Only retry on 429 or 5xx — all other statuses are returned immediately
   const shouldRetry = res.status === 429 || res.status >= 500;
@@ -41,7 +57,7 @@ export async function fetchWithRetry(
 
   const delay = BASE_DELAY_MS * Math.pow(2, attempt);
   await new Promise((resolve) => setTimeout(resolve, delay));
-  return fetchWithRetry(url, options, attempt + 1);
+  return fetchWithRetry(url, options, attempt + 1, timeoutMs);
 }
 
 const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9990,24 +9990,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",


### PR DESCRIPTION
## Description

Fixes #273 

- Added two constants `GRAPHQL_TIMEOUT_MS` and `REST_TIMEOUT_MS` for the default timeouts
- Added optional `timeoutMs` parameter to `fetchWithRetry` for `per-call override`
- Added `AbortController` with `setTimeout` — fires after the resolved timeout and aborts the fetch
- Passed `signal: controller.signal` into the fetch options
- `clearTimeout` called in both success and error paths to avoid memory leaks
- `AbortError` is caught specifically and throws a clean typed message "GitHub API request timed out after Xs"
- Recursive retry calls pass `timeoutMs` through so each attempt gets its own fresh timeout window
- All existing retry logic for network errors and 5xx remains completely intact
- No other files need changes — `route.ts` error SVG already catches all Error instances and renders them cleanly.

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

- With `GRAPHQL_TIMEOUT_MS` and `REST_TIMEOUT_MS` set to a very small value like `1`:
<img width="508" height="313" alt="Screenshot 2026-05-24 at 8 50 32 PM" src="https://github.com/user-attachments/assets/34f91c6c-2b64-4855-abc4-87c7f6b29c2b" />
<img width="516" height="210" alt="Screenshot 2026-05-24 at 8 50 52 PM" src="https://github.com/user-attachments/assets/4789b216-c796-48de-9faf-6927535ef5f5" />

- With `GRAPHQL_TIMEOUT_MS` and `REST_TIMEOUT_MS` set to appropriate values like `8000` & `5000` respectively:
<img width="668" height="546" alt="Screenshot 2026-05-24 at 8 51 35 PM" src="https://github.com/user-attachments/assets/44d7383d-e2bd-4b19-b4cf-71fbefe7a3bb" />


## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.
- The SVG output matches the CommitPulse "premium quality" aesthetic standard.