### PR TITLE
test(github): verify graceful repos fetch failure handling

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -549,6 +549,47 @@ describe('getFullDashboardData', () => {
     const result = await getFullDashboardData('testuser');
     expect(result.profile.joinedDate).toMatch(/^[A-Za-z]+ \d{4}$/);
   });
+
+  it('handles repos fetch failure gracefully', async () => {
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const urlStr = typeof url === 'string' ? url : (url?.toString() ?? '');
+
+      // Repos fetch fails
+      if (urlStr.includes('/users/octocat/repos')) {
+        throw new Error('Repos fetch failed');
+      }
+
+      // Profile fetch succeeds
+      if (urlStr.includes('/users/octocat')) {
+        return mockResponse({
+          login: 'octocat',
+          name: 'The Octocat',
+          avatar_url: 'avatar.png',
+          public_repos: 10,
+          followers: 20,
+          following: 5,
+          created_at: '2020-01-01T00:00:00Z',
+        });
+      }
+
+      // GraphQL contributions succeed
+      return mockResponse({
+        data: {
+          user: {
+            contributionsCollection: {
+              contributionCalendar: mockCalendar,
+            },
+          },
+        },
+      });
+    });
+
+    const result = await getFullDashboardData('octocat');
+
+    expect(result).toBeDefined();
+    expect(result.profile.stats.stars).toBe(0);
+    expect(result.languages).toEqual([]);
+  });
 });
 
 describe('GitHub API cache behavior', () => {
@@ -736,7 +777,7 @@ describe('getOrgDashboardData', () => {
 
   it('aggregates org data correctly', async () => {
     vi.mocked(fetch).mockImplementation(async (url) => {
-      const urlStr = url.toString();
+      const urlStr = typeof url === 'string' ? url : (url?.toString() ?? '');
       if (urlStr.includes('/orgs/vercel/members')) return mockResponse([{ login: 'alice' }]);
       if (urlStr.includes('/users/vercel/repos')) return mockResponse([{ stargazers_count: 100 }]);
       if (urlStr.includes('/users/vercel'))
@@ -761,7 +802,7 @@ describe('getOrgDashboardData', () => {
 
   it('throws an error if the target is a User instead of an Organization', async () => {
     vi.mocked(fetch).mockImplementation(async (url) => {
-      const urlStr = url.toString();
+      const urlStr = typeof url === 'string' ? url : (url?.toString() ?? '');
       // Specifically catch the repos and members endpoints so they return valid arrays
       if (urlStr.includes('/orgs/notanorg/members')) return mockResponse([]);
       if (urlStr.includes('/users/notanorg/repos')) return mockResponse([]);
@@ -788,7 +829,7 @@ describe('getWrappedData', () => {
 
   it('returns wrapped statistics and top language correctly', async () => {
     vi.mocked(fetch).mockImplementation(async (url) => {
-      const urlStr = url.toString();
+      const urlStr = typeof url === 'string' ? url : (url?.toString() ?? '');
       // Return 2 TS repos, 1 Rust repo
       if (urlStr.includes('/repos'))
         return mockResponse([


### PR DESCRIPTION
## Description

Fixes #1060

Added test coverage verifying that `getFullDashboardData` gracefully handles repository fetch failures without crashing the dashboard.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
