### PR TITLE
Refactor/jsdoc userecentsearches

### DIFF
--- a/hooks/useRecentSearches.ts
+++ b/hooks/useRecentSearches.ts
@@ -31,6 +31,14 @@ function writeStorage(searches: string[] | null): void {
   }
 }
 
+/**
+ * A hook to manage and persist a list of recent searches.
+ *
+ * It uses localStorage for persistence and ensures SSR compatibility by starting
+ * with an empty state on the first render and updating upon hydration.
+ *
+ * @returns An object containing the recent searches, a function to add a search, and a function to clear all searches.
+ */
 export function useRecentSearches() {
   // Always start with [] and mounted:false on both server and client so the
   // initial render matches (SSR-safe). A single setState in the mount effect
@@ -46,6 +54,13 @@ export function useRecentSearches() {
     setState({ searches: loadFromStorage(), mounted: true });
   }, []);
 
+  /**
+   * Adds a new search query to the recent searches list.
+   * If the query already exists, it is moved to the top.
+   * The list is truncated to the maximum number of searches allowed.
+   *
+   * @param query - The search query to add.
+   */
   const addSearch = (query: string) => {
     if (!query.trim()) return;
     setState((prev) => {
@@ -55,6 +70,9 @@ export function useRecentSearches() {
     });
   };
 
+  /**
+   * Clears all recent searches from state and localStorage.
+   */
   const clearSearches = () => {
     setState((prev) => ({ ...prev, searches: [] }));
     writeStorage(null);

--- a/lib/svg/constants.ts
+++ b/lib/svg/constants.ts
@@ -1,0 +1,14 @@
+export const SVG_WIDTH = 600;
+export const SVG_HEIGHT = 420;
+
+export const GHOST_HEIGHT_PX = 4;
+export const LOG_SCALE_MULTIPLIER = 12;
+export const LINEAR_SCALE_MULTIPLIER = 5;
+export const MAX_LOG_HEIGHT = 80;
+export const MAX_LINEAR_HEIGHT = 50;
+
+export const FONT_MAP: Record<string, string> = {
+  jetbrains: '"JetBrains Mono", monospace',
+  fira: '"Fira Code", monospace',
+  roboto: '"Roboto", sans-serif',
+};

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -5,14 +5,7 @@ import { TOWER_ANIMATION_CSS } from './animations';
 import { computeTowers, type TowerData } from './layout';
 import { sanitizeFont, sanitizeHexColor, sanitizeRadius, sanitizeGoogleFontUrl } from './sanitizer';
 
-const SVG_WIDTH = 600;
-const SVG_HEIGHT = 420;
-
-const FONT_MAP: Record<string, string> = {
-  jetbrains: '"JetBrains Mono", monospace',
-  fira: '"Fira Code", monospace',
-  roboto: '"Roboto", sans-serif',
-};
+import { SVG_WIDTH, SVG_HEIGHT, FONT_MAP } from './constants';
 
 // helpers
 function getSizeScale(size?: 'small' | 'medium' | 'large'): number {

--- a/lib/svg/layout.ts
+++ b/lib/svg/layout.ts
@@ -1,11 +1,12 @@
 import type { ContributionCalendar } from '../../types';
 
-// constants
-const GHOST_HEIGHT_PX = 4;
-const LOG_SCALE_MULTIPLIER = 12;
-const LINEAR_SCALE_MULTIPLIER = 5;
-const MAX_LOG_HEIGHT = 80;
-const MAX_LINEAR_HEIGHT = 50;
+import {
+  GHOST_HEIGHT_PX,
+  LOG_SCALE_MULTIPLIER,
+  LINEAR_SCALE_MULTIPLIER,
+  MAX_LOG_HEIGHT,
+  MAX_LINEAR_HEIGHT,
+} from './constants';
 
 /** Shared layout data for a single isometric tower. */
 export interface FaceOpacity {


### PR DESCRIPTION
## Description

Added standard JSDoc comments to `useRecentSearches`, `addSearch`, and `clearSearches` in `hooks/useRecentSearches.ts`.

Fixes #324

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
