### PR TITLE
fix(api): add X-Cache-Status header for refresh=true responses (#943)

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -163,6 +163,7 @@ export async function GET(request: Request) {
         'Content-Type': 'image/svg+xml',
         'Cache-Control': cacheControl,
         'Content-Security-Policy': SVG_CSP_HEADER,
+        'X-Cache-Status': refresh ? `BYPASS, fetched=${new Date().toISOString()}` : 'HIT',
       },
     });
   } catch (error: unknown) {


### PR DESCRIPTION
Closes #943

## What changed
Added `X-Cache-Status` response header to `app/api/streak/route.ts`:
- `BYPASS, fetched=<ISO timestamp>` when `refresh=true`
- `HIT` for normal cached responses

## How to test
```bash
curl -I "https://<your-deployment>/api/streak?user=YOUR_USERNAME&refresh=true"
# X-Cache-Status: BYPASS, fetched=2026-05-28T...

curl -I "https://<your-deployment>/api/streak?user=YOUR_USERNAME"
# X-Cache-Status: HIT
```