### PR TITLE
fix(validation): reject invalid hex colors in bg/accent/text params w…

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -483,7 +483,7 @@ describe('GET /api/streak', () => {
     it('does not crash when an invalid text color is provided', async () => {
       const response = await GET(makeRequest({ user: 'octocat', text: 'notacolor' }));
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(400);
     });
   });
 

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -32,14 +32,23 @@ export const streakParamsSchema = z.object({
   bg: z
     .string()
     .optional()
+    .refine((val) => !val || /^[0-9a-fA-F]{3,4}$|^[0-9a-fA-F]{6,8}$/.test(val.replace('#', '')), {
+      message: 'bg must be a valid 3 or 6 character hex color without #',
+    })
     .transform((val) => (val ? sanitizeHexColor(val, '0d1117') : undefined)),
   text: z
     .string()
     .optional()
+    .refine((val) => !val || /^[0-9a-fA-F]{3,4}$|^[0-9a-fA-F]{6,8}$/.test(val.replace('#', '')), {
+      message: 'text must be a valid 3 or 6 character hex color without #',
+    })
     .transform((val) => (val ? sanitizeHexColor(val, 'ffffff') : undefined)),
   accent: z
     .string()
     .optional()
+    .refine((val) => !val || /^[0-9a-fA-F]{3,4}$|^[0-9a-fA-F]{6,8}$/.test(val.replace('#', '')), {
+      message: 'accent must be a valid 3 or 6 character hex color without #',
+    })
     .transform((val) => (val ? sanitizeHexColor(val, '00ffaa') : undefined)),
 
   // Silently fall back to 'linear' for unknown values (matches old behavior)


### PR DESCRIPTION
## Description
Fixes #1107

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — validation fix. No visual change to SVG output for valid inputs.

To verify the fix:
```bash
# Before: returned 200 with broken SVG
# After: returns 400 with clear error message
curl -s "https://commitpulse.vercel.app/api/streak?user=jhasourav07&bg=ZZZZZZ"
curl -s "https://commitpulse.vercel.app/api/streak?user=jhasourav07&accent=XYZXYZ"
curl -s "https://commitpulse.vercel.app/api/streak?user=jhasourav07&text=!!!!!!!"

# Valid hex still works fine
curl -s "https://commitpulse.vercel.app/api/streak?user=jhasourav07&bg=0d1117&accent=ff6b35"
```

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.