### PR TITLE
test(streak): assert CSP security headers

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -155,15 +155,16 @@ describe('GET /api/streak', () => {
   });
 
   describe('security headers', () => {
-    it('sets a strict Content-Security-Policy that blocks all external resources', async () => {
-      const response = await GET(makeRequest({ user: 'octocat' }));
-      const csp = response.headers.get('Content-Security-Policy');
+  it('sets a strict Content-Security-Policy with safe SVG styling rules', async () => {
+    const response = await GET(makeRequest({ user: 'octocat' }));
+    const csp = response.headers.get('Content-Security-Policy');
 
-      expect(csp).toContain("default-src 'none'");
-      // SVG badges rely on inline styles for theming, so unsafe-inline must be allowed.
-      expect(csp).toContain("style-src 'unsafe-inline'");
-    });
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("style-src 'unsafe-inline'");
+    expect(csp).toContain('https://fonts.googleapis.com');
+    expect(csp).not.toContain('script-src');
   });
+});
 
   describe('speed parameter', () => {
     it('accepts a valid integer speed like "3s" and passes it to the SVG', async () => {

--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -155,16 +155,16 @@ describe('GET /api/streak', () => {
   });
 
   describe('security headers', () => {
-  it('sets a strict Content-Security-Policy with safe SVG styling rules', async () => {
-    const response = await GET(makeRequest({ user: 'octocat' }));
-    const csp = response.headers.get('Content-Security-Policy');
+    it('sets a strict Content-Security-Policy with safe SVG styling rules', async () => {
+      const response = await GET(makeRequest({ user: 'octocat' }));
+      const csp = response.headers.get('Content-Security-Policy');
 
-    expect(csp).toContain("default-src 'none'");
-    expect(csp).toContain("style-src 'unsafe-inline'");
-    expect(csp).toContain('https://fonts.googleapis.com');
-    expect(csp).not.toContain('script-src');
+      expect(csp).toContain("default-src 'none'");
+      expect(csp).toContain("style-src 'unsafe-inline'");
+      expect(csp).toContain('https://fonts.googleapis.com');
+      expect(csp).not.toContain('script-src');
+    });
   });
-});
 
   describe('speed parameter', () => {
     it('accepts a valid integer speed like "3s" and passes it to the SVG', async () => {


### PR DESCRIPTION
## Description

Fixes #702

Added additional security header assertions for the streak SVG API route Content-Security-Policy configuration.

## Changes Made

* Asserted CSP allows inline SVG styles using `style-src 'unsafe-inline'`
* Asserted CSP allows Google Fonts stylesheet source
* Asserted CSP does not include `script-src`

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
