### PR TITLE
test(github route): verify 400 error for username with spaces

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -90,6 +90,13 @@ describe('GET /api/streak', () => {
 
       expect(fetchGitHubContributions).not.toHaveBeenCalled();
     });
+    it('returns 400 when user contains spaces', async () => {
+      const response = await GET(makeRequest({ user: 'john doe' }));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.details.fieldErrors.user[0]).toContain('Invalid GitHub username');
+    });
 
     it('returns 400 for invalid monthly badge dimensions', async () => {
       const invalidDimensionParams: Array<Record<string, string>> = [


### PR DESCRIPTION
## Description

Added a route test to verify that usernames containing spaces return a 400 response with an Invalid GitHub username validation error.

Fixes #1097

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable. Test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
