### PR TITLE
test: document language chart row rendering

### DIFF
--- a/components/dashboard/LanguageChart.test.tsx
+++ b/components/dashboard/LanguageChart.test.tsx
@@ -44,6 +44,29 @@ describe('LanguageChart', () => {
     expect(screen.getAllByText('TypeScript')).toHaveLength(2);
     expect(screen.getByText('JavaScript')).toBeDefined();
   });
+
+  it('renders every language row passed to the component', () => {
+    const languages = [
+      { name: 'TypeScript', percentage: 30, color: '#3178c6' },
+      { name: 'JavaScript', percentage: 20, color: '#f1e05a' },
+      { name: 'Python', percentage: 15, color: '#3572A5' },
+      { name: 'Go', percentage: 12, color: '#00ADD8' },
+      { name: 'Rust', percentage: 8, color: '#dea584' },
+      { name: 'Ruby', percentage: 6, color: '#701516' },
+      { name: 'PHP', percentage: 5, color: '#4F5D95' },
+      { name: 'CSS', percentage: 4, color: '#563d7c' },
+    ];
+
+    render(<LanguageChart languages={languages} />);
+
+    const renderedLanguageNameElements = screen.getAllByText(
+      (content, element) =>
+        languages.some((language) => language.name === content) &&
+        element?.className === 'text-[#A1A1AA]'
+    );
+
+    expect(renderedLanguageNameElements).toHaveLength(8);
+  });
 });
 
 describe('buildGradientStops', () => {


### PR DESCRIPTION
## Description

Adds a test for `LanguageChart` to clarify rendering behavior when more than 5 languages are passed to the component.

Currently, `getFullDashboardData` slices the language list to 5, but `LanguageChart` itself does not enforce this limit. This PR adds a test documenting the current expected behavior and helping prevent silent regressions in the future.

Fixes #737 

---

## Pillar

Testing

---

## Checklist

* [x] I have tested these changes locally
* [x] I have followed the project's coding conventions
* [x] I have checked for existing conflicts/issues
* [x] Existing tests pass successfully
* [x] Added a new test case for LanguageChart behavior
