### PR TITLE
test(svg): add tests for particle count variation

### DIFF
--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateSVG, generateMonthlySVG } from './generator';
+import { generateSVG, generateMonthlySVG, particleCount } from './generator';
 import type { BadgeParams, ContributionCalendar, StreakStats, MonthlyStats } from '../../types';
 
 describe('generateSVG', () => {
@@ -422,5 +422,24 @@ describe('generateMonthlySVG', () => {
     } as unknown as BadgeParams);
     expect(svg).toContain('width="400"');
     expect(svg).toContain('height="200"');
+  });
+});
+
+describe('particleCount', () => {
+  it('returns 0 when count is 0', () => {
+    expect(particleCount(0)).toBe(0);
+  });
+
+  it('clamps to lower bound of 3 for low counts (e.g., 10 -> 3)', () => {
+    expect(particleCount(10)).toBe(3);
+  });
+
+  it('scales correctly between bounds (e.g., 16 -> 4)', () => {
+    expect(particleCount(16)).toBe(4);
+  });
+
+  it('clamps to upper bound of 5 for high counts (e.g., 20 -> 5, 100 -> 5)', () => {
+    expect(particleCount(20)).toBe(5);
+    expect(particleCount(100)).toBe(5);
   });
 });

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -45,6 +45,12 @@ export function escapeXML(str: string): string {
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 }
+
+export function particleCount(count: number): number {
+  if (count === 0) return 0;
+  return Math.min(5, Math.max(3, Math.floor(count / 4)));
+}
+
 function generateParticles(
   x: number,
   y: number,
@@ -54,9 +60,9 @@ function generateParticles(
   sf: number
 ): string {
   let particles = '';
-  const particleCount = Math.min(5, Math.max(3, Math.floor(count / 4)));
+  const numParticles = particleCount(count);
 
-  for (let i = 0; i < particleCount; i++) {
+  for (let i = 0; i < numParticles; i++) {
     const seed = `${x}:${y}:${height}:${color}:${count}:${i}`;
     const offsetX = deterministicRandom(`${seed}:offsetX`) * 6 - 3;
     const delay = deterministicRandom(`${seed}:delay`) * 1.5;
@@ -79,9 +85,9 @@ function generateAutoParticles(
   sf: number
 ): string {
   let particles = '';
-  const particleCount = Math.min(5, Math.max(3, Math.floor(count / 4)));
+  const numParticles = particleCount(count);
 
-  for (let i = 0; i < particleCount; i++) {
+  for (let i = 0; i < numParticles; i++) {
     const seed = `${x}:${y}:${height}:auto:${count}:${i}`;
     const offsetX = deterministicRandom(`${seed}:offsetX`) * 6 - 3;
     const delay = deterministicRandom(`${seed}:delay`) * 1.5;


### PR DESCRIPTION
## Description

Fixes #402

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

None needed for logic tests

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

## Summary
- extracted particleCount helper
- added unit tests for clamp/scaling behavior
- replaced inline particle count logic
