### PR TITLE
refactor(sanitizer): add sanitizeUrl() helper for validating external font URLs

### DIFF
--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -3,7 +3,7 @@ import { getLabels } from '../i18n/badgeLabels';
 import { AUTO_DARK_THEME, AUTO_LIGHT_THEME } from './themes';
 import { TOWER_ANIMATION_CSS } from './animations';
 import { computeTowers, type TowerData } from './layout';
-import { sanitizeFont, sanitizeHexColor, sanitizeRadius } from './sanitizer';
+import { sanitizeFont, sanitizeHexColor, sanitizeRadius, sanitizeGoogleFontUrl } from './sanitizer';
 
 const FONT_MAP: Record<string, string> = {
   jetbrains: '"JetBrains Mono", monospace',
@@ -215,10 +215,11 @@ export function generateSVG(
       ? `"${sanitizedFont}", sans-serif`
       : null;
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
-  const googleFontsImport =
-    sanitizedFont && !isPredefinedFont
-      ? `@import url('https://fonts.googleapis.com/css2?family=${encodeURIComponent(sanitizedFont).replace(/%20/g, '+')}&amp;display=swap');`
-      : '';
+  const googleFontUrlPart =
+    sanitizedFont && !isPredefinedFont ? sanitizeGoogleFontUrl(sanitizedFont) : null;
+  const googleFontsImport = googleFontUrlPart
+    ? `@import url('https://fonts.googleapis.com/css2?family=${googleFontUrlPart}&amp;display=swap');`
+    : '';
 
   const sf = getSizeScale(params.size);
   const radius = sanitizeRadius(params.radius, 8) * sf;
@@ -389,10 +390,11 @@ export function generateMonthlySVG(stats: MonthlyStats, params: BadgeParams): st
   const width = params.width || 300;
   const height = params.height || 120;
 
-  const googleFontsImport =
-    sanitizedFont && !isPredefinedFont
-      ? `@import url('https://fonts.googleapis.com/css2?family=${encodeURIComponent(sanitizedFont).replace(/%20/g, '+')}&amp;display=swap');`
-      : '';
+  const googleFontUrlPart =
+    sanitizedFont && !isPredefinedFont ? sanitizeGoogleFontUrl(sanitizedFont) : null;
+  const googleFontsImport = googleFontUrlPart
+    ? `@import url('https://fonts.googleapis.com/css2?family=${googleFontUrlPart}&amp;display=swap');`
+    : '';
 
   let deltaText = '';
   if (params.delta_format === 'absolute') {

--- a/lib/svg/sanitizer.test.ts
+++ b/lib/svg/sanitizer.test.ts
@@ -5,6 +5,7 @@ import {
   sanitizeSpeed,
   sanitizeRadius,
   sanitizeFont,
+  sanitizeGoogleFontUrl,
 } from './sanitizer';
 
 describe('SVG Sanitizer Utilities', () => {
@@ -95,6 +96,34 @@ describe('SVG Sanitizer Utilities', () => {
 
     it('returns null for completely invalid font', () => {
       expect(sanitizeFont('!!!')).toBe(null);
+    });
+  });
+
+  describe('sanitizeGoogleFontUrl', () => {
+    it('handles normal font names and spaces', () => {
+      expect(sanitizeGoogleFontUrl('Roboto')).toBe('Roboto');
+      expect(sanitizeGoogleFontUrl('Open Sans')).toBe('Open+Sans');
+      expect(sanitizeGoogleFontUrl('Space-Grotesk')).toBe('Space-Grotesk');
+      expect(sanitizeGoogleFontUrl('  PT Sans  ')).toBe('PT+Sans');
+    });
+
+    it('returns null for empty strings, null, and undefined', () => {
+      expect(sanitizeGoogleFontUrl('')).toBe(null);
+      expect(sanitizeGoogleFontUrl('   ')).toBe(null);
+      expect(sanitizeGoogleFontUrl(null)).toBe(null);
+      expect(sanitizeGoogleFontUrl(undefined)).toBe(null);
+    });
+
+    it('returns null for malicious or injection inputs', () => {
+      expect(sanitizeGoogleFontUrl("Open Sans'")).toBe(null);
+      expect(sanitizeGoogleFontUrl('Open Sans"')).toBe(null);
+      expect(sanitizeGoogleFontUrl('Open Sans;')).toBe(null);
+      expect(sanitizeGoogleFontUrl('Open Sans/')).toBe(null);
+      expect(sanitizeGoogleFontUrl('Open Sans\\')).toBe(null);
+      expect(sanitizeGoogleFontUrl('<script>')).toBe(null);
+      expect(sanitizeGoogleFontUrl('Open Sans); @import url(http://evil.com)')).toBe(null);
+      expect(sanitizeGoogleFontUrl('../invalid')).toBe(null);
+      expect(sanitizeGoogleFontUrl('https://example.com')).toBe(null);
     });
   });
 });

--- a/lib/svg/sanitizer.ts
+++ b/lib/svg/sanitizer.ts
@@ -70,3 +70,28 @@ export function sanitizeFont(font: string | undefined | null): string | null {
   const cleaned = trimmed.replace(/[^a-zA-Z0-9\s\-']/g, '').trim();
   return cleaned || null;
 }
+
+/**
+ * Validates and sanitizes a Google Font name for safe use in external @import URLs.
+ * Returns the URL-safe font name (spaces replaced with '+') or null if invalid/unsafe.
+ */
+export function sanitizeGoogleFontUrl(fontName: string | undefined | null): string | null {
+  if (!fontName) return null;
+
+  const trimmed = fontName.trim();
+  if (!trimmed) return null;
+
+  // Whitelist approach: Only allow alphanumeric characters, spaces, and hyphens.
+  // This completely eliminates any possibility of URL/CSS injection, path traversal,
+  // or breaking out of quotes in external font imports.
+  if (!/^[a-zA-Z0-9\s\-]+$/.test(trimmed)) {
+    return null;
+  }
+
+  // Also apply standard font name sanitization to ensure consistency
+  const cleaned = sanitizeFont(trimmed);
+  if (!cleaned) return null;
+
+  // Return the encoded font name suitable for Google Fonts API URL (spaces replaced with '+')
+  return encodeURIComponent(cleaned).replace(/%20/g, '+');
+}


### PR DESCRIPTION
## Description

Fixes #322

Implement `sanitizeGoogleFontUrl(fontName: string): string | null` in `lib/svg/sanitizer.ts` to validate external font URLs and prevent CSS/URL injection risks. Replace inline `encodeURIComponent` usage with the new helper.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=saagnik23`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.