### PR TITLE
test(svg): add escapeXML unit tests

### DIFF
--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateSVG, generateMonthlySVG, particleCount } from './generator';
+import { generateSVG, generateMonthlySVG, particleCount, escapeXML } from './generator';
 import type { BadgeParams, ContributionCalendar, StreakStats, MonthlyStats } from '../../types';
 
 describe('generateSVG', () => {
@@ -480,6 +480,39 @@ describe('generateMonthlySVG', () => {
     } as unknown as BadgeParams);
     expect(svg).toContain('width="400"');
     expect(svg).toContain('height="200"');
+  });
+});
+
+describe('escapeXML', () => {
+  it('escapes ampersands (&)', () => {
+    expect(escapeXML('foo & bar')).toBe('foo &amp; bar');
+  });
+
+  it('escapes less-than signs (<)', () => {
+    expect(escapeXML('<div>')).toBe('&lt;div&gt;');
+  });
+
+  it('escapes greater-than signs (>)', () => {
+    expect(escapeXML('a > b')).toBe('a &gt; b');
+  });
+
+  it('escapes double quotes (")', () => {
+    expect(escapeXML('class="btn"')).toBe('class=&quot;btn&quot;');
+  });
+
+  it("escapes single quotes (')", () => {
+    expect(escapeXML("it's working")).toBe('it&#39;s working');
+  });
+
+  it('escapes a string combining all five special characters', () => {
+    const combined = `<element attr="val" data-quote='yes'>&</element>`;
+    const expected = `&lt;element attr=&quot;val&quot; data-quote=&#39;yes&#39;&gt;&amp;&lt;/element&gt;`;
+    expect(escapeXML(combined)).toBe(expected);
+  });
+
+  it('leaves a safe string unchanged', () => {
+    const safe = 'Hello World 123!@#%^*()_+-=[]{}|;:,./?`~';
+    expect(escapeXML(safe)).toBe(safe);
   });
 });
 


### PR DESCRIPTION
## Description

Fixes #340

- Added direct `escapeXML()` coverage
- Covered all five XML special characters (`&`, `<`, `>`, `"`, `'`)
- Added combined-string and safe-string tests
- No behavior changes introduced

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

<img width="990" height="653" alt="image" src="https://github.com/user-attachments/assets/7b6b04ed-3e6f-4cee-8ef2-76aaefae4aa7" />

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
