### PR TITLE
fix: hide raw error message from public SVG in streak API

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -204,14 +204,16 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
     });
   }
 
+  console.error('[streak] Unhandled error:', message);
+
   const errorSvg = `
-    <svg xmlns="http://www.w3.org/2000/svg" width="400" height="150">
-      <rect width="100%" height="100%" fill="#2d0000" rx="8"/>
-      <text x="50%" y="50%" text-anchor="middle" fill="#ffcccc">
-        Error: ${escapeXML(message)}
-      </text>
-    </svg>
-  `;
+      <svg xmlns="http://www.w3.org/2000/svg" width="400" height="150">
+        <rect width="100%" height="100%" fill="#2d0000" rx="8"/>
+        <text x="50%" y="50%" text-anchor="middle" fill="#ffcccc">
+          Something went wrong. Please try again later.
+        </text>
+      </svg>
+    `;
 
   return new NextResponse(errorSvg, {
     status: 500,


### PR DESCRIPTION
## Description

Fixes #567

The `/api/streak` endpoint was embedding the raw exception message
directly inside the fallback error SVG using `escapeXML(message)`.
This exposed internal details like GitHub PAT hints, API status codes,
and timeout values to anyone who embedded the badge or visited the URL.

**Fix:** Replaced the raw error message in the public SVG with a generic
user-friendly string. The real error is now logged server-side only via
`console.error` so debugging is still possible without leaking internals.

```ts
// ❌ Before
Error: ${escapeXML(message)}   // raw error visible publicly

// ✅ After
console.error('[streak] Unhandled error:', message); // server-side only
// SVG now shows: "Something went wrong. Please try again later."
```

**File changed:** `app/api/streak/route.ts` (~line 165) — 3 line diff.

---

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

---

## Visual Preview

**Before** (with invalid PAT):
```
┌──────────────────────────────────────┐
│  Error: GitHub PAT is invalid or     │  ← internal detail leaked ❌
│  missing                             │
└──────────────────────────────────────┘
```

**After** (with invalid PAT):
```
┌──────────────────────────────────────┐
│  Something went wrong.               │  ← clean generic message ✅
│  Please try again later.             │
└──────────────────────────────────────┘
```

---

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `fix(streak): hide raw error message from public SVG`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
