### PR TITLE
Add Reddit share URL assertions to ShareSheet tests

### DIFF
--- a/components/dashboard/ShareSheet.test.tsx
+++ b/components/dashboard/ShareSheet.test.tsx
@@ -230,6 +230,30 @@ describe('ShareSheet', () => {
     });
   });
 
+  it('handles Reddit share URL correctly', async () => {
+    render(<ShareSheet {...defaultProps} />);
+
+    const redditButton = screen.getByText('Reddit').closest('button');
+
+    fireEvent.click(redditButton!);
+
+    await waitFor(() => {
+      expect(window.open).toHaveBeenCalled();
+    });
+
+    expect(window.open).toHaveBeenCalledWith(
+      expect.stringContaining('reddit.com/submit'),
+      '_blank',
+      'noopener,noreferrer'
+    );
+
+    const calledUrl = vi.mocked(window.open).mock.calls[0][0] as string;
+
+    expect(calledUrl).toContain(encodeURIComponent(`/dashboard/${defaultProps.username}`));
+
+    expect(calledUrl).toContain('title=');
+  });
+
   it('handles Download SVG action', async () => {
     // Mock fetch
     global.fetch = vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Description

Adds tests for the Reddit share action to verify:
- Reddit submit URL is used
- encoded profile URL is included
- title parameter exists

closes #740 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A-test update only

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
