### PR TITLE
test(sanitizer): verify hexColor() branded type helper returns correct values

### DIFF
--- a/lib/svg/sanitizer.test.ts
+++ b/lib/svg/sanitizer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   isValidHex,
+  hexColor,
   sanitizeHexColor,
   sanitizeSpeed,
   sanitizeRadius,
@@ -33,6 +34,24 @@ describe('SVG Sanitizer Utilities', () => {
       expect(isValidHex('f')).toBe(false);
       expect(isValidHex('ff')).toBe(false);
       expect(isValidHex('fffff')).toBe(false);
+    });
+  });
+
+  describe('hexColor', () => {
+    it('returns hex without # for valid string without #', () => {
+      expect(hexColor('ff0000')).toBe('ff0000');
+    });
+
+    it('strips # and returns valid hex', () => {
+      expect(hexColor('#ff0000')).toBe('ff0000');
+    });
+
+    it('returns fallback for invalid string', () => {
+      expect(hexColor('invalid', '000000')).toBe('000000');
+    });
+
+    it('returns default fallback for empty string', () => {
+      expect(hexColor('')).toBe('000000');
     });
   });
 


### PR DESCRIPTION
## Description

Fixes #1077 

Added 4 dedicated unit tests to `lib/svg/sanitizer.test.ts` to verify the behavior of the `hexColor()` branded type helper. This ensures the function correctly processes valid hex strings (with and without `#`), and safely falls back to default values when provided with invalid or empty strings.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs, tests)

## Visual Preview
N/A (Unit tests only, no visual changes).

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
