### PR TITLE
feat(ui): add gruvbox and highcontrast theme icons

### DIFF
--- a/app/customize/components/ThemeQuickPresets.tsx
+++ b/app/customize/components/ThemeQuickPresets.tsx
@@ -305,7 +305,46 @@ function IconSynthwave({ bg, text, accent }: IC): ReactElement {
   );
 }
 
-const ICON_MAP: Record<string, (c: IC) => ReactElement> = {
+function IconGruvbox({ text, accent }: IC): ReactElement {
+  return (
+    <svg width="22" height="22" viewBox="0 0 28 28" fill="none" aria-hidden="true">
+      {/* lantern body */}
+      <rect x="10" y="13" width="8" height="10" rx="1.5" fill={text} opacity="0.75" />
+      {/* lantern top cap */}
+      <rect x="9" y="12" width="10" height="2.5" rx="1" fill={text} opacity="0.85" />
+      {/* handle */}
+      <path
+        d="M12 12 Q14 6 16 12"
+        stroke={text}
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        fill="none"
+        opacity="0.6"
+      />
+      {/* warm glow */}
+      <ellipse cx="14" cy="18" rx="2.8" ry="3.5" fill={accent} opacity="0.85" />
+      {/* flame core */}
+      <path d="M14 15 Q12.5 18 14 20 Q15.5 18 14 15 Z" fill={accent} opacity="0.95" />
+    </svg>
+  );
+}
+
+function IconHighcontrast({ text, accent }: IC): ReactElement {
+  return (
+    <svg width="22" height="22" viewBox="0 0 28 28" fill="none" aria-hidden="true">
+      {/* outer eye shape */}
+      <path d="M2 14 C6 6 22 6 26 14 C22 22 6 22 2 14 Z" fill={accent} opacity="0.88" />
+      {/* iris */}
+      <circle cx="14" cy="14" r="5" fill={text} opacity="0.9" />
+      {/* pupil */}
+      <circle cx="14" cy="14" r="2.2" fill="#000" opacity="0.95" />
+      {/* catchlight */}
+      <circle cx="15.8" cy="12.5" r="1.2" fill="#fff" opacity="0.85" />
+    </svg>
+  );
+}
+
+const ICON_MAP: Record<ThemeKey, (c: IC) => ReactElement> = {
   dark: (c) => <IconDark {...c} />,
   light: (c) => <IconLight {...c} />,
   neon: (c) => <IconNeon {...c} />,
@@ -317,6 +356,8 @@ const ICON_MAP: Record<string, (c: IC) => ReactElement> = {
   rose: (c) => <IconRose {...c} />,
   nord: (c) => <IconNord {...c} />,
   synthwave: (c) => <IconSynthwave {...c} />,
+  gruvbox: (c) => <IconGruvbox {...c} />,
+  highcontrast: (c) => <IconHighcontrast {...c} />,
 };
 
 export function ThemeQuickPresets({ theme, onThemeChange }: ThemeQuickPresetsProps): ReactElement {


### PR DESCRIPTION
## Description

Added the missing `gruvbox` and `highcontrast` quick preset icons to the `ThemeQuickPresets` component, resolving the missing icon issue in the customization panel.
- Designed and implemented a custom SVG lantern/flame icon for the **Gruvbox** theme.
- Designed and implemented a custom SVG eye icon for the **Highcontrast** theme.
- Registered both icons in the `ICON_MAP` under `app/customize/components/ThemeQuickPresets.tsx`.

Fixes #358 

## Pillar

- [x] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

<table align="center">
<tr>
<td align="center">

## GruvBox

<img src="https://github.com/user-attachments/assets/59b8e408-91f2-4676-b0c4-717c75ea9c0c" width="500" alt="GruvBox theme preview" />

</td>

<td align="center">

## HighContrast

<img src="https://github.com/user-attachments/assets/00e5ae83-c69c-460b-9efd-31c5d7995621" width="539" alt="HighContrast theme preview" />

</td>
</tr>
</table>

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
