### PR TITLE
FIX: Year selection in the customization studio

### DIFF
--- a/app/customize/components/ThemeSelector.tsx
+++ b/app/customize/components/ThemeSelector.tsx
@@ -20,7 +20,7 @@ function StyledSelect({
       id={id}
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className="w-full bg-gray-100/80 backdrop-blur-md border border-black/10 dark:bg-white/[0.03] dark:border-white/10 rounded-xl px-4 py-2.5 text-sm text-black dark:text-white outline-none focus:border-emerald-500/50 transition-colors appearance-none cursor-pointer"
+      className="w-full bg-gray-100/80 backdrop-blur-md border border-black/10 dark:bg-white/[0.03] dark:border-white/10 rounded-xl px-4 py-2.5 text-sm text-black dark:text-white outline-none focus:border-emerald-500/50 transition-colors appearance-none cursor-pointer [color-scheme:light] dark:[color-scheme:dark] [&>option]:bg-white [&>option]:text-black dark:[&>option]:bg-[#0a0a0a] dark:[&>option]:text-white"
     >
       {children}
     </select>


### PR DESCRIPTION
## Description
This PR fixes a dark mode styling issue where the selected value in the Year dropdown becomes unreadable due to insufficient text/background contrast.

The dropdown now correctly applies dark theme styles so the selected year remains visible and accessible in dark mode.

Fixes #646 

## Pillar

- [x] 🎨 Pillar 1 — New Theme Design
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## BEFORE 

<img width="667" height="550" alt="Screenshot 2026-05-27 202142" src="https://github.com/user-attachments/assets/ea8fdffe-1d82-4a1d-af61-98095421aaa4" />

##  AFTER

<img width="631" height="392" alt="image" src="https://github.com/user-attachments/assets/70823614-375f-4ecc-9dbf-20afeca63a46" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
