### PR TITLE
fix(api): clean up fetch retry abort listeners

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   fetchGitHubContributions,
+  fetchWithRetry,
   fetchUserProfile,
   fetchUserRepos,
   getFullDashboardData,
@@ -58,6 +59,54 @@ afterEach(() => {
   } else {
     process.env.GITHUB_TOKEN = originalGitHubToken;
   }
+});
+
+describe('fetchWithRetry', () => {
+  beforeEach(() => {
+    vi.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('removes caller abort listeners after a successful request', async () => {
+    const controller = new AbortController();
+    const addListenerSpy = vi.spyOn(controller.signal, 'addEventListener');
+    const removeListenerSpy = vi.spyOn(controller.signal, 'removeEventListener');
+
+    vi.mocked(fetch).mockResolvedValue(mockResponse({ ok: true }));
+
+    await fetchWithRetry('https://api.github.com/test', { signal: controller.signal }, 0, 1000);
+
+    const abortListener = addListenerSpy.mock.calls.find(([event]) => event === 'abort')?.[1];
+
+    expect(abortListener).toEqual(expect.any(Function));
+    expect(addListenerSpy).toHaveBeenCalledWith('abort', abortListener, { once: true });
+    expect(removeListenerSpy).toHaveBeenCalledWith('abort', abortListener);
+  });
+
+  it('still aborts the in-flight request when the caller signal is aborted', async () => {
+    const controller = new AbortController();
+
+    vi.mocked(fetch).mockImplementation(
+      (_url: RequestInfo | URL, options?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => reject(new DOMException('Aborted', 'AbortError')),
+            { once: true }
+          );
+        })
+    );
+
+    const request = fetchWithRetry('https://api.github.com/test', { signal: controller.signal });
+
+    controller.abort();
+
+    await expect(request).rejects.toThrow('Aborted');
+    expect(fetch).toHaveBeenCalledOnce();
+  });
 });
 
 describe('fetchGitHubContributions', () => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -30,27 +30,39 @@ export async function fetchWithRetry(
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), resolvedTimeout);
+  const abortRequest = () => controller.abort();
 
   if (options.signal) {
-    options.signal.addEventListener('abort', () => controller.abort(), { once: true });
+    options.signal.addEventListener('abort', abortRequest, { once: true });
   }
 
   let res: Response | null = null;
+  let fetchError: unknown;
+  let didThrow = false;
+
   try {
     res = await fetch(url, { ...options, signal: controller.signal });
-  } catch (err) {
+  } catch (err: unknown) {
+    fetchError = err;
+    didThrow = true;
+  } finally {
     clearTimeout(timeoutId);
-    if (options.signal?.aborted) throw err;
-    if (err instanceof Error && err.name === 'AbortError') {
+    options.signal?.removeEventListener('abort', abortRequest);
+  }
+
+  if (didThrow) {
+    if (options.signal?.aborted) throw fetchError;
+    if (fetchError instanceof Error && fetchError.name === 'AbortError') {
       throw new Error(`GitHub API request timed out after ${resolvedTimeout / 1000}s`);
     }
-    if (attempt >= MAX_RETRIES) throw err;
+    if (attempt >= MAX_RETRIES) throw fetchError;
     const delay = BASE_DELAY_MS * Math.pow(2, attempt);
     await new Promise((resolve) => setTimeout(resolve, delay));
     return fetchWithRetry(url, options, attempt + 1, timeoutMs);
   }
 
-  clearTimeout(timeoutId);
+  if (!res) throw new Error('GitHub API request failed without a response');
+
   const shouldRetry = res.status === 429 || res.status >= 500;
   if (!shouldRetry || attempt >= MAX_RETRIES) return res;
 


### PR DESCRIPTION
## Description

Fixes #1130

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed

`fetchWithRetry` was adding an `abort` listener to the caller-provided `AbortSignal`, but the listener was never removed after the request attempt finished.

This PR keeps the abort callback in a named function and removes it in a cleanup path after each fetch attempt settles. The existing cancellation behavior is preserved: aborting the caller signal still aborts the in-flight request.

I also added regression tests covering:

- listener cleanup after a successful request
- caller-triggered abort still cancelling the active request

## Visual Preview

N/A — this is an API client cleanup fix with no UI or SVG visual change.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npm run test -- lib/github.test.ts`, `npm run test`, `npm run test:coverage`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.
