### PR TITLE
refactor: move trackUser to shared utility

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-
+import { trackUser } from '@/utils/tracking';
 import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { useRef, useState, useEffect } from 'react';
@@ -64,20 +64,6 @@ const Icons = {
     </svg>
   ),
 };
-
-function trackUser(name: string) {
-  const payload = JSON.stringify({ username: name });
-  // sendBeacon is truly fire-and-forget — it doesn't block navigation
-  if (navigator.sendBeacon) {
-    navigator.sendBeacon('/api/track-user', new Blob([payload], { type: 'application/json' }));
-  } else {
-    fetch('/api/track-user', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: payload,
-    }).catch(console.error);
-  }
-}
 
 export default function LandingPage() {
   const [username, setUsername] = useState('');

--- a/utils/tracking.test.ts
+++ b/utils/tracking.test.ts
@@ -1,10 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { trackUser } from './tracking';
 
+const originalSendBeacon = navigator.sendBeacon;
+
 describe('trackUser', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+
+    Object.defineProperty(navigator, 'sendBeacon', {
+      value: originalSendBeacon,
+      configurable: true,
+    });
   });
 
   it('uses sendBeacon when available', () => {

--- a/utils/tracking.test.ts
+++ b/utils/tracking.test.ts
@@ -18,10 +18,7 @@ describe('trackUser', () => {
     trackUser('testuser');
 
     expect(sendBeaconMock).toHaveBeenCalledTimes(1);
-    expect(sendBeaconMock).toHaveBeenCalledWith(
-      '/api/track-user',
-      expect.any(Blob)
-    );
+    expect(sendBeaconMock).toHaveBeenCalledWith('/api/track-user', expect.any(Blob));
   });
 
   it('falls back to fetch when sendBeacon is not available', () => {

--- a/utils/tracking.test.ts
+++ b/utils/tracking.test.ts
@@ -1,0 +1,42 @@
+import { trackUser } from './tracking';
+
+describe('trackUser', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses navigator.sendBeacon when available', () => {
+    const sendBeaconMock = vi.fn();
+
+    Object.defineProperty(navigator, 'sendBeacon', {
+      value: sendBeaconMock,
+      configurable: true,
+    });
+
+    trackUser('testuser');
+
+    expect(sendBeaconMock).toHaveBeenCalledTimes(1);
+    expect(sendBeaconMock).toHaveBeenCalledWith(
+      '/api/track-user',
+      expect.any(Blob)
+    );
+  });
+
+  it('falls back to fetch when sendBeacon is not available', () => {
+    Object.defineProperty(navigator, 'sendBeacon', {
+      value: undefined,
+      configurable: true,
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue({});
+    global.fetch = fetchMock;
+
+    trackUser('testuser');
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/track-user', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'testuser' }),
+    });
+  });
+});

--- a/utils/tracking.test.ts
+++ b/utils/tracking.test.ts
@@ -17,10 +17,7 @@ describe('trackUser', () => {
     trackUser('testuser');
 
     expect(sendBeaconMock).toHaveBeenCalledTimes(1);
-    expect(sendBeaconMock).toHaveBeenCalledWith(
-      '/api/track-user',
-      expect.any(Blob)
-    );
+    expect(sendBeaconMock).toHaveBeenCalledWith('/api/track-user', expect.any(Blob));
   });
 
   it('falls back to fetch when sendBeacon is not available', () => {

--- a/utils/tracking.test.ts
+++ b/utils/tracking.test.ts
@@ -1,13 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { trackUser } from './tracking';
 
 describe('trackUser', () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
-  it('uses navigator.sendBeacon when available', () => {
-    const sendBeaconMock = vi.fn();
+  it('uses sendBeacon when available', () => {
+    const sendBeaconMock = vi.fn().mockReturnValue(true);
 
     Object.defineProperty(navigator, 'sendBeacon', {
       value: sendBeaconMock,
@@ -17,7 +18,10 @@ describe('trackUser', () => {
     trackUser('testuser');
 
     expect(sendBeaconMock).toHaveBeenCalledTimes(1);
-    expect(sendBeaconMock).toHaveBeenCalledWith('/api/track-user', expect.any(Blob));
+    expect(sendBeaconMock).toHaveBeenCalledWith(
+      '/api/track-user',
+      expect.any(Blob)
+    );
   });
 
   it('falls back to fetch when sendBeacon is not available', () => {
@@ -27,7 +31,7 @@ describe('trackUser', () => {
     });
 
     const fetchMock = vi.fn().mockResolvedValue({});
-    global.fetch = fetchMock;
+    vi.stubGlobal('fetch', fetchMock);
 
     trackUser('testuser');
 
@@ -35,6 +39,23 @@ describe('trackUser', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username: 'testuser' }),
+      keepalive: true,
     });
+  });
+
+  it('falls back to fetch when sendBeacon returns false', () => {
+    const sendBeaconMock = vi.fn().mockReturnValue(false);
+
+    Object.defineProperty(navigator, 'sendBeacon', {
+      value: sendBeaconMock,
+      configurable: true,
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue({});
+    vi.stubGlobal('fetch', fetchMock);
+
+    trackUser('testuser');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/utils/tracking.test.ts
+++ b/utils/tracking.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { trackUser } from './tracking';
 
 describe('trackUser', () => {

--- a/utils/tracking.test.ts
+++ b/utils/tracking.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { trackUser } from './tracking';
 
 describe('trackUser', () => {

--- a/utils/tracking.ts
+++ b/utils/tracking.ts
@@ -4,10 +4,7 @@ export function trackUser(name: string) {
   const payload = JSON.stringify({ username: name });
 
   const beaconQueued = navigator.sendBeacon
-    ? navigator.sendBeacon(
-        '/api/track-user',
-        new Blob([payload], { type: 'application/json' })
-      )
+    ? navigator.sendBeacon('/api/track-user', new Blob([payload], { type: 'application/json' }))
     : false;
 
   if (!beaconQueued) {

--- a/utils/tracking.ts
+++ b/utils/tracking.ts
@@ -1,7 +1,7 @@
-export function trackUser(name: string) {
+export function trackUser(username: string) {
   if (typeof navigator === 'undefined' || typeof window === 'undefined') return;
 
-  const payload = JSON.stringify({ username: name });
+  const payload = JSON.stringify({ username });
 
   const beaconQueued = navigator.sendBeacon
     ? navigator.sendBeacon('/api/track-user', new Blob([payload], { type: 'application/json' }))

--- a/utils/tracking.ts
+++ b/utils/tracking.ts
@@ -1,4 +1,3 @@
-
 export function trackUser(name: string) {
   const payload = JSON.stringify({ username: name });
   // sendBeacon is truly fire-and-forget — it doesn't block navigation

--- a/utils/tracking.ts
+++ b/utils/tracking.ts
@@ -1,0 +1,14 @@
+
+export function trackUser(name: string) {
+  const payload = JSON.stringify({ username: name });
+  // sendBeacon is truly fire-and-forget — it doesn't block navigation
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon('/api/track-user', new Blob([payload], { type: 'application/json' }));
+  } else {
+    fetch('/api/track-user', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload,
+    }).catch(console.error);
+  }
+}

--- a/utils/tracking.ts
+++ b/utils/tracking.ts
@@ -1,13 +1,21 @@
 export function trackUser(name: string) {
+  if (typeof navigator === 'undefined' || typeof window === 'undefined') return;
+
   const payload = JSON.stringify({ username: name });
-  // sendBeacon is truly fire-and-forget — it doesn't block navigation
-  if (navigator.sendBeacon) {
-    navigator.sendBeacon('/api/track-user', new Blob([payload], { type: 'application/json' }));
-  } else {
+
+  const beaconQueued = navigator.sendBeacon
+    ? navigator.sendBeacon(
+        '/api/track-user',
+        new Blob([payload], { type: 'application/json' })
+      )
+    : false;
+
+  if (!beaconQueued) {
     fetch('/api/track-user', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: payload,
+      keepalive: true,
     }).catch(console.error);
   }
 }


### PR DESCRIPTION
## Description

Fixes #398 

### What changed

* Moved `trackUser` from `app/page.tsx` to `utils/tracking.ts`
* Replaced inline usage with shared utility import
* Added unit tests for:

  * `navigator.sendBeacon`
  * `fetch` fallback
* Verified all existing tests pass successfully

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (refactor + test coverage update)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally .
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
