### PR TITLE
fix(api): validate monthly badge dimensions

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -90,6 +90,25 @@ describe('GET /api/streak', () => {
 
       expect(fetchGitHubContributions).not.toHaveBeenCalled();
     });
+
+    it('returns 400 for invalid monthly badge dimensions', async () => {
+      const invalidDimensionParams: Array<Record<string, string>> = [
+        { width: 'abc' },
+        { width: '-50' },
+        { width: '1201' },
+        { height: 'abc' },
+        { height: '0' },
+        { height: '801' },
+      ];
+
+      for (const params of invalidDimensionParams) {
+        const response = await GET(makeRequest({ user: 'octocat', view: 'monthly', ...params }));
+
+        expect(response.status).toBe(400);
+      }
+
+      expect(fetchGitHubContributions).not.toHaveBeenCalled();
+    });
   });
 
   describe('successful response', () => {
@@ -605,6 +624,18 @@ describe('GET /api/streak', () => {
       expect(response.status).toBe(200);
       const body = await response.text();
       expect(body).toContain('COMMITS THIS MONTH');
+    });
+
+    it('uses valid custom width and height in monthly SVG output', async () => {
+      const response = await GET(
+        makeRequest({ user: 'octocat', view: 'monthly', width: '400', height: '200' })
+      );
+      const body = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(body).toContain('width="400"');
+      expect(body).toContain('height="200"');
+      expect(body).toContain('viewBox="0 0 400 200"');
     });
 
     it('defaults to default view when an unknown view is given', async () => {

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -129,8 +129,8 @@ export async function GET(request: Request) {
       lang,
       view,
       delta_format,
-      width: width ? parseInt(width, 10) : undefined,
-      height: height ? parseInt(height, 10) : undefined,
+      width,
+      height,
       size,
       grace,
     };

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -1,6 +1,23 @@
 import { z } from 'zod';
 import { sanitizeHexColor, sanitizeSpeed, sanitizeRadius, sanitizeFont } from './svg/sanitizer';
 
+function dimensionParam(name: string, min: number, max: number) {
+  return z
+    .string()
+    .optional()
+    .refine(
+      (val) => {
+        if (val === undefined) return true;
+        if (!/^\d+$/.test(val)) return false;
+
+        const parsed = Number(val);
+        return parsed >= min && parsed <= max;
+      },
+      { message: `${name} must be an integer between ${min} and ${max}` }
+    )
+    .transform((val) => (val === undefined ? undefined : Number(val)));
+}
+
 export const streakParamsSchema = z.object({
   // Required — missing user surfaces as "Missing" to match existing tests
   user: z
@@ -83,8 +100,8 @@ export const streakParamsSchema = z.object({
   view: z.enum(['default', 'monthly']).catch('default').default('default'),
   // Invalid delta formats fall back to percentage mode.
   delta_format: z.enum(['percent', 'absolute', 'both']).catch('percent').default('percent'),
-  width: z.string().optional(),
-  height: z.string().optional(),
+  width: dimensionParam('width', 100, 1200),
+  height: dimensionParam('height', 80, 800),
   grace: z
     .string()
     .optional()


### PR DESCRIPTION
## Description

Fixes #806

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed
The monthly badge accepted `width` and `height` as raw strings, then parsed them in the route with `parseInt`. That allowed values like `width=abc`, `height=-20`, or very large numbers to reach the SVG renderer and produce broken or unreasonable SVG dimensions.

This PR moves dimension validation into `streakParamsSchema` so invalid input is rejected before the GitHub fetch or SVG render path runs.

The accepted ranges are:
- `width`: `100` to `1200`
- `height`: `80` to `800`

The route now receives already-parsed numbers and no longer needs to call `parseInt` for these params.

## Visual Preview
N/A — this is input validation for the monthly SVG route.

## Testing
```bash
npm run format
npm run test -- app/api/streak/route.test.ts
npm run lint
npm run typecheck
npm run test
npm run build
```

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.