### PR TITLE
refactor(cache): make maxSize optional

### DIFF
--- a/lib/cache.test.ts
+++ b/lib/cache.test.ts
@@ -44,6 +44,16 @@ describe('TTLCache', () => {
   });
 
   describe('capacity eviction (maxSize)', () => {
+    it('keeps entries unlimited when maxSize is not provided', () => {
+      const cache = new TTLCache<number>();
+      for (let i = 0; i < 1001; i++) {
+        cache.set(`key-${i}`, i, 60_000);
+      }
+      expect(cache.get('key-0')).toBe(0);
+      expect(cache.get('key-1000')).toBe(1000);
+      cache.destroy();
+    });
+
     it('does not exceed maxSize — evicts the oldest key on overflow', () => {
       const cache = new TTLCache<number>(3);
       cache.set('a', 1, 60_000);

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -6,10 +6,10 @@ type CacheItem<T> = {
 export class TTLCache<T> {
   private store = new Map<string, CacheItem<T>>();
   private cleanupInterval: ReturnType<typeof setInterval> | null = null;
-  private readonly maxSize: number;
+  private readonly maxSize?: number;
 
-  constructor(maxSize: number = 1000, cleanupIntervalMs: number = 60000) {
-    this.maxSize = Math.max(1, maxSize);
+  constructor(maxSize?: number, cleanupIntervalMs: number = 60000) {
+    this.maxSize = maxSize === undefined ? undefined : Math.max(1, maxSize);
     const interval = Math.max(1000, cleanupIntervalMs);
 
     // Only run cleanup if we are in an environment that supports setInterval
@@ -49,9 +49,10 @@ export class TTLCache<T> {
 
   set(key: string, value: T, ttlMs: number): void {
     // Capacity eviction (FIFO / LRU-lite)
-    if (this.store.size >= this.maxSize && !this.store.has(key)) {
+    const maxSize = this.maxSize;
+    if (maxSize !== undefined && this.store.size >= maxSize && !this.store.has(key)) {
       this.sweep(); // Remove expired entries first to free up capacity
-      if (this.store.size >= this.maxSize) {
+      if (this.store.size >= maxSize) {
         // Find the oldest item (first inserted) and remove it
         const oldestKey = this.store.keys().next().value;
         if (oldestKey !== undefined) {


### PR DESCRIPTION
## Description

Fixes #300

Makes `TTLCache` capacity eviction opt-in by applying the FIFO limit only when `maxSize` is provided. This keeps cache instances without `maxSize` unlimited, as requested in #300, while preserving the existing eviction behavior for callers that pass a maximum size.

I also added a regression test for the unlimited default behavior.

## Pillar

- [ ] Pillar 1 - New Theme Design
- [ ] Pillar 2 - Geometric SVG Improvement
- [ ] Pillar 3 - Timezone Logic Optimization
- [x] Other (Bug fix, refactoring, docs)

## Visual Preview

N/A - cache logic and unit tests only.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run formatting checks for the changed files and `npm run lint` locally.
- [x] My commit follows the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter. N/A.
- [ ] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard. N/A.
- [ ] I joined the CommitPulse Discord server.