### PR TITLE
test(svg): add hide stats generator tests

### DIFF
--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -22,6 +22,46 @@ describe('generateSVG', () => {
     ],
   } as ContributionCalendar;
 
+  it('omits stats labels when hide_stats is true', () => {
+    const svg = generateSVG(
+      mockStats,
+      {
+        user: 'avi',
+        bg: hexColor('0d1117'),
+        text: hexColor('c9d1d9'),
+        accent: hexColor('58a6ff'),
+        speed: '8s',
+        scale: 'linear',
+        hide_stats: true,
+      },
+      mockCalendar
+    );
+
+    expect(svg).not.toContain('CURRENT_STREAK');
+    expect(svg).not.toContain('ANNUAL_SYNC_TOTAL');
+    expect(svg).not.toContain('PEAK_STREAK');
+  });
+
+  it('renders stats labels when hide_stats is false', () => {
+    const svg = generateSVG(
+      mockStats,
+      {
+        user: 'avi',
+        bg: hexColor('0d1117'),
+        text: hexColor('c9d1d9'),
+        accent: hexColor('58a6ff'),
+        speed: '8s',
+        scale: 'linear',
+        hide_stats: false,
+      },
+      mockCalendar
+    );
+
+    expect(svg).toContain('CURRENT_STREAK');
+    expect(svg).toContain('ANNUAL_SYNC_TOTAL');
+    expect(svg).toContain('PEAK_STREAK');
+  });
+
   it('uses default typography when no font is passed', () => {
     const svg = generateSVG(mockStats, { user: 'avi' } as unknown as BadgeParams, mockCalendar);
 


### PR DESCRIPTION
## Description
Added generator-level tests in lib/svg/generator.test.ts to verify that stats labels are omitted when hide_stats=true and rendered when hide_stats=false.

Fixes #721 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A (test-only change)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
