### PR TITLE
Fixed(footer): resolve mobile link layout collision with scroll-to-top button

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -2,8 +2,8 @@ import Link from 'next/link';
 
 export function Footer() {
   return (
-    <footer className="mt-14 border-t border-black/15 dark:border-white/10 bg-transparent pt-10 pb-4 text-sm transition-colors">
-      <div className="mx-auto flex max-w-7xl flex-col items-start justify-between gap-8 px-6 md:flex-row">
+    <footer className="mt-14 border-t border-black/15 dark:border-white/10 bg-transparent pt-10 pb-24 md:pb-6 text-sm transition-colors">
+      <div className="mx-auto flex max-w-7xl flex-col items-center text-center  justify-between gap-8 px-6 md:flex-row md:items-start md:text-left">
         {/* LEFT */}
         <div className="text-center md:text-left">
           <h2 className="text-lg font-semibold text-black dark:text-white">CommitPulse</h2>
@@ -14,7 +14,7 @@ export function Footer() {
         </div>
 
         {/* RIGHT */}
-        <div className="flex items-start gap-6 text-sm font-medium text-zinc-600 dark:text-zinc-400">
+        <div className="flex flex-wrap justify-center items-center gap-6 font-medium text-zinc-600 dark:text-zinc-400">
           {' '}
           <Link
             href="/contributors"


### PR DESCRIPTION

### Description
This PR fixes a layout bug on mobile screens where the footer navigation links were overlapping and colliding with the floating blue scroll-to-top action button.

### Changes Made
- Added `pb-24 md:pb-6` padding to the `<footer>` container to create a safe spacing cushion on mobile views.
- Centered and wrapped the stacked layout items cleanly on mobile viewports for a better responsive layout flow.

### Closes
Closes #653

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

- **Before:** The "Creator" navigation link was hidden directly underneath the floating back-to-top button on mobile screen widths.
- 
<img width="402" height="557" alt="Screenshot (1565)" src="https://github.com/user-attachments/assets/27581722-f959-4721-a23e-58da354ca2b3" />

- **After:** The footer elements wrap dynamically and feature increased bottom padding (`pb-24`), safely lifting the links entirely clear of the floating button.
- 
<img width="436" height="542" alt="Screenshot (1583)" src="https://github.com/user-attachments/assets/890d74f9-9b0a-4c19-820e-237de66cec04" />


## Checklist before requesting a review:

- [x ] I have read the `CONTRIBUTING.md` file.
- [x ] I have tested these changes locally (`localhost:3000/api/streak?user=pujaux`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x ] I have updated `README.md` if I added a new theme or URL parameter.
- [x ] I have started the repo.
- [x ] I have made sure that i have only one commit to merge in this PR.
- [x ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
