### PR TITLE
fix: add /api/stats and /api/og to rate limiting middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,8 @@ import { rateLimit } from './lib/rate-limit';
  * - /api/streak
  * - /api/github
  * - /api/track-user
+ * - /api/stats
+ * - /api/og
  *
  * Limit: 60 requests per minute per IP.
  */
@@ -52,5 +54,11 @@ export function middleware(request: NextRequest) {
  * Using a matcher is more efficient than checking pathnames inside the middleware.
  */
 export const config = {
-  matcher: ['/api/streak/:path*', '/api/github/:path*', '/api/track-user/:path*'],
+  matcher: [
+    '/api/streak/:path*',
+    '/api/github/:path*',
+    '/api/track-user/:path*',
+    '/api/stats/:path*',
+    '/api/og/:path*',
+  ],
 };


### PR DESCRIPTION
Fixes #902 

## Description
Both `/api/stats` and `/api/og` endpoints were excluded from the rate limiting middleware matcher, allowing unlimited requests with no throttling. `/api/og` is especially severe as it always passes `bypassCache: true`, meaning every call triggers a fresh GitHub API request regardless of volume.

This fix adds both routes to the middleware matcher in `middleware.ts`, consistent with how `/api/streak` and `/api/github` are already protected.

**Files changed:** `middleware.ts` only — 1 line changed in the matcher array, JSDoc comment updated.

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — middleware change, no SVG output affected.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.