### PR TITLE
test(svg generator): verify .scan-line CSS class is on the radar rect in both renderers

### DIFF
--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -386,6 +386,20 @@ describe('generateSVG', () => {
       expect(svg).toContain('prefers-reduced-motion');
     });
 
+    it('includes the scan-line class on the radar rect in the static renderer output', () => {
+      const staticParams: BadgeParams = {
+        user: 'avi',
+        autoTheme: false, // forces static renderer path
+      };
+      const svg = generateSVG(mockStats, staticParams, mockCalendar);
+      expect(svg).toContain('class="cp-accent-fill scan-line"');
+    });
+
+    it('includes the scan-line class on the radar rect in the auto-theme renderer output', () => {
+      const svg = generateSVG(mockStats, autoParams, mockCalendar); // autoParams has autoTheme: true
+      expect(svg).toContain('class="cp-accent-fill scan-line"');
+    });
+
     it('emits tower-raising CSS animations and staggered delays in auto mode', () => {
       const svg = generateSVG(mockStats, autoParams, mockCalendar);
 

--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -387,16 +387,17 @@ describe('generateSVG', () => {
     });
 
     it('includes the scan-line class on the radar rect in the static renderer output', () => {
-      const staticParams: BadgeParams = {
+      const staticParams = {
         user: 'avi',
-        autoTheme: false, // forces static renderer path
-      };
+        autoTheme: false,
+      } as unknown as BadgeParams;
+
       const svg = generateSVG(mockStats, staticParams, mockCalendar);
       expect(svg).toContain('class="cp-accent-fill scan-line"');
     });
 
     it('includes the scan-line class on the radar rect in the auto-theme renderer output', () => {
-      const svg = generateSVG(mockStats, autoParams, mockCalendar); // autoParams has autoTheme: true
+      const svg = generateSVG(mockStats, autoParams, mockCalendar);
       expect(svg).toContain('class="cp-accent-fill scan-line"');
     });
 


### PR DESCRIPTION
## Description

Fixes #1083

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes (Pure test coverage improvement).

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `test(svg generator): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.