### PR TITLE
test: cover auto theme in streak route

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -297,6 +297,15 @@ describe('GET /api/streak', () => {
       expect(response.status).toBe(200);
     });
 
+    it('returns auto-theme SVG markup with dark-mode CSS variables when theme=auto', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', theme: 'auto' }));
+      const body = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(body).toContain('prefers-color-scheme: dark');
+      expect(body).toContain('--cp-bg');
+    });
+
     it('falls back to the dark theme without crashing when an unknown theme is given', async () => {
       const response = await GET(makeRequest({ user: 'octocat', theme: 'does-not-exist' }));
       const body = await response.text();


### PR DESCRIPTION
## Description
- add one focused route-level test for the ?theme=auto path in pp/api/streak/route.test.ts
- assert the response stays 200
- assert the generated SVG includes both prefers-color-scheme: dark and the --cp-bg CSS variable
- keep the change test-only and aligned with issue #396

## Pillar
- Testing

## Checklist
- [x] Linked to the assigned issue
- [x] Kept the change scoped to the requested file
- [x] Added the exact assertions requested by the issue
- [x] Ran git diff --check
- [ ] Full local test suite not run in this workspace because dependencies are not installed here and the machine is nearly out of disk space

Closes #396