### PR TITLE
test(api): add unit tests for hide_title and hide_stats query parameters in streak route

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -430,4 +430,37 @@ describe('GET /api/streak', () => {
       expect(body).toContain('CURRENT_STREAK');
     });
   });
+  describe('hide_title and hide_stats parameters', () => {
+    it('removes username when hide_title=true', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', hide_title: 'true' }));
+      const body = await response.text();
+
+      expect(body).not.toContain('OCTOCAT');
+    });
+
+    it('removes stats section when hide_stats=true', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', hide_stats: 'true' }));
+      const body = await response.text();
+
+      expect(body).not.toContain('CURRENT_STREAK');
+    });
+
+    it('shows everything when both params are false', async () => {
+      const response = await GET(makeRequest({ user: 'octocat' }));
+      const body = await response.text();
+
+      expect(body).toContain('OCTOCAT');
+      expect(body).toContain('CURRENT_STREAK');
+    });
+
+    it('removes both when both params are true', async () => {
+      const response = await GET(
+        makeRequest({ user: 'octocat', hide_title: 'true', hide_stats: 'true' })
+      );
+      const body = await response.text();
+
+      expect(body).not.toContain('OCTOCAT');
+      expect(body).not.toContain('CURRENT_STREAK');
+    });
+  });
 });


### PR DESCRIPTION
## 📌 Description

This PR adds focused unit tests for the `hide_title` and `hide_stats` query parameters in the `/api/streak` route.

These parameters control visibility of the username/title and stats section in the generated SVG, and previously lacked direct test coverage.

---

## ✅ Changes Made

- Added test cases for:
  - `hide_title=true` → ensures username/title is removed from SVG
  - `hide_stats=true` → ensures stats section is removed
  - default behavior → verifies all elements are present
  - both parameters together → ensures both sections are removed

- Ensured all existing tests pass without modification

---

## 🔗 Related Issue

Closes #329

---

## 🧪 Testing

- All tests pass locally (`241/241`)
- No regressions introduced
- Verified SVG output conditions using string assertions

---

## 📂 Files Modified

- `app/api/streak/route.test.ts`

---

## 📋 Checklist

- [x] I have read the `CONTRIBUTING.md` file  
- [x] I have tested changes locally  
- [x] All existing tests pass  
- [x] No unrelated changes included  
- [x] Follows project coding standards  

---