### PR TITLE
fix(api): correct malformed stale-while-revalidate cache header

### DIFF
--- a/app/api/github/route.test.ts
+++ b/app/api/github/route.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from './route';
+
+vi.mock('@/lib/github', () => ({
+  getFullDashboardData: vi.fn(),
+}));
+
+import { getFullDashboardData } from '@/lib/github';
+
+function makeRequest(params: Record<string, string> = {}): Request {
+  const url = new URL('http://localhost/api/github');
+
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+
+  return new Request(url.toString());
+}
+
+describe('GET /api/github', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getFullDashboardData).mockResolvedValue({
+      profile: { username: 'octocat' },
+      repositories: [],
+      languages: [],
+      insights: [],
+      commitClock: [],
+    } as never);
+  });
+
+  it('returns a standards-compliant Cache-Control header', async () => {
+    const response = await GET(makeRequest({ username: 'octocat' }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe(
+      's-maxage=3600, stale-while-revalidate=86400'
+    );
+  });
+
+  it('bypasses cache with refresh=true', async () => {
+    const response = await GET(makeRequest({ username: 'octocat', refresh: 'true' }));
+
+    expect(response.headers.get('Cache-Control')).toBe('no-cache, no-store, must-revalidate');
+    expect(getFullDashboardData).toHaveBeenCalledWith('octocat', { bypassCache: true });
+  });
+});

--- a/app/api/github/route.ts
+++ b/app/api/github/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: Request) {
     const data = await getFullDashboardData(username, { bypassCache: refresh });
     const cacheControl = refresh
       ? 'no-cache, no-store, must-revalidate'
-      : 's-maxage=3600, stale-while-revalidate';
+      : 's-maxage=3600, stale-while-revalidate=86400';
 
     return NextResponse.json(data, {
       status: 200,


### PR DESCRIPTION
## Description

Fixes #620

Fixes the malformed `Cache-Control` header in the GitHub API route by adding an explicit numeric value for the `stale-while-revalidate` directive.

The previous response header used:

`s-maxage=3600, stale-while-revalidate`

which is not standards-compliant and may cause inconsistent CDN/browser caching behavior.

This PR updates the header to:

`s-maxage=3600, stale-while-revalidate=86400`

while preserving the existing cache strategy and refresh behavior.

---

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

---

## Visual Preview

N/A — this PR only modifies API caching behavior and test coverage. No SVG/UI changes were made.

---

## Changes Made

* Fixed malformed `Cache-Control` header syntax in the GitHub API route
* Added regression tests for cache header validation
* Added test coverage for refresh cache bypass behavior
* Preserved existing API response and caching logic

---

## Validation

* `npm run format` ✅
* `npm run lint` ✅
* `npm run test` ✅ (277 tests passing)

---

## Notes

A live end-to-end header verification against the local dev server could not be completed because GitHub credentials were not configured locally, causing the endpoint to return a development-time `500` response.

However:

* route-level tests pass successfully
* cache header behavior is validated through automated regression tests

---

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
