### PR TITLE
fix(api): return 400 for invalid GitHub usernames in /api/streak

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -78,6 +78,18 @@ describe('GET /api/streak', () => {
 
       expect(fetchGitHubContributions).not.toHaveBeenCalled();
     });
+
+    it('returns 400 for malformed GitHub usernames', async () => {
+      const invalidUsers = ['http://localhost', 'harendra-', 'a--b', 'a'.repeat(40)];
+
+      for (const user of invalidUsers) {
+        const response = await GET(makeRequest({ user }));
+
+        expect(response.status).toBe(400);
+      }
+
+      expect(fetchGitHubContributions).not.toHaveBeenCalled();
+    });
   });
 
   describe('successful response', () => {

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -3,7 +3,13 @@ import { sanitizeHexColor, sanitizeSpeed, sanitizeRadius, sanitizeFont } from '.
 
 export const streakParamsSchema = z.object({
   // Required — missing user surfaces as "Missing" to match existing tests
-  user: z.string({ error: 'Missing user parameter' }).min(1, { message: 'Missing user parameter' }),
+  user: z
+    .string({ error: 'Missing user parameter' })
+    .min(1, { message: 'Missing user parameter' })
+    .max(39, { message: 'GitHub username cannot exceed 39 characters' })
+    .regex(/^(?!-)[a-zA-Z0-9-]+(?<!-)$/, {
+      message: 'Invalid GitHub username',
+    }),
 
   theme: z.string().default('dark'),
   bg: z

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -7,7 +7,7 @@ export const streakParamsSchema = z.object({
     .string({ error: 'Missing user parameter' })
     .min(1, { message: 'Missing user parameter' })
     .max(39, { message: 'GitHub username cannot exceed 39 characters' })
-    .regex(/^(?!-)[a-zA-Z0-9-]+(?<!-)$/, {
+    .regex(/^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9]))*$/, {
       message: 'Invalid GitHub username',
     }),
 


### PR DESCRIPTION
## Description

Closes #496

Added stricter validation for the `user` query parameter in the `/api/streak` endpoint using Zod schema validation.

This prevents malformed or invalid GitHub usernames (such as URLs, empty values, or usernames ending with hyphens) from reaching the GitHub API and causing a `500 Internal Server Error`.

The endpoint now returns a proper `400 Bad Request` response with validation errors for invalid input.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

### Before

Invalid usernames like:

```bash
/api/streak?user=http://localhost
/api/streak?user=harendra-
```

returned:

```txt
500 Internal Server Error
```

### After

Invalid usernames now correctly return:

```txt
400 Bad Request
```

Valid usernames continue to work correctly.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
