### PR TITLE
docs(github): document fetch retry backoff constants

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -9,13 +9,16 @@ interface GitHubRepo {
   language: string | null;
 }
 
+// Maximum number of attempts (initial + retries).
 const MAX_RETRIES = 3;
+// Initial delay in ms; doubles on each retry.
 const BASE_DELAY_MS = 500;
 const CONTRIBUTION_MILESTONES = [1, 10, 100, 250, 500, 1000];
 const STREAK_MILESTONES = [3, 7, 30, 100];
 const GRAPHQL_TIMEOUT_MS = 8000; // 8s for GraphQL endpoint
 const REST_TIMEOUT_MS = 5000; // 5s for REST endpoints
 
+// Retry delay uses exponential backoff: delay = BASE_DELAY_MS * 2^attempt.
 export async function fetchWithRetry(
   url: string,
   options: RequestInit,


### PR DESCRIPTION
## Description

Fixes #393

Added inline comments documenting the retry constants and exponential backoff formula used by `fetchWithRetry`.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — docs-only code comment change.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.