### PR TITLE
test(svg): add hideBackground generator coverage

### DIFF
--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -59,15 +59,15 @@ describe('generateSVG', () => {
   });
 
   it('uses transparent background when hideBackground is true', () => {
-  const svg = generateSVG(
-    mockStats,
-    {
-      user: 'avi',
-      hideBackground: true,
-    } as unknown as BadgeParams,
-    mockCalendar
-  );
-  expect(svg).toContain('fill="transparent"');
+    const svg = generateSVG(
+      mockStats,
+      {
+        user: 'avi',
+        hideBackground: true,
+      } as unknown as BadgeParams,
+      mockCalendar
+    );
+    expect(svg).toContain('fill="transparent"');
   });
 
   it('uses normal background when hideBackground is false or omitted', () => {

--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -58,6 +58,30 @@ describe('generateSVG', () => {
     expect(svg).toContain('svg');
   });
 
+  it('uses transparent background when hideBackground is true', () => {
+  const svg = generateSVG(
+    mockStats,
+    {
+      user: 'avi',
+      hideBackground: true,
+    } as unknown as BadgeParams,
+    mockCalendar
+  );
+  expect(svg).toContain('fill="transparent"');
+  });
+
+  it('uses normal background when hideBackground is false or omitted', () => {
+    const svg = generateSVG(
+      mockStats,
+      {
+        user: 'avi',
+        bg: '0d1117',
+      } as unknown as BadgeParams,
+      mockCalendar
+    );
+    expect(svg).not.toContain('fill="transparent"');
+  });
+
   it('generates particles for days with 10 or more contributions', () => {
     const svg = generateSVG(mockStats, { user: 'avi' } as unknown as BadgeParams, mockCalendar);
     expect(svg).toContain('class="heat-particles"');


### PR DESCRIPTION
## Description

Closes #720

Added generator-level test coverage for the `hideBackground` parameter in `generateSVG`.

### What Changed

* Added a test verifying that `hideBackground: true` renders the SVG background with `fill="transparent"`
* Added a test verifying that the default/false behavior does not render a transparent background
* Ensured all existing SVG generator tests continue to pass successfully

### Why

The transparent background feature already existed in the SVG generator, but this behavior was not explicitly covered by automated tests.

These tests improve regression protection and help ensure the background rendering behavior remains stable in future updates.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run lint` locally and resolved all errors.
* [x] I have run the relevant Vitest test suite successfully.
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
