### PR TITLE
refactor(svg): standardise sanitizeRadius usage in monthly SVG renderers

### DIFF
--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -638,8 +638,7 @@ export function generateMonthlySVG(stats: MonthlyStats, params: BadgeParams): st
       : null;
 
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
-  const parsedRadius = Number(params.radius);
-  const radius = Math.max(0, Math.min(Number.isNaN(parsedRadius) ? 8 : parsedRadius, 50));
+  const radius = sanitizeRadius(params.radius, 8);
   const labels = getLabels(params.lang);
 
   const width = params.width || 300;
@@ -748,8 +747,7 @@ export function generateWrappedSVG(
       : null;
 
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
-  const parsedRadius = Number(params.radius);
-  const radius = Math.max(0, Math.min(Number.isNaN(parsedRadius) ? 8 : parsedRadius, 50));
+  const radius = sanitizeRadius(params.radius, 8);
 
   const width = params.width || 420;
   const height = params.height || 260;
@@ -1008,8 +1006,7 @@ function generateAutoThemeMonthlySVG(stats: MonthlyStats, params: BadgeParams): 
   const googleFontsImport = googleFontUrlPart
     ? `@import url('https://fonts.googleapis.com/css2?family=${googleFontUrlPart}&display=swap');`
     : '';
-  const parsedRadius = Number(params.radius);
-  const radius = Math.max(0, Math.min(Number.isNaN(parsedRadius) ? 8 : parsedRadius, 50));
+  const radius = sanitizeRadius(params.radius, 8);
   const labels = getLabels(params.lang);
 
   const width = params.width || 300;


### PR DESCRIPTION
## Description

Fixes #932

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

None (Internal refactor of monthly SVG rendering helper function)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).