### PR TITLE
test(generator): add coverage for hide_title parameter in generateSVG

### DIFF
--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -511,6 +511,28 @@ describe('generateSVG', () => {
       expect(svg).not.toContain('fill="white" fill-opacity="0.2"');
     });
   });
+
+  describe('hide_title parameter', () => {
+    it('omits the username title text when hide_title is true', () => {
+      const svg = generateSVG(
+        mockStats,
+        { user: 'octocat', hide_title: true } as unknown as BadgeParams,
+        mockCalendar
+      );
+
+      expect(svg).not.toContain('OCTOCAT');
+    });
+
+    it('renders the username title text when hide_title is false', () => {
+      const svg = generateSVG(
+        mockStats,
+        { user: 'octocat', hide_title: false } as unknown as BadgeParams,
+        mockCalendar
+      );
+
+      expect(svg).toContain('OCTOCAT');
+    });
+  });
 });
 
 describe('generateMonthlySVG', () => {


### PR DESCRIPTION
## Description

Fixes #722 

- Added generator-level test coverage for the `hide_title` parameter, verifying that the `username title` is correctly `omitted` when `enabled`.
- Added a complementary assertion ensuring the uppercase username title still renders normally when `hide_title` is disabled.

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.
