### PR TITLE
Refactor: rename auto theme aliases

### DIFF
--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -1,6 +1,6 @@
 import type { BadgeParams, ContributionCalendar, StreakStats, MonthlyStats } from '../../types';
 import { getLabels, type BadgeLabels } from '../i18n/badgeLabels';
-import { AUTO_DARK_THEME, AUTO_LIGHT_THEME } from './themes';
+import { AUTO_THEME_DARK, AUTO_THEME_LIGHT } from './themes';
 import { TOWER_ANIMATION_CSS } from './animations';
 import { computeTowers, type TowerData } from './layout';
 import { sanitizeFont, sanitizeHexColor, sanitizeRadius, sanitizeGoogleFontUrl } from './sanitizer';
@@ -237,8 +237,8 @@ function generateAutoThemeSVG(
   params: BadgeParams,
   calendar: ContributionCalendar
 ): string {
-  const light = AUTO_LIGHT_THEME;
-  const dark = AUTO_DARK_THEME;
+  const light = AUTO_THEME_LIGHT;
+  const dark = AUTO_THEME_DARK;
   const safeUser = escapeXML(params.user || 'GitHub User');
   const sanitizedFont = sanitizeFont(params.font);
   const selectedFont = sanitizedFont
@@ -428,8 +428,8 @@ export function generateMonthlySVG(stats: MonthlyStats, params: BadgeParams): st
 }
 
 function generateAutoThemeMonthlySVG(stats: MonthlyStats, params: BadgeParams): string {
-  const light = AUTO_LIGHT_THEME;
-  const dark = AUTO_DARK_THEME;
+  const light = AUTO_THEME_LIGHT;
+  const dark = AUTO_THEME_DARK;
   const safeUser = escapeXML(params.user || 'GitHub User');
   const sanitizeFont = (name: string) => name.replace(/[^a-zA-Z0-9\s-]/g, '').trim();
   const sanitizedFont = params.font ? sanitizeFont(params.font) : null;

--- a/lib/svg/themes.ts
+++ b/lib/svg/themes.ts
@@ -72,5 +72,5 @@ export const themes: Record<string, BadgeTheme> = {
 // Auto-theme pairs: the SVG switches between these two palettes
 // using @media (prefers-color-scheme) so the badge adapts to the
 // viewer's OS-level light/dark setting without any JavaScript.
-export const AUTO_LIGHT_THEME: BadgeTheme = themes.light;
-export const AUTO_DARK_THEME: BadgeTheme = themes.dark;
+export const AUTO_THEME_LIGHT: BadgeTheme = themes.light;
+export const AUTO_THEME_DARK: BadgeTheme = themes.dark;


### PR DESCRIPTION
## Description

Fixes #357 

Refactored the auto theme alias naming for better clarity and consistency across the SVG theme generation logic.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

### Changes made

* Renamed 'AUTO_LIGHT_THEME' to 'AUTO_THEME_LIGHT'
* Renamed 'AUTO_DARK_THEME' to 'AUTO_THEME_DARK'
* Verified there are no leftover references to old aliases

## Visual Preview

N/A — This PR only includes internal constant renaming/refactoring changes.

## Checklist before requesting a review:

* [x] I have read the 'CONTRIBUTING.md' file.
* [x] I have tested these changes locally ('localhost:3000/api/streak?user=Harshitbhardwaj468').
* [x] I have run 'npm run format' and 'npm run lint' locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., 'feat(themes): ...', 'fix(calculate): ...').
* [ ] I have updated 'README.md' if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.

