### PR TITLE
test(generator): add coverage for tower top white highlight on count > 5

### DIFF
--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -377,6 +377,52 @@ describe('generateSVG', () => {
       expect(svg).not.toContain('attributeName="opacity" values="1;0.4;1"');
     });
   });
+
+  describe('tower top highlight', () => {
+    it('renders white highlight on tower top when contributionCount > 5', () => {
+      const calendarWithHighCount: ContributionCalendar = {
+        totalContributions: 9,
+        weeks: [
+          {
+            contributionDays: [
+              { contributionCount: 6, date: '2024-06-10' },
+              { contributionCount: 3, date: '2024-06-11' },
+            ],
+          },
+        ],
+      };
+
+      const svg = generateSVG(
+        mockStats,
+        { user: 'avi' } as unknown as BadgeParams,
+        calendarWithHighCount
+      );
+
+      expect(svg).toContain('fill="white" fill-opacity="0.2"');
+    });
+
+    it('does not render white highlight when all days have contributionCount <= 5', () => {
+      const calendarWithLowCount: ContributionCalendar = {
+        totalContributions: 8,
+        weeks: [
+          {
+            contributionDays: [
+              { contributionCount: 3, date: '2024-06-10' },
+              { contributionCount: 5, date: '2024-06-11' },
+            ],
+          },
+        ],
+      };
+
+      const svg = generateSVG(
+        mockStats,
+        { user: 'avi' } as unknown as BadgeParams,
+        calendarWithLowCount
+      );
+
+      expect(svg).not.toContain('fill="white" fill-opacity="0.2"');
+    });
+  });
 });
 
 describe('generateMonthlySVG', () => {


### PR DESCRIPTION
## Description

Fixes #404 

- Added focused `test coverage` for the `tower-top white highlight rendering` in `generateSVG`, verifying it appears when `contributionCount > 5`.
- Added a complementary `negative test` to ensure the highlight is not rendered when all contribution counts are ≤ 5, improving regression safety for SVG rendering behaviour.

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format).
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.
