### PR TITLE
fix(api): fail fast when GitHub token is missing

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -27,6 +27,9 @@ const mockCalendar: ContributionCalendar = {
   ],
 };
 
+const originalGitHubPat = process.env.GITHUB_PAT;
+const originalGitHubToken = process.env.GITHUB_TOKEN;
+
 function mockResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -36,10 +39,23 @@ function mockResponse(body: unknown, status = 200): Response {
 
 beforeEach(() => {
   clearGitHubApiCacheForTests();
+  process.env.GITHUB_PAT = 'test-token';
+  delete process.env.GITHUB_TOKEN;
 });
 
 afterEach(() => {
   clearGitHubApiCacheForTests();
+  if (originalGitHubPat === undefined) {
+    delete process.env.GITHUB_PAT;
+  } else {
+    process.env.GITHUB_PAT = originalGitHubPat;
+  }
+
+  if (originalGitHubToken === undefined) {
+    delete process.env.GITHUB_TOKEN;
+  } else {
+    process.env.GITHUB_TOKEN = originalGitHubToken;
+  }
 });
 
 describe('fetchGitHubContributions', () => {
@@ -81,11 +97,44 @@ describe('fetchGitHubContributions', () => {
     const [url, options] = vi.mocked(fetch).mock.calls[0];
     expect(url).toBe('https://api.github.com/graphql');
     expect(options?.method).toBe('POST');
+    expect(options?.headers).toMatchObject({
+      Authorization: 'bearer test-token',
+      'Content-Type': 'application/json',
+    });
 
     // Make sure the username is wired into the GraphQL variables, not hardcoded.
     const body = JSON.parse(options?.body as string);
     expect(body.variables).toEqual({ login: 'octocat' });
     expect(body.query).toContain('contributionCalendar');
+  });
+
+  it('uses GITHUB_TOKEN when GITHUB_PAT is not configured', async () => {
+    delete process.env.GITHUB_PAT;
+    process.env.GITHUB_TOKEN = 'actions-token';
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse({
+        data: {
+          user: { contributionsCollection: { contributionCalendar: mockCalendar } },
+        },
+      })
+    );
+
+    await fetchGitHubContributions('octocat');
+
+    const [, options] = vi.mocked(fetch).mock.calls[0];
+    expect(options?.headers).toMatchObject({
+      Authorization: 'bearer actions-token',
+    });
+  });
+
+  it('throws before fetching when no GitHub token is configured', async () => {
+    delete process.env.GITHUB_PAT;
+    delete process.env.GITHUB_TOKEN;
+
+    await expect(fetchGitHubContributions('octocat')).rejects.toThrow(
+      'GitHub token is missing. Set GITHUB_PAT or GITHUB_TOKEN.'
+    );
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it('works correctly for a brand-new user who has zero contribution weeks', async () => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -80,6 +80,7 @@ export async function fetchWithRetry(
 
 const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql';
 const GITHUB_REST_URL = 'https://api.github.com';
+const MISSING_GITHUB_TOKEN_MESSAGE = 'GitHub token is missing. Set GITHUB_PAT or GITHUB_TOKEN.';
 
 type GitHubContributionResponse = {
   data?: {
@@ -182,8 +183,17 @@ export function clearGitHubApiCacheForTests(): void {
   reposCache.clear();
 }
 
+function getGitHubToken(): string {
+  const token = process.env.GITHUB_PAT || process.env.GITHUB_TOKEN;
+  if (!token || token.trim() === '') {
+    throw new Error(MISSING_GITHUB_TOKEN_MESSAGE);
+  }
+
+  return token;
+}
+
 const getHeaders = () => ({
-  Authorization: `bearer ${process.env.GITHUB_PAT || process.env.GITHUB_TOKEN}`,
+  Authorization: `bearer ${getGitHubToken()}`,
   'Content-Type': 'application/json',
 });
 


### PR DESCRIPTION
## Description

Fixes #847

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed
The GitHub client always built an `Authorization` header from `GITHUB_PAT || GITHUB_TOKEN`. When neither environment variable was set, requests were sent with:

```http
Authorization: bearer undefined
```

This PR resolves the token before building request headers and throws a clear configuration error when no usable token is available. That keeps malformed credentials out of outgoing GitHub requests and makes local setup failures easier to understand.

The existing `GITHUB_PAT` behavior is preserved, and `GITHUB_TOKEN` remains supported as the fallback token.

## Visual Preview
N/A — this is API/client error handling only.

## Testing
```bash
npm run format
npm run test -- lib/github.test.ts
npm run lint
npm run typecheck
npm run test
npm run build
```

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.