### PR TITLE
fix(svg): increase zero-contribution tile opacity from 0.02 to 0.08

### DIFF
--- a/lib/svg/layout.test.ts
+++ b/lib/svg/layout.test.ts
@@ -101,6 +101,7 @@ describe('computeTowers edge cases', () => {
     expect(towers[0].h).toBe(4); // GHOST_HEIGHT_PX
     expect(towers[0].strokeOpacity).toBe(0.3);
     expect(towers[0].strokeWidth).toBe(0.5);
+    expect(towers[0].faceOpacity.top).toBe(0.08);
   });
 
   it('marks every tower as a ghost with ghost height for an all-zero calendar', () => {
@@ -126,6 +127,7 @@ describe('computeTowers edge cases', () => {
     towers.forEach((tower) => {
       expect(tower.isGhost).toBe(true);
       expect(tower.h).toBe(4); // GHOST_HEIGHT_PX
+      expect(tower.faceOpacity.top).toBe(0.08);
     });
   });
 
@@ -147,8 +149,10 @@ describe('computeTowers edge cases', () => {
     expect(towers[0].h).toBe(0); // 0 count non-ghost = 0 height
     expect(towers[0].strokeOpacity).toBe(0);
     expect(towers[0].strokeWidth).toBe(0);
+    expect(towers[0].faceOpacity.top).toBe(0.08);
     expect(towers[1].isGhost).toBe(false);
     expect(towers[1].h).toBeGreaterThan(0);
+    expect(towers[1].faceOpacity.top).toBe(0.7);
   });
 
   it('uses logarithmic scale heights', () => {

--- a/lib/svg/layout.ts
+++ b/lib/svg/layout.ts
@@ -48,10 +48,10 @@ function computeTowerHeight(
 
 function computeFaceOpacity(count: number, isGhostCityMode: boolean): FaceOpacity {
   if (isGhostCityMode) {
-    return { left: 0, right: 0, top: 0.02 };
+    return { left: 0, right: 0, top: 0.08 };
   }
   if (count === 0) {
-    return { left: 0, right: 0, top: 0.02 };
+    return { left: 0, right: 0, top: 0.08 };
   }
   return { left: 0.35, right: 0.21, top: 0.7 };
 }


### PR DESCRIPTION
## Description

Fixes #1229

Zero-contribution tiles were rendering with a top-face opacity of `0.02` in
`lib/svg/layout.ts`. On dark backgrounds like `#0d1117` (used in the `dark`
and `github` themes), this made tiles visually indistinguishable from the
background — breaking the cohesive 3D isometric grid.

Increased the minimum `computeFaceOpacity` value from `0.02` → `0.08` so
empty tiles remain faintly visible, maintaining the full grid structure
across zero-contribution days. Updated unit tests to assert the new minimum.

## Pillar

- [x] 📐 Pillar 2 — Geometric SVG Improvement

## Visual Preview

Tested on `theme=dark` (`bg: #0d1117`) with a profile that has significant
zero-contribution days.

| Before (opacity `0.02`) | After (opacity `0.08`) |
|---|---|
| <img width="1194" height="935" alt="before" src="https://github.com/user-attachments/assets/65009931-47ca-4768-bfe8-6b2b32e31a0f" /> | <img width="1265" height="952" alt="after" src="https://github.com/user-attachments/assets/9f51717f-e149-4583-aa29-72386fe1952a" /> |

Zero-contribution days previously disappeared into the dark background.
After the fix, the full isometric grid floor is visible as a faint
blueprint structure.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=Pranav-IIITM`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format (`fix(svg): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [x] I joined the CommitPulse Discord community for contributor discussions.