### PR TITLE
Test testing ssr guard

### DIFF
--- a/lib/cache.test.ts
+++ b/lib/cache.test.ts
@@ -226,6 +226,26 @@ describe('TTLCache', () => {
 
       cache.destroy();
     });
+    it('returns correct values around the exact TTL boundary', () => {
+      vi.useFakeTimers();
+
+      const cache = new TTLCache<string>();
+      cache.set('key', 'value', 1000);
+
+      // 999ms -> still valid
+      vi.advanceTimersByTime(999);
+      expect(cache.get('key')).toBe('value');
+
+      // 1000ms exact boundary -> still valid
+      vi.advanceTimersByTime(1);
+      expect(cache.get('key')).toBe('value');
+
+      // 1001ms -> expired
+      vi.advanceTimersByTime(1);
+      expect(cache.get('key')).toBeNull();
+
+      cache.destroy();
+    });
 
     it('returns null after passing TTL expiry', () => {
       vi.useFakeTimers();

--- a/utils/tracking.test.ts
+++ b/utils/tracking.test.ts
@@ -62,4 +62,31 @@ describe('trackUser', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+  it('does not run in SSR context when window is undefined', () => {
+    const originalWindow = globalThis.window;
+    const sendBeaconMock = vi.fn();
+    const fetchMock = vi.fn();
+
+    Object.defineProperty(globalThis, 'window', {
+      value: undefined,
+      configurable: true,
+    });
+
+    Object.defineProperty(navigator, 'sendBeacon', {
+      value: sendBeaconMock,
+      configurable: true,
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    trackUser('octocat');
+
+    expect(sendBeaconMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    Object.defineProperty(globalThis, 'window', {
+      value: originalWindow,
+      configurable: true,
+    });
+  });
 });


### PR DESCRIPTION
## Description
Added an SSR guard test for `trackUser` to ensure it does not call tracking APIs when `window` is undefined.

### Changes Made
- Temporarily mocked `globalThis.window` as undefined
- Verified `navigator.sendBeacon` is not called
- Verified `fetch` is not called
- Restored `window` after test execution

Closes #1090

---

## Pillar
- [x] Tests
- [ ] Bug Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor

---

## Checklist
- [x] My code follows the project style guidelines
- [x] I have tested my changes locally
- [x] All tests are passing
- [x] I have linked the related issue
- [x] This PR is ready for review