### PR TITLE
feat: add IP allowlist and blocklist support [ GSSOC'26 ]

### DIFF
--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -18,6 +18,8 @@ export class RateLimiter {
   private cache: TTLCache<number>;
   private limit: number;
   private windowMs: number;
+  private allowlist = new Set<string>();
+  private blocklist = new Set<string>();
 
   /**
    * Creates a new RateLimiter instance.
@@ -46,6 +48,8 @@ export class RateLimiter {
    * }
    */
   check(ip: string): boolean {
+    if (this.allowlist.has(ip)) return true; // for check()
+    if (this.blocklist.has(ip)) return false; // for check()
     const current = this.cache.get(ip) || 0;
     if (current >= this.limit) {
       return false;
@@ -54,6 +58,15 @@ export class RateLimiter {
     return true;
   }
   checkWithResult(ip: string): RateLimitResult {
+    if (this.allowlist.has(ip))
+      return {
+        success: true,
+        limit: this.limit,
+        remaining: this.limit,
+        reset: Date.now() + this.windowMs,
+      };
+    if (this.blocklist.has(ip))
+      return { success: false, limit: this.limit, remaining: 0, reset: Date.now() + this.windowMs };
     const now = Date.now();
     const current = this.cache.get(ip) ?? 0;
 
@@ -87,6 +100,24 @@ export class RateLimiter {
    */
   reset(ip: string): void {
     this.cache.delete(ip);
+  }
+
+  allow(ip: string): void {
+    this.allowlist.add(ip);
+    this.blocklist.delete(ip);
+  }
+
+  block(ip: string): void {
+    this.blocklist.add(ip);
+    this.allowlist.delete(ip);
+  }
+
+  unallow(ip: string): void {
+    this.allowlist.delete(ip);
+  }
+
+  unblock(ip: string): void {
+    this.blocklist.delete(ip);
   }
 }
 


### PR DESCRIPTION
## Description

Added allowlist and blocklist support to the `RateLimiter` class via 
`allow()`, `block()`, `unallow()`, and `unblock()` methods. Allowlisted 
IPs always pass, blocklisted IPs are always denied — both bypass the 
counter logic in `check()` and `checkWithResult()`. Useful for trusted 
internal services and known bad actors.

Fixes #1196 

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — internal utility methods, no visual output.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(rate-limiter): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.