### PR TITLE
fix(api): guard malformed GraphQL error responses

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -135,8 +135,32 @@ describe('fetchGitHubContributions', () => {
       })
     );
 
-    // Only the first error surfaces — the source always reads errors[0].
+    // Preserve the existing behavior of surfacing the first GitHub error message.
     await expect(fetchGitHubContributions('octocat')).rejects.toThrow('Bad credentials');
+  });
+
+  it('throws a stable fallback when GraphQL returns an empty errors array', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse({
+        errors: [],
+      })
+    );
+
+    await expect(fetchGitHubContributions('octocat')).rejects.toThrow(
+      'GitHub GraphQL API returned an unknown error'
+    );
+  });
+
+  it('throws a stable fallback when the first GraphQL error has no message', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse({
+        errors: [{}],
+      })
+    );
+
+    await expect(fetchGitHubContributions('octocat')).rejects.toThrow(
+      'GitHub GraphQL API returned an unknown error'
+    );
   });
 
   it('throws a descriptive "user not found" error when the username does not exist on GitHub', async () => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -82,15 +82,34 @@ const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql';
 const GITHUB_REST_URL = 'https://api.github.com';
 
 type GitHubContributionResponse = {
-  data: {
+  data?: {
     user: {
       contributionsCollection: {
         contributionCalendar: ContributionCalendar;
       };
     } | null;
   };
-  errors?: Array<{ message: string }>;
+  errors?: unknown;
 };
+
+const UNKNOWN_GRAPHQL_ERROR_MESSAGE = 'GitHub GraphQL API returned an unknown error';
+
+function getGraphQLErrorMessage(errors: unknown): string {
+  if (!Array.isArray(errors)) return UNKNOWN_GRAPHQL_ERROR_MESSAGE;
+
+  const firstError = errors[0];
+  if (
+    firstError &&
+    typeof firstError === 'object' &&
+    'message' in firstError &&
+    typeof firstError.message === 'string' &&
+    firstError.message.trim() !== ''
+  ) {
+    return firstError.message;
+  }
+
+  return UNKNOWN_GRAPHQL_ERROR_MESSAGE;
+}
 
 /**
  * Configuration options for GitHub API fetch requests.
@@ -264,11 +283,11 @@ export async function fetchGitHubContributions(
 
   const data: GitHubContributionResponse = await res.json();
 
-  if (data.errors) {
-    throw new Error(data.errors[0].message);
+  if (data.errors !== undefined) {
+    throw new Error(getGraphQLErrorMessage(data.errors));
   }
 
-  if (!data.data.user) {
+  if (!data.data?.user) {
     throw new Error(`GitHub user "${username}" not found`);
   }
 


### PR DESCRIPTION
## Description

Fixes #807

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed
The GitHub GraphQL client assumed every GraphQL error response had a non-empty `errors` array with a `message` string at index `0`.

That meant responses like:

```json
{ "errors": [] }
```

or:

```json
{ "errors": [{}] }
```

could throw a runtime `TypeError` instead of a controlled API error. I added a small guard that normalizes malformed GraphQL error payloads to a stable fallback message while preserving the existing behavior for normal GitHub errors such as `Bad credentials`.

I also made the response `data` field optional in the local response type and changed the user lookup to use optional chaining so malformed responses do not crash while checking `data.user`.

## Visual Preview
N/A — this is API error handling and test coverage only.

## Testing
```bash
npm run format
npm run test -- lib/github.test.ts
npm run lint
npm run typecheck
npm run test
npm run build
```

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.