### PR TITLE
Feature: Custom Date Range Windows (from and to parameters)

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -39,6 +39,8 @@ export async function GET(request: Request) {
       radius,
       font,
       year,
+      from: customFrom,
+      to: customTo,
       refresh,
       hide_title,
       hide_background,
@@ -57,8 +59,16 @@ export async function GET(request: Request) {
     } = parseResult.data;
 
     const themeName = theme || 'dark';
-    const from = year ? `${year}-01-01T00:00:00Z` : undefined;
-    const to = year ? `${year}-12-31T23:59:59Z` : undefined;
+    const from = customFrom
+      ? new Date(customFrom).toISOString()
+      : year
+        ? `${year}-01-01T00:00:00Z`
+        : undefined;
+    const to = customTo
+      ? new Date(customTo).toISOString()
+      : year
+        ? `${year}-12-31T23:59:59Z`
+        : undefined;
 
     const tzParam = searchParams.get('tz');
     let timezone = 'UTC';

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -95,6 +95,26 @@ export const streakParamsSchema = z.object({
         message: 'GitHub was founded in 2008. Please provide a year of 2008 or later.',
       }
     ),
+  from: z
+    .string()
+    .optional()
+    .refine(
+      (val) => {
+        if (!val) return true;
+        return !isNaN(Date.parse(val));
+      },
+      { message: 'Invalid "from" date format. Use ISO 8601 (e.g. 2023-01-01).' }
+    ),
+  to: z
+    .string()
+    .optional()
+    .refine(
+      (val) => {
+        if (!val) return true;
+        return !isNaN(Date.parse(val));
+      },
+      { message: 'Invalid "to" date format. Use ISO 8601 (e.g. 2023-12-31).' }
+    ),
   refresh: z
     .string()
     .optional()


### PR DESCRIPTION
## Description
Fixes #981
Adds support for explicit \rom\ and \	o\ query parameters in the API to specify custom date ranges. These overwrite the \year\ parameter when provided.

## Pillar
Feature

## Checklist
- [x] Tested locally
- [x] Linted
- [x] Build passes