### PR TITLE
test(layout): verify row and col mapping

### DIFF
--- a/lib/svg/layout.test.ts
+++ b/lib/svg/layout.test.ts
@@ -160,3 +160,36 @@ describe('computeTowers edge cases', () => {
     expect(towers[0].h).toBe(24);
   });
 });
+
+it('assigns correct row and col values based on week/day position', () => {
+  const calendar = {
+    totalContributions: 0,
+    weeks: [
+      {
+        contributionDays: [
+          { contributionCount: 1, date: '2024-06-10' },
+          { contributionCount: 1, date: '2024-06-11' },
+          { contributionCount: 1, date: '2024-06-12' },
+        ],
+      },
+      {
+        contributionDays: [
+          { contributionCount: 1, date: '2024-06-13' },
+          { contributionCount: 1, date: '2024-06-14' },
+          { contributionCount: 1, date: '2024-06-15' },
+        ],
+      },
+    ],
+  } as unknown as ContributionCalendar;
+
+  const towers = computeTowers(calendar, 'linear', '2024-06-15');
+
+  expect(towers[0].row).toBe(0);
+  expect(towers[0].col).toBe(0);
+
+  expect(towers[1].row).toBe(0);
+  expect(towers[1].col).toBe(1);
+
+  expect(towers[3].row).toBe(1);
+  expect(towers[3].col).toBe(0);
+});


### PR DESCRIPTION
## Description

Closes #730

Added test coverage to verify that `TowerData.row` and `TowerData.col` are correctly mapped to the week index and day index in `computeTowers`.

### What Changed

* Added a layout test using a 2-week × 3-day mock contribution calendar
* Verified the first tower maps to `row=0`, `col=0`
* Verified the second tower maps to `row=0`, `col=1`
* Verified the first tower of the second week maps to `row=1`, `col=0`
* Ensured all existing layout tests continue to pass successfully

### Why

`row` and `col` values are used to calculate staggered SVG animation delays.

These tests help prevent regressions where week/day indices could accidentally become swapped, which would cause incorrect animation ordering in the visualization.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] I have run the relevant Vitest test suite successfully.
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.