### PR TITLE
fix(api): encode GitHub REST username paths

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -84,7 +84,9 @@ describe('fetchWithRetry', () => {
     const abortListener = addListenerSpy.mock.calls.find(([event]) => event === 'abort')?.[1];
 
     expect(abortListener).toEqual(expect.any(Function));
-    expect(addListenerSpy).toHaveBeenCalledWith('abort', abortListener, { once: true });
+    expect(addListenerSpy).toHaveBeenCalledWith('abort', abortListener, {
+      once: true,
+    });
     expect(removeListenerSpy).toHaveBeenCalledWith('abort', abortListener);
   });
 
@@ -102,7 +104,9 @@ describe('fetchWithRetry', () => {
         })
     );
 
-    const request = fetchWithRetry('https://api.github.com/test', { signal: controller.signal });
+    const request = fetchWithRetry('https://api.github.com/test', {
+      signal: controller.signal,
+    });
 
     controller.abort();
 
@@ -124,7 +128,9 @@ describe('fetchGitHubContributions', () => {
     vi.mocked(fetch).mockResolvedValue(
       mockResponse({
         data: {
-          user: { contributionsCollection: { contributionCalendar: mockCalendar } },
+          user: {
+            contributionsCollection: { contributionCalendar: mockCalendar },
+          },
         },
       })
     );
@@ -139,7 +145,9 @@ describe('fetchGitHubContributions', () => {
     vi.mocked(fetch).mockResolvedValue(
       mockResponse({
         data: {
-          user: { contributionsCollection: { contributionCalendar: mockCalendar } },
+          user: {
+            contributionsCollection: { contributionCalendar: mockCalendar },
+          },
         },
       })
     );
@@ -167,7 +175,9 @@ describe('fetchGitHubContributions', () => {
     vi.mocked(fetch).mockResolvedValue(
       mockResponse({
         data: {
-          user: { contributionsCollection: { contributionCalendar: mockCalendar } },
+          user: {
+            contributionsCollection: { contributionCalendar: mockCalendar },
+          },
         },
       })
     );
@@ -191,12 +201,17 @@ describe('fetchGitHubContributions', () => {
   });
 
   it('works correctly for a brand-new user who has zero contribution weeks', async () => {
-    const emptyCalendar: ContributionCalendar = { totalContributions: 0, weeks: [] };
+    const emptyCalendar: ContributionCalendar = {
+      totalContributions: 0,
+      weeks: [],
+    };
 
     vi.mocked(fetch).mockResolvedValue(
       mockResponse({
         data: {
-          user: { contributionsCollection: { contributionCalendar: emptyCalendar } },
+          user: {
+            contributionsCollection: { contributionCalendar: emptyCalendar },
+          },
         },
       })
     );
@@ -287,7 +302,9 @@ describe('fetchGitHubContributions', () => {
     vi.mocked(fetch).mockResolvedValue(
       mockResponse({
         data: {
-          user: { contributionsCollection: { contributionCalendar: sparseCalendar } },
+          user: {
+            contributionsCollection: { contributionCalendar: sparseCalendar },
+          },
         },
       })
     );
@@ -298,18 +315,27 @@ describe('fetchGitHubContributions', () => {
   });
 
   it('is deterministic: two calls with empty-year response return identical data', async () => {
-    const emptyCalendar: ContributionCalendar = { totalContributions: 0, weeks: [] };
+    const emptyCalendar: ContributionCalendar = {
+      totalContributions: 0,
+      weeks: [],
+    };
 
     vi.mocked(fetch).mockImplementation(async () =>
       mockResponse({
         data: {
-          user: { contributionsCollection: { contributionCalendar: emptyCalendar } },
+          user: {
+            contributionsCollection: { contributionCalendar: emptyCalendar },
+          },
         },
       })
     );
 
-    const r1 = await fetchGitHubContributions('empty-user', { bypassCache: true });
-    const r2 = await fetchGitHubContributions('empty-user', { bypassCache: true });
+    const r1 = await fetchGitHubContributions('empty-user', {
+      bypassCache: true,
+    });
+    const r2 = await fetchGitHubContributions('empty-user', {
+      bypassCache: true,
+    });
     expect(r1.totalContributions).toBe(r2.totalContributions);
     expect(r1.weeks).toEqual(r2.weeks);
   });
@@ -347,6 +373,29 @@ describe('fetchUserProfile', () => {
     expect(result.avatar_url).toBe(mockProfile.avatar_url);
   });
 
+  it('encodes the username before using it in the REST profile path', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse({
+        login: 'octo/cat',
+        name: 'Slash User',
+        avatar_url: 'avatar.png',
+        public_repos: 1,
+        followers: 0,
+        following: 0,
+        created_at: '2024-01-01T00:00:00Z',
+        bio: null,
+        location: null,
+      })
+    );
+
+    await fetchUserProfile('octo/cat');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.github.com/users/octo%2Fcat',
+      expect.objectContaining({ cache: 'no-store' })
+    );
+  });
+
   it('throws "User not found" on 404', async () => {
     vi.mocked(fetch).mockResolvedValue(mockResponse({ message: 'Not Found' }, 404));
     await expect(fetchUserProfile('ghost')).rejects.toThrow('User not found');
@@ -368,6 +417,19 @@ describe('fetchUserRepos', () => {
     );
     const result = await fetchUserRepos('octocat');
     expect(result[0].stargazers_count).toBe(1);
+  });
+
+  it('encodes the username before using it in the REST repos path', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse([{ stargazers_count: 1, language: 'TypeScript' }])
+    );
+
+    await fetchUserRepos('octo/cat');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.github.com/users/octo%2Fcat/repos?per_page=100&page=1&sort=pushed',
+      expect.objectContaining({ cache: 'no-store' })
+    );
   });
 
   it('throws status code error on failure', async () => {
@@ -492,7 +554,9 @@ describe('getFullDashboardData', () => {
       }
       return mockResponse({
         data: {
-          user: { contributionsCollection: { contributionCalendar: mockCalendar } },
+          user: {
+            contributionsCollection: { contributionCalendar: mockCalendar },
+          },
         },
       });
     });
@@ -568,7 +632,11 @@ describe('getFullDashboardData', () => {
       if (typeof url === 'string' && url.includes('/users/octocat'))
         throw new Error('Network error');
       return mockResponse({
-        data: { user: { contributionsCollection: { contributionCalendar: mockCalendar } } },
+        data: {
+          user: {
+            contributionsCollection: { contributionCalendar: mockCalendar },
+          },
+        },
       });
     });
     await expect(getFullDashboardData('octocat')).rejects.toThrow(
@@ -593,7 +661,11 @@ describe('getFullDashboardData', () => {
         });
       }
       return mockResponse({
-        data: { user: { contributionsCollection: { contributionCalendar: mockCalendar } } },
+        data: {
+          user: {
+            contributionsCollection: { contributionCalendar: mockCalendar },
+          },
+        },
       });
     });
 
@@ -659,7 +731,11 @@ describe('GitHub API cache behavior', () => {
   it('cache hit: second contributions call uses cached value', async () => {
     vi.mocked(fetch).mockResolvedValue(
       mockResponse({
-        data: { user: { contributionsCollection: { contributionCalendar: mockCalendar } } },
+        data: {
+          user: {
+            contributionsCollection: { contributionCalendar: mockCalendar },
+          },
+        },
       })
     );
 
@@ -672,7 +748,11 @@ describe('GitHub API cache behavior', () => {
   it('refresh bypass: bypassCache=true forces a fresh fetch', async () => {
     vi.mocked(fetch).mockImplementation(async () =>
       mockResponse({
-        data: { user: { contributionsCollection: { contributionCalendar: mockCalendar } } },
+        data: {
+          user: {
+            contributionsCollection: { contributionCalendar: mockCalendar },
+          },
+        },
       })
     );
 
@@ -689,7 +769,9 @@ describe('GitHub API cache behavior', () => {
     vi.mocked(fetch).mockImplementation(async () =>
       mockResponse({
         data: {
-          user: { contributionsCollection: { contributionCalendar: mockCalendar } },
+          user: {
+            contributionsCollection: { contributionCalendar: mockCalendar },
+          },
         },
       })
     );
@@ -977,7 +1059,11 @@ describe('getOrgDashboardData', () => {
         });
       // GraphQL fetch fallback
       return mockResponse({
-        data: { user: { contributionsCollection: { contributionCalendar: mockCalendar } } },
+        data: {
+          user: {
+            contributionsCollection: { contributionCalendar: mockCalendar },
+          },
+        },
       });
     });
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -122,7 +122,9 @@ function throwIfRateLimited(res: Response): void {
 
 type GitHubContributionResponse = {
   data?: {
-    user: { contributionsCollection: { contributionCalendar: ContributionCalendar } } | null;
+    user: {
+      contributionsCollection: { contributionCalendar: ContributionCalendar };
+    } | null;
   };
   errors?: unknown;
 };
@@ -302,12 +304,13 @@ export async function fetchUserProfile(
   options: FetchOptions = {}
 ): Promise<GitHubUserProfile> {
   const key = cacheKey('profile', username);
+  const encodedUsername = encodeURIComponent(username);
   if (!options.bypassCache) {
     const cached = profileCache.get(key);
     if (cached) return cached;
   }
 
-  const res = await fetchWithRetry(`${GITHUB_REST_URL}/users/${username}`, {
+  const res = await fetchWithRetry(`${GITHUB_REST_URL}/users/${encodedUsername}`, {
     headers: getHeaders(),
     cache: 'no-store',
     signal: options.signal,
@@ -329,13 +332,14 @@ export async function fetchUserRepos(
   options: FetchOptions = {}
 ): Promise<GitHubRepo[]> {
   const key = cacheKey('repos', username);
+  const encodedUsername = encodeURIComponent(username);
   if (!options.bypassCache) {
     const cached = reposCache.get(key);
     if (cached) return cached;
   }
 
   const firstPageRes = await fetchWithRetry(
-    `${GITHUB_REST_URL}/users/${username}/repos?per_page=100&page=1&sort=pushed`,
+    `${GITHUB_REST_URL}/users/${encodedUsername}/repos?per_page=100&page=1&sort=pushed`,
     {
       headers: getHeaders(),
       cache: 'no-store',
@@ -359,7 +363,7 @@ export async function fetchUserRepos(
     const responses = await Promise.all(
       remainingPages.map((page) =>
         fetchWithRetry(
-          `${GITHUB_REST_URL}/users/${username}/repos?per_page=100&page=${page}&sort=pushed`,
+          `${GITHUB_REST_URL}/users/${encodedUsername}/repos?per_page=100&page=${page}&sort=pushed`,
           {
             headers: getHeaders(),
             cache: 'no-store',


### PR DESCRIPTION
## Description

Fixes #1242

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed

The GitHub REST helpers were inserting the raw `username` value directly into `/users/${username}` URL paths. That works for normal GitHub usernames, but malformed input containing path/query characters can reshape the REST URL instead of being treated as one path segment.

This PR encodes the username with `encodeURIComponent` before building REST profile and repo URLs:

- `fetchUserProfile`
- `fetchUserRepos`
- repo pagination requests

I also added regression tests for usernames containing `/` so the mocked REST URLs now assert `%2F` is used in both profile and repo fetches.

## Visual Preview

N/A — this is an API client URL handling fix with no visual change.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npm run test -- lib/github.test.ts`, `npm run test`, `npm run test:coverage`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.
