### PR TITLE
feat: rateLimit()  replace raw Map with TTLCache to remove manual cleanup logic [ GSSOC'26 ]

### DIFF
--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -45,16 +45,8 @@ interface RateLimitResult {
   reset: number;
 }
 
-const trackers = new Map<string, { count: number; expires: number }>();
+const trackers = new TTLCache<{ count: number }>(2000, 60000);
 
-/**
- * Checks if a request from a given IP should be rate limited.
- *
- * @param ip The IP address to track
- * @param limit Maximum number of requests allowed in the window
- * @param windowMs Time window in milliseconds
- * @returns RateLimitResult
- */
 export function rateLimit(
   ip: string,
   limit: number = 60,
@@ -63,39 +55,25 @@ export function rateLimit(
   const now = Date.now();
   const tracker = trackers.get(ip);
 
-  // Periodic cleanup of the map to prevent memory leaks.
-  // We perform a partial cleanup if the map grows too large.
-  if (trackers.size > 2000) {
-    let cleaned = 0;
-    for (const [key, value] of trackers.entries()) {
-      if (now > value.expires) {
-        trackers.delete(key);
-        cleaned++;
-      }
-      // Stop cleaning after some work to avoid blocking the request for too long
-      if (cleaned > 500) break;
-    }
-  }
-
-  if (!tracker || now > tracker.expires) {
-    const expires = now + windowMs;
-    trackers.set(ip, { count: 1, expires });
+  if (!tracker) {
+    trackers.set(ip, { count: 1 }, windowMs);
     return {
       success: true,
       limit,
       remaining: limit - 1,
-      reset: expires,
+      reset: now + windowMs,
     };
   }
 
   tracker.count++;
+  trackers.set(ip, tracker, windowMs);
 
   if (tracker.count > limit) {
     return {
       success: false,
       limit,
       remaining: 0,
-      reset: tracker.expires,
+      reset: now + windowMs,
     };
   }
 
@@ -103,6 +81,6 @@ export function rateLimit(
     success: true,
     limit,
     remaining: limit - tracker.count,
-    reset: tracker.expires,
+    reset: now + windowMs,
   };
 }


### PR DESCRIPTION
## Description
Fixes #1135 
The `rateLimit()` function used a raw `Map` with manual periodic
cleanup to handle expiry and capacity. `TTLCache` is already imported
in the same file and handles both automatically. This PR replaces the
raw Map with a `TTLCache` instance, removing ~15 lines of manual
cleanup logic and making the implementation consistent with the
existing `RateLimiter` class.

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — internal rate limiting logic, no visual output.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.