### PR TITLE
test(streak route): verify mode=loc returns valid SVG without crashing

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -145,6 +145,22 @@ describe('GET /api/streak', () => {
       expect(body).toContain('</svg>');
     });
 
+    it('returns valid SVG when mode=loc is given', async () => {
+      const response = await GET(
+        makeRequest({
+          user: 'octocat',
+          mode: 'loc',
+        })
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+
+      const body = await response.text();
+
+      expect(body).toContain('<svg');
+    });
+
     it('forwards the username to fetchGitHubContributions', async () => {
       await GET(makeRequest({ user: 'octocat' }));
 


### PR DESCRIPTION
## Description

Closes #1038

Adds a route-level test to verify that `?mode=loc` returns a valid SVG response without crashing.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`npm test app/api/streak/route.test.ts`).
* [x] I have run `npm run format` and `npm run lint` locally.
* [x] My commits follow the Conventional Commits format.
* [x] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse quality standards. (Not applicable – test-only change)
* [x] I joined the CommitPulse Discord community.
