### PR TITLE
refactor(ci): enforce no-console rule in production code

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,17 @@ const eslintConfig = defineConfig([
   ...nextTs,
   eslintConfigPrettier,
   globalIgnores(['.next/**', 'out/**', 'build/**', 'next-env.d.ts', 'coverage/**', '.github/**']),
+  {
+    rules: {
+      'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
+    },
+  },
+  {
+    files: ['**/*.test.{js,jsx,ts,tsx}', '**/__tests__/**/*.{js,jsx,ts,tsx}', 'scripts/**/*.{js,jsx,ts,tsx}'],
+    rules: {
+      'no-console': 'off',
+    },
+  },
 ]);
 
 export default eslintConfig;


### PR DESCRIPTION
## Description
This PR adds an ESLint no-console rule to warn against accidental console.log usage in production code while still allowing console.warn, console.error, and console.info.

It also adds overrides for test files and scripts to avoid affecting development/debug workflows.

Fixes #379

---

## Pillar
- [x] Code Quality / Refactor
- [ ] Bug Fix
- [ ] Feature
- [ ] Documentation

---

## Changes Made
- Updated eslint.config.mjs
- Added no-console ESLint rule
- Allowed:
  - console.warn
  - console.error
  - console.info
- Added overrides for:
  - test files
  - __tests__
  - scripts/
- Verified no existing console.log usages remain in:
  - lib/
  - app/api/
  - utils/

---

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines
- [x] I ran npm run lint
- [x] I ran npm run test
- [x] I verified the production build passes
- [x] This PR is linked to an assigned issue
- [x] My changes are focused and minimal