### PR TITLE
fix(validation): add max-length and regex validation to githubParamsSchema username

### DIFF
--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -175,7 +175,11 @@ export const streakParamsSchema = z.object({
 export const githubParamsSchema = z.object({
   username: z
     .string({ error: 'Missing "username" parameter' })
-    .min(1, { message: 'Username is required' }),
+    .min(1, { message: 'Username is required' })
+    .max(39, { message: 'GitHub username cannot exceed 39 characters' })
+    .regex(/^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9]))*$/, {
+      message: 'Invalid GitHub username format',
+    }),
   refresh: z
     .string()
     .optional()


### PR DESCRIPTION
## Description

Fixes #1281

The `/api/github` endpoint accepts arbitrary username strings with only a `.min(1)` check -- no max length, no character restrictions. Contrast this with `/api/streak` which validates with `.max(39)` and a regex for valid GitHub username format. This inconsistency creates a defense-in-depth gap: unvalidated usernames are interpolated directly into REST API URLs like `${GITHUB_REST_URL}/users/${username}`.

## Root Cause

The `githubParamsSchema` at `lib/validations.ts:175-183` was written before the stricter validation pattern was established. The `streakParamsSchema` (lines 32-38) already had the correct pattern but it was not replicated to the github endpoint schema.

## Changes

Added the same validation rules used by `streakParamsSchema`:
- `.max(39)` to cap username length (GitHub usernames max at 39 chars)
- `.regex(/^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9]))*$/` to restrict to valid GitHub username characters
- Ensures `/api/github` has parity with `/api/streak` and rejects malformed usernames with a clear 400 error

## Pillar

- [ ] Pillar 1 - New Theme Design
- [ ] Pillar 2 - Geometric SVG Improvement
- [ ] Pillar 3 - Timezone Logic Optimization
- [X] Other (Bug fix, refactoring, docs)

## Visual Preview

N/A - Backend validation fix, no visual changes.

## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [X] I have tested these changes locally.
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [X] I have started the repo.
- [X] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse premium quality aesthetic standard (no raw elements, smooth animations, correct fonts).