### PR TITLE
test(useRecentSearches): verify clearSearches removes the localStorage key

### DIFF
--- a/app/(root)/dashboard/[username]/page.test.tsx
+++ b/app/(root)/dashboard/[username]/page.test.tsx
@@ -129,7 +129,7 @@ describe('DashboardPage', () => {
       expect(screen.getByTestId('heatmap')).toBeDefined();
       expect(screen.getByTestId('ai-insights')).toBeDefined();
       expect(screen.getByTestId('achievements')).toBeDefined();
-
+      expect(screen.getAllByTestId('stats-card')).toHaveLength(3);
       expect(screen.getByText('Current Streak: 5')).toBeDefined();
       expect(screen.getByText('Peak Streak: 15')).toBeDefined();
       expect(screen.getByText('Contributions: 500')).toBeDefined();

--- a/hooks/useRecentSearches.test.ts
+++ b/hooks/useRecentSearches.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useRecentSearches, MAX_SEARCHES } from './useRecentSearches';
+import { useRecentSearches, MAX_SEARCHES, STORAGE_KEY } from './useRecentSearches';
 
 const store: Record<string, string> = {};
 
@@ -62,14 +62,20 @@ describe('useRecentSearches', () => {
     expect(result.current.searches.length).toBe(MAX_SEARCHES);
   });
 
-  it('clears all searches', () => {
+  it('clears all searches and removes localStorage key', () => {
+    const removeItemSpy = vi.spyOn(window.localStorage, 'removeItem');
+
     const { result } = renderHook(() => useRecentSearches());
+
     act(() => {
       result.current.addSearch('torvalds');
     });
+
     act(() => {
       result.current.clearSearches();
     });
+
     expect(result.current.searches).toEqual([]);
+    expect(removeItemSpy).toHaveBeenCalledWith(STORAGE_KEY);
   });
 });

--- a/hooks/useRecentSearches.ts
+++ b/hooks/useRecentSearches.ts
@@ -56,8 +56,12 @@ export function useRecentSearches() {
   };
 
   const clearSearches = () => {
-    setState((prev) => ({ ...prev, searches: [] }));
     writeStorage(null);
+
+    setState((prev) => ({
+      ...prev,
+      searches: [],
+    }));
   };
 
   // Return empty searches until after hydration to prevent SSR/client mismatch.


### PR DESCRIPTION
## Description

Fixes #717 
This PR improves test coverage for the useRecentSearches hook by verifying that clearSearches correctly removes the persisted localStorage entry.

● Changes Made
Added a spy for localStorage.removeItem
Verified clearSearches() calls:
removeItem('recentSearches')
Preserved all existing hook test behavior

## Pillar
Testing / Quality Assurance

## Visual Preview
<img width="1920" height="1080" alt="Screenshot 2026-05-28 004327" src="https://github.com/user-attachments/assets/3018699d-abb8-4466-aefa-041ce22fe584" />
<img width="1920" height="1080" alt="Screenshot 2026-05-28 004343" src="https://github.com/user-attachments/assets/cf412082-6cd3-45c0-8b29-d3daf4d18844" />
<img width="1920" height="1080" alt="Screenshot 2026-05-28 004419" src="https://github.com/user-attachments/assets/c465f5db-5fab-4c93-a144-f0af325c0893" />


● Why This Matters
This ensures:
localStorage cleanup works correctly
stale recent search data is removed properly
future regressions in persistence behavior are caught automatically

## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- I have updated `README.md` if I added a new theme or URL parameter.
- I have started the repo.
- I have made sure that i have only one commit to merge in this PR.
- The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements,     smooth animations, correct fonts).
- I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
