### PR TITLE
docs(readme): add examples for missing URL parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,22 @@ URL Parameter > Theme Default > System Fallback
 <!-- Hide GitHub username/title -->
 
 ![](https://commitpulse.vercel.app/api/streak?user=jhasourav07&hide_title=true)
+
+<!-- Hide bottom statistics row -->
+
+![](https://commitpulse.vercel.app/api/streak?user=jhasourav07&hide_stats=true)
+
+<!-- Use local timezone instead of UTC -->
+
+![](https://commitpulse.vercel.app/api/streak?user=jhasourav07&tz=Asia/Kolkata)
+
+<!-- Render labels in Hindi -->
+
+![](https://commitpulse.vercel.app/api/streak?user=jhasourav07&lang=hi)
+
+<!-- Large badge size -->
+
+![](https://commitpulse.vercel.app/api/streak?user=jhasourav07&size=large)
 ```
 
 ---


### PR DESCRIPTION
## Description

Fixes #383

Added example URL snippets for the following undocumented README parameters:

1. hide_stats
2. tz
3. lang
4. size

These examples follow the existing canonical URL format and improve usability for new users.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="1245" height="1007" alt="image" src="https://github.com/user-attachments/assets/91b8cbcc-428a-450d-bfd7-a57bfd9c92d1" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
