### PR TITLE
test(heatmapUtils): add full getIntensityColor coverage

### DIFF
--- a/components/dashboard/heatmapUtils.test.ts
+++ b/components/dashboard/heatmapUtils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { getIntensityColor } from './heatmapUtils';
+
+describe('getIntensityColor', () => {
+  it('returns the default gray class for intensity 0', () => {
+    expect(getIntensityColor(0)).toBe('bg-gray-200 dark:bg-[#161616]');
+  });
+
+  it('returns the correct class for intensity 1', () => {
+    expect(getIntensityColor(1)).toBe('bg-gray-400 dark:bg-zinc-700');
+  });
+
+  it('returns the correct class for intensity 2', () => {
+    expect(getIntensityColor(2)).toBe('bg-gray-500 dark:bg-zinc-500');
+  });
+
+  it('returns the correct class for intensity 3', () => {
+    expect(getIntensityColor(3)).toBe('bg-gray-700 dark:bg-zinc-300');
+  });
+
+  it('returns the correct class for intensity 4', () => {
+    expect(getIntensityColor(4)).toBe('bg-black dark:bg-white');
+  });
+
+  it('returns the default fallback class for intensity 99', () => {
+    expect(getIntensityColor(99)).toBe('bg-gray-200 dark:bg-[#161616]');
+  });
+
+  it('returns the default fallback class for intensity -1', () => {
+    expect(getIntensityColor(-1)).toBe('bg-gray-200 dark:bg-[#161616]');
+  });
+});


### PR DESCRIPTION
## Description
- Added unit tests for `getIntensityColor`
- Covered intensity levels `0` to `4`
- Added fallback tests for out-of-range values `99` and `-1`

Fixes # (issue number)
Fixes #1007 

## Type of change
- [x] Tests

## Testing
- [x] `npm test -- components/dashboard/heatmapUtils.test.ts`
- [x] `npm run format`
- [x] `npm run lint

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
Not applicable. This PR only adds unit tests and does not change the UI or SVG output.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

## Notes
This PR only adds unit tests, so visual preview, localhost API testing, README updates, and SVG output changes are not applicable.