### PR TITLE
refactor(api): extract SVG_CSP_HEADER constant to eliminate duplication

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -12,6 +12,8 @@ import { getSecondsUntilUTCMidnight, getSecondsUntilMidnightInTimezone } from '.
 import type { BadgeParams } from '../../../types';
 import { themes } from '../../../lib/svg/themes';
 import { streakParamsSchema } from '../../../lib/validations';
+const SVG_CSP_HEADER =
+  "default-src 'none'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src https://fonts.gstatic.com;";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -126,8 +128,7 @@ export async function GET(request: Request) {
       headers: {
         'Content-Type': 'image/svg+xml',
         'Cache-Control': cacheControl,
-        'Content-Security-Policy':
-          "default-src 'none'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src https://fonts.gstatic.com;",
+        'Content-Security-Policy': SVG_CSP_HEADER,
       },
     });
   } catch (error: unknown) {
@@ -157,8 +158,7 @@ export async function GET(request: Request) {
         headers: {
           'Content-Type': 'image/svg+xml',
           'Cache-Control': 'no-cache',
-          'Content-Security-Policy':
-            "default-src 'none'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com;",
+          'Content-Security-Policy': SVG_CSP_HEADER,
         },
       });
     }


### PR DESCRIPTION
## Description

Fixes #370 
- `app/api/streak/route.ts` — extracted the repeated CSP header string into a single `SVG_CSP_HEADER` constant defined at the module top level, and replaced all inline occurrences in the success and not-found response branches with a reference to it — eliminating duplication and ensuring any future CSP changes only need to be made in one place.

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- I have started the repo.
- I have made sure that i have only one commit to merge in this PR.
