### PR TITLE
test(streak route): add Content-Type checks for theme variants

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -373,6 +373,24 @@ describe('GET /api/streak', () => {
       expect(response.status).toBe(200);
     });
 
+    it('returns SVG content type for theme=neon', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', theme: 'neon' }));
+
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+    });
+
+    it('returns SVG content type for theme=dracula', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', theme: 'dracula' }));
+
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+    });
+
+    it('returns SVG content type for theme=auto', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', theme: 'auto' }));
+
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+    });
+
     it('returns auto-theme SVG markup with dark-mode CSS variables when theme=auto', async () => {
       const response = await GET(makeRequest({ user: 'octocat', theme: 'auto' }));
       const body = await response.text();


### PR DESCRIPTION
## Description

Fixes #698
Program: GSSoC 2026

This PR adds test coverage for ensuring that the streak API always returns the correct `Content-Type` header (`image/svg+xml`) across all supported theme variants.

Previously, tests only validated the default theme response. This update extends coverage to ensure consistency across named themes.

### Changes Made

* Added 3 new test cases in `app/api/streak/route.test.ts`
* Verified `Content-Type: image/svg+xml` for:

  * `theme=neon`
  * `theme=dracula`
  * `theme=auto`
* Ensured backward compatibility with existing default theme test cases

### Why this matters

Ensures that all theme variations maintain correct SVG response headers, preventing broken GitHub README badge rendering across different theme configurations.

---

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)
---

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.
