### PR TITLE
test(validations): verify width and height ranges

### DIFF
--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -53,6 +53,89 @@ describe('githubParamsSchema', () => {
 });
 
 describe('streakParamsSchema', () => {
+  it('accepts a valid width value', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      width: '400',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.width).toBe(400);
+    }
+  });
+
+  it('rejects width below minimum', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      width: '99',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects width above maximum', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      width: '1201',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a valid height value', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      height: '120',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.height).toBe(120);
+    }
+  });
+
+  it('rejects height below minimum', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      height: '79',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects height above maximum', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      height: '801',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-numeric width values', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      width: 'abc',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('leaves width undefined when omitted', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.width).toBeUndefined();
+    }
+  });
+
   it('should fail when user is missing', () => {
     const result = streakParamsSchema.safeParse({});
 


### PR DESCRIPTION
## Description

Fixes #1045

Added boundary and validation tests for the `width` and `height` parameters in `streakParamsSchema`.

### Test Coverage Added

* Valid width parsing (`400`).
* Width minimum boundary validation (`99`).
* Width maximum boundary validation (`1201`).
* Valid height parsing (`120`).
* Height minimum boundary validation (`79`).
* Height maximum boundary validation (`801`).
* Non-numeric width validation (`abc`).
* Omitted width handling (`undefined`).

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
