### PR TITLE
fix(api): return 400 for malformed JSON bodies in /api/track-user

### DIFF
--- a/app/api/track-user/route.test.ts
+++ b/app/api/track-user/route.test.ts
@@ -33,6 +33,21 @@ describe('POST /api/track-user', () => {
   });
 
   describe('Validation', () => {
+    it('returns 400 for malformed JSON request bodies', async () => {
+      const malformedRequest = {
+        json: vi.fn().mockRejectedValue(new SyntaxError('Unexpected token')),
+      } as unknown as Request;
+
+      const response = await POST(malformedRequest);
+
+      expect(response.status).toBe(400);
+
+      const data = await response.json();
+
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Malformed JSON request body');
+    });
+
     it('returns 400 when username is missing', async () => {
       const response = await POST(makeRequest({}));
       expect(response.status).toBe(400);

--- a/app/api/track-user/route.ts
+++ b/app/api/track-user/route.ts
@@ -1,11 +1,20 @@
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/mongodb';
 import { User } from '@/models/User';
-
 export async function POST(req: Request) {
+  let body: unknown;
+
   try {
-    const body = await req.json();
-    const { username } = body;
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Malformed JSON request body' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { username } = body as { username?: unknown };
 
     if (!username || typeof username !== 'string') {
       return NextResponse.json(
@@ -35,6 +44,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Error tracking user:', error);
+
     return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Description

Fixes #422
## Changes made

- Added dedicated handling for malformed JSON request bodies in `/api/track-user`
- Returns `400 Bad Request` instead of generic `500 Internal Server Error`
- Added focused test coverage for malformed JSON parsing failures
- Preserved existing behavior for valid requests and server-side failures


## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
