### PR TITLE
test(calculate): verify aggregateCalendars handles uneven weeks

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -470,6 +470,35 @@ describe('calculateStreak — empty and sparse year edge cases', () => {
 // ---------- EPIC ENHANCEMENT TESTS ----------
 
 describe('aggregateCalendars', () => {
+  it('handles calendars with different numbers of weeks', () => {
+    const cal1 = {
+      totalContributions: 15,
+      weeks: [
+        {
+          contributionDays: [{ date: '2024-01-01', contributionCount: 5 }],
+        },
+        {
+          contributionDays: [{ date: '2024-01-08', contributionCount: 10 }],
+        },
+      ],
+    };
+
+    const cal2 = {
+      totalContributions: 3,
+      weeks: [
+        {
+          contributionDays: [{ date: '2024-01-01', contributionCount: 3 }],
+        },
+      ],
+    };
+
+    const result = aggregateCalendars([cal1, cal2]);
+
+    expect(result.weeks).toHaveLength(2);
+    expect(result.weeks[0].contributionDays[0].contributionCount).toBe(8);
+    expect(result.weeks[1].contributionDays[0].contributionCount).toBe(10);
+  });
+
   it('returns an empty calendar if no calendars are provided', () => {
     const result = aggregateCalendars([]);
     expect(result.totalContributions).toBe(0);


### PR DESCRIPTION
## Description

Fixes #1053

Added a unit test for `aggregateCalendars` to verify that calendars with different numbers of weeks are aggregated correctly.

### Test Coverage Added

* Verifies the aggregated result preserves the base calendar structure.
* Verifies contribution totals are summed correctly for overlapping weeks.
* Verifies additional weeks from a longer calendar remain unchanged when another calendar has fewer weeks.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
