### PR TITLE
test(layout): verify computeTowers calculates height using loc mode #1080

### DIFF
--- a/lib/svg/layout.test.ts
+++ b/lib/svg/layout.test.ts
@@ -160,6 +160,37 @@ describe('computeTowers edge cases', () => {
     // Math.log2(3 + 1) * 12 = 2 * 12 = 24
     expect(towers[0].h).toBe(24);
   });
+
+  // =========================================================================
+  // ISSUE OBJECTIVE: LoC Mode Tests
+  // =========================================================================
+  it('calculates tower height based on LoC additions and deletions in "loc" mode', () => {
+    const todayDate = '2026-05-29';
+    const calendar = {
+      totalContributions: 0,
+      weeks: [
+        {
+          contributionDays: [
+            {
+              date: todayDate,
+              contributionCount: 0,
+              locAdditions: 50,
+              locDeletions: 10,
+            },
+          ],
+        },
+      ],
+    } as unknown as ContributionCalendar;
+
+    // Call computeTowers with 'loc' mode parameter
+    const towers = computeTowers(calendar, 'linear', todayDate, 'loc');
+    const testTower = towers[0];
+
+    // Assert the computed count is 60 (50 + 10)
+    expect(testTower.contributionCount).toBe(60);
+    // Assert h > 0 (not ghost despite 0 normal contributions)
+    expect(testTower.h).toBeGreaterThan(0);
+  });
 });
 
 it('assigns correct row and col values based on week/day position', () => {


### PR DESCRIPTION
…#ISSUE_NUMBER)

## Description
Added a new test case in lib/svg/layout.test.ts to verify that the computeTowers function correctly processes the loc mode parameter. The test ensures that the tower height and contributionCount are correctly calculated using the sum of locAdditions and locDeletions instead of the standard contribution count, and explicitly asserts that the tower does not render as a "ghost" building.

Fixes #1080

## Pillar

[ ] 🎨 Pillar 1 — New Theme Design
[ ] 📐 Pillar 2 — Geometric SVG Improvement
[ ] 🕐 Pillar 3 — Timezone Logic Optimization
[x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="929" height="360" alt="Screenshot 2026-05-29 092616" src="https://github.com/user-attachments/assets/7568a800-4d10-4ba1-bc2a-200c31cf18c9" />

## Checklist before requesting a review:

[x] I have read the CONTRIBUTING.md file.
[x] I have tested these changes locally (localhost:3000/api/streak?user=YOUR_USERNAME).
[x] I have run npm run format and npm run lint locally and resolved all errors (CI will fail otherwise).
[x] My commits follow the Conventional Commits format (e.g., feat(themes): ..., fix(calculate): ...).
[ ] I have updated README.md if I added a new theme or URL parameter.
[x] I have started the repo.
[x] I have made sure that i have only one commit to merge in this PR.
[x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
[x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.