### PR TITLE
test(dashboard): verified that compare modal input can be cleared

### DIFF
--- a/components/dashboard/DashboardClient.test.tsx
+++ b/components/dashboard/DashboardClient.test.tsx
@@ -311,4 +311,29 @@ describe('DashboardClient', () => {
       expect(screen.getByText(/Cannot compare a profile with itself/i)).toBeDefined();
     });
   });
+
+  // =========================================================================
+  // ISSUE OBJECTIVE #1063: Verify compare modal input can be cleared
+  // =========================================================================
+  it('verify compare modal input can be cleared', async () => {
+    render(<DashboardClient initialData={mockInitialData} username="Shivangi1515" />);
+
+    // 1. Open modal
+    const compareBtn = screen.getByText('Compare Profile');
+    fireEvent.click(compareBtn);
+
+    // 2. Type a username into the input
+    const input = screen.getByPlaceholderText('Enter GitHub Username');
+    fireEvent.change(input, { target: { value: 'testuser' } });
+
+    // 3. Assert 'Clear input' (aria-label) button appears
+    const clearButton = screen.getByRole('button', { name: 'Clear input' });
+    expect(clearButton).toBeDefined();
+
+    // 4. Click clear button
+    fireEvent.click(clearButton);
+
+    // 5. Assert input value is empty
+    expect((input as HTMLInputElement).value).toBe('');
+  });
 });


### PR DESCRIPTION
## Description
Fixes #1063

**Context:**
The Compare Modal inside the `DashboardClient` component features a 'Clear input' (X) button to clear out the search field if you had typed any username in it. I wrote the test case to verify that it actually works as intended.

**Solution:**
I added a new test block to `DashboardClient.test.tsx` using Vitest and React Testing Library. The test simulates a user interaction by opening the modal, typing in a username, and verifying that clicking the rendered 'Clear input' button successfully resets the input field to an empty string.

Later I had the tests and, all 638 tests are passing successfully.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview of tests passing
<img width="1325" height="749" alt="image" src="https://github.com/user-attachments/assets/d51071a2-0a92-4501-96fa-7db909394724" />



## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. *(I only wrote test case so no)*
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support. *(I'll join it)*
