### PR TITLE
feat: add reset() method to clear rate limit state for a given IP [ GSSOC '26 ]

### DIFF
--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -46,6 +46,20 @@ export class RateLimiter {
     this.cache.set(ip, current + 1, this.windowMs);
     return true;
   }
+  /**
+   * Resets the request count for a given IP address.
+   *
+   * Useful for clearing rate limit state after a successful
+   * authentication or admin action.
+   *
+   * @param ip - The IP address to reset.
+   *
+   * @example
+   * rateLimiter.reset("192.168.1.1");
+   */
+  reset(ip: string): void {
+    this.cache.delete(ip);
+  }
 }
 
 // Global instance for track-user endpoint (5 requests per IP per minute)


### PR DESCRIPTION
## Description
Fixes #1165 

Adds a `reset(ip)` method to `RateLimiter` that clears the request
count for a given IP by calling `cache.delete(ip)`. This allows
rate limit state to be cleared immediately after a successful
authentication or admin action, without waiting for TTL expiry.

Depends on the `delete()` method added to `TTLCache` in the previous
contribution.

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — internal rate limiting logic, no visual output.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.