### PR TITLE
feat: Support for Server-Side PNG Rasterization (/api/streak/png)

### DIFF
--- a/app/api/streak/png/route.test.ts
+++ b/app/api/streak/png/route.test.ts
@@ -1,0 +1,94 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from './route';
+import { GET as getStreakSvg } from '../route';
+import { NextResponse } from 'next/server';
+
+// Mock the core route
+vi.mock('../route', () => ({
+  GET: vi.fn(),
+}));
+
+// Mock resvg-js
+vi.mock('@resvg/resvg-js', () => {
+  return {
+    Resvg: class {
+      constructor() {
+        if ((global as any).throwResvgError) {
+          throw new Error('Resvg crash');
+        }
+      }
+      render() {
+        return {
+          asPng: () => Buffer.from('mock-png-data'),
+        };
+      }
+    },
+  };
+});
+
+describe('PNG Route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('converts SVG to PNG successfully', async () => {
+    const mockRequest = new Request('http://localhost:3000/api/streak/png?user=testuser');
+
+    // Setup mock SVG response
+    const mockSvgResponse = new NextResponse('<svg>test</svg>', {
+      status: 200,
+      headers: {
+        'Content-Type': 'image/svg+xml',
+        'Cache-Control': 'public, max-age=3600',
+      },
+    });
+    vi.mocked(getStreakSvg).mockResolvedValue(mockSvgResponse);
+
+    const response = await GET(mockRequest);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('image/png');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
+
+    // Check if body contains buffer
+    const buffer = Buffer.from(await response.arrayBuffer());
+    expect(buffer.toString()).toBe('mock-png-data');
+  });
+
+  it('returns errors from the base route directly', async () => {
+    const mockRequest = new Request('http://localhost:3000/api/streak/png');
+
+    const mockErrorResponse = NextResponse.json({ error: 'Invalid parameters' }, { status: 400 });
+    vi.mocked(getStreakSvg).mockResolvedValue(mockErrorResponse);
+
+    const response = await GET(mockRequest);
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe('Invalid parameters');
+  });
+
+  it('handles SVG conversion errors', async () => {
+    const mockRequest = new Request('http://localhost:3000/api/streak/png?user=testuser');
+
+    const mockSvgResponse = new NextResponse('<svg>invalid</svg>', {
+      status: 200,
+      headers: {
+        'Content-Type': 'image/svg+xml',
+      },
+    });
+    vi.mocked(getStreakSvg).mockResolvedValue(mockSvgResponse);
+
+    // Force an error in Resvg
+    (global as any).throwResvgError = true;
+
+    const response = await GET(mockRequest);
+
+    (global as any).throwResvgError = false;
+
+    expect(response.status).toBe(500);
+    const data = await response.json();
+    expect(data.error).toBe('Failed to convert SVG to PNG');
+  });
+});

--- a/app/api/streak/png/route.ts
+++ b/app/api/streak/png/route.ts
@@ -35,7 +35,7 @@ export async function GET(request: Request) {
       headers.set('Cache-Control', cacheControl);
     }
 
-    return new NextResponse(pngBuffer, {
+    return new NextResponse(pngBuffer as unknown as BodyInit, {
       status: 200,
       headers,
     });

--- a/app/api/streak/png/route.ts
+++ b/app/api/streak/png/route.ts
@@ -1,0 +1,48 @@
+import { GET as getStreakSvg } from '../route';
+import { Resvg } from '@resvg/resvg-js';
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  // Call the original endpoint which returns the SVG text
+  const response = await getStreakSvg(request);
+
+  if (!response.ok || response.headers.get('Content-Type') !== 'image/svg+xml') {
+    // Return errors as is
+    return response;
+  }
+
+  const svgText = await response.text();
+
+  try {
+    const resvg = new Resvg(svgText, {
+      font: {
+        loadSystemFonts: true,
+      },
+      fitTo: {
+        mode: 'original',
+      },
+    });
+
+    const pngData = resvg.render();
+    const pngBuffer = pngData.asPng();
+
+    // Preserve the original cache headers
+    const cacheControl = response.headers.get('Cache-Control');
+
+    const headers = new Headers();
+    headers.set('Content-Type', 'image/png');
+    if (cacheControl) {
+      headers.set('Cache-Control', cacheControl);
+    }
+
+    return new NextResponse(pngBuffer, {
+      status: 200,
+      headers,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'Failed to convert SVG to PNG', details: String(err) },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -4,7 +4,7 @@ import type { BadgeParams, ContributionCalendar, StreakStats, MonthlyStats } fro
 import { getLabels, type BadgeLabels } from '../i18n/badgeLabels';
 import { AUTO_THEME_DARK, AUTO_THEME_LIGHT } from './themes';
 import { TOWER_ANIMATION_CSS } from './animations';
-import { computeTowers, projectIsometric, type TowerData } from './layout';
+import { computeTowers, type TowerData } from './layout';
 import { sanitizeFont, sanitizeHexColor, sanitizeRadius, sanitizeGoogleFontUrl } from './sanitizer';
 
 import { SVG_WIDTH, SVG_HEIGHT, FONT_MAP, isFontKey } from './generatorConstants';

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,7 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   // Prevent Turbopack from bundling next/og through its shared module context,
   // which causes the "Next.js package not found" HMR panic on dynamic routes.
-  serverExternalPackages: ['next/og'],
+  serverExternalPackages: ['next/og', '@resvg/resvg-js'],
   // Allow the local network IP to access dev resources without cross-origin warnings
   allowedDevOrigins: ['172.31.128.1'],
   devIndicators: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "github-streak-badge",
       "version": "0.1.0",
       "dependencies": {
+        "@resvg/resvg-js": "^2.6.2",
         "@tailwindcss/postcss": "^4.2.2",
         "@vercel/analytics": "^1.6.1",
         "framer-motion": "^12.38.0",
@@ -1984,6 +1985,221 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "*.{md,css,json,yml,yaml}": "prettier --write"
   },
   "dependencies": {
+    "@resvg/resvg-js": "^2.6.2",
     "@tailwindcss/postcss": "^4.2.2",
     "@vercel/analytics": "^1.6.1",
     "framer-motion": "^12.38.0",


### PR DESCRIPTION
## Description — What does this PR do? Which issue does it fix?
This PR implements server-side PNG Rasterization by introducing a new endpoint at `/api/streak/png` that returns a PNG buffer image instead of an SVG. It leverages the `@resvg/resvg-js` library for accurate headless SVG-to-PNG conversion without relying on browser rendering.

Fixes #980

## Pillar — Which contribution pillar does this fall under?
- [x] 🚀 New Feature
- [ ] 🐛 Bug Fix
- [ ] 🎨 New Theme Design
- [ ] 📐 Geometric SVG Improvement
- [ ] ⏱️ Timezone Logic Optimization
- [ ] 🧹 Other (Bug fix, refactoring, docs)

## Checklist — Have you ticked off the quality checklist?
- [x] I have read the CONTRIBUTING.md guidelines.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have kept the scope of my changes strictly related to the issue.
