### PR TITLE
test(export3d): verify STL base plate is always included

### DIFF
--- a/lib/export3d.test.ts
+++ b/lib/export3d.test.ts
@@ -89,3 +89,11 @@ it('generates structurally valid ASCII STL facets', () => {
     expect(line.trim()).toMatch(/^vertex -?\d+\.\d+ -?\d+\.\d+ -?\d+\.\d+$/);
   });
 });
+
+it('always includes a base plate even with no tower data', () => {
+  const stl = generateMonolithSTL([]);
+
+  expect(stl).toContain('solid commitpulse_monolith');
+  expect(stl).toContain('endsolid commitpulse_monolith');
+  expect(stl).toContain('facet normal');
+});


### PR DESCRIPTION
## Description

Fixes #1025

Added a test to verify that `generateMonolithSTL()` always includes the STL base plate, even when no tower data is provided.

The test:

* Calls `generateMonolithSTL([])`
* Verifies the STL header and footer are present
* Verifies at least one `facet normal` exists, confirming the base plate geometry is generated

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
