### PR TITLE
test(validations): verify streakParamsSchema validates ?delta_format parameter

### DIFF
--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -116,6 +116,69 @@ describe('streakParamsSchema', () => {
       expect(result.error.issues[0]?.message).toBe('Invalid GitHub username');
     }
   });
+  it('should accept delta_format percent', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      delta_format: 'percent',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.delta_format).toBe('percent');
+    }
+  });
+
+  it('should accept delta_format absolute', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      delta_format: 'absolute',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.delta_format).toBe('absolute');
+    }
+  });
+
+  it('should accept delta_format both', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      delta_format: 'both',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.delta_format).toBe('both');
+    }
+  });
+
+  it('should fallback to percent for invalid delta_format', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      delta_format: 'unknown',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.delta_format).toBe('percent');
+    }
+  });
+
+  it('should default delta_format to percent when omitted', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.delta_format).toBe('percent');
+    }
+  });
 });
 
 function parse(params: Record<string, string>) {


### PR DESCRIPTION
## Description

Fixes #1042

Added tests to verify that `streakParamsSchema` correctly validates the `delta_format` parameter.

Covered test cases:

* `delta_format: 'percent'`
* `delta_format: 'absolute'`
* `delta_format: 'both'`
* Invalid `delta_format` falls back to `'percent'`
* Omitted `delta_format` defaults to `'percent'`

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable – validation tests only)
* [x] I joined the CommitPulse Discord community.

