### PR TITLE
test(cache): verify near-zero positive TTL values do not throw

### DIFF
--- a/lib/cache.test.ts
+++ b/lib/cache.test.ts
@@ -381,6 +381,25 @@ describe('TTLCache', () => {
       expect([null, 'lived']).toContain(result);
       cache.destroy();
     });
+    it('does not throw when ttlMs is Number.EPSILON', () => {
+      const cache = new TTLCache<string>();
+
+      expect(() => {
+        cache.set('key', 'value', Number.EPSILON);
+      }).not.toThrow();
+
+      cache.destroy();
+    });
+
+    it('does not throw when ttlMs is a very small positive number', () => {
+      const cache = new TTLCache<string>();
+
+      expect(() => {
+        cache.set('key', 'value', 0.0001);
+      }).not.toThrow();
+
+      cache.destroy();
+    });
 
     it('multiple clear operations work correctly', () => {
       const cache = new TTLCache<string>();


### PR DESCRIPTION
## Description

Added tests to verify that very small positive TTL values such as `Number.EPSILON` and `0.0001` do not throw errors in `TTLCache#set()`.

Fixes #1096

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable. Test-only change.

## Checklist

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commit follows the Conventional Commits format.
* [x] I have made sure that I have only one commit to merge in this PR.
