### PR TITLE
refactor(github): add type annotation to fetchWithRetry return type

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -17,7 +17,7 @@ const GRAPHQL_TIMEOUT_MS = 8000; // 8s for GraphQL endpoint
 const REST_TIMEOUT_MS = 5000; // 5s for REST endpoints
 
 export async function fetchWithRetry(
-  url: string,
+  url: string | URL,
   options: RequestInit,
   attempt = 0,
   timeoutMs?: number
@@ -25,7 +25,7 @@ export async function fetchWithRetry(
   // Determine default timeout based on endpoint type if not explicitly provided.
   // GraphQL calls carry a larger payload and need a slightly longer window.
   const resolvedTimeout =
-    timeoutMs ?? (url.includes('graphql') ? GRAPHQL_TIMEOUT_MS : REST_TIMEOUT_MS);
+    timeoutMs ?? (url.toString().includes('graphql') ? GRAPHQL_TIMEOUT_MS : REST_TIMEOUT_MS);
 
   if (options.signal?.aborted) {
     throw new Error('AbortError');


### PR DESCRIPTION
## Description

Fixes #381

Updated the `url` parameter type in `fetchWithRetry` to `string | URL` to align with the native fetch API signature. Verified that there are no type errors using `tsc --noEmit`.

## Pillar

- [ ]  Pillar 1 — New Theme Design
- [ ]  Pillar 2 — Geometric SVG Improvement
- [ ]  Pillar 3 — Timezone Logic Optimization
- [x]  Other (Bug fix, refactoring, docs)

## Visual Preview
N/A (TypeScript type refactor)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
