### PR TITLE
test(glow): add useGlowEffect hook tests

### DIFF
--- a/hooks/useGlowEffect.test.ts
+++ b/hooks/useGlowEffect.test.ts
@@ -1,0 +1,66 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useGlowEffect } from './useGlowEffect';
+
+class MockResizeObserver {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+describe('useGlowEffect', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the public API for the glow effect', () => {
+    const { result } = renderHook(() => useGlowEffect());
+
+    expect(result.current.shellRef).toBeDefined();
+    expect(result.current.shellVars).toBeDefined();
+    expect(result.current.handleMouseEnter).toEqual(expect.any(Function));
+    expect(result.current.handleMouseMove).toEqual(expect.any(Function));
+    expect(result.current.handleMouseLeave).toEqual(expect.any(Function));
+  });
+
+  it('returns CSS variable keys in shellVars', () => {
+    const { result } = renderHook(() => useGlowEffect());
+
+    expect(result.current.shellVars).toHaveProperty('--mx');
+    expect(result.current.shellVars).toHaveProperty('--my');
+    expect(result.current.shellVars).toHaveProperty('--glow-opacity');
+    expect(result.current.shellVars).toHaveProperty('--border-opacity');
+  });
+
+  it('defaults glow opacity to 0', () => {
+    const { result } = renderHook(() => useGlowEffect());
+
+    expect(result.current.shellVars['--glow-opacity']).toBe('0');
+  });
+
+  it('cancels animation frame on unmount after pointer movement', () => {
+    const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame');
+
+    const { result, unmount } = renderHook(() => useGlowEffect());
+
+    result.current.handleMouseMove({
+      clientX: 100,
+      clientY: 50,
+      currentTarget: document.createElement('div'),
+    } as unknown as React.MouseEvent<HTMLDivElement>);
+
+    unmount();
+
+    expect(cancelAnimationFrameSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1019

Added test coverage for the `useGlowEffect` hook.

### Test Coverage Added

* Verifies the hook returns the expected public API.
* Verifies `shellVars` contains the required CSS variable keys.
* Verifies `--glow-opacity` defaults to `'0'`.
* Verifies `cancelAnimationFrame` is called during cleanup after pointer movement.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
