### PR TITLE
refactor(svg): add hide_background=true tests in streak route

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -414,6 +414,22 @@ describe('GET /api/streak', () => {
     });
   });
 
+  describe('hide_background parameter', () => {
+    it('produces a transparent background when ?hide_background=true is set', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', hide_background: 'true' }));
+      const body = await response.text();
+
+      expect(body).toContain('fill="transparent"');
+    });
+
+    it('does not produce a transparent background when ?hide_background is omitted', async () => {
+      const response = await GET(makeRequest({ user: 'octocat' }));
+      const body = await response.text();
+
+      expect(body).not.toContain('fill="transparent"');
+    });
+  });
+
   describe('monthly view parameter', () => {
     it('returns 200 when view=monthly is given', async () => {
       const response = await GET(makeRequest({ user: 'octocat', view: 'monthly' }));


### PR DESCRIPTION
## Description

Fixes #352

Adds two route-level tests for the `?hide_background=true` parameter in `app/api/streak/route.test.ts:`

1.   Asserts the SVG body contains `fill="transparent"` when `?hide_background=true` is set.
2.   Asserts the SVG body does not contain `fill="transparent"` when the parameter is omitted.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [X] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual change

## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
