### PR TITLE
test(api route): verify 400 error response body is valid JSON

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -69,9 +69,12 @@ describe('GET /api/streak', () => {
       const response = await GET(makeRequest());
 
       expect(response.status).toBe(400);
-     const body = await response.json();
+      const body = await response.json();
+      expect(response.status).toBe(400);
       expect(body.error).toBe('Invalid parameters');
+      expect(body.details).not.toBeNull();
       expect(typeof body.details).toBe('object');
+      expect(Array.isArray(body.details)).toBe(false);
     });
 
     it('does not hit the GitHub API at all when user is missing', async () => {

--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -69,8 +69,9 @@ describe('GET /api/streak', () => {
       const response = await GET(makeRequest());
 
       expect(response.status).toBe(400);
-      const body = await response.text();
-      expect(body).toContain('Missing');
+     const body = await response.json();
+      expect(body.error).toBe('Invalid parameters');
+      expect(typeof body.details).toBe('object');
     });
 
     it('does not hit the GitHub API at all when user is missing', async () => {


### PR DESCRIPTION
## Description
Fixes #745

Updated the 400 test in `app/api/streak/route.test.ts` to properly verify 
the response body is valid JSON with the correct structure.

**Changes Made:**
- Replaced `response.text()` with `response.json()`
- Added assertion: `body.error === 'Invalid parameters'`
- Added assertion: `typeof body.details === 'object'`

## Pillar
🧪 Testing — Improving test quality and coverage

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] `npm run lint` passes locally
- [x] `npm run test` passes locally (477 tests ✅)
- [x] No SVG output changes (test-only PR)