### PR TITLE
test(calculate): verify weekend ratio for weekday-only calendar

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -490,6 +490,27 @@ describe('aggregateCalendars', () => {
 });
 
 describe('calculateWrappedStats', () => {
+  it('returns weekendRatio as 0 when all contributions occur on weekdays', () => {
+    const calendar = {
+      totalContributions: 25,
+      weeks: [
+        {
+          contributionDays: [
+            { date: '2024-01-01', contributionCount: 5 }, // Mon
+            { date: '2024-01-02', contributionCount: 5 }, // Tue
+            { date: '2024-01-03', contributionCount: 5 }, // Wed
+            { date: '2024-01-04', contributionCount: 5 }, // Thu
+            { date: '2024-01-05', contributionCount: 5 }, // Fri
+          ],
+        },
+      ],
+    };
+
+    const result = calculateWrappedStats(calendar);
+
+    expect(result.weekendRatio).toBe(0);
+  });
+
   it('calculates GitHub Wrapped stats accurately', () => {
     // 2024-01-01 was a Monday. Indices 5 (Sat) and 6 (Sun) are the weekend.
     const cal = buildCalendar([0, 0, 0, 0, 0, 5, 15]);


### PR DESCRIPTION
## Description

Fixes #1054

Added a unit test for `calculateWrappedStats` to verify that `weekendRatio` is calculated correctly when all contributions occur on weekdays (Monday–Friday).

### Test Coverage Added

* Creates a calendar containing contributions only on weekdays.
* Verifies that no weekend contributions are counted.
* Asserts that `weekendRatio` is `0`.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
