### PR TITLE
test(svg): add tooltip format teststest(svg): add tooltip format tests for today and non-today towers

### DIFF
--- a/lib/svg/layout.test.ts
+++ b/lib/svg/layout.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { computeTowers } from './layout';
+import type { ContributionCalendar } from '../../types';
+
+describe('computeTowers tooltip format', () => {
+  it('adds TODAY prefix for today tower with commits', () => {
+    const calendar: ContributionCalendar = {
+      weeks: [
+        {
+          contributionDays: [
+            {
+              contributionCount: 5,
+              date: '2024-06-12',
+            },
+          ],
+        },
+      ],
+    } as ContributionCalendar;
+
+    const towers = computeTowers(calendar, 'linear', '2024-06-12');
+
+    expect(towers[0].tooltip).toContain('TODAY:');
+  });
+
+  it('does not add TODAY prefix for non-today tower', () => {
+    const calendar: ContributionCalendar = {
+      weeks: [
+        {
+          contributionDays: [
+            {
+              contributionCount: 5,
+              date: '2024-06-10',
+            },
+            {
+              contributionCount: 2,
+              date: '2024-06-12',
+            },
+          ],
+        },
+      ],
+    } as ContributionCalendar;
+
+    const towers = computeTowers(calendar, 'linear', '2024-06-12');
+
+    expect(towers[0].tooltip).not.toContain('TODAY:');
+  });
+});


### PR DESCRIPTION
## Description
## Summary

Added tests verifying tooltip formatting for today and non-today towers.

## Changes

* Added test for TODAY prefix in tooltip
* Added test ensuring non-today towers do not include TODAY prefix

Closes #390

Fixes # (issue number)

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [ ] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [ ] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [ ] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
