### PR TITLE
fix: return null deltaPercentage when previous month has zero contributions

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -348,7 +348,7 @@ describe('calculateMonthlyStats', () => {
 
     expect(result.previousMonthTotal).toBe(0);
     expect(result.currentMonthTotal).toBe(10);
-    expect(result.deltaPercentage).toBe(100);
+    expect(result.deltaPercentage).toBeNull();
   });
 
   it('handles zero current month contributions', () => {

--- a/lib/calculate.ts
+++ b/lib/calculate.ts
@@ -207,16 +207,16 @@ export function calculateMonthlyStats(
   }).format(now);
 
   const deltaAbsolute = currentMonthTotal - previousMonthTotal;
-  let deltaPercentage = 0;
-
-  if (previousMonthTotal === 0) {
-    if (currentMonthTotal > 0) {
-      deltaPercentage = 100;
-    }
-  } else {
-    deltaPercentage = Math.round((deltaAbsolute / previousMonthTotal) * 100);
-    if (deltaPercentage === -0) deltaPercentage = 0;
-  }
+  // When there is no baseline (previous month = 0), the percentage change is
+  // mathematically undefined. Return null so the renderer can display 'N/A'
+  // instead of the misleading hardcoded +100%.
+  const deltaPercentage: number | null =
+    previousMonthTotal === 0
+      ? null
+      : (() => {
+          const pct = Math.round((deltaAbsolute / previousMonthTotal) * 100);
+          return pct === -0 ? 0 : pct;
+        })();
 
   return {
     currentMonthTotal,

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -434,18 +434,22 @@ export function generateMonthlySVG(stats: MonthlyStats, params: BadgeParams): st
           : `${stats.deltaAbsolute} commits`;
   } else if (params.delta_format === 'both') {
     deltaText =
-      stats.deltaPercentage > 0
-        ? `+${stats.deltaPercentage}% (+${stats.deltaAbsolute})`
-        : stats.deltaPercentage < 0
-          ? `${stats.deltaPercentage}% (${stats.deltaAbsolute})`
-          : `0% (${stats.deltaAbsolute > 0 ? '+' : ''}${stats.deltaAbsolute})`;
+      stats.deltaPercentage === null
+        ? `N/A (${stats.deltaAbsolute > 0 ? '+' : ''}${stats.deltaAbsolute})`
+        : stats.deltaPercentage > 0
+          ? `+${stats.deltaPercentage}% (+${stats.deltaAbsolute})`
+          : stats.deltaPercentage < 0
+            ? `${stats.deltaPercentage}% (${stats.deltaAbsolute})`
+            : `0% (${stats.deltaAbsolute > 0 ? '+' : ''}${stats.deltaAbsolute})`;
   } else {
     deltaText =
-      stats.deltaPercentage > 0
-        ? `+${stats.deltaPercentage}%`
-        : stats.deltaPercentage < 0
-          ? `${stats.deltaPercentage}%`
-          : `0%`;
+      stats.deltaPercentage === null
+        ? 'N/A'
+        : stats.deltaPercentage > 0
+          ? `+${stats.deltaPercentage}%`
+          : stats.deltaPercentage < 0
+            ? `${stats.deltaPercentage}%`
+            : `0%`;
   }
   const deltaColor = stats.deltaAbsolute >= 0 ? accent : '#ff4444';
 
@@ -514,18 +518,22 @@ function generateAutoThemeMonthlySVG(stats: MonthlyStats, params: BadgeParams): 
           : `${stats.deltaAbsolute} commits`;
   } else if (params.delta_format === 'both') {
     deltaText =
-      stats.deltaPercentage > 0
-        ? `+${stats.deltaPercentage}% (+${stats.deltaAbsolute})`
-        : stats.deltaPercentage < 0
-          ? `${stats.deltaPercentage}% (${stats.deltaAbsolute})`
-          : `0% (${stats.deltaAbsolute > 0 ? '+' : ''}${stats.deltaAbsolute})`;
+      stats.deltaPercentage === null
+        ? `N/A (${stats.deltaAbsolute > 0 ? '+' : ''}${stats.deltaAbsolute})`
+        : stats.deltaPercentage > 0
+          ? `+${stats.deltaPercentage}% (+${stats.deltaAbsolute})`
+          : stats.deltaPercentage < 0
+            ? `${stats.deltaPercentage}% (${stats.deltaAbsolute})`
+            : `0% (${stats.deltaAbsolute > 0 ? '+' : ''}${stats.deltaAbsolute})`;
   } else {
     deltaText =
-      stats.deltaPercentage > 0
-        ? `+${stats.deltaPercentage}%`
-        : stats.deltaPercentage < 0
-          ? `${stats.deltaPercentage}%`
-          : `0%`;
+      stats.deltaPercentage === null
+        ? 'N/A'
+        : stats.deltaPercentage > 0
+          ? `+${stats.deltaPercentage}%`
+          : stats.deltaPercentage < 0
+            ? `${stats.deltaPercentage}%`
+            : `0%`;
   }
 
   return `

--- a/types/index.ts
+++ b/types/index.ts
@@ -77,8 +77,8 @@ export interface MonthlyStats {
   /** Total number of contributions in the previous calendar month. */
   previousMonthTotal: number;
 
-  /** Percentage change in contributions compared to the previous month (can be negative). */
-  deltaPercentage: number;
+  /** Percentage change in contributions compared to the previous month (can be negative). Null when previous month has zero contributions (undefined baseline). */
+  deltaPercentage: number | null;
 
   /** Absolute change in contribution count compared to the previous month (can be negative). */
   deltaAbsolute: number;


### PR DESCRIPTION
Fixes #908

## Description
`calculateMonthlyStats` in `lib/calculate.ts` hardcoded `deltaPercentage = 100` whenever `previousMonthTotal === 0`, regardless of how many contributions were made this month. This is mathematically undefined — dividing by zero has no meaningful percentage result. A user with 1 commit vs 0 last month and a user with 500 commits vs 0 last month both saw `+100%`, which is misleading and factually incorrect.

**Changes:**
- `deltaPercentage` is now typed as `number | null` in `MonthlyStats` (`types/index.ts`)
- `calculateMonthlyStats` returns `null` when `previousMonthTotal === 0` instead of hardcoded `100`
- `generateMonthlySVG` and `generateAutoThemeMonthlySVG` now render `N/A` when `deltaPercentage` is `null`
- Updated existing test in `lib/calculate.test.ts` to expect `null` instead of `100`

**Files changed:** `lib/calculate.ts`, `lib/svg/generator.ts`, `types/index.ts`, `lib/calculate.test.ts`

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — delta indicator will now show `N/A` instead of `+100%` for users with zero contributions last month.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.