### PR TITLE
refactor(github): add retry count to fetchWithRetry error message

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -106,7 +106,7 @@ describe('fetchGitHubContributions', () => {
     vi.mocked(fetch).mockResolvedValue(mockResponse({ message: 'Internal Server Error' }, 500));
 
     await expect(fetchGitHubContributions('octocat')).rejects.toThrow(
-      'GitHub GraphQL API returned status 500'
+      'GitHub GraphQL API returned status 500 after 3 retries'
     );
   });
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -193,7 +193,9 @@ export async function fetchGitHubContributions(
 
   if (!res.ok) {
     if (res.status === 401) throw new Error('GitHub PAT is invalid or missing');
-    throw new Error(`GitHub GraphQL API returned status ${res.status}`);
+    throw new Error(
+      `GitHub GraphQL API returned status ${res.status} after ${MAX_RETRIES} retries`
+    );
   }
 
   const data: GitHubContributionResponse = await res.json();


### PR DESCRIPTION
## Description

Updated the error message thrown by `fetchWithRetry` after exhausting retries to include both the HTTP status code and retry count for improved observability and debugging.

## Changes Made

* Updated final retry exhaustion error message in:

  * `lib/github.ts`
* Updated tests to match new error message in:

  * `lib/github.test.ts`

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint`.
- [x] My commits follow the Conventional Commits format.
- [x] I have made sure this PR only contains relevant changes.

## Result

* Improved debugging visibility
* Retry count now included in thrown error
* Existing retry behavior preserved
* No unrelated functionality changed

## Validation

* [x] Tests passing
* [x] TypeScript checks passing
* [x] ESLint checks passing
* [x] Only required files modified

Closes #361
