### PR TITLE
test(calculate): cover large grace on small calendar

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -200,6 +200,14 @@ describe('calculateStreak', () => {
     expect(result.longestStreak).toBe(1);
   });
 
+  it('does not walk past the start of a 1-day calendar when grace is larger than the available days', () => {
+    const calendar = buildCalendar([1]);
+
+    expect(() => calculateStreak(calendar, 'UTC', undefined, 7)).not.toThrow();
+    const result = calculateStreak(calendar, 'UTC', undefined, 7);
+    expect(result.currentStreak).toBe(1);
+  });
+
   it('handles a single inactive day safely (0 contributions)', () => {
     const calendar = buildCalendar([0]);
     expect(() => calculateStreak(calendar)).not.toThrow();

--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -203,7 +203,6 @@ describe('calculateStreak', () => {
   it('does not walk past the start of a 1-day calendar when grace is larger than the available days', () => {
     const calendar = buildCalendar([1]);
 
-    expect(() => calculateStreak(calendar, 'UTC', undefined, 7)).not.toThrow();
     const result = calculateStreak(calendar, 'UTC', undefined, 7);
     expect(result.currentStreak).toBe(1);
   });


### PR DESCRIPTION
## Description
Fixes #1102

Adds a regression test for `calculateStreak` to ensure a large grace value does not make the backwards loop walk below index `0` on a small calendar.

The new test builds a 1-day calendar with `contributionCount: 1`, calls `calculateStreak(calendar, 'UTC', undefined, 7)`, and verifies:
- it does not throw
- `currentStreak === 1`

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [ ] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

