### PR TITLE
fix(og): resolve 500 internal server error in OG image generation endpoint

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -59,10 +59,20 @@ export async function GET(req: NextRequest) {
           left: '300px',
         }}
       />
-      <div style={{ fontSize: '48px', color: '#58a6ff', fontWeight: 'bold', marginBottom: '24px' }}>
+      <div
+        style={{
+          display: 'flex',
+          fontSize: '48px',
+          color: '#58a6ff',
+          fontWeight: 'bold',
+          marginBottom: '24px',
+        }}
+      >
         ⚡ CommitPulse
       </div>
-      <div style={{ fontSize: '32px', color: '#c9d1d9', marginBottom: '48px' }}>@{user}</div>
+      <div
+        style={{ display: 'flex', fontSize: '32px', color: '#c9d1d9', marginBottom: '48px' }}
+      >{`@${user}`}</div>
       <div style={{ display: 'flex', gap: '48px' }}>
         <div
           style={{
@@ -117,7 +127,15 @@ export async function GET(req: NextRequest) {
           </div>
         </div>
       </div>
-      <div style={{ position: 'absolute', bottom: '32px', fontSize: '16px', color: '#484f58' }}>
+      <div
+        style={{
+          display: 'flex',
+          position: 'absolute',
+          bottom: '32px',
+          fontSize: '16px',
+          color: '#484f58',
+        }}
+      >
         commitpulse.vercel.app
       </div>
     </div>,


### PR DESCRIPTION
## Description

Resolves the 500 Internal Server Error when visiting the `/api/og` endpoint. 

### Cause of the bug:

1. Satori (used by `@vercel/og`) requires any `div` element with more than one child node to explicitly have `display: flex`, `display: contents`, or `display: none` configured in its styles.
2. In `app/api/og/route.tsx`, React compiled `@{user}` as two separate children (a literal string `"@"` and a dynamic variable `user`). Because the parent container did not explicitly set `display: flex`, Satori failed to compute the layout and crashed with a 500 Internal Server Error.

### How it was fixed:

1. Replaced the text node structure `@{user}` with `{`@${user}`}` to combine them into a single string expression, ensuring Satori treats it as a single child node.
2. Added explicit `display: 'flex'` styles to the layout containers to adhere to Satori's strict layout guidelines and prevent similar failures.

Fixes #494 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.