### PR TITLE
test(languageColors): add language colors coverage

### DIFF
--- a/lib/svg/languageColors.test.ts
+++ b/lib/svg/languageColors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { LANGUAGE_COLORS } from './languageColors';
+
+describe('LANGUAGE_COLORS', () => {
+  it('contains the correct TypeScript color', () => {
+    expect(LANGUAGE_COLORS.TypeScript).toBe('#3178c6');
+  });
+
+  it('contains the correct JavaScript color', () => {
+    expect(LANGUAGE_COLORS.JavaScript).toBe('#f1e05a');
+  });
+
+  it('defines Python color', () => {
+    expect(LANGUAGE_COLORS.Python).toBeDefined();
+  });
+
+  it('uses valid 6-digit hex colors for every language', () => {
+    for (const color of Object.values(LANGUAGE_COLORS)) {
+      expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+
+  it('contains at least 20 languages', () => {
+    expect(Object.keys(LANGUAGE_COLORS).length).toBeGreaterThanOrEqual(20);
+  });
+
+  it('does not contain empty language names', () => {
+    for (const language of Object.keys(LANGUAGE_COLORS)) {
+      expect(language.trim()).not.toBe('');
+    }
+  });
+});


### PR DESCRIPTION
## Description
Added Vitest coverage for LANGUAGE_COLORS in lib/svg/languageColors.test.ts.

This PR adds 6 test cases covering:
- TypeScript color value
- JavaScript color value
- Python color existence
- Valid 6-digit hex color format
- Minimum language count
- Empty language key validation

Fixes #1016 

## Testing

- npm test -- lib/svg/languageColors.test.ts
   - 1 test file passed
   - 6 tests passed

- npm run typecheck
   - Passed

- npx vitest run
   - 50 test files passed
   - 684 tests passed

- npm run lint
   - Passed with 0 errors
   - 2 pre-existing warnings in components/dashboard/ComparisonStatsCard.test.tsx

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
Not applicable. This PR only adds test coverage and does not change the UI or SVG output.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
