### PR TITLE
test(page): add disabled copy link button tests

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -166,6 +166,24 @@ describe('LandingPage', () => {
     });
   });
 
+  it('disables Copy Link button when username is empty', () => {
+    render(<LandingPage />);
+
+    const copyButton = screen.getByText('Copy Link').closest('button');
+
+    expect(copyButton?.disabled).toBe(true);
+  });
+
+  it('does not copy link when username is empty', () => {
+    render(<LandingPage />);
+
+    const copyButton = screen.getByText('Copy Link').closest('button');
+
+    fireEvent.click(copyButton!);
+
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+  });
+
   it('renders the FeatureCards', () => {
     render(<LandingPage />);
     expect(screen.getByText('Real-time Sync')).toBeDefined();


### PR DESCRIPTION
## Description
Added tests in app/page.test.tsx to verify that the Copy Link button remains disabled when the username input is empty and that clicking it does not trigger navigator.clipboard.writeText.

Fixes #711 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A (test-only change)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
