### PR TITLE
test(api): verify delta_format=absolute shows commit count in monthly SVG (#1035)

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -737,6 +737,37 @@ describe('GET /api/streak', () => {
       expect(response.status).toBe(200);
       expect(body).toContain('CURRENT_STREAK');
     });
+    // =========================================================================
+    // ISSUE OBJECTIVE: Route test for ?view=monthly&delta_format=absolute
+    // =========================================================================
+    it('applies delta_format=absolute to show raw commit counts in the monthly SVG', async () => {
+      // 1. Mock the GitHub fetch with actual weekly data using vi.mocked
+      vi.mocked(fetchGitHubContributions).mockResolvedValueOnce({
+        totalContributions: 150,
+        weeks: [
+          { contributionDays: [{ date: '2026-04-15', contributionCount: 10 }] },
+          { contributionDays: [{ date: '2026-05-15', contributionCount: 15 }] },
+        ],
+      } as unknown as ContributionCalendar);
+
+      // 2. Lock the system time to May 2026 so the calendar calculation aligns
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-20T12:00:00Z'));
+
+      // 3. Make request using the file's built-in makeRequest helper
+      const req = makeRequest({ user: 'octocat', view: 'monthly', delta_format: 'absolute' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+
+      const body = await res.text();
+
+      // 4. Assert body contains 'commits' (the absolute delta unit)
+      expect(body).toContain('commits');
+
+      // Cleanup
+      vi.useRealTimers();
+    });
   });
 
   describe('theme=random cache header', () => {


### PR DESCRIPTION


## Description
Added a new route-level test case in app/api/streak/route.test.ts to verify the ?delta_format=absolute query parameter in the monthly view. The test mocks the GitHub API response with realistic weekly contribution data, requests the streak endpoint with ?view=monthly&delta_format=absolute, asserts a 200 OK status, and explicitly checks the resulting SVG body for the presence of the word commits to confirm the raw absolute delta string is rendering properly.

Fixes #1035 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="943" height="344" alt="Screenshot 2026-05-29 120057" src="https://github.com/user-attachments/assets/08295c0f-a553-4aea-a504-a714a7e12f13" />

## Checklist before requesting a review:

[x] I have read the CONTRIBUTING.md file.

[x] I have tested these changes locally (localhost:3000/api/streak?user=YOUR_USERNAME).

[x] I have run npm run format and npm run lint locally and resolved all errors (CI will fail otherwise).

[x] My commits follow the Conventional Commits format (e.g., feat(themes): ..., fix(calculate): ...).

[ ] I have updated README.md if I added a new theme or URL parameter.

[x] I have starred the repo.

[x] I have made sure that I have only one commit to merge in this PR.

[x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.

[x] (Recommended) I joined the CommitPulse Discord community for contributor discussions.