### PR TITLE
test(dashboard): add ActivityLandscape filtering tests

### DIFF
--- a/components/dashboard/ActivityLandscape.test.ts
+++ b/components/dashboard/ActivityLandscape.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { getFilteredData } from './ActivityLandscape';
+import { ActivityData } from '@/types/dashboard';
+
+const generateData = (days: number): ActivityData[] => {
+  return Array.from({ length: days }, (_, i) => ({
+    date: `2024-01-${(i + 1).toString().padStart(2, '0')}`,
+    count: i,
+    intensity: (i % 5) as 0 | 1 | 2 | 3 | 4,
+  }));
+};
+
+describe('ActivityLandscape Filtering Logic', () => {
+  it('filters 1W correctly (last 7 days)', () => {
+    const data = generateData(10);
+    const result = getFilteredData(data, '1W');
+    expect(result.length).toBe(7);
+    expect(result[0].count).toBe(3);
+    expect(result[result.length - 1].count).toBe(9);
+  });
+
+  it('filters 1M correctly (last 30 days)', () => {
+    const data = generateData(40);
+    const result = getFilteredData(data, '1M');
+    expect(result.length).toBe(30);
+    expect(result[0].count).toBe(10);
+    expect(result[result.length - 1].count).toBe(39);
+  });
+
+  it('filters 3M correctly (last 90 days, downsampled to <=60)', () => {
+    const data = generateData(100);
+    const result = getFilteredData(data, '3M');
+    expect(result.length).toBeLessThanOrEqual(60);
+    expect(result.length).toBe(45);
+    expect(result[0].count).toBe(10);
+  });
+
+  it('filters 1Y correctly (last 365 days, downsampled to <=60)', () => {
+    const data = generateData(400);
+    const result = getFilteredData(data, '1Y');
+    expect(result.length).toBeLessThanOrEqual(60);
+    expect(result.length).toBe(53);
+  });
+
+  it('applies downsampling when items exceed 60', () => {
+    const data60 = generateData(60);
+    const result60 = getFilteredData(data60, '3M');
+    expect(result60.length).toBe(60);
+
+    const data61 = generateData(61);
+    const result61 = getFilteredData(data61, '3M');
+    expect(result61.length).toBeLessThanOrEqual(60);
+    expect(result61.length).toBe(31);
+  });
+});

--- a/components/dashboard/ActivityLandscape.tsx
+++ b/components/dashboard/ActivityLandscape.tsx
@@ -6,23 +6,23 @@ import { ActivityData } from '@/types/dashboard';
 
 const tabs = ['1W', '1M', '3M', '1Y'];
 
+export const getFilteredData = (data: ActivityData[], activeTab: string): ActivityData[] => {
+  let days = 90;
+  if (activeTab === '1W') days = 7;
+  if (activeTab === '1M') days = 30;
+  if (activeTab === '1Y') days = 365;
+  const recent = data.slice(-days);
+  if (recent.length > 60) {
+    const step = Math.ceil(recent.length / 60);
+    return recent.filter((_, i) => i % step === 0).slice(-60);
+  }
+  return recent;
+};
+
 export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
   const [activeTab, setActiveTab] = useState('3M');
 
-  const getFilteredData = () => {
-    let days = 90;
-    if (activeTab === '1W') days = 7;
-    if (activeTab === '1M') days = 30;
-    if (activeTab === '1Y') days = 365;
-    const recent = data.slice(-days);
-    if (recent.length > 60) {
-      const step = Math.ceil(recent.length / 60);
-      return recent.filter((_, i) => i % step === 0).slice(-60);
-    }
-    return recent;
-  };
-
-  const displayData = getFilteredData();
+  const displayData = getFilteredData(data, activeTab);
   const maxCount = Math.max(...displayData.map((d) => d.count), 1);
 
   return (


### PR DESCRIPTION
## Description

Fixes #335

Summary of changes:
- Extracted filtering logic (`getFilteredData`) from `ActivityLandscape` into a pure, testable exported function.
- Added test coverage for all tab scenarios (`1W`, `1M`, `3M`, `1Y`).
- Added tests to verify the downsampling logic (>60 items returns <=60 items).
- No UI or behavior changes, strictly refactoring for testability and adding tests.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No visual changes.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.
