### PR TITLE
refactor(dashboard): add role and aria-labels to ActivityLandscape chart for screen reader support

### DIFF
--- a/components/dashboard/ActivityLandscape.tsx
+++ b/components/dashboard/ActivityLandscape.tsx
@@ -58,13 +58,21 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
       </div>
 
       {/* Graph */}
-      <div className="h-[200px] w-full flex items-end justify-between gap-[2px] relative">
+      <div
+        className="h-[200px] w-full flex items-end justify-between gap-[2px] relative"
+        role="img"
+        aria-label="Activity chart showing commit frequency over time"
+      >
         {displayData.map((day, i) => {
           const heightPercent = Math.max((day.count / maxCount) * 100, 3);
           const isHigh = day.intensity >= 3;
 
           return (
-            <div key={i} className="relative flex-1 flex items-end group/bar h-full">
+            <div
+              key={i}
+              className="relative flex-1 flex items-end group/bar h-full"
+              aria-label={`${day.date}: ${day.count} commits`}
+            >
               {/* Tooltip */}
               <div className="absolute -top-11 left-1/2 -translate-x-1/2 bg-[#111] border border-[rgba(255,255,255,0.1)] px-2.5 py-1.5 rounded-md opacity-0 group-hover/bar:opacity-100 transition-opacity duration-150 pointer-events-none z-20 flex flex-col items-center whitespace-nowrap shadow-xl">
                 <span className="text-[10px] text-[#A1A1AA]">{day.date}</span>


### PR DESCRIPTION
## Description

Fixes #405

- `components/dashboard/ActivityLandscape.tsx` — added `role="img"` and `aria-label="Activity chart showing commit frequency over time"` to the chart container `<div>`, and added descriptive `aria-label` attributes to each individual bar in the format `"<date>: <count> commits"` so screen readers can meaningfully announce both the chart as a whole and each day's contribution data.

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="1373" height="628" alt="Screenshot 2026-05-25 at 1 54 43 PM" src="https://github.com/user-attachments/assets/bbc6404e-543f-4b09-97b9-263c326932b4" />

- Note: The `chart container div` has `role="img"` and `aria-label="Activity chart showing commit frequency over time"`.


## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/dashboard/YOUR_USERNAME`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.
