### PR TITLE
test(not-found): add 404 page tests

### DIFF
--- a/app/not-found.test.tsx
+++ b/app/not-found.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import NotFound from './not-found';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('NotFound', () => {
+  it('renders without crashing', () => {
+    render(<NotFound />);
+
+    expect(document.body).toBeTruthy();
+  });
+
+  it('renders the oops text', () => {
+    render(<NotFound />);
+
+    expect(screen.getAllByText('𝒐𝒐𝒑𝒔')).toHaveLength(2);
+  });
+
+  it('renders git checkout main text', () => {
+    render(<NotFound />);
+
+    expect(screen.getByText(/git checkout main/i)).toBeTruthy();
+  });
+
+  it('renders go back home link with root href', () => {
+    render(<NotFound />);
+
+    const homeLink = screen.getByRole('link', {
+      name: /go back home/i,
+    });
+
+    expect(homeLink.getAttribute('href')).toBe('/');
+  });
+
+  it('renders github link pointing to commitpulse repository', () => {
+    render(<NotFound />);
+
+    const githubLink = screen.getByRole('link', {
+      name: /git checkout main/i,
+    });
+
+    expect(githubLink.getAttribute('href')).toContain('github.com');
+    expect(githubLink.getAttribute('href')).toContain('commitpulse');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1033

Added test coverage for the custom Not Found page.

### Test Coverage Added

* Verifies the page renders successfully.
* Verifies the stylized "𝒐𝒐𝒑𝒔" text is displayed.
* Verifies the "git checkout main" link text is rendered.
* Verifies the "Go back home" link points to `/`.
* Verifies the GitHub link points to the CommitPulse repository.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if required.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
* [x] (Recommended) I joined the CommitPulse Discord community.
