### PR TITLE
test(export3d): verify STL output is valid ASCII STL format

### DIFF
--- a/lib/export3d.test.ts
+++ b/lib/export3d.test.ts
@@ -49,3 +49,43 @@ describe('generateMonolithSTL', () => {
     expect(stl).toContain('endsolid commitpulse_monolith');
   });
 });
+
+it('generates structurally valid ASCII STL facets', () => {
+  const mockTowers: TowerData[] = [
+    {
+      x: 0,
+      y: 0,
+      h: 10,
+      hasCommits: true,
+      isGhost: false,
+      isToday: false,
+      isTodayWithCommits: false,
+      tooltip: '',
+      contributionCount: 5,
+      faceOpacity: { left: 1, right: 1, top: 1 },
+      strokeOpacity: 1,
+      strokeWidth: 1,
+      row: 0,
+      col: 0,
+    },
+  ];
+
+  const stl = generateMonolithSTL(mockTowers);
+
+  const facetCount = (stl.match(/facet normal/g) ?? []).length;
+  const endFacetCount = (stl.match(/endfacet/g) ?? []).length;
+
+  const outerLoopCount = (stl.match(/outer loop/g) ?? []).length;
+  const endLoopCount = (stl.match(/endloop/g) ?? []).length;
+
+  expect(facetCount).toBe(endFacetCount);
+  expect(outerLoopCount).toBe(endLoopCount);
+
+  const vertexLines = stl.split('\n').filter((line) => line.trim().startsWith('vertex'));
+
+  expect(vertexLines.length).toBeGreaterThan(0);
+
+  vertexLines.forEach((line) => {
+    expect(line.trim()).toMatch(/^vertex -?\d+\.\d+ -?\d+\.\d+ -?\d+\.\d+$/);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1026

Added a structural validation test for ASCII STL output generated by `generateMonolithSTL()`.

The test verifies that:

* Every `facet normal` has a matching `endfacet`
* Every `outer loop` has a matching `endloop`
* All `vertex` lines match the expected ASCII STL vertex format

This helps ensure the generated STL remains structurally valid for downstream 3D printing and slicing tools.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
