### PR TITLE
test(dashboard): verify exit compare mode resets state properly 

### DIFF
--- a/components/dashboard/DashboardClient.test.tsx
+++ b/components/dashboard/DashboardClient.test.tsx
@@ -233,6 +233,54 @@ describe('DashboardClient', () => {
     expect(screen.getAllByText('Shivangi').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Sourav').length).toBeGreaterThan(0);
   });
+
+  // =========================================================================
+  // ISSUE OBJECTIVE: Add a test for exiting compare mode
+  // =========================================================================
+  it('exits compare mode and restores single profile view', async () => {
+    // Mock successful fetch response to enter compare mode first
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockSecondData),
+      })
+    );
+    vi.stubGlobal('fetch', mockFetch);
+
+    render(<DashboardClient initialData={mockInitialData} username="Shivangi1515" />);
+
+    // 1. Enter compare mode
+    const compareBtn = screen.getByText('Compare Profile');
+    fireEvent.click(compareBtn);
+
+    const input = screen.getByPlaceholderText('Enter GitHub Username');
+    fireEvent.change(input, { target: { value: 'JhaSourav07' } });
+
+    const submitBtn = screen.getByText('Compare');
+    fireEvent.click(submitBtn);
+
+    // Wait for state to update and Exit button to render
+    await waitFor(() => {
+      expect(screen.getByText('Exit Compare Mode')).toBeDefined();
+    });
+
+    // 2. Assert 'Exit Compare Mode' button is visible
+    const exitBtn = screen.getByText('Exit Compare Mode');
+    expect(exitBtn).toBeDefined();
+
+    // 3. Click it
+    fireEvent.click(exitBtn);
+
+    // 4. Assert 'Compare Profile' button is visible again
+    expect(screen.getByText('Compare Profile')).toBeDefined();
+
+    // 5. Assert 'Exit Compare Mode' button is gone
+    expect(screen.queryByText('Exit Compare Mode')).toBeNull();
+
+    // Verify the second profile is removed from the DOM
+    expect(screen.queryByText('Sourav')).toBeNull();
+  });
+
   it('generate your own button points to root /', () => {
     render(<DashboardClient initialData={mockInitialData} username="Shivangi1515" />);
 


### PR DESCRIPTION

## Description
Added a new test case in components/dashboard/DashboardClient.test.tsx to verify the state reset logic for the "Exit Compare Mode" functionality. The test simulates a successful comparison fetch, asserts the appearance of the exit button, clicks it, and finally verifies that the UI reverts to the default single-profile state (the original compare button returns and the exit button is removed from the DOM).

Fixes #1065 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="948" height="387" alt="Screenshot 2026-05-29 102110" src="https://github.com/user-attachments/assets/e494f792-8302-44f5-8441-6bf0e2cebe4c" />

## Checklist before requesting a review:

[x] I have read the CONTRIBUTING.md file.

[x] I have tested these changes locally (localhost:3000/api/streak?user=YOUR_USERNAME).

[x] I have run npm run format and npm run lint locally and resolved all errors (CI will fail otherwise).

[x] My commits follow the Conventional Commits format (e.g., feat(themes): ..., fix(calculate): ...).

[ ] I have updated README.md if I added a new theme or URL parameter.

[x] I have starred the repo.

[x] I have made sure that I have only one commit to merge in this PR.

[x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.

[x] (Recommended) I joined the CommitPulse Discord community for contributor discussions.