### PR TITLE
feat: implement versus mode for comparing commit activity between usersFeat/versus mode

### DIFF
--- a/app/(root)/dashboard/[username]/page.tsx
+++ b/app/(root)/dashboard/[username]/page.tsx
@@ -57,16 +57,34 @@ export default async function DashboardPage({
   searchParams,
 }: {
   params: Promise<{ username: string }>;
-  searchParams: Promise<{ refresh?: string }>;
+  searchParams: Promise<{ refresh?: string; versus?: string }>;
 }) {
   const { username } = await params;
   const refreshParams = await searchParams;
   const bypassCache = refreshParams?.refresh === 'true';
+  const versusUsername = refreshParams?.versus;
 
   let data;
+  let versusData = null;
+  let versusError = null;
 
   try {
     data = await getFullDashboardData(username, { bypassCache });
+
+    // Fetch versus user data if provided
+    if (versusUsername) {
+      try {
+        versusData = await getFullDashboardData(versusUsername, { bypassCache });
+      } catch (versusErrorCatch) {
+        console.error(`Failed to fetch versus user "${versusUsername}":`, versusErrorCatch);
+        // Don't throw - continue with single user view, but set error flag
+        versusData = null;
+        versusError =
+          versusErrorCatch instanceof Error
+            ? versusErrorCatch.message
+            : 'Failed to load versus user data';
+      }
+    }
   } catch (error) {
     if (error instanceof Error && error.message.includes('not found')) {
       // Smart Redirect: If the GraphQL "user" query fails, check if it's actually an Organization
@@ -124,8 +142,21 @@ export default async function DashboardPage({
 
         {/* Main Content */}
         <div className="flex flex-col gap-6 lg:gap-8 min-w-0">
+          {versusError && (
+            <section className="p-4 rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
+              <p className="text-sm text-red-800 dark:text-red-200">
+                ⚠️ Could not load versus user &quot;{versusUsername}&quot;: {versusError}. Showing
+                single user view.
+              </p>
+            </section>
+          )}
           <section>
-            <ActivityLandscape data={data.activity} />
+            <ActivityLandscape
+              data={data.activity}
+              versusData={versusData?.activity || null}
+              username={data.profile.username}
+              versusUsername={versusData?.profile.username ?? ''}
+            />
           </section>
 
           <section className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -9,10 +9,13 @@ import { calculateStreak } from '@/lib/calculate';
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const { user } = ogParamsSchema.parse(Object.fromEntries(searchParams.entries()));
+  const versus = searchParams.get('versus');
 
   let totalCommits = 0;
   let longestStreak = 0;
   let currentStreak = 0;
+  let versusTotalCommits = 0;
+  let versusLongestStreak = 0;
 
   // Only the data fetching is wrapped in try/catch — not the JSX rendering.
   try {
@@ -24,6 +27,19 @@ export async function GET(req: NextRequest) {
   } catch (err) {
     console.error('[OG] stats fetch failed:', err);
     // fallback to zeros if GitHub is unreachable
+  }
+
+  // Fetch versus user data if provided
+  if (versus) {
+    try {
+      const versusCalendar = await fetchGitHubContributions(versus, { bypassCache: true });
+      const versusStats = calculateStreak(versusCalendar);
+      versusTotalCommits = versusStats.totalContributions;
+      versusLongestStreak = versusStats.longestStreak;
+    } catch (err) {
+      console.error('[OG] versus stats fetch failed:', err);
+      // fallback to zeros if GitHub is unreachable
+    }
   }
 
   return new ImageResponse(
@@ -70,67 +86,223 @@ export async function GET(req: NextRequest) {
           marginBottom: '48px',
         }}
       >
-        {`@${user}`}
+        {versus ? `@${user} vs @${versus}` : `@${user}`}
       </div>
-      <div style={{ display: 'flex', gap: '48px' }}>
-        {/* Total Commits */}
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            background: '#161b22',
-            border: '1px solid #30363d',
-            borderRadius: '16px',
-            padding: '32px 48px',
-          }}
-        >
-          <div style={{ display: 'flex', fontSize: '56px', fontWeight: 'bold', color: '#58a6ff' }}>
-            {String(totalCommits)}
+      {versus ? (
+        <div style={{ display: 'flex', gap: '24px' }}>
+          {/* User 1 Stats */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              background: '#161b22',
+              border: '1px solid #30363d',
+              borderRadius: '16px',
+              padding: '24px 32px',
+            }}
+          >
+            <div
+              style={{ display: 'flex', fontSize: '24px', color: '#58a6ff', marginBottom: '16px' }}
+            >
+              {`@${user}`}
+            </div>
+            <div style={{ display: 'flex', gap: '16px' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    fontSize: '36px',
+                    fontWeight: 'bold',
+                    color: '#58a6ff',
+                  }}
+                >
+                  {String(totalCommits)}
+                </div>
+                <div
+                  style={{ display: 'flex', fontSize: '14px', color: '#8b949e', marginTop: '4px' }}
+                >
+                  Commits
+                </div>
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    fontSize: '36px',
+                    fontWeight: 'bold',
+                    color: '#f78166',
+                  }}
+                >
+                  {String(longestStreak)}
+                </div>
+                <div
+                  style={{ display: 'flex', fontSize: '14px', color: '#8b949e', marginTop: '4px' }}
+                >
+                  Streak
+                </div>
+              </div>
+            </div>
           </div>
-          <div style={{ display: 'flex', fontSize: '18px', color: '#8b949e', marginTop: '8px' }}>
-            Total Commits
+          {/* VS Badge */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '32px',
+              fontWeight: 'bold',
+              color: '#f78166',
+            }}
+          >
+            VS
+          </div>
+          {/* User 2 Stats */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              background: '#161b22',
+              border: '1px solid #30363d',
+              borderRadius: '16px',
+              padding: '24px 32px',
+            }}
+          >
+            <div
+              style={{ display: 'flex', fontSize: '24px', color: '#a855f7', marginBottom: '16px' }}
+            >
+              {`@${versus}`}
+            </div>
+            <div style={{ display: 'flex', gap: '16px' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    fontSize: '36px',
+                    fontWeight: 'bold',
+                    color: '#a855f7',
+                  }}
+                >
+                  {String(versusTotalCommits)}
+                </div>
+                <div
+                  style={{ display: 'flex', fontSize: '14px', color: '#8b949e', marginTop: '4px' }}
+                >
+                  Commits
+                </div>
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    fontSize: '36px',
+                    fontWeight: 'bold',
+                    color: '#f78166',
+                  }}
+                >
+                  {String(versusLongestStreak)}
+                </div>
+                <div
+                  style={{ display: 'flex', fontSize: '14px', color: '#8b949e', marginTop: '4px' }}
+                >
+                  Streak
+                </div>
+              </div>
+            </div>
           </div>
         </div>
-        {/* Longest Streak */}
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            background: '#161b22',
-            border: '1px solid #30363d',
-            borderRadius: '16px',
-            padding: '32px 48px',
-          }}
-        >
-          <div style={{ display: 'flex', fontSize: '56px', fontWeight: 'bold', color: '#f78166' }}>
-            {String(longestStreak)}
+      ) : (
+        <div style={{ display: 'flex', gap: '48px' }}>
+          {/* Total Commits */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              background: '#161b22',
+              border: '1px solid #30363d',
+              borderRadius: '16px',
+              padding: '32px 48px',
+            }}
+          >
+            <div
+              style={{ display: 'flex', fontSize: '56px', fontWeight: 'bold', color: '#58a6ff' }}
+            >
+              {String(totalCommits)}
+            </div>
+            <div style={{ display: 'flex', fontSize: '18px', color: '#8b949e', marginTop: '8px' }}>
+              Total Commits
+            </div>
           </div>
-          <div style={{ display: 'flex', fontSize: '18px', color: '#8b949e', marginTop: '8px' }}>
-            {'Longest Streak 🔥'}
+          {/* Longest Streak */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              background: '#161b22',
+              border: '1px solid #30363d',
+              borderRadius: '16px',
+              padding: '32px 48px',
+            }}
+          >
+            <div
+              style={{ display: 'flex', fontSize: '56px', fontWeight: 'bold', color: '#f78166' }}
+            >
+              {String(longestStreak)}
+            </div>
+            <div style={{ display: 'flex', fontSize: '18px', color: '#8b949e', marginTop: '8px' }}>
+              {'Longest Streak 🔥'}
+            </div>
+          </div>
+          {/* Current Streak */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              background: '#161b22',
+              border: '1px solid #30363d',
+              borderRadius: '16px',
+              padding: '32px 48px',
+            }}
+          >
+            <div
+              style={{ display: 'flex', fontSize: '56px', fontWeight: 'bold', color: '#3fb950' }}
+            >
+              {String(currentStreak)}
+            </div>
+            <div style={{ display: 'flex', fontSize: '18px', color: '#8b949e', marginTop: '8px' }}>
+              {'Current Streak ⚡'}
+            </div>
           </div>
         </div>
-        {/* Current Streak */}
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            background: '#161b22',
-            border: '1px solid #30363d',
-            borderRadius: '16px',
-            padding: '32px 48px',
-          }}
-        >
-          <div style={{ display: 'flex', fontSize: '56px', fontWeight: 'bold', color: '#3fb950' }}>
-            {String(currentStreak)}
-          </div>
-          <div style={{ display: 'flex', fontSize: '18px', color: '#8b949e', marginTop: '8px' }}>
-            {'Current Streak ⚡'}
-          </div>
-        </div>
-      </div>
+      )}
       <div
         style={{
           display: 'flex',

--- a/components/dashboard/ActivityLandscape.tsx
+++ b/components/dashboard/ActivityLandscape.tsx
@@ -22,17 +22,31 @@ export const getFilteredData = (data: ActivityData[], activeTab: string): Activi
   return recent;
 };
 
-export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
+export default function ActivityLandscape({
+  data,
+  versusData = null,
+  username = '',
+  versusUsername = '',
+}: {
+  data: ActivityData[];
+  versusData: ActivityData[] | null;
+  username: string;
+  versusUsername: string;
+}) {
   const [activeTab, setActiveTab] = useState('3M');
   const [mode, setMode] = useState<'commits' | 'loc'>('commits');
 
   const displayData = getFilteredData(data, activeTab);
+  const displayVersusData = versusData ? getFilteredData(versusData, activeTab) : null;
 
   // Helper to extract the proper value based on the selected mode
   const getValue = (day: ActivityData) =>
     mode === 'loc' ? (day.locAdditions || 0) + (day.locDeletions || 0) : day.count;
 
-  const maxCount = Math.max(...displayData.map(getValue), 1);
+  // Calculate max count across both users for proper scaling
+  const maxCount = displayVersusData
+    ? Math.max(...displayData.map(getValue), ...displayVersusData.map(getValue), 1)
+    : Math.max(...displayData.map(getValue), 1);
 
   return (
     <motion.div
@@ -46,9 +60,18 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
         <div>
           <h2 className="text-base font-semibold text-gray-900 dark:text-white tracking-tight flex items-center gap-2">
             Activity Landscape
+            {versusData && (
+              <span className="text-xs font-normal text-[#A1A1AA]">
+                ({username} vs {versusUsername})
+              </span>
+            )}
           </h2>
           <p className="text-xs text-[#A1A1AA] mt-1">
-            {mode === 'loc' ? 'Lines of code modified over time' : 'Commit frequency over time'}
+            {versusData
+              ? `Comparing ${username} and ${versusUsername}`
+              : mode === 'loc'
+                ? 'Lines of code modified over time'
+                : 'Commit frequency over time'}
           </p>
         </div>
 
@@ -105,42 +128,107 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
         {displayData.map((day, i) => {
           const val = getValue(day);
           const heightPercent = Math.max((val / maxCount) * 100, 3);
+          const versusVal = displayVersusData
+            ? getValue(
+                displayVersusData[i] || {
+                  count: 0,
+                  locAdditions: 0,
+                  locDeletions: 0,
+                  intensity: 0,
+                  date: day.date,
+                }
+              )
+            : 0;
+          const versusHeightPercent = displayVersusData
+            ? Math.max((versusVal / maxCount) * 100, 3)
+            : 0;
 
           // Recalculate intensity for LoC mode visually
           const isHigh = mode === 'loc' ? val > maxCount * 0.7 : day.intensity >= 3;
           const isMedium = mode === 'loc' ? val > 0 : day.intensity > 0;
 
+          const versusIsHigh =
+            displayVersusData &&
+            (mode === 'loc'
+              ? versusVal > maxCount * 0.7
+              : (displayVersusData[i]?.intensity || 0) >= 3);
+          const versusIsMedium =
+            displayVersusData &&
+            (mode === 'loc' ? versusVal > 0 : (displayVersusData[i]?.intensity || 0) > 0);
+
           return (
             <div
               key={i}
               className="relative flex-1 flex items-end group/bar h-full"
-              aria-label={`${day.date}: ${val} ${mode === 'loc' ? 'lines' : 'commits'}`}
+              aria-label={`${day.date}: ${val} ${mode === 'loc' ? 'lines' : 'commits'}${displayVersusData ? ` vs ${versusVal}` : ''}`}
             >
               {/* Tooltip */}
-              <div className="absolute -top-11 left-1/2 -translate-x-1/2 bg-white dark:bg-[#111] border border-black/10 dark:border-[rgba(255,255,255,0.1)] px-2.5 py-1.5 rounded-md opacity-0 group-hover/bar:opacity-100 transition-opacity duration-150 pointer-events-none z-20 flex flex-col items-center whitespace-nowrap shadow-[0_4px_12px_rgba(0,0,0,0.1)] dark:shadow-xl">
-                <span className="text-[10px] text-[#A1A1AA]">{day.date}</span>
-                <span className="text-xs font-semibold text-gray-900 dark:text-white">
-                  {val} {mode === 'loc' ? 'lines' : 'commits'}
-                </span>
+              <div className="absolute -top-16 left-1/2 -translate-x-1/2 bg-white dark:bg-[#111] border border-black/10 dark:border-[rgba(255,255,255,0.1)] px-3 py-2 rounded-md opacity-0 group-hover/bar:opacity-100 transition-opacity duration-150 pointer-events-none z-20 flex flex-col items-center whitespace-nowrap shadow-[0 4px 12px_rgba(0,0,0,0.1)] dark:shadow-xl">
+                <span className="text-[10px] text-[#A1A1AA] mb-1">{day.date}</span>
+                {displayVersusData ? (
+                  <>
+                    <div className="flex items-center gap-3">
+                      <div className="flex items-center gap-1">
+                        <div className="w-2 h-2 rounded-full bg-black dark:bg-white" />
+                        <span className="text-xs font-semibold text-gray-900 dark:text-white">
+                          {username}: {val}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <div className="w-2 h-2 rounded-full bg-indigo-500 dark:bg-indigo-400" />
+                        <span className="text-xs font-semibold text-gray-900 dark:text-white">
+                          {versusUsername}: {versusVal}
+                        </span>
+                      </div>
+                    </div>
+                  </>
+                ) : (
+                  <span className="text-xs font-semibold text-gray-900 dark:text-white">
+                    {val} {mode === 'loc' ? 'lines' : 'commits'}
+                  </span>
+                )}
               </div>
 
-              {/* Bar */}
-              <motion.div
-                initial={{ height: 0 }}
-                animate={{ height: `${heightPercent}%` }}
-                transition={{ duration: 0.6, delay: i * 0.008, ease: [0.16, 1, 0.3, 1] }}
-                className={`w-full rounded-t-[2px] transition-all duration-200 ${
-                  isHigh
-                    ? mode === 'loc'
-                      ? 'bg-indigo-500 dark:bg-indigo-400'
-                      : 'bg-black dark:bg-white'
-                    : isMedium
+              {/* Bars Container */}
+              <div className="w-full h-full flex items-end gap-[1px]">
+                {/* Primary User Bar */}
+                <motion.div
+                  initial={{ height: 0 }}
+                  animate={{ height: `${heightPercent}%` }}
+                  transition={{ duration: 0.6, delay: i * 0.008, ease: [0.16, 1, 0.3, 1] }}
+                  className={`flex-1 rounded-t-[2px] transition-all duration-200 ${
+                    isHigh
                       ? mode === 'loc'
-                        ? 'bg-indigo-300 dark:bg-indigo-500/50 hover:bg-indigo-400'
-                        : 'bg-zinc-500 dark:bg-zinc-600 hover:bg-zinc-700 dark:hover:bg-zinc-400'
-                      : 'bg-gray-200 dark:bg-zinc-800 hover:bg-gray-300 dark:hover:bg-zinc-700'
-                }`}
-              />
+                        ? 'bg-indigo-500 dark:bg-indigo-400'
+                        : 'bg-black dark:bg-white'
+                      : isMedium
+                        ? mode === 'loc'
+                          ? 'bg-indigo-300 dark:bg-indigo-500/50 hover:bg-indigo-400'
+                          : 'bg-zinc-500 dark:bg-zinc-600 hover:bg-zinc-700 dark:hover:bg-zinc-400'
+                        : 'bg-gray-200 dark:bg-zinc-800 hover:bg-gray-300 dark:hover:bg-zinc-700'
+                  }`}
+                />
+
+                {/* Versus User Bar */}
+                {displayVersusData && (
+                  <motion.div
+                    initial={{ height: 0 }}
+                    animate={{ height: `${versusHeightPercent}%` }}
+                    transition={{ duration: 0.6, delay: i * 0.008 + 0.05, ease: [0.16, 1, 0.3, 1] }}
+                    className={`flex-1 rounded-t-[2px] transition-all duration-200 ${
+                      versusIsHigh
+                        ? mode === 'loc'
+                          ? 'bg-indigo-500 dark:bg-indigo-400'
+                          : 'bg-indigo-500 dark:bg-indigo-400'
+                        : versusIsMedium
+                          ? mode === 'loc'
+                            ? 'bg-indigo-300 dark:bg-indigo-500/50 hover:bg-indigo-400'
+                            : 'bg-indigo-300 dark:bg-indigo-500/50 hover:bg-indigo-400'
+                          : 'bg-indigo-100 dark:bg-indigo-900/30 hover:bg-indigo-200 dark:hover:bg-indigo-800/50'
+                    }`}
+                  />
+                )}
+              </div>
             </div>
           );
         })}

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -120,6 +120,22 @@ export const streakParamsSchema = z.object({
   mode: z.enum(['commits', 'loc']).catch('commits').default('commits'),
   repo: z.string().optional(),
   org: z.string().optional(),
+
+  // Versus mode — second username for side-by-side city comparison
+  versus: z
+    .string()
+    .optional()
+    .refine(
+      (val) => {
+        if (!val) return true;
+        return (
+          val.length >= 1 &&
+          val.length <= 39 &&
+          /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9]))*$/.test(val)
+        );
+      },
+      { message: 'Invalid GitHub username for versus parameter' }
+    ),
 });
 
 export const githubParamsSchema = z.object({

--- a/types/index.ts
+++ b/types/index.ts
@@ -167,4 +167,11 @@ export interface BadgeParams {
 
   /** Organization name to generate a Mega-City for. */
   org?: string;
+
+  /**
+   * Second GitHub username for head-to-head versus mode.
+   * When provided, renders both users' isometric cities side-by-side on one canvas.
+   * Usage: /api/streak?user=alice&versus=bob
+   */
+  versus?: string;
 }


### PR DESCRIPTION
Implements versus mode for comparing commit activity between two users.

## Changes
- Add ?versus=username2 parameter to dashboard
- Update ActivityLandscape to render two users side-by-side
- Update OG route to support versus mode for social sharing
- Add error handling for invalid versus usernames
- Graceful degradation when versus user fails to load

## Usage
- Compare users: /dashboard/username1?versus=username2
- OG images: /api/og?user=username1&versus=username2

## Testing
- Tested with sonusharma6-dsa vs torvalds
- Error handling tested with invalid usernames
- Both single-user and versus modes working correctly

Fixes #982