### PR TITLE
test(track-user): verified plain text body returns 400

### DIFF
--- a/app/api/track-user/route.test.ts
+++ b/app/api/track-user/route.test.ts
@@ -48,6 +48,17 @@ describe('POST /api/track-user', () => {
       expect(data.success).toBe(false);
       expect(data.error).toBe('Malformed JSON request body');
     });
+    it('returns 400 when body is plain text (not JSON)', async () => {
+      const req = new Request('http://localhost/api/track-user', {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/plain' },
+        body: 'not json',
+      });
+      const response = await POST(req);
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.success).toBe(false);
+    });
 
     it('returns 400 when username is missing', async () => {
       const response = await POST(makeRequest({}));


### PR DESCRIPTION
## Description
- Adds a test that sends a plain text body (`'not json'`) to `POST /api/track-user`
- Asserts the route returns a clean `400` response instead of an unhandled exception
- Covers the regression case where removing the `try-catch` around `req.json()` would cause the handler to crash

## Test plan
- [x] Run `npx vitest app/api/track-user/route.test.ts` and confirm all tests pass including the new one
- [x] Confirm no existing tests were removed or modified

Fixes #694 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
