### PR TITLE
test(svg): add auto-theme desc accessibility test

### DIFF
--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -264,6 +264,13 @@ describe('generateSVG', () => {
       expect(svg).not.toContain('class="cp-bg-fill"');
     });
 
+    it('includes desc element in auto-theme SVG output', () => {
+      const svg = generateSVG(mockStats, autoParams, mockCalendar);
+
+      expect(svg).toContain('<desc>');
+      expect(svg).toContain(String(mockStats.totalContributions));
+    });
+
     it('generates heat particles with CSS class instead of inline fill', () => {
       const svg = generateSVG(mockStats, autoParams, mockCalendar);
 


### PR DESCRIPTION
## Description
Added a new test in lib/svg/generator.test.ts to verify that auto-theme SVG output includes a <desc> element for accessibility and contains the totalContributions value.

Fixes #725 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A (test-only change)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
