### PR TITLE
test(cache): verify TTLCache exact TTL boundary behavior

### DIFF
--- a/lib/cache.test.ts
+++ b/lib/cache.test.ts
@@ -381,6 +381,25 @@ describe('TTLCache', () => {
       expect([null, 'lived']).toContain(result);
       cache.destroy();
     });
+    it('does not throw when ttlMs is Number.EPSILON', () => {
+      const cache = new TTLCache<string>();
+
+      expect(() => {
+        cache.set('key', 'value', Number.EPSILON);
+      }).not.toThrow();
+
+      cache.destroy();
+    });
+
+    it('does not throw when ttlMs is a very small positive number', () => {
+      const cache = new TTLCache<string>();
+
+      expect(() => {
+        cache.set('key', 'value', 0.0001);
+      }).not.toThrow();
+
+      cache.destroy();
+    });
 
     it('multiple clear operations work correctly', () => {
       const cache = new TTLCache<string>();

--- a/lib/cache.test.ts
+++ b/lib/cache.test.ts
@@ -226,6 +226,26 @@ describe('TTLCache', () => {
 
       cache.destroy();
     });
+    it('returns correct values around the exact TTL boundary', () => {
+      vi.useFakeTimers();
+
+      const cache = new TTLCache<string>();
+      cache.set('key', 'value', 1000);
+
+      // 999ms -> still valid
+      vi.advanceTimersByTime(999);
+      expect(cache.get('key')).toBe('value');
+
+      // 1000ms exact boundary -> still valid
+      vi.advanceTimersByTime(1);
+      expect(cache.get('key')).toBe('value');
+
+      // 1001ms -> expired
+      vi.advanceTimersByTime(1);
+      expect(cache.get('key')).toBeNull();
+
+      cache.destroy();
+    });
 
     it('returns null after passing TTL expiry', () => {
       vi.useFakeTimers();


### PR DESCRIPTION
## Description

Added a precise TTL boundary test to verify cache behavior at 999ms, exactly 1000ms, and after 1001ms expiry timing.

Fixes #1095

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable. Test-only change.

## Checklist

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commit follows the Conventional Commits format.
* [x] I have made sure that I have only one commit to merge in this PR.
