### PR TITLE
test(api): add hide params route tests

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -322,6 +322,36 @@ describe('GET /api/streak', () => {
     });
   });
 
+  describe('hide parameters', () => {
+    it('removes the username title when hide_title=true', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', hide_title: 'true' }));
+      const body = await response.text();
+
+      expect(body).not.toContain('OCTOCAT');
+    });
+
+    it('keeps the username title when hide_title=false', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', hide_title: 'false' }));
+      const body = await response.text();
+
+      expect(body).toContain('OCTOCAT');
+    });
+
+    it('removes the stats section when hide_stats=true', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', hide_stats: 'true' }));
+      const body = await response.text();
+
+      expect(body).not.toContain('CURRENT_STREAK');
+    });
+
+    it('keeps the stats section when hide_stats=false', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', hide_stats: 'false' }));
+      const body = await response.text();
+
+      expect(body).toContain('CURRENT_STREAK');
+    });
+  });
+
   describe('error handling', () => {
     it('returns 500 with SVG content type when fetchGitHubContributions throws', async () => {
       vi.mocked(fetchGitHubContributions).mockRejectedValue(new Error('API is down'));


### PR DESCRIPTION
## Description

Fixes #329 

Added route-level tests for the `?hide_title` and `?hide_stats` parameters to verify that SVG title and stats sections are correctly shown or hidden.

## Changes made

- Added test for `?hide_title=true`
- Added test for `?hide_title=false`
- Added test for `?hide_stats=true`
- Added test for `?hide_stats=false`

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [x] I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
