### PR TITLE
test(route): verify invalid view falls back to default

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -87,6 +87,18 @@ describe('GET /api/streak', () => {
     vi.mocked(getSecondsUntilMidnightInTimezone).mockReturnValue(7200);
   });
 
+  it('falls back to the default isometric view when an invalid view is provided', async () => {
+    const request = new Request('http://localhost:3000/api/streak?user=octocat&view=invalid');
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+
+    const body = await response.text();
+
+    expect(body).toContain('@keyframes grow-up');
+  });
+
   describe('parameter validation', () => {
     it('returns 400 when the user parameter is missing', async () => {
       const response = await GET(makeRequest());


### PR DESCRIPTION
## Description

Fixes #1037

Added a route-level test to verify that an invalid `view` parameter falls back to the default isometric view.

### Test Coverage Added

* Sends a request with `?user=octocat&view=invalid`
* Verifies the response status is `200`
* Verifies the generated SVG contains `@keyframes grow-up`
* Confirms unknown view values render the default isometric monolith view

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
