### PR TITLE
fix: Update Contribution Count Label to 'Last 365 Days' (Fixes #223)

### DIFF
--- a/app/(root)/dashboard/[username]/page.tsx
+++ b/app/(root)/dashboard/[username]/page.tsx
@@ -153,7 +153,7 @@ export default async function DashboardPage({
             <StatsCard
               title="Contributions"
               value={data.stats.totalContributions.toString()}
-              description="Last Year"
+              description="Last 365 Days"
               icon="GitCommit"
             />
           </div>


### PR DESCRIPTION
This Pull Request updates the description label on the contribution metric from `'Last Year'` to `'Last 365 Days'` to match the rolling 12-month data retrieved from the GitHub API, resolving user confusion.

Closes #223.