### PR TITLE
test(github): verify contribution LoC injection

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -85,6 +85,64 @@ describe('fetchGitHubContributions', () => {
     expect(result.weeks[0].contributionDays[0]).toHaveProperty('locAdditions');
   });
 
+  it('injects positive locAdditions and non-negative locDeletions for contribution days', async () => {
+    const calendarWithContributions: ContributionCalendar = {
+      totalContributions: 5,
+      weeks: [
+        {
+          contributionDays: [{ contributionCount: 5, date: '2024-06-10' }],
+        },
+      ],
+    };
+
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse({
+        data: {
+          user: {
+            contributionsCollection: {
+              contributionCalendar: calendarWithContributions,
+            },
+          },
+        },
+      })
+    );
+
+    const result = await fetchGitHubContributions('octocat');
+    const day = result.weeks[0].contributionDays[0];
+
+    expect(day.locAdditions).toBeGreaterThan(0);
+    expect(day.locDeletions).toBeGreaterThanOrEqual(0);
+  });
+
+  it('sets locAdditions and locDeletions to zero for zero-contribution days', async () => {
+    const calendarWithZeroContribution: ContributionCalendar = {
+      totalContributions: 0,
+      weeks: [
+        {
+          contributionDays: [{ contributionCount: 0, date: '2024-06-11' }],
+        },
+      ],
+    };
+
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse({
+        data: {
+          user: {
+            contributionsCollection: {
+              contributionCalendar: calendarWithZeroContribution,
+            },
+          },
+        },
+      })
+    );
+
+    const result = await fetchGitHubContributions('octocat');
+    const day = result.weeks[0].contributionDays[0];
+
+    expect(day.locAdditions).toBe(0);
+    expect(day.locDeletions).toBe(0);
+  });
+
   it('sends a POST request to the GitHub GraphQL endpoint with the correct body', async () => {
     vi.mocked(fetch).mockResolvedValue(
       mockResponse({


### PR DESCRIPTION
## Description

Fixes #1059

Added test coverage verifying that `fetchGitHubContributions` correctly injects `locAdditions` and `locDeletions` values for contribution days in LoC mode.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
