### PR TITLE
fix(github): validate username format before API call

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -411,4 +411,16 @@ describe('validateGitHubUsername', () => {
   it('returns false for a username with spaces', () => {
     expect(validateGitHubUsername('invalid username')).toBe(false);
   });
+
+  it('returns false for a leading hyphen', () => {
+    expect(validateGitHubUsername('-invalid')).toBe(false);
+  });
+
+  it('returns false for a trailing hyphen', () => {
+    expect(validateGitHubUsername('invalid-')).toBe(false);
+  });
+
+  it('returns false for consecutive hyphens', () => {
+    expect(validateGitHubUsername('in--valid')).toBe(false);
+  });
 });

--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -8,6 +8,7 @@ import {
   generateAchievements,
   clearGitHubApiCacheForTests,
   GITHUB_CACHE_TTL_MS,
+  validateGitHubUsername,
 } from './github';
 import type { ContributionCalendar } from '../types';
 
@@ -391,5 +392,23 @@ describe('generateAchievements', () => {
     expect(unlocked.some((a) => a.title === '30 Day Streak')).toBe(true);
 
     expect(unlocked.some((a) => a.title === '100 Day Streak')).toBe(false);
+  });
+});
+
+describe('validateGitHubUsername', () => {
+  it('returns true for a valid username', () => {
+    expect(validateGitHubUsername('valid-username-123')).toBe(true);
+  });
+
+  it('returns false for a too long username', () => {
+    expect(validateGitHubUsername('a'.repeat(40))).toBe(false);
+  });
+
+  it('returns false for a username with underscore', () => {
+    expect(validateGitHubUsername('invalid_username')).toBe(false);
+  });
+
+  it('returns false for a username with spaces', () => {
+    expect(validateGitHubUsername('invalid username')).toBe(false);
   });
 });

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -102,10 +102,18 @@ const getHeaders = () => ({
   'Content-Type': 'application/json',
 });
 
+export function validateGitHubUsername(username: string): boolean {
+  return /^[a-zA-Z0-9-]{1,39}$/.test(username);
+}
+
 export async function fetchGitHubContributions(
   username: string,
   options: FetchOptions = {}
 ): Promise<ContributionCalendar> {
+  if (!validateGitHubUsername(username)) {
+    throw new Error('Invalid GitHub username format');
+  }
+
   const key = cacheKey('contributions', username, options.from?.substring(0, 4));
 
   if (!options.bypassCache) {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -103,7 +103,7 @@ const getHeaders = () => ({
 });
 
 export function validateGitHubUsername(username: string): boolean {
-  return /^[a-zA-Z0-9-]{1,39}$/.test(username);
+  return /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i.test(username);
 }
 
 export async function fetchGitHubContributions(
@@ -178,6 +178,10 @@ export async function fetchUserProfile(
   username: string,
   options: FetchOptions = {}
 ): Promise<GitHubUserProfile> {
+  if (!validateGitHubUsername(username)) {
+    throw new Error('Invalid GitHub username format');
+  }
+
   const key = cacheKey('profile', username);
 
   if (!options.bypassCache) {
@@ -208,6 +212,10 @@ export async function fetchUserRepos(
   username: string,
   options: FetchOptions = {}
 ): Promise<GitHubRepo[]> {
+  if (!validateGitHubUsername(username)) {
+    throw new Error('Invalid GitHub username format');
+  }
+
   const key = cacheKey('repos', username);
 
   if (!options.bypassCache) {
@@ -281,6 +289,9 @@ export function generateAchievements(totalContributions: number, currentStreak: 
 }
 
 export async function getFullDashboardData(username: string, options: FetchOptions = {}) {
+  if (!validateGitHubUsername(username)) {
+    throw new Error('Invalid GitHub username format');
+  }
   try {
     const [profileData, reposData, calendarData] = await Promise.all([
       fetchUserProfile(username, options),


### PR DESCRIPTION
## Description
Added GitHub username validation before making API calls.
- Added validateGitHubUsername helper
- Added early validation before API request
- Throw clear error for invalid usernames
- Added tests for valid username, too long username, underscore, and spaces.

Fixes #407

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
