### PR TITLE
feat: TTL Cache -  add delete() method for explicit single-key removal [ GSSOC'26 ]

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -97,6 +97,20 @@ export class TTLCache<T> {
 
     return true;
   }
+  /**
+   * Removes a single entry from the cache.
+   *
+   * Does nothing if the key does not exist.
+   *
+   * @param key - Cache key to remove.
+   * @returns `true` if the key existed and was deleted, `false` otherwise.
+   *
+   * @example
+   * cache.delete("user:1");
+   */
+  delete(key: string): boolean {
+    return this.store.delete(key);
+  }
 
   /**
    * Stores a value in the cache with a TTL.


### PR DESCRIPTION
## Description
Fixes #878 

Adds a `delete(key)` method to `TTLCache` that removes a single entry
and returns `true` if the key existed, `false` otherwise. Delegates
directly to the underlying `Map.delete()` — no TTL check needed since
the entry is being removed regardless.

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — internal cache logic, no visual output.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.