### PR TITLE
fix: resolve site domain dynamically for OG footer and landing page markdown

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -7,6 +7,18 @@ import { themes } from '@/lib/svg/themes';
 import { fetchGitHubContributions } from '@/lib/github';
 import { calculateStreak } from '@/lib/calculate';
 
+const appUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'https://commitpulse.vercel.app');
+
+const displayDomain = (() => {
+  try {
+    return new URL(appUrl).host;
+  } catch {
+    return 'commitpulse.vercel.app';
+  }
+})();
+
 function getLuminance(hex: string) {
   let normalizedHex = hex.trim();
   // Normalize short hex (e.g., #fff or #ffff) to #rrggbb (alpha is ignored for luminance)
@@ -170,7 +182,7 @@ export async function GET(req: NextRequest) {
           color: subText,
         }}
       >
-        commitpulse.vercel.app
+        {displayDomain}
       </div>
     </div>,
     {

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -182,9 +182,7 @@ describe('LandingPage', () => {
     fireEvent.click(copyButton!);
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-      expect.stringContaining(
-        '![CommitPulse](https://commitpulse.vercel.app/api/streak?user=jhasourav07)'
-      )
+      expect.stringContaining('/api/streak?user=jhasourav07')
     );
 
     await waitFor(() => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -86,7 +86,11 @@ export default function LandingPage() {
   }, []);
 
   const badgeUrl = `/api/streak?user=${debouncedUsername}`;
-  const markdown = `![CommitPulse](https://commitpulse.vercel.app/api/streak?user=${trimmedUsername})`;
+  const markdown = `![CommitPulse](${
+    mounted
+      ? window.location.origin
+      : (process.env.NEXT_PUBLIC_SITE_URL ?? 'https://commitpulse.vercel.app')
+  }/api/streak?user=${trimmedUsername})`;
 
   // Fetch SVG content whenever debounced username changes.
   useEffect(() => {


### PR DESCRIPTION
# fix: resolve site domain dynamically for OG footer and landing page markdown

## Description

Fixes #1276

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A (Non-visual backend and snippet improvement. Dynamically substitutes domain hostnames in the OG image footer and landing page markdown copy link snippet instead of hardcoding `commitpulse.vercel.app`).

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
