### PR TITLE
test(ai-insights): add skeleton tests

### DIFF
--- a/components/dashboard/AIInsightsSkeleton.test.tsx
+++ b/components/dashboard/AIInsightsSkeleton.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import AIInsightsSkeleton from './AIInsightsSkeleton';
+
+describe('AIInsightsSkeleton', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<AIInsightsSkeleton />);
+
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it('renders exactly 3 insight skeleton rows', () => {
+    const { container } = render(<AIInsightsSkeleton />);
+
+    const rows = container.querySelectorAll('.flex.items-start.gap-3');
+
+    expect(rows).toHaveLength(3);
+  });
+
+  it('renders shimmer elements inside each insight row', () => {
+    const { container } = render(<AIInsightsSkeleton />);
+
+    const rows = container.querySelectorAll('.flex.items-start.gap-3');
+
+    rows.forEach((row) => {
+      expect(row.querySelectorAll('.shimmer').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('renders icon shimmer and text shimmer blocks for each row', () => {
+    const { container } = render(<AIInsightsSkeleton />);
+
+    const rows = container.querySelectorAll('.flex.items-start.gap-3');
+
+    rows.forEach((row) => {
+      const iconShimmer = row.querySelector('.w-4.h-4.shimmer.rounded-full');
+      const textShimmers = row.querySelectorAll('.h-3.shimmer.rounded');
+
+      expect(iconShimmer).toBeTruthy();
+      expect(textShimmers).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1012

Added test coverage for the `AIInsightsSkeleton` loading placeholder component.

### Test Coverage Added

* Verifies the component renders without crashing.
* Verifies exactly 3 insight skeleton rows are rendered.
* Verifies each row contains shimmer elements.
* Verifies each row contains an icon shimmer and text shimmer blocks.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
