### PR TITLE
fix: add maxLength validation on username input field

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -69,9 +69,12 @@ describe('GET /api/streak', () => {
       const response = await GET(makeRequest());
 
       expect(response.status).toBe(400);
-     const body = await response.json();
+      const body = await response.json();
+      expect(response.status).toBe(400);
       expect(body.error).toBe('Invalid parameters');
+      expect(body.details).not.toBeNull();
       expect(typeof body.details).toBe('object');
+      expect(Array.isArray(body.details)).toBe(false);
     });
 
     it('does not hit the GitHub API at all when user is missing', async () => {

--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -69,8 +69,9 @@ describe('GET /api/streak', () => {
       const response = await GET(makeRequest());
 
       expect(response.status).toBe(400);
-      const body = await response.text();
-      expect(body).toContain('Missing');
+     const body = await response.json();
+      expect(body.error).toBe('Invalid parameters');
+      expect(typeof body.details).toBe('object');
     });
 
     it('does not hit the GitHub API at all when user is missing', async () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -208,26 +208,33 @@ export default function LandingPage() {
               }}
               className="flex flex-col sm:flex-row gap-4 w-full"
             >
-              <div className="relative flex-1 flex items-center">
-                <input
-                  type="text"
-                  placeholder="Enter GitHub Username"
-                  className="flex-1 rounded-xl border border-black/10 bg-gray-100 px-5 py-3.5 text-sm text-black outline-none transition-all duration-200 placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-[#00ffaa] focus:border-transparent dark:border-[rgba(255,255,255,0.08)] dark:bg-[#111] dark:text-white dark:placeholder:text-[#A1A1AA]"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                />
-                {username.length > 0 ? (
-                  <button
-                    onClick={() => setUsername('')}
-                    className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500 transition-colors hover:text-black dark:text-[#A1A1AA] dark:hover:text-white"
-                    aria-label="Clear input"
-                    type="button"
-                  >
-                    <X size={18} />
-                  </button>
-                ) : null}
+              <div className="relative flex-1 flex items-center flex-col">
+                <div className="relative flex-1 flex items-center w-full">
+                  <input
+                    type="text"
+                    placeholder="Enter GitHub Username"
+                    className="flex-1 rounded-xl border border-black/10 bg-gray-100 px-5 py-3.5 text-sm text-black outline-none transition-all duration-200 placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-[#00ffaa] focus:border-transparent dark:border-[rgba(255,255,255,0.08)] dark:bg-[#111] dark:text-white dark:placeholder:text-[#A1A1AA]"
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                    maxLength={39}
+                  />
+                  {username.length > 0 ? (
+                    <button
+                      onClick={() => setUsername('')}
+                      className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500 transition-colors hover:text-black dark:text-[#A1A1AA] dark:hover:text-white"
+                      aria-label="Clear input"
+                      type="button"
+                    >
+                      <X size={18} />
+                    </button>
+                  ) : null}
+                </div>
+                {username.length === 39 && (
+                  <p className="text-red-500 text-xs mt-1 self-start pl-1">
+                    GitHub usernames cannot exceed 39 characters
+                  </p>
+                )}
               </div>
-
               <div className="flex flex-col sm:flex-row gap-4">
                 <button
                   type="submit"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -231,7 +231,7 @@ export default function LandingPage() {
                 </div>
                 {username.length === 39 && (
                   <p className="text-red-500 text-xs mt-1 self-start pl-1">
-                    GitHub usernames cannot exceed 39 characters
+                    GitHub username limit reached (39 characters maximum)
                   </p>
                 )}
               </div>


### PR DESCRIPTION
Fixes #930

## Description
Added input validation on the username field to prevent inputs exceeding GitHub's 39 character username limit.

## Changes Made
- Added `maxLength={39}` attribute to username input
- Added a user-friendly warning message when the character limit is reached

## Pillar
🐛 Bug Fix — Input validation

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] `npm run lint` passes locally
- [x] `npm run test` passes locally ✅
- [x] No SVG output changes