### PR TITLE
fix(TTLCache): reset insertion order on key update in set() [ GSSOC '26 ]

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -47,22 +47,24 @@ export class TTLCache<T> {
     return hit.value;
   }
 
-  set(key: string, value: T, ttlMs: number): void {
-    // Capacity eviction (FIFO / LRU-lite)
-    const maxSize = this.maxSize;
-    if (maxSize !== undefined && this.store.size >= maxSize && !this.store.has(key)) {
-      this.sweep(); // Remove expired entries first to free up capacity
-      if (this.store.size >= maxSize) {
-        // Find the oldest item (first inserted) and remove it
-        const oldestKey = this.store.keys().next().value;
-        if (oldestKey !== undefined) {
-          this.store.delete(oldestKey);
-        }
+ set(key: string, value: T, ttlMs: number): void {
+  if (ttlMs <= 0) throw new RangeError(`ttlMs must be positive, got ${ttlMs}`);
+
+  const maxSize = this.maxSize;
+  if (maxSize !== undefined && this.store.size >= maxSize && !this.store.has(key)) {
+    this.sweep();
+    if (this.store.size >= maxSize) {
+      const oldestKey = this.store.keys().next().value as string | undefined;
+      if (oldestKey !== undefined) {
+        this.store.delete(oldestKey);
       }
     }
-
-    this.store.set(key, { value, expiresAt: Date.now() + ttlMs });
   }
+
+  // Fix: delete first so updated keys move to end (newest position)
+  this.store.delete(key);
+  this.store.set(key, { value, expiresAt: Date.now() + ttlMs });
+}
 
   clear(): void {
     this.store.clear();

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -47,24 +47,24 @@ export class TTLCache<T> {
     return hit.value;
   }
 
- set(key: string, value: T, ttlMs: number): void {
-  if (ttlMs <= 0) throw new RangeError(`ttlMs must be positive, got ${ttlMs}`);
+  set(key: string, value: T, ttlMs: number): void {
+    if (ttlMs <= 0) throw new RangeError(`ttlMs must be positive, got ${ttlMs}`);
 
-  const maxSize = this.maxSize;
-  if (maxSize !== undefined && this.store.size >= maxSize && !this.store.has(key)) {
-    this.sweep();
-    if (this.store.size >= maxSize) {
-      const oldestKey = this.store.keys().next().value as string | undefined;
-      if (oldestKey !== undefined) {
-        this.store.delete(oldestKey);
+    const maxSize = this.maxSize;
+    if (maxSize !== undefined && this.store.size >= maxSize && !this.store.has(key)) {
+      this.sweep();
+      if (this.store.size >= maxSize) {
+        const oldestKey = this.store.keys().next().value as string | undefined;
+        if (oldestKey !== undefined) {
+          this.store.delete(oldestKey);
+        }
       }
     }
-  }
 
-  // Fix: delete first so updated keys move to end (newest position)
-  this.store.delete(key);
-  this.store.set(key, { value, expiresAt: Date.now() + ttlMs });
-}
+    // Fix: delete first so updated keys move to end (newest position)
+    this.store.delete(key);
+    this.store.set(key, { value, expiresAt: Date.now() + ttlMs });
+  }
 
   clear(): void {
     this.store.clear();


### PR DESCRIPTION
## Description
Fixes #596 

When an existing key was updated via `set()`, it retained its original
Map insertion position, causing it to be evicted before older entries.
This PR fixes the eviction order by deleting the key before re-inserting
it, and also adds validation to reject non-positive `ttlMs` values.

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — internal cache logic fix, no visual output.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format (e.g., `fix(TTLCache): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.