### PR TITLE
test(validations): verify view parameter behavior

### DIFF
--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -432,3 +432,21 @@ describe('ogParamsSchema', () => {
     expect(result.user).toBe('unknown');
   });
 });
+
+describe('streakParamsSchema — view fallback behavior', () => {
+  it('accepts "default" as a valid view value', () => {
+    expect(parse({ view: 'default' }).view).toBe('default');
+  });
+
+  it('accepts "monthly" as a valid view value', () => {
+    expect(parse({ view: 'monthly' }).view).toBe('monthly');
+  });
+
+  it('falls back to "default" for unknown view value', () => {
+    expect(parse({ view: 'radar' }).view).toBe('default');
+  });
+
+  it('defaults to "default" when view is omitted', () => {
+    expect(parse({}).view).toBe('default');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1041

Added validation tests for the `view` parameter in `streakParamsSchema`.

The tests verify that:

* `view: "default"` is accepted
* `view: "monthly"` is accepted
* invalid values (e.g. `"radar"`) fall back to `"default"`
* omitted `view` defaults to `"default"`

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable — test-only change).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.