### PR TITLE
feat: add Copy as Image option to ShareSheet exports

### DIFF
--- a/components/dashboard/ShareSheet.tsx
+++ b/components/dashboard/ShareSheet.tsx
@@ -58,6 +58,7 @@ export default function ShareSheet({ username, isOpen, onClose, exportData }: Sh
     handleReddit,
     handleDownloadPNG,
     handleDownloadWEBP,
+    handleCopyImage,
     handleDownloadSVG,
     handleCopyMarkdown,
     handleDownloadCSV,
@@ -191,6 +192,15 @@ endsolid commitpulse_monolith`;
       gradient: 'bg-zinc-800',
       glow: 'transparent',
       action: handleDownloadWEBP,
+    },
+    {
+      key: 'copyImage',
+      icon: Download,
+      label: 'Copy as Image',
+      description: 'Copy dashboard image to clipboard',
+      gradient: 'bg-zinc-800',
+      glow: 'transparent',
+      action: handleCopyImage,
     },
     {
       key: 'svg',
@@ -333,13 +343,17 @@ endsolid commitpulse_monolith`;
                                   ? 'Downloaded!'
                                   : opt.key === 'csv'
                                     ? 'CSV Downloaded!'
-                                    : opt.key === 'json'
-                                      ? 'JSON Downloaded!'
-                                      : opt.key === 'svg'
-                                        ? 'SVG Downloaded!'
-                                        : opt.key === 'stl'
-                                          ? 'STL Generated!'
-                                          : opt.label
+                                    : opt.key === 'copyImage'
+                                      ? 'Image Copied!'
+                                      : opt.key === 'png'
+                                        ? 'Downloaded!'
+                                        : opt.key === 'json'
+                                          ? 'JSON Downloaded!'
+                                          : opt.key === 'svg'
+                                            ? 'SVG Downloaded!'
+                                            : opt.key === 'stl'
+                                              ? 'STL Generated!'
+                                              : opt.label
                               : state === 'error'
                                 ? 'Failed — try again'
                                 : opt.label}

--- a/hooks/useShareActions.test.ts
+++ b/hooks/useShareActions.test.ts
@@ -3,6 +3,13 @@ import { renderHook, act } from '@testing-library/react';
 import { useShareActions } from './useShareActions';
 import type { DashboardExportData } from '@/types/dashboard';
 
+vi.mock('html-to-image', () => ({
+  toCanvas: vi.fn().mockResolvedValue({
+    toBlob: (cb: (blob: Blob) => void) => {
+      cb(new Blob(['test'], { type: 'image/png' }));
+    },
+  }),
+}));
 const mockExportData: DashboardExportData = {
   stats: { currentStreak: 5, peakStreak: 10, totalContributions: 100 },
   languages: [],
@@ -49,8 +56,12 @@ describe('useShareActions', () => {
   });
   it('copies dashboard image to clipboard successfully', async () => {
     const writeMock = vi.fn().mockResolvedValue(undefined);
+    class MockClipboardItem {
+      constructor(public data: Record<string, Blob>) {}
+    }
+
     Object.defineProperty(globalThis, 'ClipboardItem', {
-      value: vi.fn((data: Record<string, Blob>) => data),
+      value: MockClipboardItem,
       writable: true,
     });
 
@@ -63,24 +74,12 @@ describe('useShareActions', () => {
 
     document.body.innerHTML = '<div id="dashboard-root">Dashboard</div>';
 
-    const mockBlob = new Blob(['test'], { type: 'image/png' });
-
-    vi.mock('html-to-image', async () => {
-      const actual = await vi.importActual('html-to-image');
-      return {
-        ...actual,
-        toCanvas: vi.fn().mockResolvedValue({
-          toBlob: (cb: (blob: Blob) => void) => cb(mockBlob),
-        }),
-      };
-    });
-
     const { result } = renderHook(() => useShareActions('testuser', mockExportData, vi.fn()));
 
     await act(async () => {
       await result.current.handleCopyImage();
     });
-
+    console.log('copyImage state:', result.current.states['copyImage']);
     expect(writeMock).toHaveBeenCalled();
     expect(result.current.states['copyImage']).toBe('success');
   });

--- a/hooks/useShareActions.test.ts
+++ b/hooks/useShareActions.test.ts
@@ -47,4 +47,37 @@ describe('useShareActions', () => {
 
     expect(result.current.states['copy']).toBe('idle');
   });
+  it('copies dashboard image to clipboard successfully', async () => {
+    const writeMock = vi.fn().mockResolvedValue(undefined);
+
+    Object.assign(navigator, {
+      clipboard: {
+        write: writeMock,
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+
+    document.body.innerHTML = '<div id="dashboard-root">Dashboard</div>';
+
+    const mockBlob = new Blob(['test'], { type: 'image/png' });
+
+    vi.mock('html-to-image', async () => {
+      const actual = await vi.importActual('html-to-image');
+      return {
+        ...actual,
+        toCanvas: vi.fn().mockResolvedValue({
+          toBlob: (cb: (blob: Blob) => void) => cb(mockBlob),
+        }),
+      };
+    });
+
+    const { result } = renderHook(() => useShareActions('testuser', mockExportData, vi.fn()));
+
+    await act(async () => {
+      await result.current.handleCopyImage();
+    });
+
+    expect(writeMock).toHaveBeenCalled();
+    expect(result.current.states['copyImage']).toBe('success');
+  });
 });

--- a/hooks/useShareActions.test.ts
+++ b/hooks/useShareActions.test.ts
@@ -49,6 +49,10 @@ describe('useShareActions', () => {
   });
   it('copies dashboard image to clipboard successfully', async () => {
     const writeMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(globalThis, 'ClipboardItem', {
+      value: vi.fn((data: Record<string, Blob>) => data),
+      writable: true,
+    });
 
     Object.assign(navigator, {
       clipboard: {

--- a/hooks/useShareActions.ts
+++ b/hooks/useShareActions.ts
@@ -136,6 +136,55 @@ export function useShareActions(
     }
   };
 
+  const handleCopyImage = async () => {
+    setOptionState('copyImage', 'loading');
+
+    try {
+      if (!navigator.clipboard || typeof ClipboardItem === 'undefined') {
+        throw new Error('Clipboard image API not supported');
+      }
+
+      const node =
+        document.getElementById('dashboard-root') ??
+        document.querySelector<HTMLElement>('[data-dashboard]') ??
+        document.body;
+
+      const isDark =
+        typeof document !== 'undefined' && document.documentElement.classList.contains('dark');
+
+      const canvas = await toCanvas(node, {
+        quality: 0.95,
+        pixelRatio: 2,
+        backgroundColor: isDark ? '#050505' : '#ffffff',
+        filter: (el) => {
+          if (el instanceof HTMLElement) {
+            if (el.id === 'share-sheet-overlay') return false;
+            if (el.id === 'generate-dashboard-btn') return false;
+          }
+          return true;
+        },
+      });
+
+      const blob = await new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob((blob) => {
+          if (blob) resolve(blob);
+          else reject(new Error('Failed to create image blob'));
+        }, 'image/png');
+      });
+
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          'image/png': blob,
+        }),
+      ]);
+
+      setOptionState('copyImage', 'success');
+      setTimeout(() => onClose(), 800);
+    } catch {
+      setOptionState('copyImage', 'error');
+    }
+  };
+
   const handleDownloadSVG = async () => {
     setOptionState('svg', 'loading');
     try {
@@ -286,6 +335,7 @@ export function useShareActions(
     handleReddit,
     handleDownloadPNG,
     handleDownloadWEBP,
+    handleCopyImage,
     handleDownloadSVG,
     handleCopyMarkdown,
     handleDownloadCSV,


### PR DESCRIPTION
## Description

Fixes #1254

Adds a new **Copy as Image** option to the ShareSheet export menu.

Users can now copy dashboard snapshots directly to their clipboard without downloading an image file first. The implementation reuses the existing `toCanvas()` workflow, converts the generated dashboard into a PNG Blob, and uses the Clipboard API (`ClipboardItem` and `navigator.clipboard.write`) to enable direct pasting into applications such as WhatsApp, Discord, Slack, LinkedIn, and other supported platforms.

## Pillar

* [x] 🎨 Pillar 1 — New Theme Design
* [x] 📐 Pillar 2 — Geometric SVG Improvement
* [x] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

* Added **Copy as Image** action to the ShareSheet.
* Successfully tested by copying a dashboard snapshot and pasting it into WhatsApp.
* Existing PNG, WebP and SVG export functionality remains unaffected.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [x] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
