### PR TITLE
test(calculate): verify weekendRatio is 100 when all contributions are on weekends #1055

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -509,4 +509,27 @@ describe('calculateWrappedStats', () => {
     expect(result.busiestMonth).toBe('2024-01');
     expect(result.weekendRatio).toBe(100);
   });
+  // =========================================================================
+  // ISSUE OBJECTIVE: Verify weekendRatio is 100 when all commits are on weekends
+  // =========================================================================
+  it('returns weekendRatio === 100 when all contributions are on weekends', () => {
+    // Note: 2026-05-02 is a Saturday, 2026-05-03 is a Sunday, 2026-05-04 is a Monday
+    const weekendCalendar = {
+      totalContributions: 10,
+      weeks: [
+        {
+          contributionDays: [
+            { date: '2026-05-02', contributionCount: 5 }, // Saturday (Weekend)
+            { date: '2026-05-03', contributionCount: 5 }, // Sunday (Weekend)
+            { date: '2026-05-04', contributionCount: 0 }, // Monday (Weekday - 0 commits)
+          ],
+        },
+      ],
+    } as Parameters<typeof calculateWrappedStats>[0]; // Safely infers the exact type the function expects!
+
+    const result = calculateWrappedStats(weekendCalendar);
+
+    // Assert the ratio is exactly 100%
+    expect(result.weekendRatio).toBe(100);
+  });
 });


### PR DESCRIPTION

## Description
Added a new edge-case test in lib/calculate.test.ts for the calculateWrappedStats function. The test constructs a mock calendar where all non-zero contributions occur exclusively on a Saturday and Sunday (2026-05-02 and 2026-05-03), and successfully asserts that the resulting weekendRatio evaluates to exactly 100.

Fixes #1055 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="938" height="372" alt="Screenshot 2026-05-29 103604" src="https://github.com/user-attachments/assets/be70674a-777a-4b66-a2b4-3479fb71601d" />


## Checklist before requesting a review:

[x] I have read the CONTRIBUTING.md file.

[x] I have tested these changes locally (localhost:3000/api/streak?user=YOUR_USERNAME).

[x] I have run npm run format and npm run lint locally and resolved all errors (CI will fail otherwise).

[x] My commits follow the Conventional Commits format (e.g., feat(themes): ..., fix(calculate): ...).

[ ] I have updated README.md if I added a new theme or URL parameter.

[x] I have starred the repo.

[x] I have made sure that I have only one commit to merge in this PR.

[x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.

[x] (Recommended) I joined the CommitPulse Discord community for contributor discussions.