### PR TITLE
fix(api): do not cache error SVG responses on CDN

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -443,7 +443,7 @@ describe('GET /api/streak', () => {
 
       const response = await GET(makeRequest({ user: 'octocat' }));
 
-      expect(response.headers.get('Cache-Control')).toBe('public, s-maxage=60');
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
     });
 
     it('returns a valid 500 SVG even when something non-Error is thrown', async () => {

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -217,7 +217,7 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
     status: 500,
     headers: {
       'Content-Type': 'image/svg+xml',
-      'Cache-Control': 'public, s-maxage=60',
+      'Cache-Control': 'no-store',
     },
   });
 }


### PR DESCRIPTION
## Description

Fixes #622

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed
The catch-all error handler in `app/api/streak/route.ts:175` was returning error SVG responses with `Cache-Control: public, s-maxage=60`. This allowed CDNs to cache broken error badges for up to 60 seconds, meaning users embedding the badge in a README would continue seeing the error SVG even after the backend or GitHub had fully recovered.

Changed the Cache-Control header on error responses to `no-store` so CDNs never cache transient failures. Success responses are unaffected.

## Visual Preview
N/A — this is a response header change only.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format (e.g., `fix(api): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.