### PR TITLE
fix: prevent redirect() from being swallowed by try-catch in dashboard [username] page

### DIFF
--- a/app/(root)/dashboard/[username]/page.tsx
+++ b/app/(root)/dashboard/[username]/page.tsx
@@ -73,14 +73,14 @@ export default async function DashboardPage({
   } catch (error) {
     if (error instanceof Error && error.message.includes('not found')) {
       // Smart Redirect: If the GraphQL "user" query fails, check if it's actually an Organization
+      let fallbackProfile;
       try {
-        const fallbackProfile = await fetchUserProfile(username, { bypassCache });
-        if (fallbackProfile.type === 'Organization') {
-          redirect(`/dashboard/org/${username}`);
-        }
+        fallbackProfile = await fetchUserProfile(username, { bypassCache });
       } catch {
-        // If it's truly neither a user nor an org, show 404
         return notFound();
+      }
+      if (fallbackProfile.type === 'Organization') {
+        redirect(`/dashboard/org/${username}`);
       }
       return notFound();
     }


### PR DESCRIPTION
## Description

Fixes #1280

The Organization smart redirect in the dashboard [username] page was completely broken. When a user visits `/dashboard/<orgname>` for a GitHub Organization, they saw a 404 page instead of being redirected to `/dashboard/org/<orgname>`. This happened because Next.js `redirect()` from `next/navigation` throws a `RedirectError` internally, and the surrounding try-catch block was intercepting it before the framework could handle it.

## Root Cause

The `redirect()` call was nested inside a try-catch block. Since Next.js implements redirects by throwing a special error, the catch block caught it and returned `notFound()` instead, preventing the redirect from ever reaching the framework.

## Changes

Extracted the `redirect()` call outside the nested try-catch. The `fetchUserProfile` call remains protected by try-catch for network errors, but the `redirect()` now propagates to the framework properly.

## Pillar

- [ ] Pillar 1 - New Theme Design
- [ ] Pillar 2 - Geometric SVG Improvement
- [ ] Pillar 3 - Timezone Logic Optimization
- [X] Other (Bug fix, refactoring, docs)

## Visual Preview

N/A - Server-side redirect fix, no visual changes.

## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [X] I have tested these changes locally.
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [X] I have started the repo.
- [X] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse premium quality aesthetic standard (no raw elements, smooth animations, correct fonts).