### PR TITLE
Test dashboard client

### DIFF
--- a/components/dashboard/ComparisonStatsCard.test.tsx
+++ b/components/dashboard/ComparisonStatsCard.test.tsx
@@ -90,4 +90,39 @@ describe('ComparisonStatsCard', () => {
 
     expect(screen.queryByText('Winner')).toBeNull();
   });
+  it('renders neutral fallback progress bar when both values are zero', () => {
+    const { container } = render(
+      <ComparisonStatsCard
+        title="Developer Score"
+        valueA={0}
+        valueB={0}
+        labelA="User One"
+        labelB="User Two"
+        icon="Award"
+      />
+    );
+
+    const fallbackBar = container.querySelector('.bg-gray-700\\/50');
+
+    expect(fallbackBar).toBeDefined();
+  });
+
+  it('renders both progress bar segments when total is greater than zero', () => {
+    const { container } = render(
+      <ComparisonStatsCard
+        title="Developer Score"
+        valueA={75}
+        valueB={25}
+        labelA="User One"
+        labelB="User Two"
+        icon="Award"
+      />
+    );
+
+    const userOneSegment = container.querySelector('.bg-cyan-400');
+    const userTwoSegment = container.querySelector('.bg-purple-400');
+
+    expect(userOneSegment).toBeDefined();
+    expect(userTwoSegment).toBeDefined();
+  });
 });

--- a/components/dashboard/DashboardClient.test.tsx
+++ b/components/dashboard/DashboardClient.test.tsx
@@ -233,4 +233,30 @@ describe('DashboardClient', () => {
     expect(screen.getAllByText('Shivangi').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Sourav').length).toBeGreaterThan(0);
   });
+  it('renders personality tags for both profiles in compare mode', async () => {
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockSecondData),
+      })
+    );
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    render(<DashboardClient initialData={mockInitialData} username="Shivangi1515" />);
+
+    fireEvent.click(screen.getByText('Compare Profile'));
+
+    fireEvent.change(screen.getByPlaceholderText('Enter GitHub Username'), {
+      target: { value: 'JhaSourav07' },
+    });
+
+    fireEvent.click(screen.getByText('Compare'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Exit Compare Mode')).toBeDefined();
+    });
+
+    expect(screen.getByText(/Full Stack Builder/i)).toBeDefined();
+  });
 });

--- a/lib/cache.test.ts
+++ b/lib/cache.test.ts
@@ -226,6 +226,26 @@ describe('TTLCache', () => {
 
       cache.destroy();
     });
+    it('returns correct values around the exact TTL boundary', () => {
+      vi.useFakeTimers();
+
+      const cache = new TTLCache<string>();
+      cache.set('key', 'value', 1000);
+
+      // 999ms -> still valid
+      vi.advanceTimersByTime(999);
+      expect(cache.get('key')).toBe('value');
+
+      // 1000ms exact boundary -> still valid
+      vi.advanceTimersByTime(1);
+      expect(cache.get('key')).toBe('value');
+
+      // 1001ms -> expired
+      vi.advanceTimersByTime(1);
+      expect(cache.get('key')).toBeNull();
+
+      cache.destroy();
+    });
 
     it('returns null after passing TTL expiry', () => {
       vi.useFakeTimers();

--- a/lib/svg/themes.test.ts
+++ b/lib/svg/themes.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { themes } from './themes';
+
+describe('themes', () => {
+  it('should not use # prefix in background colors', () => {
+    Object.values(themes).forEach((theme) => {
+      expect(theme.bg.startsWith('#')).toBe(false);
+    });
+  });
+
+  it('should not use # prefix in text colors', () => {
+    Object.values(themes).forEach((theme) => {
+      expect(theme.text.startsWith('#')).toBe(false);
+    });
+  });
+
+  it('should not use # prefix in accent colors', () => {
+    Object.values(themes).forEach((theme) => {
+      expect(theme.accent.startsWith('#')).toBe(false);
+    });
+  });
+});

--- a/utils/tracking.test.ts
+++ b/utils/tracking.test.ts
@@ -62,4 +62,31 @@ describe('trackUser', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+  it('does not run in SSR context when window is undefined', () => {
+    const originalWindow = globalThis.window;
+    const sendBeaconMock = vi.fn();
+    const fetchMock = vi.fn();
+
+    Object.defineProperty(globalThis, 'window', {
+      value: undefined,
+      configurable: true,
+    });
+
+    Object.defineProperty(navigator, 'sendBeacon', {
+      value: sendBeaconMock,
+      configurable: true,
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    trackUser('octocat');
+
+    expect(sendBeaconMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    Object.defineProperty(globalThis, 'window', {
+      value: originalWindow,
+      configurable: true,
+    });
+  });
 });


### PR DESCRIPTION
## Description

Added a test to verify that DashboardClient renders personality tags for both profiles in compare mode.

### Changes Made

* Added compare mode test coverage for personality tags.
* Mocked successful second profile fetch.
* Verified compare mode renders personality tag content after profile comparison.

Fixes #1066

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
