### PR TITLE
test(customize): add tests for export and placeholder snippets

### DIFF
--- a/app/customize/utils.test.ts
+++ b/app/customize/utils.test.ts
@@ -1,82 +1,66 @@
-import { describe, it, expect } from 'vitest';
-import { stripHash, isValidHex } from './utils';
+import { describe, expect, it } from 'vitest';
+import { getExportSnippet, getPlaceholderSnippet } from './utils';
 
-describe('Customize Utils', () => {
-  describe('stripHash', () => {
-    it('removes leading # from hex color', () => {
-      expect(stripHash('#ff0000')).toBe('ff0000');
+describe('Export Snippet utilities', () => {
+  const EXPECTED_BASE_URL = 'https://commitpulse.vercel.app/api/streak';
+
+  describe('getExportSnippet', () => {
+    it('generates markdown snippet', () => {
+      const queryString = 'user=testuser&theme=dark';
+      const result = getExportSnippet('markdown', queryString);
+
+      expect(typeof result).toBe('string');
+      expect(result.startsWith('![CommitPulse]')).toBe(true);
+      expect(result).toContain(EXPECTED_BASE_URL);
+      expect(result).toBe(`![CommitPulse](${EXPECTED_BASE_URL}?${queryString})`);
     });
 
-    it('returns unchanged string if no # prefix', () => {
-      expect(stripHash('ff0000')).toBe('ff0000');
+    it('generates html snippet', () => {
+      const queryString = 'user=testuser&theme=dark';
+      const result = getExportSnippet('html', queryString);
+
+      expect(typeof result).toBe('string');
+      expect(result.startsWith('<img src=')).toBe(true);
+      expect(result).toContain(EXPECTED_BASE_URL);
+      expect(result).toBe(`<img src="${EXPECTED_BASE_URL}?${queryString}" alt="CommitPulse" />`);
     });
 
-    it('handles empty string', () => {
-      expect(stripHash('')).toBe('');
+    it('handles empty query string', () => {
+      const emptyQuery = '';
+      const markdownResult = getExportSnippet('markdown', emptyQuery);
+      const htmlResult = getExportSnippet('html', emptyQuery);
+
+      expect(markdownResult.startsWith('![CommitPulse]')).toBe(true);
+      expect(markdownResult).toContain(EXPECTED_BASE_URL);
+
+      expect(htmlResult.startsWith('<img src=')).toBe(true);
+      expect(htmlResult).toContain(EXPECTED_BASE_URL);
     });
 
-    it('only removes leading #, not all occurrences', () => {
-      expect(stripHash('##ff0000')).toBe('#ff0000');
-    });
+    it('handles complex query strings', () => {
+      const complexQuery = 'user=complex%20name&ring=ff0000%2C00ff00&fire=true';
+      const result = getExportSnippet('markdown', complexQuery);
 
-    it('handles just # character', () => {
-      expect(stripHash('#')).toBe('');
+      expect(result).toContain(complexQuery);
+      expect(result).toBe(`![CommitPulse](${EXPECTED_BASE_URL}?${complexQuery})`);
     });
   });
 
-  describe('isValidHex', () => {
-    describe('valid 6-digit hex colors', () => {
-      it('accepts lowercase hex without #', () => {
-        expect(isValidHex('ffffff')).toBe(true);
-        expect(isValidHex('000000')).toBe(true);
-        expect(isValidHex('ff0000')).toBe(true);
-      });
+  describe('getPlaceholderSnippet', () => {
+    it('includes placeholder username in markdown', () => {
+      const result = getPlaceholderSnippet('markdown');
 
-      it('accepts uppercase hex without #', () => {
-        expect(isValidHex('FFFFFF')).toBe(true);
-        expect(isValidHex('FF0000')).toBe(true);
-      });
-
-      it('accepts mixed case hex without #', () => {
-        expect(isValidHex('FfFfFf')).toBe(true);
-        expect(isValidHex('aAbBcC')).toBe(true);
-      });
-
-      it('accepts 6-digit hex with # prefix', () => {
-        expect(isValidHex('#ffffff')).toBe(true);
-        expect(isValidHex('#000000')).toBe(true);
-      });
+      expect(result.startsWith('![CommitPulse]')).toBe(true);
+      expect(result).toContain('your-github-username');
+      expect(result).toContain(EXPECTED_BASE_URL);
     });
 
-    describe('invalid hex colors', () => {
-      it('rejects non-hex characters', () => {
-        expect(isValidHex('zzzzzz')).toBe(false);
-        expect(isValidHex('gggggg')).toBe(false);
-        expect(isValidHex('ff@0000')).toBe(false);
-      });
+    it('includes placeholder username in html', () => {
+      const result = getPlaceholderSnippet('html');
 
-      it('rejects wrong length', () => {
-        expect(isValidHex('f')).toBe(false);
-        expect(isValidHex('ff')).toBe(false);
-        expect(isValidHex('fff')).toBe(false);
-        expect(isValidHex('fffff')).toBe(false);
-        expect(isValidHex('fffffff')).toBe(false);
-        expect(isValidHex('ffffffff')).toBe(false);
-      });
-
-      it('rejects hex with # but invalid length', () => {
-        expect(isValidHex('#fff')).toBe(false);
-        expect(isValidHex('#fffff')).toBe(false);
-      });
-
-      it('rejects empty string', () => {
-        expect(isValidHex('')).toBe(false);
-      });
-
-      it('rejects hex with invalid characters and #', () => {
-        expect(isValidHex('#zzzzzz')).toBe(false);
-        expect(isValidHex('#ff@000')).toBe(false);
-      });
+      expect(result.startsWith('<img src=')).toBe(true);
+      expect(result).toContain('your-github-username');
+      expect(result).toContain(EXPECTED_BASE_URL);
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -470,6 +471,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -518,6 +520,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -528,6 +531,7 @@
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -539,6 +543,7 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2620,8 +2625,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2668,6 +2672,7 @@
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2678,6 +2683,7 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2688,6 +2694,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2752,6 +2759,7 @@
       "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -3359,6 +3367,7 @@
       "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.7",
@@ -3488,6 +3497,7 @@
       "integrity": "sha512-TP6utB2yX6rsJNVRo2qAlsi48i1YwFTrLV2tnTtWqJaYX7m4lRCCLirZBjU6xC5m0RsPHr+L2+N+eIPhgEzFfw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.7",
         "fflate": "^0.8.2",
@@ -3539,6 +3549,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3595,7 +3606,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3629,7 +3639,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3986,6 +3995,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4414,7 +4424,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4446,8 +4455,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4772,6 +4780,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4973,6 +4982,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7060,7 +7070,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7503,6 +7512,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
       "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
@@ -8020,6 +8030,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -8068,7 +8079,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8084,7 +8094,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8097,8 +8106,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8164,6 +8172,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8173,6 +8182,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9185,6 +9195,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9322,6 +9333,7 @@
       "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -9446,6 +9458,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9599,6 +9612,7 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -9690,6 +9704,7 @@
       "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.7",
         "@vitest/mocker": "4.1.7",
@@ -10056,6 +10071,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Description

Fixes #348

Added Vitest coverage for `getExportSnippet` and `getPlaceholderSnippet` in `app/customize/utils.ts`.

### Added Tests

* markdown snippet generation
* html snippet generation
* placeholder snippet generation
* empty query string handling
* complex query string handling

All existing tests pass locally.

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable for test-only changes).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
