### PR TITLE
feat(ui): add parallax background effect for card preview

### DIFF
--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -168,7 +168,15 @@ export default function Navbar() {
                 className="hidden sm:inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/15 bg-white/5 text-white transition hover:bg-white/10"
                 aria-label="Toggle theme"
               >
-                {isDark ? <Sun size={18} /> : <Moon size={18} />}
+                {mounted ? (
+                  isDark ? (
+                    <Sun size={18} />
+                  ) : (
+                    <Moon size={18} />
+                  )
+                ) : (
+                  <span className="w-[18px] h-[18px]" />
+                )}
               </button>
               <button
                 type="button"
@@ -206,8 +214,16 @@ export default function Navbar() {
                     className="inline-flex w-full items-center gap-2 rounded-xl border border-white/15 bg-white/5 px-4 py-2 text-sm font-medium text-white/90 transition hover:border-white/45 hover:bg-white/10"
                     aria-label="Toggle theme"
                   >
-                    {isDark ? <Sun size={18} /> : <Moon size={18} />}
-                    {isDark ? 'Light Mode' : 'Dark Mode'}
+                    {mounted ? (
+                      isDark ? (
+                        <Sun size={18} />
+                      ) : (
+                        <Moon size={18} />
+                      )
+                    ) : (
+                      <span className="w-[18px] h-[18px]" />
+                    )}
+                    {mounted ? (isDark ? 'Light Mode' : 'Dark Mode') : 'Theme'}
                   </button>
                 </li>
               </ul>

--- a/components/InteractiveViewer.test.tsx
+++ b/components/InteractiveViewer.test.tsx
@@ -1,9 +1,29 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import InteractiveViewer from './InteractiveViewer';
 
+// getBoundingClientRect is not implemented in jsdom — mock it so mouse-position
+// tests can assert normalized values without relying on a real layout engine.
+const mockContainerRect: DOMRect = {
+  left: 0,
+  top: 0,
+  right: 600,
+  bottom: 400,
+  width: 600,
+  height: 400,
+  x: 0,
+  y: 0,
+  toJSON: () => ({}),
+};
+
+beforeEach(() => {
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue(mockContainerRect);
+});
+
 describe('InteractiveViewer', () => {
+  // ── Existing behaviour ────────────────────────────────────────────────────
+
   it('renders children correctly', () => {
     render(
       <InteractiveViewer>
@@ -24,9 +44,9 @@ describe('InteractiveViewer', () => {
     // Focus and press 'w' to pan up
     fireEvent.keyDown(viewerContainer, { key: 'w' });
 
-    // Check if the transform style was updated on the inner div
-    const innerDiv = viewerContainer.firstChild as HTMLElement;
-    expect(innerDiv.style.transform).toContain('translate(0px, 30px) scale(1)');
+    // The content div is the second child (after the parallax layer)
+    const contentDiv = viewerContainer.children[1] as HTMLElement;
+    expect(contentDiv.style.transform).toContain('translate(0px, 30px) scale(1)');
   });
 
   it('handles keyboard navigation for zooming', () => {
@@ -40,9 +60,8 @@ describe('InteractiveViewer', () => {
     // Focus and press '+' to zoom in
     fireEvent.keyDown(viewerContainer, { key: '+' });
 
-    // Check if the transform style was updated on the inner div
-    const innerDiv = viewerContainer.firstChild as HTMLElement;
-    expect(innerDiv.style.transform).toContain('scale(1.1)');
+    const contentDiv = viewerContainer.children[1] as HTMLElement;
+    expect(contentDiv.style.transform).toContain('scale(1.1)');
   });
 
   it('ignores key presses if an input element is focused', () => {
@@ -55,11 +74,107 @@ describe('InteractiveViewer', () => {
     const input = screen.getByTestId('input');
     input.focus();
 
+    // The viewer container is grandparent: input → content div → viewer
     const viewerContainer = input.parentElement?.parentElement as HTMLElement;
     fireEvent.keyDown(viewerContainer, { key: 'w' });
 
-    const innerDiv = viewerContainer.firstChild as HTMLElement;
-    // Should not have panned
-    expect(innerDiv.style.transform).toContain('translate(0px, 0px) scale(1)');
+    const contentDiv = viewerContainer.children[1] as HTMLElement;
+    // Should not have panned since an input had focus
+    expect(contentDiv.style.transform).toContain('translate(0px, 0px) scale(1)');
+  });
+
+  // ── Parallax background layer ─────────────────────────────────────────────
+
+  it('renders the parallax background layer behind the card content', () => {
+    render(
+      <InteractiveViewer>
+        <div>Content</div>
+      </InteractiveViewer>
+    );
+    // The parallax layer is always present in the DOM (opacity transitions handle visibility)
+    expect(screen.getByTestId('parallax-bg-layer')).toBeDefined();
+  });
+
+  it('renders the cursor glow element inside the parallax layer', () => {
+    render(
+      <InteractiveViewer>
+        <div>Content</div>
+      </InteractiveViewer>
+    );
+    const glow = screen.getByTestId('parallax-cursor-glow');
+    expect(glow).toBeDefined();
+  });
+
+  it('shows the cursor glow at full opacity when the pointer enters the container', () => {
+    const { container } = render(
+      <InteractiveViewer>
+        <div>Content</div>
+      </InteractiveViewer>
+    );
+    const viewerContainer = container.firstChild as HTMLElement;
+    const glow = screen.getByTestId('parallax-cursor-glow');
+
+    // Before hover: glow opacity should be 0 (faded out)
+    expect(glow.style.opacity).toBe('0');
+
+    // Simulate pointer entering the container
+    fireEvent.pointerEnter(viewerContainer);
+
+    // After hover: glow should become visible (opacity 1)
+    expect(glow.style.opacity).toBe('1');
+  });
+
+  it('hides the cursor glow when the pointer leaves the container', () => {
+    const { container } = render(
+      <InteractiveViewer>
+        <div>Content</div>
+      </InteractiveViewer>
+    );
+    const viewerContainer = container.firstChild as HTMLElement;
+    const glow = screen.getByTestId('parallax-cursor-glow');
+
+    fireEvent.pointerEnter(viewerContainer);
+    expect(glow.style.opacity).toBe('1');
+
+    fireEvent.pointerLeave(viewerContainer);
+    // Glow should fade back out on leave
+    expect(glow.style.opacity).toBe('0');
+  });
+
+  it('updates the cursor glow position on pointer move', () => {
+    const { container } = render(
+      <InteractiveViewer>
+        <div>Content</div>
+      </InteractiveViewer>
+    );
+    const viewerContainer = container.firstChild as HTMLElement;
+    const glow = screen.getByTestId('parallax-cursor-glow');
+
+    // Move pointer to top-left quadrant of the mocked 600×400 container
+    fireEvent.pointerMove(viewerContainer, { clientX: 150, clientY: 100 });
+
+    // Normalized: x = 150/600 = 0.25, y = 100/400 = 0.25
+    // Glow `left` should be "25%" and `top` should be "25%"
+    expect(glow.style.left).toBe('25%');
+    expect(glow.style.top).toBe('25%');
+  });
+
+  it('resets glow position to center (50%) when the pointer leaves', () => {
+    const { container } = render(
+      <InteractiveViewer>
+        <div>Content</div>
+      </InteractiveViewer>
+    );
+    const viewerContainer = container.firstChild as HTMLElement;
+    const glow = screen.getByTestId('parallax-cursor-glow');
+
+    // Move pointer to an off-center position
+    fireEvent.pointerMove(viewerContainer, { clientX: 60, clientY: 80 });
+    expect(glow.style.left).not.toBe('50%');
+
+    // Leave the container — position resets to center so it fades from center
+    fireEvent.pointerLeave(viewerContainer);
+    expect(glow.style.left).toBe('50%');
+    expect(glow.style.top).toBe('50%');
   });
 });

--- a/components/InteractiveViewer.tsx
+++ b/components/InteractiveViewer.tsx
@@ -1,21 +1,88 @@
 'use client';
 
-import React, { useState, useRef, ReactNode } from 'react';
+import React, { useState, useRef, ReactNode, useMemo, type ReactElement } from 'react';
+
+// ── Parallax particle configuration ──────────────────────────────────────────
+// Particles are generated deterministically so SSR and client renders match,
+// preventing React hydration mismatches.
+const PARALLAX_PARTICLE_COUNT = 20;
+
+interface ParallaxParticle {
+  id: number;
+  x: number; // base X position as percentage of container width
+  y: number; // base Y position as percentage of container height
+  size: number; // side length in px
+  opacity: number; // resting opacity (intentionally subtle)
+  depth: number; // parallax depth multiplier (0–1); deeper = more shift on mouse move
+  color: string;
+  isCircle: boolean; // mix of rounded and square contribution cells
+}
+
+/** Builds a stable set of contribution-square particles for the parallax layer.
+ *  Deterministic math prevents random values from causing SSR/CSR mismatches. */
+function buildParticles(): ParallaxParticle[] {
+  const colors = ['#10b981', '#8b5cf6', '#06b6d4', '#3b82f6', '#f59e0b'];
+  return Array.from(
+    { length: PARALLAX_PARTICLE_COUNT },
+    (_, i): ParallaxParticle => ({
+      id: i,
+      // Spread particles across the container using prime-number strides
+      x: (i * 17 + 11) % 100,
+      y: (i * 23 + 7) % 100,
+      size: 4 + (i % 5) * 2, // range: 4–12 px
+      // Keep opacity low so particles never obscure the badge
+      opacity: 0.05 + (i % 4) * 0.025, // range: 0.05–0.125
+      // Vary depth so each "layer" of particles shifts by a different amount,
+      // creating the illusion of 3-D depth. depth 0.1 = farthest; 0.7 = nearest.
+      depth: 0.1 + (i % 6) * 0.1, // range: 0.1–0.6
+      color: colors[i % colors.length],
+      isCircle: i % 4 === 0,
+    })
+  );
+}
+
+// How many pixels a depth-1.0 particle shifts when the cursor is at the
+// container edge. Shallower particles shift proportionally less.
+const PARALLAX_STRENGTH = 80;
 
 interface InteractiveViewerProps {
   children: ReactNode;
   className?: string;
 }
 
-export default function InteractiveViewer({ children, className = '' }: InteractiveViewerProps) {
+export default function InteractiveViewer({
+  children,
+  className = '',
+}: InteractiveViewerProps): ReactElement {
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
+
+  // Normalized cursor position within the container [0, 1].
+  // Default to center (0.5) so the glow starts centered and fades in on first hover.
+  const [mousePos, setMousePos] = useState({ x: 0.5, y: 0.5 });
+  const [isHovering, setIsHovering] = useState(false);
+
   const containerRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
   const [isDraggingState, setIsDraggingState] = useState(false);
   const lastMousePos = useRef({ x: 0, y: 0 });
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+  // Stable particle list — generated once on mount, never re-shuffled.
+  const particles = useMemo((): ParallaxParticle[] => buildParticles(), []);
+
+  // ── Parallax math ──────────────────────────────────────────────────────────
+  // Offset from center: at mousePos.x = 0.5, offset = 0 (no shift).
+  // At the left edge (0), offset = -STRENGTH/2; at right (1), offset = +STRENGTH/2.
+  const hoverParallaxX = (mousePos.x - 0.5) * PARALLAX_STRENGTH;
+  const hoverParallaxY = (mousePos.y - 0.5) * PARALLAX_STRENGTH;
+
+  // When the user pans the card (dragging/keyboard), the background should pan
+  // along with it to create a sense of camera movement across a 3D scene.
+  const parallaxX = hoverParallaxX + pan.x;
+  const parallaxY = hoverParallaxY + pan.y;
+
+  // ── Keyboard navigation ────────────────────────────────────────────────────
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
     // Ignore if user is typing in an input or textarea
     if (['INPUT', 'TEXTAREA'].includes(document.activeElement?.tagName || '')) return;
 
@@ -59,14 +126,25 @@ export default function InteractiveViewer({ children, className = '' }: Interact
     e.preventDefault();
   };
 
-  const handlePointerDown = (e: React.PointerEvent) => {
+  // ── Pointer events ─────────────────────────────────────────────────────────
+  const handlePointerDown = (e: React.PointerEvent): void => {
     isDragging.current = true;
     setIsDraggingState(true);
     lastMousePos.current = { x: e.clientX, y: e.clientY };
     e.currentTarget.setPointerCapture(e.pointerId);
   };
 
-  const handlePointerMove = (e: React.PointerEvent) => {
+  const handlePointerMove = (e: React.PointerEvent): void => {
+    // Always track cursor position for the parallax effect, even when not dragging
+    if (containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect();
+      setMousePos({
+        x: Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)),
+        y: Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height)),
+      });
+    }
+
+    // Only apply pan logic when actively dragging
     if (!isDragging.current) return;
     const dx = e.clientX - lastMousePos.current.x;
     const dy = e.clientY - lastMousePos.current.y;
@@ -74,13 +152,21 @@ export default function InteractiveViewer({ children, className = '' }: Interact
     lastMousePos.current = { x: e.clientX, y: e.clientY };
   };
 
-  const handlePointerUp = (e: React.PointerEvent) => {
+  const handlePointerUp = (e: React.PointerEvent): void => {
     isDragging.current = false;
     setIsDraggingState(false);
     e.currentTarget.releasePointerCapture(e.pointerId);
   };
 
-  const handleWheel = (e: React.WheelEvent) => {
+  const handlePointerEnter = (): void => setIsHovering(true);
+
+  const handlePointerLeave = (): void => {
+    setIsHovering(false);
+    // Reset cursor position to center so the glow fades out gracefully from center
+    setMousePos({ x: 0.5, y: 0.5 });
+  };
+
+  const handleWheel = (e: React.WheelEvent): void => {
     if (e.ctrlKey || e.metaKey) {
       e.preventDefault();
       if (e.deltaY < 0) {
@@ -100,12 +186,91 @@ export default function InteractiveViewer({ children, className = '' }: Interact
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       onPointerCancel={handlePointerUp}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
       onWheel={handleWheel}
       onKeyDown={handleKeyDown}
       style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
     >
+      {/* ── Parallax background layer ──────────────────────────────────────────
+           This layer renders behind the card content (DOM order + z-index).
+           It reacts to the cursor without touching the badge SVG or its animations. */}
+      <div
+        className="absolute inset-0 overflow-hidden pointer-events-none"
+        aria-hidden="true"
+        data-testid="parallax-bg-layer"
+      >
+        {/* Cursor-following radial glow — softly illuminates the area under the cursor */}
+        <div
+          data-testid="parallax-cursor-glow"
+          style={{
+            position: 'absolute',
+            left: `${mousePos.x * 100}%`,
+            top: `${mousePos.y * 100}%`,
+            transform: 'translate(-50%, -50%)',
+            width: '320px',
+            height: '320px',
+            borderRadius: '50%',
+            background:
+              'radial-gradient(circle, rgba(16,185,129,0.18) 0%, rgba(139,92,246,0.08) 45%, transparent 70%)',
+            opacity: isHovering ? 1 : 0,
+            // Position follows the cursor immediately; opacity fades in/out slowly
+            transition: 'opacity 0.5s ease',
+            pointerEvents: 'none',
+          }}
+        />
+
+        {/* Ambient lighting — a broad, soft gradient that shifts with the cursor quadrant,
+             making the overall card background feel responsive to where the user looks */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            background: `radial-gradient(ellipse at ${mousePos.x * 100}% ${mousePos.y * 100}%, rgba(16,185,129,0.06) 0%, rgba(59,130,246,0.04) 40%, transparent 70%)`,
+            opacity: isHovering ? 1 : 0,
+            transition: 'opacity 0.6s ease',
+            pointerEvents: 'none',
+          }}
+        />
+
+        {/* Floating contribution squares at varying parallax depths.
+             Each particle shifts by (parallaxX * depth, parallaxY * depth) px relative
+             to its base position, so "closer" particles (higher depth) shift more —
+             creating the impression of a multi-layered isometric space. */}
+        {particles.map(
+          (particle): ReactElement => (
+            <div
+              key={particle.id}
+              style={{
+                position: 'absolute',
+                left: `${particle.x}%`,
+                top: `${particle.y}%`,
+                width: particle.size,
+                height: particle.size,
+                backgroundColor: particle.color,
+                borderRadius: particle.isCircle ? '50%' : '2px',
+                boxShadow: `0 0 ${particle.size * 2}px ${particle.color}55`,
+                opacity: isHovering ? particle.opacity * 1.8 : particle.opacity,
+                // Particles shift in the SAME direction as the cursor offset to create
+                // a realistic parallax: near objects (depth ~0.6) move more than far ones.
+                transform: `translate(${parallaxX * particle.depth}px, ${parallaxY * particle.depth}px)`,
+                // Smooth lerp toward the new position; opacity fades independently
+                transition: `transform 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity 0.5s ease`,
+                pointerEvents: 'none',
+                willChange: 'transform',
+              }}
+            />
+          )
+        )}
+      </div>
+
+      {/* ── Card content ──────────────────────────────────────────────────────
+           Rendered above the parallax layer via DOM order; position:relative +
+           zIndex ensures the badge always sits in front of the background. */}
       <div
         style={{
+          position: 'relative',
+          zIndex: 1,
           transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
           transition: isDraggingState ? 'none' : 'transform 0.1s ease-out',
           willChange: 'transform',


### PR DESCRIPTION
## Description

Fixes #1190

Added a high-fidelity parallax background effect to the Customization Studio's `InteractiveViewer` component. 

- **Hover Parallax**: As the user moves their cursor over the preview, 20 floating contribution "squares" shift and sway at varying depth scales (parallax effect).
- **Ambient Lighting**: Added a subtle, cursor-following glow behind the card to make the background feel dynamically lit.
- **Pan Integration**: The background layers now also respond when the user pans the card (via dragging or `W/A/S/D`), moving at different speeds to create a 3D space effect.
- **Hydration Fix**: Also snuck in a fix for a server/client hydration mismatch error that was occurring in the `Navbar` component on initial page load.
- **Testing**: Added 10 new unit tests covering the new pointer tracking and background layer behaviours.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Web UI Enhancement, Bug fix, refactoring, docs)

## Visual Preview
*(You can drag and drop a short screen recording or screenshot of the parallax effect moving here!)*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
