### PR TITLE
test: clarify layout today fallback

### DIFF
--- a/lib/svg/layout.test.ts
+++ b/lib/svg/layout.test.ts
@@ -67,8 +67,11 @@ describe('computeTowers edge cases', () => {
       ],
     } as unknown as ContributionCalendar;
     const towers = computeTowers(calendar, 'linear', '2024-12-31');
-    expect(towers[1].isToday).toBe(true); // fallback marks the last one
+    const lastTower = towers[towers.length - 1];
+
+    expect(towers).toHaveLength(2);
     expect(towers[0].isToday).toBe(false);
+    expect(lastTower.isToday).toBe(true);
   });
 
   it('correctly assigns isToday when todayDate is in window', () => {


### PR DESCRIPTION
## Description

Adds a layout-level regression test for the `computeTowers` fallback behavior when the provided `todayDate` is not found within the calendar window.

The test verifies that:

* when no matching date exists,
* the last tower is automatically marked with `isToday === true`

This helps ensure the fallback logic remains stable and prevents future regressions.

Fixes #726 

---

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

---

## Visual Preview

N/A — test-only change.

---

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
