### PR TITLE
test(streak): assert dark theme accent color appears when unknown theme is given

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -299,8 +299,10 @@ describe('GET /api/streak', () => {
 
     it('falls back to the dark theme without crashing when an unknown theme is given', async () => {
       const response = await GET(makeRequest({ user: 'octocat', theme: 'does-not-exist' }));
+      const body = await response.text();
 
       expect(response.status).toBe(200);
+      expect(body).toContain('58a6ff'); // Dark theme accent is #58a6ff — confirms the dark fallback is actually applied
     });
   });
 


### PR DESCRIPTION
## Description

Fixes #372 
- `app/api/streak/route.test.ts` — added a focused test asserting that when an unknown theme is passed via `?theme=does-not-exist`, the response body contains `58a6ff` (the dark theme accent color), confirming the silent dark fallback is actually applied at the route level and not just returning a `200` with potentially wrong colors.

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.
