### PR TITLE
refactor(types): add Speed, Scale, BadgeSize literal types

### DIFF
--- a/lib/svg/sanitizer.ts
+++ b/lib/svg/sanitizer.ts
@@ -4,6 +4,7 @@
  */
 
 import type { HexColor } from '../../types/index';
+import type { SpeedString } from '../../types/index';
 
 const HEX_COLOR_REGEX = /^([0-9A-Fa-f]{3}|[0-9A-Fa-f]{4}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
 
@@ -54,17 +55,17 @@ export function sanitizeHexColor(input: string | undefined | null, fallback: str
  * Expected format: [number]s (e.g., "8s", "1.5s").
  * Valid range: 2s to 20s.
  */
-export function sanitizeSpeed(speed: string | undefined | null, fallback = '8s'): string {
-  if (!speed) return fallback;
+export function sanitizeSpeed(speed: string | undefined | null, fallback = '8s'): SpeedString {
+  if (!speed) return fallback as SpeedString;
   const trimmed = speed.trim();
   const match = trimmed.match(/^(\d+(\.\d+)?)s$/);
   if (match) {
     const numeric = parseFloat(match[1]);
     if (numeric >= 2 && numeric <= 20) {
-      return trimmed;
+      return trimmed as SpeedString;
     }
   }
-  return fallback;
+  return fallback as SpeedString;
 }
 
 /**

--- a/scripts/benchmark-svg.ts
+++ b/scripts/benchmark-svg.ts
@@ -1,6 +1,6 @@
 import { performance } from 'perf_hooks';
 import { generateSVG } from '../lib/svg/generator';
-import { hexColor } from '../lib/svg/sanitizer';
+import { hexColor, sanitizeSpeed } from '../lib/svg/sanitizer';
 
 const stats = {
   currentStreak: 12,
@@ -15,7 +15,7 @@ const baseParams = {
   accent: '00ffaa',
   text: 'ffffff',
   scale: 'linear' as const,
-  speed: '8s',
+  speed: sanitizeSpeed('8s'),
 };
 
 const calendar = {

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,5 +1,11 @@
 export type HexColor = string & { __brand: 'HexColor' };
 
+export type Scale = 'linear' | 'log';
+
+export type BadgeSize = 'small' | 'medium' | 'large';
+
+export type SpeedString = `${number}s`;
+
 /**
  * Processed streak statistics calculated from the user's GitHub contribution data.
  */
@@ -102,10 +108,10 @@ export interface BadgeParams {
   accent: HexColor;
 
   /** Duration of the radar scan line animation (e.g. '4s', '8s', '12s'). Defaults to '8s'. */
-  speed: string;
+  speed: SpeedString;
 
   /** Tower height scaling algorithm. 'linear' scales proportionally; 'log' uses logarithmic scale for high contributors. Defaults to 'linear'. */
-  scale: 'linear' | 'log';
+  scale: Scale;
 
   /** Font family override for badge typography (e.g. 'monospace'). Defaults to theme font. */
   font?: string;
@@ -141,5 +147,5 @@ export interface BadgeParams {
   height?: number;
 
   /** Preset size of the badge. 'small', 'medium', or 'large'. Overrides width and height. */
-  size?: 'small' | 'medium' | 'large';
+  size?: BadgeSize;
 }


### PR DESCRIPTION
## Description

Centralizes `Speed`, `Scale`, and `BadgeSize` as literal/branded types in `types/index.ts`.

Fixes #319 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
