### PR TITLE
refactor(hooks): extract localStorage read/write helpers

### DIFF
--- a/hooks/useRecentSearches.ts
+++ b/hooks/useRecentSearches.ts
@@ -7,6 +7,30 @@ const MAX = 5;
 
 type State = { searches: string[]; mounted: boolean };
 
+function loadFromStorage(): string[] {
+  let saved: string[] = [];
+  try {
+    const stored = localStorage.getItem(KEY);
+    if (stored) saved = JSON.parse(stored) as string[];
+  } catch {
+    // ignore malformed storage
+  }
+  return saved;
+}
+
+function writeStorage(searches: string[] | null): void {
+  try {
+    if (searches === null) {
+      localStorage.removeItem(KEY);
+      return;
+    }
+
+    localStorage.setItem(KEY, JSON.stringify(searches));
+  } catch {
+    // ignore storage write failures
+  }
+}
+
 export function useRecentSearches() {
   // Always start with [] and mounted:false on both server and client so the
   // initial render matches (SSR-safe). A single setState in the mount effect
@@ -16,13 +40,8 @@ export function useRecentSearches() {
   const [state, setState] = useState<State>({ searches: [], mounted: false });
 
   useEffect(() => {
-    let saved: string[] = [];
-    try {
-      const stored = localStorage.getItem(KEY);
-      if (stored) saved = JSON.parse(stored) as string[];
-    } catch {
-      // ignore malformed storage
-    }
+    const saved = loadFromStorage();
+
     // Single setState call — reads external system (localStorage) and syncs
     // React state in one update, which is exactly what effects are for.
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -33,18 +52,16 @@ export function useRecentSearches() {
     if (!query.trim()) return;
     setState((prev) => {
       const deduped = [query, ...prev.searches.filter((s) => s !== query)].slice(0, MAX);
-      try {
-        localStorage.setItem(KEY, JSON.stringify(deduped));
-      } catch {}
+
+      writeStorage(deduped);
+
       return { ...prev, searches: deduped };
     });
   };
 
   const clearSearches = () => {
     setState((prev) => ({ ...prev, searches: [] }));
-    try {
-      localStorage.removeItem(KEY);
-    } catch {}
+    writeStorage(null);
   };
 
   // Return empty searches until after hydration to prevent SSR/client mismatch.


### PR DESCRIPTION
## Description

Fixes #325

Refactored `useRecentSearches` by extracting localStorage access into helper functions for cleaner and symmetric storage handling.

### Changes made
- extracted `loadFromStorage()` for reading from localStorage
- added `writeStorage()` for writing/removing localStorage entries
- updated `addSearch()` to use `writeStorage()`
- updated `clearSearches()` to use `writeStorage()`
- preserved existing behavior while reducing duplicated storage logic

### Verification
- `npm run format`
- `npm run lint`
- `npm run test`

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.