### PR TITLE
fix(calculate): resolve data corruption in aggregateCalendars by using date-keyed map (#1267)

### DIFF
--- a/lib/calculate.ts
+++ b/lib/calculate.ts
@@ -150,32 +150,46 @@ export function calculateMonthlyStats(
  * Used for Organization and Team dashboards.
  */
 export function aggregateCalendars(calendars: ContributionCalendar[]): ContributionCalendar {
-  if (calendars.length === 0) return { totalContributions: 0, weeks: [] };
+  if (calendars.length === 0) {
+    return { totalContributions: 0, weeks: [] };
+  }
 
-  // Clone the structure of the first valid calendar to act as our base accumulator
-  const baseCalendar = JSON.parse(JSON.stringify(calendars[0])) as ContributionCalendar;
+  // Calculate total contributions across all calendars
+  const totalContributions = calendars.reduce((sum, cal) => sum + cal.totalContributions, 0);
 
-  let totalOrgContributions = baseCalendar.totalContributions;
+  // Use a Map keyed by the date string 'YYYY-MM-DD' to safely aggregate daily counts
+  const dateMap = new Map<string, number>();
 
-  // Add all subsequent calendars onto the base
-  for (let i = 1; i < calendars.length; i++) {
-    const cal = calendars[i];
-    totalOrgContributions += cal.totalContributions;
+  // Find the calendar with the most weeks to serve as our structural base
+  let baseCalendar = calendars[0];
+  for (const cal of calendars) {
+    if (cal.weeks.length > baseCalendar.weeks.length) {
+      baseCalendar = cal;
+    }
 
-    cal.weeks.forEach((week, weekIdx) => {
-      week.contributionDays.forEach((day, dayIdx) => {
-        if (baseCalendar.weeks[weekIdx] && baseCalendar.weeks[weekIdx].contributionDays[dayIdx]) {
-          baseCalendar.weeks[weekIdx].contributionDays[dayIdx].contributionCount +=
-            day.contributionCount;
-        }
+    // Populate the Map with all contributions from all calendars
+    cal.weeks.forEach((week) => {
+      week.contributionDays.forEach((day) => {
+        const currentCount = dateMap.get(day.date) || 0;
+        dateMap.set(day.date, currentCount + day.contributionCount);
       });
     });
   }
 
-  baseCalendar.totalContributions = totalOrgContributions;
-  return baseCalendar;
-}
+  // Deep clone the base calendar so we don't mutate the original object
+  const aggregatedBase = JSON.parse(JSON.stringify(baseCalendar)) as ContributionCalendar;
 
+  aggregatedBase.totalContributions = totalContributions;
+
+  // Re-map the structural base using our aggregated date map
+  aggregatedBase.weeks.forEach((week) => {
+    week.contributionDays.forEach((day) => {
+      day.contributionCount = dateMap.get(day.date) || 0;
+    });
+  });
+
+  return aggregatedBase;
+}
 /**
  * Processes a calendar to generate deep insights for "GitHub Wrapped"
  */


### PR DESCRIPTION

## Description
This PR resolves a critical data corruption issue in the aggregateCalendars function used for Mega-City Organization dashboards.

Fixes #1267 

Changes made:

Removed the fragile, index-based iteration loop that incorrectly assumed all user calendars had identical array lengths (which caused silent data dropping or misalignment for users who joined mid-year).

Implemented a robust Map<string, number> keyed by the actual date string (YYYY-MM-DD).

The function now safely accumulates all daily contributions regardless of the calendar's structural shape, and then maps those correct totals back onto the base structural calendar for the SVG generator.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="949" height="411" alt="Screenshot 2026-05-29 170227" src="https://github.com/user-attachments/assets/5e4d276a-6d6e-4012-ad95-894ad37d25bc" />


## Checklist before requesting a review:

[x] I have read the CONTRIBUTING.md file.

[x] I have tested these changes locally.

[x] I have run npm run format and npm run lint locally and resolved all errors (CI will fail otherwise).

[x] My commits follow the Conventional Commits format (e.g., feat(themes): ..., fix(calculate): ...).

[x] I have starred the repo.

[x] I have made sure that I have only one commit to merge in this PR.

[x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.

[x] (Recommended) I joined the CommitPulse Discord community for contributor discussions.
