### PR TITLE
fix(repo): add missing MIT license file to match README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sourav Jha
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Description
This pull request adds the missing `LICENSE` file to the root of the repository to resolve the discrepancy between the repository's contents and the `README.md`. 

While the `README.md` explicitly claimed that the project was licensed under the MIT License, the actual repository lacked the required license file. This PR introduces the standard MIT License attributed to the project author, ensuring proper legal coverage and increasing trustworthiness for viewers and contributors.

## Fixes Issue
Fixes #955
Fixes #957

## Changes Made
- Added a `LICENSE` file containing the standard MIT License text.
- Attributed the copyright to Sourav Jha as specified in the `README.md`.
