### PR TITLE
test(models): verify createdAt default is callable and returns timestamp

### DIFF
--- a/models/User.test.ts
+++ b/models/User.test.ts
@@ -16,6 +16,21 @@ describe('User Model', () => {
       expect(usernamePath.options.lowercase).toBe(true);
     });
 
+    describe('createdAt schema', () => {
+      it('uses a callable default that returns a timestamp', () => {
+        const createdAtPath = User.schema.path('createdAt') as mongoose.SchemaType & {
+          options: { default?: unknown };
+        };
+
+        // Assertion 1: the default is a function
+        expect(typeof createdAtPath.options.default).toBe('function');
+
+        // Assertion 2: calling the default returns a numeric timestamp
+        const result = (createdAtPath.options.default as () => number)();
+        expect(typeof result).toBe('number');
+        expect(Number.isFinite(result)).toBe(true);
+      });
+    });
     it('has trim: true on username path', () => {
       const usernamePath = User.schema.path('username') as mongoose.SchemaType & {
         options: Record<string, unknown>;


### PR DESCRIPTION
## Description
Added a unit test to ensure the createdAt filed on the users model uses a callable default(i..Date.now)not a static timestamp.
The test checks:
the schema default is function  and calling that function returns a numeric, finite timestamp.

Why:
Prevents a regression where Date.now() might be used at schema compile time (creating a fixed timestamp for all new documents) instead of Date.now as a callable.


Fixes #1108 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x]My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
