### PR TITLE
fix(github): remove fabricated lines of code (LoC) generation #1265

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -133,65 +133,6 @@ describe('fetchGitHubContributions', () => {
 
     expect(result.totalContributions).toBe(mockCalendar.totalContributions);
     expect(result.weeks[0].contributionDays[0].contributionCount).toBe(3);
-    expect(result.weeks[0].contributionDays[0]).toHaveProperty('locAdditions');
-  });
-
-  it('injects positive locAdditions and non-negative locDeletions for contribution days', async () => {
-    const calendarWithContributions: ContributionCalendar = {
-      totalContributions: 5,
-      weeks: [
-        {
-          contributionDays: [{ contributionCount: 5, date: '2024-06-10' }],
-        },
-      ],
-    };
-
-    vi.mocked(fetch).mockResolvedValue(
-      mockResponse({
-        data: {
-          user: {
-            contributionsCollection: {
-              contributionCalendar: calendarWithContributions,
-            },
-          },
-        },
-      })
-    );
-
-    const result = await fetchGitHubContributions('octocat');
-    const day = result.weeks[0].contributionDays[0];
-
-    expect(day.locAdditions).toBeGreaterThan(0);
-    expect(day.locDeletions).toBeGreaterThanOrEqual(0);
-  });
-
-  it('sets locAdditions and locDeletions to zero for zero-contribution days', async () => {
-    const calendarWithZeroContribution: ContributionCalendar = {
-      totalContributions: 0,
-      weeks: [
-        {
-          contributionDays: [{ contributionCount: 0, date: '2024-06-11' }],
-        },
-      ],
-    };
-
-    vi.mocked(fetch).mockResolvedValue(
-      mockResponse({
-        data: {
-          user: {
-            contributionsCollection: {
-              contributionCalendar: calendarWithZeroContribution,
-            },
-          },
-        },
-      })
-    );
-
-    const result = await fetchGitHubContributions('octocat');
-    const day = result.weeks[0].contributionDays[0];
-
-    expect(day.locAdditions).toBe(0);
-    expect(day.locDeletions).toBe(0);
   });
 
   it('sends a POST request to the GitHub GraphQL endpoint with the correct body', async () => {
@@ -330,7 +271,6 @@ describe('fetchGitHubContributions', () => {
       'GitHub user "ghost-user-xyz" not found'
     );
   });
-
   it('handles calendar with all days having zero contributions', async () => {
     const sparseCalendar: ContributionCalendar = {
       totalContributions: 0,
@@ -343,6 +283,7 @@ describe('fetchGitHubContributions', () => {
         },
       ],
     };
+
     vi.mocked(fetch).mockResolvedValue(
       mockResponse({
         data: {
@@ -350,6 +291,7 @@ describe('fetchGitHubContributions', () => {
         },
       })
     );
+
     const result = await fetchGitHubContributions('sparse-user');
     expect(result.totalContributions).toBe(0);
     expect(result.weeks).toHaveLength(1);
@@ -890,7 +832,6 @@ describe('validateGitHubUsername', () => {
     expect(validateGitHubUsername('invalid_username')).toBe(false);
   });
 });
-
 describe('cacheKey', () => {
   it('creates key without year', () => {
     expect(cacheKey('profile', 'DeepSikha')).toBe('profile:deepsikha');

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -262,35 +262,35 @@ export async function fetchGitHubContributions(
 
   const calendar = data.data.user.contributionsCollection.contributionCalendar;
 
-  // Inject deterministic Lines of Code (LoC) approximation
-  // Since GitHub's contributionCalendar doesn't provide native LoC metrics,
-  // we generate a consistent estimation based on the day's commit volume.
-  calendar.weeks.forEach((week) => {
-    week.contributionDays.forEach((day) => {
-      if (day.contributionCount > 0) {
-        let hash1 = 2166136261,
-          hash2 = 2166136261;
-        const seed1 = day.date + 'add',
-          seed2 = day.date + 'del';
-        for (let i = 0; i < seed1.length; i++) {
-          hash1 ^= seed1.charCodeAt(i);
-          hash1 = Math.imul(hash1, 16777619);
-        }
-        for (let i = 0; i < seed2.length; i++) {
-          hash2 ^= seed2.charCodeAt(i);
-          hash2 = Math.imul(hash2, 16777619);
-        }
-        const randAdd = (hash1 >>> 0) / 4294967296;
-        const randDel = (hash2 >>> 0) / 4294967296;
+  // // Inject deterministic Lines of Code (LoC) approximation
+  // // Since GitHub's contributionCalendar doesn't provide native LoC metrics,
+  // // we generate a consistent estimation based on the day's commit volume.
+  // calendar.weeks.forEach((week) => {
+  //   week.contributionDays.forEach((day) => {
+  //     if (day.contributionCount > 0) {
+  //       let hash1 = 2166136261,
+  //         hash2 = 2166136261;
+  //       const seed1 = day.date + 'add',
+  //         seed2 = day.date + 'del';
+  //       for (let i = 0; i < seed1.length; i++) {
+  //         hash1 ^= seed1.charCodeAt(i);
+  //         hash1 = Math.imul(hash1, 16777619);
+  //       }
+  //       for (let i = 0; i < seed2.length; i++) {
+  //         hash2 ^= seed2.charCodeAt(i);
+  //         hash2 = Math.imul(hash2, 16777619);
+  //       }
+  //       const randAdd = (hash1 >>> 0) / 4294967296;
+  //       const randDel = (hash2 >>> 0) / 4294967296;
 
-        day.locAdditions = Math.floor(day.contributionCount * (25 + randAdd * 85));
-        day.locDeletions = Math.floor(day.contributionCount * (5 + randDel * 35));
-      } else {
-        day.locAdditions = 0;
-        day.locDeletions = 0;
-      }
-    });
-  });
+  //       day.locAdditions = Math.floor(day.contributionCount * (25 + randAdd * 85));
+  //       day.locDeletions = Math.floor(day.contributionCount * (5 + randDel * 35));
+  //     } else {
+  //       day.locAdditions = 0;
+  //       day.locDeletions = 0;
+  //     }
+  //   });
+  // });
 
   if (!options.bypassCache) contributionsCache.set(key, calendar, GITHUB_CACHE_TTL_MS);
 


### PR DESCRIPTION

## Description
This PR addresses a critical data integrity issue by removing the fabricated Lines of Code (LoC) generation logic. Previously, the fetchGitHubContributions function mutated the raw GitHub API response by injecting fake locAdditions and locDeletions generated via a deterministic FNV-1a hash of the date string.

Fixes #1265 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="926" height="406" alt="Screenshot 2026-05-29 164253" src="https://github.com/user-attachments/assets/b6455935-8a62-4a0f-9c8f-2afaf6c64705" />


## Checklist before requesting a review:

[x] I have read the CONTRIBUTING.md file.

[x] I have tested these changes locally.

[x] I have run npm run format and npm run lint locally and resolved all errors (CI will fail otherwise).

[x] My commits follow the Conventional Commits format (e.g., feat(themes): ..., fix(calculate): ...).

[x] I have starred the repo.

[x] I have made sure that I have only one commit to merge in this PR.

[x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.

[x] (Recommended) I joined the CommitPulse Discord community for contributor discussions.