### PR TITLE
test(calculate): verify calculateMonthlyStats handles empty calendar gracefully #1052

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -443,6 +443,29 @@ describe('calculateMonthlyStats', () => {
     expect(result.currentMonthTotal).toBe(5);
     expect(result.currentMonthName).toBe('January');
   });
+  // =========================================================================
+  // ISSUE OBJECTIVE: Empty calendar passed to calculateMonthlyStats
+  // =========================================================================
+  it('returns zeros and does not crash when given an empty calendar', () => {
+    const emptyCalendar = {
+      totalContributions: 0,
+      weeks: [],
+    } as Parameters<typeof calculateMonthlyStats>[0];
+
+    const testDate = new Date('2026-05-29T12:00:00Z');
+    let result: ReturnType<typeof calculateMonthlyStats>;
+
+    // 1. Assert does not throw
+    expect(() => {
+      result = calculateMonthlyStats(emptyCalendar, 'UTC', testDate);
+    }).not.toThrow();
+
+    // 2. Assert currentMonthTotal === 0
+    expect(result!.currentMonthTotal).toBe(0);
+
+    // 3. Assert previousMonthTotal === 0
+    expect(result!.previousMonthTotal).toBe(0);
+  });
 });
 
 describe('calculateStreak — empty and sparse year edge cases', () => {


### PR DESCRIPTION


## Description
Added a new edge-case test in lib/calculate.test.ts for the calculateMonthlyStats function. The test constructs an explicitly empty calendar ({ totalContributions: 0, weeks: [] }) and verifies that the function does not throw an error during execution. It also asserts that both currentMonthTotal and previousMonthTotal safely return 0.

Fixes #1052 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="929" height="386" alt="Screenshot 2026-05-29 104429" src="https://github.com/user-attachments/assets/cd025746-06b3-4853-a37b-df373b85cf6b" />


## Checklist before requesting a review:

[x] I have read the CONTRIBUTING.md file.

[x] I have tested these changes locally (localhost:3000/api/streak?user=YOUR_USERNAME).

[x] I have run npm run format and npm run lint locally and resolved all errors (CI will fail otherwise).

[x] My commits follow the Conventional Commits format (e.g., feat(themes): ..., fix(calculate): ...).

[ ] I have updated README.md if I added a new theme or URL parameter.

[x] I have starred the repo.

[x] I have made sure that I have only one commit to merge in this PR.

[x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.

[x] (Recommended) I joined the CommitPulse Discord community for contributor discussions.