### PR TITLE
refactor(svg): replace magic numbers 600/420 with SVG_WIDTH/SVG_HEIGHT constants

### DIFF
--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -5,6 +5,9 @@ import { TOWER_ANIMATION_CSS } from './animations';
 import { computeTowers, type TowerData } from './layout';
 import { sanitizeFont, sanitizeHexColor, sanitizeRadius } from './sanitizer';
 
+const SVG_WIDTH = 600;
+const SVG_HEIGHT = 420;
+
 const FONT_MAP: Record<string, string> = {
   jetbrains: '"JetBrains Mono", monospace',
   fira: '"Fira Code", monospace',
@@ -13,8 +16,8 @@ const FONT_MAP: Record<string, string> = {
 
 // helpers
 function getSizeScale(size?: 'small' | 'medium' | 'large'): number {
-  if (size === 'small') return 400 / 600;
-  if (size === 'large') return 800 / 600;
+  if (size === 'small') return 400 / SVG_WIDTH;
+  if (size === 'large') return 800 / SVG_WIDTH;
   return 1; // medium (default)
 }
 
@@ -223,8 +226,8 @@ export function generateSVG(
   const sf = getSizeScale(params.size);
   const radius = sanitizeRadius(params.radius, 8) * sf;
   const labels = getLabels(params.lang);
-  const W = Math.round(600 * sf);
-  const H = Math.round(420 * sf);
+  const W = Math.round(SVG_WIDTH * sf);
+  const H = Math.round(SVG_HEIGHT * sf);
 
   const towerData = scaleTowerData(computeTowers(calendar, params.scale, stats.todayDate), sf);
   const towers = renderTowers(towerData, accent, text, sf);
@@ -257,8 +260,8 @@ function generateAutoThemeSVG(
   const radius = sanitizeRadius(params.radius, 8) * sf;
   const labels = getLabels(params.lang);
 
-  const W = Math.round(600 * sf);
-  const H = Math.round(420 * sf);
+  const W = Math.round(SVG_WIDTH * sf);
+  const H = Math.round(SVG_HEIGHT * sf);
   const towerData = scaleTowerData(computeTowers(calendar, params.scale, stats.todayDate), sf);
   let towers = '';
 
@@ -626,9 +629,9 @@ export function generateNotFoundSVG(
 
   return `<svg
   xmlns="http://www.w3.org/2000/svg"
-  width="600"
-  height="420"
-  viewBox="0 0 600 420"
+  width="${SVG_WIDTH}"
+  height="${SVG_HEIGHT}"
+  viewBox="0 0 ${SVG_WIDTH} ${SVG_HEIGHT}"
   fill="none"
   role="img"
 >
@@ -660,7 +663,7 @@ export function generateNotFoundSVG(
   </style>
 
   <!-- Background -->
-  <rect width="600" height="420" rx="${radius}" fill="${bg}"/>
+  <rect width="${SVG_WIDTH}" height="${SVG_HEIGHT}" rx="${radius}" fill="${bg}"/>
 
   <!-- Ghost isometric city — same grid as real badge -->
   <g transform="translate(0, 20)" class="ghost-pulse">
@@ -668,7 +671,7 @@ export function generateNotFoundSVG(
   </g>
 
   <!-- Fade overlay so ghost city dissolves into background -->
-  <rect width="600" height="420" rx="${radius}" fill="url(#ghostFade)"/>
+  <rect width="${SVG_WIDTH}" height="${SVG_HEIGHT}" rx="${radius}" fill="url(#ghostFade)"/>
 
   <!-- Radar scan line (same as real badge, but very faint) -->
   <rect x="100" y="60" width="400" height="1" fill="${accent}" fill-opacity="0.12">


### PR DESCRIPTION

## Description
Declares `SVG_WIDTH = 600` and `SVG_HEIGHT = 420 `as named module-level constants in `lib/svg/generator.ts` and replaces all bare `600/420` literals in SVG rendering paths. CSS `font-weight: 600` and Google Fonts query strings were intentionally left unchanged as they are unrelated to SVG dimensions.

**Note**: `lib/svg/layout.ts` was inspected but contains no `600/420` literals. No changes were needed there.

Fixes #291

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [x] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual change. SVG output is identical.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
