### PR TITLE
test: add githubParamsSchema validation tests

### DIFF
--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { githubParamsSchema } from './validations';
+
+describe('githubParamsSchema', () => {
+  it('should pass when username is valid', () => {
+    const result = githubParamsSchema.safeParse({
+      username: 'octocat',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should fail when username is omitted', () => {
+    const result = githubParamsSchema.safeParse({});
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe('Missing "username" parameter');
+    }
+  });
+
+  it('should fail when username is empty', () => {
+    const result = githubParamsSchema.safeParse({
+      username: '',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should transform refresh true string to boolean true', () => {
+    const result = githubParamsSchema.safeParse({
+      username: 'octocat',
+      refresh: 'true',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.refresh).toBe(true);
+    }
+  });
+
+  it('should transform refresh false string to boolean false', () => {
+    const result = githubParamsSchema.safeParse({
+      username: 'octocat',
+      refresh: 'false',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.refresh).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Description
Added unit tests for `githubParamsSchema` in `lib/validations.test.ts`.

### Changes Made
- Added success test for valid username
- Added failure test for omitted username
- Added failure test for empty username
- Added refresh=true boolean transform test
- Added refresh=false boolean transform test

Closes #663

---

## Pillar
- [x] Tests
- [ ] Bug Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor

---

## Checklist
- [x] My code follows the project style guidelines
- [x] I have tested my changes locally
- [x] All tests are passing
- [x] I have linked the related issue
- [x] This PR is ready for review