### PR TITLE
test(ShareSheet): verify navigator.share is called

### DIFF
--- a/components/dashboard/ShareSheet.test.tsx
+++ b/components/dashboard/ShareSheet.test.tsx
@@ -163,6 +163,27 @@ describe('ShareSheet', () => {
     expect(defaultProps.onClose).toHaveBeenCalled();
   });
 
+  it('handles Share via OS Sheet action', async () => {
+    const shareMock = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      share: shareMock,
+    });
+    render(<ShareSheet {...defaultProps} />);
+    const shareButton = screen.getByText('Share via OS Sheet').closest('button');
+    fireEvent.click(shareButton!);
+    await waitFor(() => {
+      expect(shareMock).toHaveBeenCalled();
+    });
+
+    expect(shareMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.any(String),
+        text: expect.any(String),
+        url: expect.any(String),
+      })
+    );
+  });
+
   it('handles Download PNG action', async () => {
     render(<ShareSheet {...defaultProps} />);
 


### PR DESCRIPTION
▶ Description

      Fixes #739

This PR adds test coverage for the native OS sharing flow inside the `ShareSheet` component by mocking `navigator.share` and verifying it is triggered correctly when the **"Share via OS Sheet"** button is clicked.

The native share sheet path is especially important for mobile devices, and this test ensures the integration remains stable and regression-safe.

▶ Changes Made
● Added a new unit test in:
                                                         "txt
                                                          components/dashboard/ShareSheet.test.tsx"
▶ Test coverage includes:
    - Mocking "navigator.share" using "vi.fn()"
    - Rendering the "ShareSheet" component
    - Simulating user interaction with the native share button
    - Verifying "navigator.share" is invoked
    - Verifying the payload contains:
                       • title
                       • text
                       • url

▶ Pillar
Testing / Quality Assurance

▶ Validation
Successfully ran the complete Vitest test suite locally.
● Result:
                             "txt
                              Test Files  27 passed (27)
                              Tests 353 passed (353)"
        No existing tests were broken.

▶ Why This Matters
The OS share sheet flow is a mobile-critical feature.
This test improves reliability by ensuring:
                                                                    * native sharing continues working correctly
                                                                    * payload structure remains consistent
                                                                    * future regressions are caught automatically
✅ Checklist
[x] Added unit test for "navigator.share"
[x] Verified correct payload structure
[x] Followed existing test conventions
[x] All tests passing
[x] No unrelated files modified


<img width="1920" height="1080" alt="Screenshot 2026-05-27 221308" src="https://github.com/user-attachments/assets/99d4e85c-644f-439d-8e4c-f6befa29a464" />
<img width="1920" height="1080" alt="Screenshot 2026-05-27 221344" src="https://github.com/user-attachments/assets/f49ba90c-596f-4ee7-9044-0ffe7d19b15b" />
