### PR TITLE
test(github): assert all fetchUserProfile fields

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -148,10 +148,32 @@ describe('fetchUserProfile', () => {
   beforeEach(() => vi.spyOn(global, 'fetch'));
   afterEach(() => vi.restoreAllMocks());
 
-  it('returns profile data on success', async () => {
-    vi.mocked(fetch).mockResolvedValue(mockResponse({ login: 'octocat', name: 'The Octocat' }));
+  it('returns all profile fields on success', async () => {
+    const mockProfile = {
+      login: 'octocat',
+      name: 'The Octocat',
+      avatar_url: 'https://github.com/images/error/octocat_happy.gif',
+      public_repos: 8,
+      followers: 100,
+      following: 5,
+      created_at: '2011-01-25T18:44:36Z',
+      bio: 'GitHub mascot',
+      location: 'San Francisco',
+      plan: { name: 'pro' },
+    };
+
+    vi.mocked(fetch).mockResolvedValue(mockResponse(mockProfile));
+
     const result = await fetchUserProfile('octocat');
-    expect(result.name).toBe('The Octocat');
+
+    expect(result.login).toBe(mockProfile.login);
+    expect(result.bio).toBe(mockProfile.bio);
+    expect(result.location).toBe(mockProfile.location);
+    expect(result.created_at).toBe(mockProfile.created_at);
+    expect(result.public_repos).toBe(mockProfile.public_repos);
+    expect(result.followers).toBe(mockProfile.followers);
+    expect(result.following).toBe(mockProfile.following);
+    expect(result.avatar_url).toBe(mockProfile.avatar_url);
   });
 
   it('throws "User not found" on 404', async () => {


### PR DESCRIPTION
## Description

Fixes #685

Expanded the `fetchUserProfile` test coverage to verify all returned GitHub profile fields from the REST API response.

## Changes Made

Added assertions for:

* `login`
* `bio`
* `location`
* `created_at`
* `public_repos`
* `followers`
* `following`
* `avatar_url`

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
