### PR TITLE
refactor(svg): unify particle generator functions

### DIFF
--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -55,45 +55,24 @@ function generateParticles(
   x: number,
   y: number,
   height: number,
-  color: string,
   count: number,
-  sf: number
+  sf: number,
+  autoTheme: boolean = false,
+  color: string = ''
 ): string {
   let particles = '';
   const numParticles = particleCount(count);
 
   for (let i = 0; i < numParticles; i++) {
-    const seed = `${x}:${y}:${height}:${color}:${count}:${i}`;
+    const themeSeed = autoTheme ? 'auto' : color;
+    const seed = `${x}:${y}:${height}:${themeSeed}:${count}:${i}`;
     const offsetX = deterministicRandom(`${seed}:offsetX`) * 6 - 3;
     const delay = deterministicRandom(`${seed}:delay`) * 1.5;
 
-    particles += `
-      <circle cx="${x + offsetX}" cy="${y - height}" r="${1.5 * sf}" fill="${color}" opacity="1">
-        <animate attributeName="cy" from="${y - height}" to="${y - height - 20}" dur="1.5s" begin="${delay}s" repeatCount="indefinite" />
-        <animate attributeName="opacity" from="1" to="0" dur="1.5s" begin="${delay}s" repeatCount="indefinite" />
-      </circle>
-    `;
-  }
-  return `<g class="heat-particles">${particles}</g>`;
-}
-
-function generateAutoParticles(
-  x: number,
-  y: number,
-  height: number,
-  count: number,
-  sf: number
-): string {
-  let particles = '';
-  const numParticles = particleCount(count);
-
-  for (let i = 0; i < numParticles; i++) {
-    const seed = `${x}:${y}:${height}:auto:${count}:${i}`;
-    const offsetX = deterministicRandom(`${seed}:offsetX`) * 6 - 3;
-    const delay = deterministicRandom(`${seed}:delay`) * 1.5;
+    const fillAttr = autoTheme ? 'class="cp-accent-fill"' : `fill="${color}"`;
 
     particles += `
-      <circle class="cp-accent-fill" cx="${x + offsetX}" cy="${y - height}" r="${1.5 * sf}" opacity="1">
+      <circle ${fillAttr} cx="${x + offsetX}" cy="${y - height}" r="${1.5 * sf}" opacity="1">
         <animate attributeName="cy" from="${y - height}" to="${y - height - 20}" dur="1.5s" begin="${delay}s" repeatCount="indefinite" />
         <animate attributeName="opacity" from="1" to="0" dur="1.5s" begin="${delay}s" repeatCount="indefinite" />
       </circle>
@@ -155,7 +134,7 @@ function renderTowers(towerData: TowerData[], accent: string, text: string, sf: 
           </g>
         </g>`;
     if (t.contributionCount >= 10)
-      towers += generateParticles(t.x, t.y, t.h, accent, t.contributionCount, sf);
+      towers += generateParticles(t.x, t.y, t.h, t.contributionCount, sf, false, accent);
   }
   return towers;
 }
@@ -287,7 +266,7 @@ function generateAutoThemeSVG(
           </g>
         </g>`;
     if (t.contributionCount >= 10)
-      towers += generateAutoParticles(t.x, t.y, t.h, t.contributionCount, sf);
+      towers += generateParticles(t.x, t.y, t.h, t.contributionCount, sf, true);
   }
 
   const s = (n: number) => Math.round(n * sf);


### PR DESCRIPTION
## Description

Fixes #287

This PR removes the duplicated `generateAutoParticles` function and unifies the particle generation logic into a single `generateParticles` function. 

- Removed the duplicate function.
- Implemented `autoTheme` parameter in the unified function to conditionally emit inline fill attributes or CSS classes (`cp-accent-fill`).
- Replaced all existing call sites in `renderTowers` and `generateAutoThemeSVG` to use the unified function.
- The SVG output behavior remains identical for both static and auto themes.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — Refactoring only, identical SVG output.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
