### PR TITLE
fix: replace hardcoded BADGE_BASE_URL with NEXT_PUBLIC_SITE_URL env var

### DIFF
--- a/app/customize/utils.ts
+++ b/app/customize/utils.ts
@@ -1,6 +1,6 @@
 import type { ExportFormat } from './types';
 
-const BADGE_BASE_URL = 'https://commitpulse.vercel.app/api/streak';
+const BADGE_BASE_URL = `${process.env.NEXT_PUBLIC_SITE_URL ?? 'https://commitpulse.vercel.app'}/api/streak`;
 
 /**
  * Removes the leading # from a hex color string.


### PR DESCRIPTION
Fixes #985 

## Description
`BADGE_BASE_URL` in `app/customize/utils.ts` was hardcoded to `https://commitpulse.vercel.app/api/streak`, causing the customize page to always generate badge URLs pointing to production — even when running locally or on a staging deployment. Developers testing locally would generate badges hitting the production API instead of their local server.

Fixed by replacing the hardcoded URL with `NEXT_PUBLIC_SITE_URL` env var with a production fallback, consistent with how `BASE_URL` is already defined in `app/(root)/dashboard/[username]/page.tsx`.

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — one line change in utils.ts, no SVG output affected.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.