### PR TITLE
refactor(generator): hoist ghostLayout to module-level GHOST_LAYOUT constant

### DIFF
--- a/app/(root)/dashboard/[username]/page.tsx
+++ b/app/(root)/dashboard/[username]/page.tsx
@@ -75,7 +75,7 @@ export default async function DashboardPage({
         if (fallbackProfile.type === 'Organization') {
           redirect(`/dashboard/org/${username}`);
         }
-      } catch (fallbackError) {
+      } catch {
         // If it's truly neither a user nor an org, show 404
         return notFound();
       }

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -3,12 +3,7 @@
 import { NextResponse } from 'next/server';
 import { fetchGitHubContributions, getOrgDashboardData } from '@/lib/github';
 import { calculateStreak, calculateMonthlyStats } from '@/lib/calculate';
-import {
-  generateNotFoundSVG,
-  generateSVG,
-  generateMonthlySVG,
-  escapeXML,
-} from '@/lib/svg/generator';
+import { generateNotFoundSVG, generateSVG, generateMonthlySVG } from '@/lib/svg/generator';
 import { getSecondsUntilUTCMidnight, getSecondsUntilMidnightInTimezone } from '@/utils/time';
 import type { BadgeParams } from '@/types';
 import { themes } from '@/lib/svg/themes';

--- a/app/customize/components/ThemeQuickPresets.tsx
+++ b/app/customize/components/ThemeQuickPresets.tsx
@@ -508,7 +508,6 @@ const ICON_MAP: Record<string, (c: IC) => ReactElement> = {
   nord: (c) => <IconNord {...c} />,
   synthwave: (c) => <IconSynthwave {...c} />,
   gruvbox: (c) => <IconGruvbox {...c} />,
-  aurora_cyberpunk: (c) => <IconDark {...c} />,
   highcontrast: (c) => <IconHighcontrast {...c} />,
   aurora_cyberpunk: (c) => <IconAuroraCyberpunk {...c} />,
   catppuccin_latte: (c) => <IconCatppuccinLatte {...c} />,

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -528,6 +528,88 @@ function generateAutoThemeMonthlySVG(stats: MonthlyStats, params: BadgeParams): 
 `;
 }
 
+/**
+ * Generates a fallback SVG badge for users that do not exist
+ * or when contribution data cannot be loaded.
+ *
+ * The SVG renders a ghost-style city layout with an animated
+ * error-state design while preserving the standard badge layout.
+ *
+ * @param username - GitHub username displayed in the error badge.
+ * @param bg - Background color used for the SVG container.
+ * @param accent - Accent color used for highlights, outlines,
+ * and animated elements.
+ * @param text - Primary text color used throughout the badge.
+ * @param radius - Border radius applied to the SVG background.
+ * @param speed - Animation speed for the radar scan effect.
+ * Defaults to '8s'.
+ *
+ * @returns A generated SVG string representing the not-found state.
+ *
+ * @example
+ * const svg = generateNotFoundSVG(
+ *   'octocat',
+ *   '#0d1117',
+ *   '#00ffaa',
+ *   '#ffffff',
+ *   8,
+ *   '8s'
+ * );
+ */
+// Fixed isometric tower layout for the not-found ghost city.
+// Heights are deterministic so the silhouette always looks like a real city
+// regardless of the username or theme passed to generateNotFoundSVG.
+const GHOST_LAYOUT: { col: number; row: number; h: number }[] = [
+  { col: 0, row: 0, h: 8 },
+  { col: 1, row: 0, h: 20 },
+  { col: 2, row: 0, h: 12 },
+  { col: 3, row: 0, h: 30 },
+  { col: 4, row: 0, h: 16 },
+  { col: 5, row: 0, h: 10 },
+  { col: 6, row: 0, h: 24 },
+  { col: 7, row: 0, h: 8 },
+  { col: 0, row: 1, h: 6 },
+  { col: 1, row: 1, h: 14 },
+  { col: 2, row: 1, h: 36 },
+  { col: 3, row: 1, h: 22 },
+  { col: 4, row: 1, h: 44 },
+  { col: 5, row: 1, h: 18 },
+  { col: 6, row: 1, h: 10 },
+  { col: 7, row: 1, h: 28 },
+  { col: 0, row: 2, h: 10 },
+  { col: 1, row: 2, h: 26 },
+  { col: 2, row: 2, h: 16 },
+  { col: 3, row: 2, h: 38 },
+  { col: 4, row: 2, h: 20 },
+  { col: 5, row: 2, h: 32 },
+  { col: 6, row: 2, h: 14 },
+  { col: 7, row: 2, h: 6 },
+  { col: 0, row: 3, h: 4 },
+  { col: 1, row: 3, h: 18 },
+  { col: 2, row: 3, h: 28 },
+  { col: 3, row: 3, h: 12 },
+  { col: 4, row: 3, h: 34 },
+  { col: 5, row: 3, h: 8 },
+  { col: 6, row: 3, h: 22 },
+  { col: 7, row: 3, h: 16 },
+  { col: 0, row: 4, h: 8 },
+  { col: 1, row: 4, h: 30 },
+  { col: 2, row: 4, h: 10 },
+  { col: 3, row: 4, h: 20 },
+  { col: 4, row: 4, h: 16 },
+  { col: 5, row: 4, h: 40 },
+  { col: 6, row: 4, h: 12 },
+  { col: 7, row: 4, h: 24 },
+  { col: 0, row: 5, h: 14 },
+  { col: 1, row: 5, h: 8 },
+  { col: 2, row: 5, h: 22 },
+  { col: 3, row: 5, h: 32 },
+  { col: 4, row: 5, h: 10 },
+  { col: 5, row: 5, h: 18 },
+  { col: 6, row: 5, h: 28 },
+  { col: 7, row: 5, h: 6 },
+];
+
 export function generateNotFoundSVG(
   username: string,
   bg: string,
@@ -537,65 +619,8 @@ export function generateNotFoundSVG(
   speed: string = '8s'
 ): string {
   const safeName = escapeXML(username.toUpperCase());
-
-  const ghostLayout: { col: number; row: number; h: number }[] = [
-    { col: 0, row: 0, h: 8 },
-    { col: 1, row: 0, h: 20 },
-    { col: 2, row: 0, h: 12 },
-    { col: 3, row: 0, h: 30 },
-    { col: 4, row: 0, h: 16 },
-    { col: 5, row: 0, h: 10 },
-    { col: 6, row: 0, h: 24 },
-    { col: 7, row: 0, h: 8 },
-
-    { col: 0, row: 1, h: 6 },
-    { col: 1, row: 1, h: 14 },
-    { col: 2, row: 1, h: 36 },
-    { col: 3, row: 1, h: 22 },
-    { col: 4, row: 1, h: 44 },
-    { col: 5, row: 1, h: 18 },
-    { col: 6, row: 1, h: 10 },
-    { col: 7, row: 1, h: 28 },
-
-    { col: 0, row: 2, h: 10 },
-    { col: 1, row: 2, h: 26 },
-    { col: 2, row: 2, h: 16 },
-    { col: 3, row: 2, h: 38 },
-    { col: 4, row: 2, h: 20 },
-    { col: 5, row: 2, h: 32 },
-    { col: 6, row: 2, h: 14 },
-    { col: 7, row: 2, h: 6 },
-
-    { col: 0, row: 3, h: 4 },
-    { col: 1, row: 3, h: 18 },
-    { col: 2, row: 3, h: 28 },
-    { col: 3, row: 3, h: 12 },
-    { col: 4, row: 3, h: 34 },
-    { col: 5, row: 3, h: 8 },
-    { col: 6, row: 3, h: 22 },
-    { col: 7, row: 3, h: 16 },
-
-    { col: 0, row: 4, h: 8 },
-    { col: 1, row: 4, h: 30 },
-    { col: 2, row: 4, h: 10 },
-    { col: 3, row: 4, h: 20 },
-    { col: 4, row: 4, h: 16 },
-    { col: 5, row: 4, h: 40 },
-    { col: 6, row: 4, h: 12 },
-    { col: 7, row: 4, h: 24 },
-
-    { col: 0, row: 5, h: 14 },
-    { col: 1, row: 5, h: 8 },
-    { col: 2, row: 5, h: 22 },
-    { col: 3, row: 5, h: 32 },
-    { col: 4, row: 5, h: 10 },
-    { col: 5, row: 5, h: 18 },
-    { col: 6, row: 5, h: 28 },
-    { col: 7, row: 5, h: 6 },
-  ];
-
   let ghostTowers = '';
-  for (const { col, row, h } of ghostLayout) {
+  for (const { col, row, h } of GHOST_LAYOUT) {
     const tx = 300 + (col - row) * 16;
     const ty = 120 + (col + row) * 9;
 


### PR DESCRIPTION
## Description

Fixes #378 

- Refactored `generateNotFoundSVG` by hoisting the inline `ghostLayout` array into a module-level `GHOST_LAYOUT` constant, reducing function size and improving readability.

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.
- The SVG output matches the CommitPulse "premium quality" aesthetic standard.
