### PR TITLE
fix(streak): add boundary tests for speed validation

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -224,21 +224,21 @@ describe('GET /api/streak', () => {
       const body = await response.text();
 
       expect(body).toContain('2s');
-  });
+    });
 
-  it('accepts the maximum boundary speed "20s"', async () => {
-    const response = await GET(makeRequest({ user: 'octocat', speed: '20s' }));
-    const body = await response.text();
+    it('accepts the maximum boundary speed "20s"', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', speed: '20s' }));
+      const body = await response.text();
 
-    expect(body).toContain('20s');
-  });
+      expect(body).toContain('20s');
+    });
 
-  it('falls back to 8s when speed is a non-integer decimal like "2.0s"', async () => {
-    const response = await GET(makeRequest({ user: 'octocat', speed: '2.0s' }));
-    const body = await response.text();
+    it('falls back to 8s when speed is a non-integer decimal like "2.0s"', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', speed: '2.0s' }));
+      const body = await response.text();
 
-    expect(body).toContain('8s');
-    expect(body).not.toContain('2.0s');
+      expect(body).toContain('8s');
+      expect(body).not.toContain('2.0s');
     });
   });
 

--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -218,6 +218,28 @@ describe('GET /api/streak', () => {
 
       expect(body).toContain('8s');
     });
+
+    it('accepts the minimum boundary speed "2s"', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', speed: '2s' }));
+      const body = await response.text();
+
+      expect(body).toContain('2s');
+  });
+
+  it('accepts the maximum boundary speed "20s"', async () => {
+    const response = await GET(makeRequest({ user: 'octocat', speed: '20s' }));
+    const body = await response.text();
+
+    expect(body).toContain('20s');
+  });
+
+  it('falls back to 8s when speed is a non-integer decimal like "2.0s"', async () => {
+    const response = await GET(makeRequest({ user: 'octocat', speed: '2.0s' }));
+    const body = await response.text();
+
+    expect(body).toContain('8s');
+    expect(body).not.toContain('2.0s');
+    });
   });
 
   describe('scale parameter', () => {

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -86,7 +86,7 @@ export async function GET(request: Request) {
       text: isAutoTheme ? selectedTheme.text : text || selectedTheme.text,
       accent: isAutoTheme ? selectedTheme.accent : accent || selectedTheme.accent,
       radius,
-      speed,
+      speed: speed && /^(?:[2-9]|1\d|20)s$/.test(speed) ? speed : '8s',
       scale,
       font,
       autoTheme: isAutoTheme,


### PR DESCRIPTION
## Description

Fixes #366 

Added boundary validation test coverage for the `speed` parameter in `app/api/streak/route.test.ts`.

### Changes made

* Added test for minimum valid speed boundary: `2s`
* Added test for maximum valid speed boundary: `20s`
* Added validation test to ensure decimal values like `2.0s` are treated as invalid and fall back to the default `8s`
* Updated speed validation logic in `app/api/streak/route.ts` to allow only integer values between `2s` and `20s`

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No, test coverage and validation logic update only.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [x] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
