### PR TITLE
test: add stricter assertions for fetchOrgMembers

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -739,9 +739,19 @@ describe('fetchOrgMembers', () => {
   });
 
   it('fetches organization members successfully', async () => {
-    vi.mocked(fetch).mockResolvedValue(mockResponse([{ login: 'alice' }, { login: 'bob' }]));
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse([
+        { login: 'alice', id: 1 },
+        { login: 'bob', id: 2 },
+      ])
+    );
+
     const members = await fetchOrgMembers('vercel');
-    expect(members).toEqual(['alice', 'bob']);
+
+    expect(Array.isArray(members)).toBe(true);
+    expect(members.every((member) => typeof member === 'string')).toBe(true);
+    expect(members[0]).toBe('alice');
+    expect(members[1]).toBe('bob');
   });
 });
 


### PR DESCRIPTION
## Description

Adds stricter assertions to the `fetchOrgMembers` test.

### Changes

* Mock GitHub organization members with additional fields (`id`) to better represent the API response.
* Verify the returned result is an array.
* Verify every element in the result is a string.
* Verify login values are correctly extracted (`alice`, `bob`).

Fixes #<1105>

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.

- [ ] I have started the repo.
- [ ] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
