### PR TITLE
test(validations): verify mode parameter

### DIFF
--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -62,6 +62,57 @@ describe('streakParamsSchema user validation', () => {
 });
 
 describe('streakParamsSchema', () => {
+  it('accepts commits mode', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      mode: 'commits',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.mode).toBe('commits');
+    }
+  });
+
+  it('accepts loc mode', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      mode: 'loc',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.mode).toBe('loc');
+    }
+  });
+
+  it('falls back to commits for unknown mode', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      mode: 'unknown',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.mode).toBe('commits');
+    }
+  });
+
+  it('defaults to commits when mode is omitted', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.mode).toBe('commits');
+    }
+  });
+
   it('accepts a valid width value', () => {
     const result = streakParamsSchema.safeParse({
       user: 'octocat',


### PR DESCRIPTION
## Description

Fixes #1044

Added validation tests for the `mode` parameter in `streakParamsSchema`.

### Test Coverage Added

* Validates `mode: 'commits'`.
* Validates `mode: 'loc'`.
* Verifies unknown values fall back to `'commits'`.
* Verifies omitted values default to `'commits'`.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if required.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] I joined the Discord community.
