### PR TITLE
fix(svg): scale particle float height by badge scale factor sf

### DIFF
--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -133,6 +133,42 @@ describe('generateSVG', () => {
     expect(svg).toContain('class="heat-particles"');
   });
 
+  it('scales particle floating height according to badge size', () => {
+    const svgMedium = generateSVG(
+      mockStats,
+      { user: 'avi', size: 'medium' } as unknown as BadgeParams,
+      mockCalendar
+    );
+    const svgSmall = generateSVG(
+      mockStats,
+      { user: 'avi', size: 'small' } as unknown as BadgeParams,
+      mockCalendar
+    );
+    const svgLarge = generateSVG(
+      mockStats,
+      { user: 'avi', size: 'large' } as unknown as BadgeParams,
+      mockCalendar
+    );
+
+    const mediumMatch = svgMedium.match(/<animate attributeName="cy" from="([\d.-]+)" to="([\d.-]+)"/);
+    expect(mediumMatch).not.toBeNull();
+    const fromMedium = parseFloat(mediumMatch![1]);
+    const toMedium = parseFloat(mediumMatch![2]);
+    expect(Math.round(fromMedium - toMedium)).toBe(20);
+
+    const smallMatch = svgSmall.match(/<animate attributeName="cy" from="([\d.-]+)" to="([\d.-]+)"/);
+    expect(smallMatch).not.toBeNull();
+    const fromSmall = parseFloat(smallMatch![1]);
+    const toSmall = parseFloat(smallMatch![2]);
+    expect(Math.round(fromSmall - toSmall)).toBe(13);
+
+    const largeMatch = svgLarge.match(/<animate attributeName="cy" from="([\d.-]+)" to="([\d.-]+)"/);
+    expect(largeMatch).not.toBeNull();
+    const fromLarge = parseFloat(largeMatch![1]);
+    const toLarge = parseFloat(largeMatch![2]);
+    expect(Math.round(fromLarge - toLarge)).toBe(27);
+  });
+
   it('supports dynamic Google Fonts for non-predefined fonts', () => {
     const svg = generateSVG(
       mockStats,

--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -150,19 +150,25 @@ describe('generateSVG', () => {
       mockCalendar
     );
 
-    const mediumMatch = svgMedium.match(/<animate attributeName="cy" from="([\d.-]+)" to="([\d.-]+)"/);
+    const mediumMatch = svgMedium.match(
+      /<animate attributeName="cy" from="([\d.-]+)" to="([\d.-]+)"/
+    );
     expect(mediumMatch).not.toBeNull();
     const fromMedium = parseFloat(mediumMatch![1]);
     const toMedium = parseFloat(mediumMatch![2]);
     expect(Math.round(fromMedium - toMedium)).toBe(20);
 
-    const smallMatch = svgSmall.match(/<animate attributeName="cy" from="([\d.-]+)" to="([\d.-]+)"/);
+    const smallMatch = svgSmall.match(
+      /<animate attributeName="cy" from="([\d.-]+)" to="([\d.-]+)"/
+    );
     expect(smallMatch).not.toBeNull();
     const fromSmall = parseFloat(smallMatch![1]);
     const toSmall = parseFloat(smallMatch![2]);
     expect(Math.round(fromSmall - toSmall)).toBe(13);
 
-    const largeMatch = svgLarge.match(/<animate attributeName="cy" from="([\d.-]+)" to="([\d.-]+)"/);
+    const largeMatch = svgLarge.match(
+      /<animate attributeName="cy" from="([\d.-]+)" to="([\d.-]+)"/
+    );
     expect(largeMatch).not.toBeNull();
     const fromLarge = parseFloat(largeMatch![1]);
     const toLarge = parseFloat(largeMatch![2]);

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -86,7 +86,7 @@ function generateParticles(
 
     particles += `
       <circle ${fillAttr} cx="${x + offsetX}" cy="${y - height}" r="${1.5 * sf}" opacity="1">
-        <animate attributeName="cy" from="${y - height}" to="${y - height - 20}" dur="1.5s" begin="${delay}s" repeatCount="indefinite" />
+        <animate attributeName="cy" from="${y - height}" to="${y - height - Math.round(20 * sf)}" dur="1.5s" begin="${delay}s" repeatCount="indefinite" />
         <animate attributeName="opacity" from="1" to="0" dur="1.5s" begin="${delay}s" repeatCount="indefinite" />
       </circle>
     `;


### PR DESCRIPTION
## Description

Fixes #1257 

In `generateParticles` inside `lib/svg/generator.ts`, the vertical floating 
animation used a hardcoded `20px` rise height regardless of the badge scale 
factor `sf`. This caused particles to float too high on `size=small` and 
barely rise on `size=large`.

Changed `to="${y - height - 20}"` to `to="${y - height - Math.round(20 * sf)}"` 
so the float height scales proportionally with the badge size. Updated unit 
tests to assert correct scaled heights for all three sizes.

## Pillar

- [x] 📐 Pillar 2 — Geometric SVG Improvement

## Visual Preview

This is an animation/geometry bug — no static screenshot can capture it.
To reproduce, open the badge URLs in a browser and observe particle behavior:

Small (particles float too high):
`https://commitpulse.vercel.app/api/streak?user=jhasourav07&size=small`

Large (particles barely rise):
`https://commitpulse.vercel.app/api/streak?user=jhasourav07&size=large`

After the fix, particle float height is proportional to tower height across
all badge sizes.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=Pranav-IIITM`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format (`fix(svg): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [x] I joined the CommitPulse Discord community for contributor discussions.