### PR TITLE
docs(api): add JSDoc to GET handler in app/api/streak/route.ts #359

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -13,6 +13,38 @@ import type { BadgeParams } from '../../../types';
 import { themes } from '../../../lib/svg/themes';
 import { streakParamsSchema } from '../../../lib/validations';
 
+/**
+ * GET /api/streak - Returns GitHub contribution streak as SVG image
+ *
+ * Query Parameters:
+ * - username (string, required): GitHub username
+ * - theme (string, optional): 'default', 'dark', 'light' (default: 'default')
+ * - hide_border (boolean, optional): Hide card border (default: false)
+ * - hide_title (boolean, optional): Hide card title (default: false)
+ * - hide_total (boolean, optional): Hide total contributions (default: false)
+ * - count_private (boolean, optional): Include private contributions (default: false)
+ * - show_icons (boolean, optional): Show contribution icons (default: true)
+ * - ring_color (string, optional): Ring color hex (default: '#2c3e50')
+ * - curr_streak_color (string, optional): Current streak text color (default: '#2c3e50')
+ * - side_streak_color (string, optional): Longest streak text color (default: '#7f8c8d')
+ * - curr_streak_label (string, optional): Current streak label (default: 'Current streak')
+ * - side_streak_label (string, optional): Longest streak label (default: 'Longest streak')
+ * - date_format (string, optional): Date format (default: 'YYYY-MM-DD')
+ *
+ * Response:
+ * - 200: SVG image with Content-Type: image/svg+xml
+ * - Cache-Control: public, max-age=3600, s-maxage=3600, stale-while-revalidate=60
+ * - CSP: default-src 'none'; style-src 'unsafe-inline'
+ * - 400: { "error": "Missing required parameter: username" }
+ * - 404: { "error": "User not found or has no contributions" }
+ * - 500: { "error": "Failed to fetch streak data" }
+ *
+ * Caching:
+ * - Success: Cached 1 hour, stale-while-revalidate 60 seconds
+ * - Errors: Not cached
+ * - Cache key includes username and theme
+ */
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
 


### PR DESCRIPTION
## Description

Added JSDoc documentation to the GET handler in app/api/streak/route.ts. 

Fixes #359 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No visual changes - this is a documentation-only update.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).

