### PR TITLE
test(DashboardPage): verify all three StatsCards render with correct titles

### DIFF
--- a/app/(root)/dashboard/[username]/page.test.tsx
+++ b/app/(root)/dashboard/[username]/page.test.tsx
@@ -129,7 +129,7 @@ describe('DashboardPage', () => {
       expect(screen.getByTestId('heatmap')).toBeDefined();
       expect(screen.getByTestId('ai-insights')).toBeDefined();
       expect(screen.getByTestId('achievements')).toBeDefined();
-
+      expect(screen.getAllByTestId('stats-card')).toHaveLength(3);
       expect(screen.getByText('Current Streak: 5')).toBeDefined();
       expect(screen.getByText('Peak Streak: 15')).toBeDefined();
       expect(screen.getByText('Contributions: 500')).toBeDefined();


### PR DESCRIPTION
▶ Description

Fixes #742

This PR improves test coverage for the DashboardPage by verifying that all three "StatsCard" components render correctly with the expected titles and values.

▶ Changes Made
Verified the following StatsCard text content:
● "Current Streak: 5"
● "Peak Streak: 15"
● "Contributions: 500"

Added a new assertion to ensure exactly three StatsCard components are rendered:
                                                                                "ts id="kgduut"
                                                                                expect(screen.getAllByTestId('stats-card')).toHaveLength(3);"

▶ Pillar
Testing / Quality Assurance

▶ Validation
Successfully ran the complete Vitest test suite locally.
                                                                                       "txt id='uw3jzu'
                                                                                        Test Files 27 passed (27)
                                                                                        Tests 353 passed (353)"
All existing tests continue to pass successfully.


▶ Why This Matters
This improves dashboard reliability by ensuring:
● all expected statistics render consistently
● the exact number of StatsCard components is validated
● future UI regressions can be caught automatically


▶ Checklist
[x] Added StatsCard count assertion
[x] Verified all required stat titles
[x] Followed existing testing conventions
[x] All tests passing
[x] No unrelated files modified


<img width="1920" height="1080" alt="Screenshot 2026-05-27 230731" src="https://github.com/user-attachments/assets/668e1ea7-a78c-4f35-8996-4c420b999c6a" />
<img width="1920" height="1080" alt="Screenshot 2026-05-27 230759" src="https://github.com/user-attachments/assets/45424146-ec96-496e-8988-c242a496cd86" />

