### PR TITLE
test(github): add max achievements unlock test

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -497,6 +497,12 @@ describe('generateAchievements', () => {
     expect(unlocked.some((a) => a.title === '1000 Contributions')).toBe(false);
   });
 
+  it('unlocks all achievements for max contribution and streak values', () => {
+    const achievements = generateAchievements(1001, 101);
+
+    expect(achievements.every((achievement) => achievement.isUnlocked === true)).toBe(true);
+  });
+
   it('marks streak milestones correctly', () => {
     const achievements = generateAchievements(50, 35);
 


### PR DESCRIPTION
## Description
Added a new test in lib/github.test.ts to verify that all achievements are unlocked when generateAchievements(1001, 101) is called, ensuring the max contribution and streak scenario is fully covered.

Fixes #691 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A (test-only change)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
