### PR TITLE
test(dashboard): verify error is shown when comparing with same username (#1064)

### DIFF
--- a/components/dashboard/DashboardClient.test.tsx
+++ b/components/dashboard/DashboardClient.test.tsx
@@ -239,4 +239,28 @@ describe('DashboardClient', () => {
     const generateLink = screen.getByRole('link', { name: /generate your own/i });
     expect(generateLink.getAttribute('href')).toBe('/');
   });
+  // =========================================================================
+  // ISSUE OBJECTIVE: Verify error is shown when comparing with same username
+  // =========================================================================
+  it('shows an error when comparing with the same username (case-insensitive)', async () => {
+    render(<DashboardClient initialData={mockInitialData} username="Shivangi1515" />);
+
+    // 1. Open modal
+    const compareBtn = screen.getByText('Compare Profile');
+    fireEvent.click(compareBtn);
+
+    // 2. Type the same username as props.username, but all lowercase to test case-insensitivity
+    const input = screen.getByPlaceholderText('Enter GitHub Username');
+    fireEvent.change(input, { target: { value: 'shivangi1515' } });
+
+    // 3. Click 'Compare'
+    const submitBtn = screen.getByText('Compare');
+    fireEvent.click(submitBtn);
+
+    // 4. Assert error message 'Cannot compare a profile with itself.' appears
+    await waitFor(() => {
+      // Using Regex /.../i to match the text even if there is an emoji next to it!
+      expect(screen.getByText(/Cannot compare a profile with itself/i)).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION

## Description
Added a new test case in components/dashboard/DashboardClient.test.tsx to verify that the application prevents self-comparison. The test opens the compare modal, inputs the exact same username as the active profile (using lowercase to verify case-insensitivity), clicks the compare button, and successfully asserts that the expected error message "Cannot compare a profile with itself." is rendered to the DOM.

Fixes #1064 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="938" height="375" alt="Screenshot 2026-05-29 102944" src="https://github.com/user-attachments/assets/2ccbd93c-52f9-4cea-be5e-8e3464ff52f9" />


## Checklist before requesting a review:

[x] I have read the CONTRIBUTING.md file.
[x] I have tested these changes locally (localhost:3000/api/streak?user=YOUR_USERNAME).
[x] I have run npm run format and npm run lint locally and resolved all errors (CI will fail otherwise).
[x] My commits follow the Conventional Commits format (e.g., feat(themes): ..., fix(calculate): ...).
[ ] I have updated README.md if I added a new theme or URL parameter.
[x] I have starred the repo.
[x] I have made sure that I have only one commit to merge in this PR.
[x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
[x] (Recommended) I joined the CommitPulse Discord community for contributor discussions.
