### PR TITLE
test(calculate): verify longest streak is found in middle of calendar

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -210,6 +210,54 @@ describe('calculateStreak', () => {
     expect(result.currentStreak).toBe(0);
     expect(result.longestStreak).toBe(0);
   });
+
+  it('should find the longest streak when it is in the middle of the calendar', () => {
+    // buildCalendar groups elements by sets of 7 (weeks) from left to right.
+    // The very last element of the flat array represents "today".
+    const calendar = buildCalendar([
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0, // Week 1 — Buffer gap
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1, // Week 2 — Longest streak start (7 days)
+      1,
+      1,
+      1,
+      0,
+      0,
+      0,
+      0, // Week 3 — Longest streak ends (+3 days = 10 total) followed by a gap
+      1,
+      1,
+      1,
+      1,
+      1,
+      0,
+      0, // Week 4 — Intermediate streak (5 days) broken by a gap
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+      1, // Week 5 — 5-day active current streak ending on the final day ("today")
+    ]);
+
+    const result = calculateStreak(calendar);
+
+    // Assertions (Definition of Done)
+    expect(result.longestStreak).toBe(10);
+    expect(result.currentStreak).toBe(5);
+  });
 });
 
 describe('calculateStreak — timezone awareness', () => {


### PR DESCRIPTION
## Description

Fixes #683

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs, tests)

## Visual Preview
*(You can leave this blank or delete it, since this is a unit test change and does not alter the look of the SVG badge).*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.