### PR TITLE
test(dashboard): add LanguageChart gradient tests

### DIFF
--- a/components/dashboard/LanguageChart.test.tsx
+++ b/components/dashboard/LanguageChart.test.tsx
@@ -2,6 +2,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import LanguageChart from './LanguageChart';
+import { buildGradientStops } from './LanguageChart';
 
 vi.mock('framer-motion', () => ({
   motion: {
@@ -42,5 +43,53 @@ describe('LanguageChart', () => {
     expect(screen.getAllByText('72%')).toHaveLength(2);
     expect(screen.getAllByText('TypeScript')).toHaveLength(2);
     expect(screen.getByText('JavaScript')).toBeDefined();
+  });
+});
+
+describe('buildGradientStops', () => {
+  it('builds gradient for one language', () => {
+    const result = buildGradientStops([
+      {
+        name: 'TypeScript',
+        percentage: 100,
+        color: '#3178c6',
+      },
+    ]);
+
+    expect(result).toBe('#3178c6 0% 100%');
+  });
+
+  it('builds gradient for two languages', () => {
+    const result = buildGradientStops([
+      {
+        name: 'TypeScript',
+        percentage: 60,
+        color: '#3178c6',
+      },
+      {
+        name: 'JavaScript',
+        percentage: 40,
+        color: '#f7df1e',
+      },
+    ]);
+
+    expect(result).toBe('#3178c6 0% 60%, #f7df1e 60% 100%');
+  });
+
+  it('handles decimal percentages correctly', () => {
+    const result = buildGradientStops([
+      {
+        name: 'TS',
+        percentage: 33.3,
+        color: '#3178c6',
+      },
+      {
+        name: 'JS',
+        percentage: 66.7,
+        color: '#f7df1e',
+      },
+    ]);
+
+    expect(result).toBe('#3178c6 0% 33.3%, #f7df1e 33.3% 100%');
   });
 });

--- a/components/dashboard/LanguageChart.tsx
+++ b/components/dashboard/LanguageChart.tsx
@@ -3,6 +3,23 @@
 import { motion } from 'framer-motion';
 import { LanguageData } from '@/types/dashboard';
 
+export function buildGradientStops(languages: LanguageData[]): string {
+  return languages
+    .reduce<{ stops: string[]; current: number }>(
+      (acc, lang) => {
+        const next = acc.current + lang.percentage;
+
+        acc.stops.push(`${lang.color} ${acc.current}% ${next}%`);
+
+        return {
+          stops: acc.stops,
+          current: next,
+        };
+      },
+      { stops: [], current: 0 }
+    )
+    .stops.join(', ');
+}
 export default function LanguageChart({ languages }: { languages: LanguageData[] }) {
   if (languages.length === 0) {
     return (
@@ -24,16 +41,7 @@ export default function LanguageChart({ languages }: { languages: LanguageData[]
     );
   }
 
-  const gradientStops = languages
-    .reduce<{ stops: string[]; current: number }>(
-      (acc, lang) => {
-        const next = acc.current + lang.percentage;
-        acc.stops.push(`${lang.color} ${acc.current}% ${next}%`);
-        return { stops: acc.stops, current: next };
-      },
-      { stops: [], current: 0 }
-    )
-    .stops.join(', ');
+  const gradientStops = buildGradientStops(languages);
 
   return (
     <motion.div


### PR DESCRIPTION
## Description

Fixes #339

Extracted LanguageChart gradient computation into a reusable helper function and added unit tests for gradient generation logic.

### Changes made

* extracted `buildGradientStops(languages)` helper
* added unit tests for:

  * single language gradients
  * two-language gradients
  * decimal/rounded percentage handling
* verified existing LanguageChart render tests still pass

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test/refactor-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

Closes #339 