### PR TITLE
feat(export): add CSV and JSON stats downloads

### DIFF
--- a/components/dashboard/DashboardClient.tsx
+++ b/components/dashboard/DashboardClient.tsx
@@ -478,6 +478,7 @@ export default function DashboardClient({ initialData, username }: DashboardClie
               exportData={{
                 stats: initialData.stats,
                 languages: initialData.languages,
+                activity: initialData.activity,
               }}
             />
             <Achievements achievements={initialData.achievements} />
@@ -540,6 +541,7 @@ export default function DashboardClient({ initialData, username }: DashboardClie
                 exportData={{
                   stats: initialData.stats,
                   languages: initialData.languages,
+                  activity: initialData.activity,
                 }}
                 badges={badgesA}
               />
@@ -562,6 +564,7 @@ export default function DashboardClient({ initialData, username }: DashboardClie
                 exportData={{
                   stats: secondUserData.stats,
                   languages: secondUserData.languages,
+                  activity: secondUserData.activity,
                 }}
                 badges={badgesB}
               />

--- a/components/dashboard/ShareSheet.test.tsx
+++ b/components/dashboard/ShareSheet.test.tsx
@@ -46,6 +46,10 @@ describe('ShareSheet', () => {
         { name: 'TypeScript', percentage: 72, color: '#3178c6' },
         { name: 'JavaScript', percentage: 28, color: '#f1e05a' },
       ],
+      activity: [
+        { date: '2026-05-01', count: 3, intensity: 2 as const },
+        { date: '2026-05-02', count: 0, intensity: 0 as const },
+      ],
     },
   };
 
@@ -89,6 +93,7 @@ describe('ShareSheet', () => {
     expect(screen.getByText('Copy Link')).toBeDefined();
     expect(screen.getByText('Share on X')).toBeDefined();
     expect(screen.getByText('Download JSON')).toBeDefined();
+    expect(screen.getByText('Download CSV')).toBeDefined();
   });
   it('renders close button with correct aria-label and calls onClose', () => {
     render(<ShareSheet {...defaultProps} />);
@@ -254,6 +259,31 @@ describe('ShareSheet', () => {
     document.body.removeChild(mockRoot);
   });
 
+  it('downloads dashboard data as CSV', async () => {
+    render(<ShareSheet {...defaultProps} />);
+
+    const csvButton = screen.getByText('Download CSV').closest('button');
+    fireEvent.click(csvButton!);
+
+    const blob = vi.mocked(URL.createObjectURL).mock.calls[0][0] as Blob;
+    const csv = await blob.text();
+
+    expect(blob.type).toBe('text/csv;charset=utf-8');
+    expect(csv).toContain('username,octocat');
+    expect(csv).toContain('totalContributions,365');
+    expect(csv).toContain('currentStreak,7');
+    expect(csv).toContain('longestStreak,14');
+    expect(csv).toContain('date,dailyContributionCount,intensity');
+    expect(csv).toContain('2026-05-01,3,2');
+
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-download');
+
+    await waitFor(() => {
+      expect(screen.getByText('CSV Downloaded!')).toBeDefined();
+    });
+  });
+
   it('downloads dashboard data as formatted JSON', async () => {
     render(<ShareSheet {...defaultProps} />);
 
@@ -271,6 +301,11 @@ describe('ShareSheet', () => {
       topLanguages: defaultProps.exportData.languages,
     });
     expect(json.profileUrl).toContain('/octocat');
+    expect(json.contributionDates).toEqual(['2026-05-01', '2026-05-02']);
+    expect(json.dailyContributions).toEqual([
+      { date: '2026-05-01', count: 3, intensity: 2 },
+      { date: '2026-05-02', count: 0, intensity: 0 },
+    ]);
     expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-download');
 

--- a/components/dashboard/ShareSheet.tsx
+++ b/components/dashboard/ShareSheet.tsx
@@ -7,6 +7,7 @@ import {
   Code,
   Download,
   FileJson,
+  FileText,
   Link2,
   Loader2,
   Share2,
@@ -59,6 +60,7 @@ export default function ShareSheet({ username, isOpen, onClose, exportData }: Sh
     handleDownloadWEBP,
     handleDownloadSVG,
     handleCopyMarkdown,
+    handleDownloadCSV,
     handleDownloadJSON,
     handleNativeShare,
   } = useShareActions(username, exportData, onClose);
@@ -209,6 +211,15 @@ endsolid commitpulse_monolith`;
       action: handleDownloadSTL,
     },
     {
+      key: 'csv',
+      icon: FileText,
+      label: 'Download CSV',
+      description: 'Export stats and daily contribution counts',
+      gradient: 'bg-zinc-800',
+      glow: 'transparent',
+      action: handleDownloadCSV,
+    },
+    {
       key: 'json',
       icon: FileJson,
       label: 'Download JSON',
@@ -320,13 +331,15 @@ endsolid commitpulse_monolith`;
                                 ? 'Link Copied!'
                                 : opt.key === 'png'
                                   ? 'Downloaded!'
-                                  : opt.key === 'json'
-                                    ? 'JSON Downloaded!'
-                                    : opt.key === 'svg'
-                                      ? 'SVG Downloaded!'
-                                      : opt.key === 'stl'
-                                        ? 'STL Generated!'
-                                        : opt.label
+                                  : opt.key === 'csv'
+                                    ? 'CSV Downloaded!'
+                                    : opt.key === 'json'
+                                      ? 'JSON Downloaded!'
+                                      : opt.key === 'svg'
+                                        ? 'SVG Downloaded!'
+                                        : opt.key === 'stl'
+                                          ? 'STL Generated!'
+                                          : opt.label
                               : state === 'error'
                                 ? 'Failed — try again'
                                 : opt.label}

--- a/hooks/useShareActions.ts
+++ b/hooks/useShareActions.ts
@@ -167,25 +167,86 @@ export function useShareActions(
     }
   };
 
+  const downloadTextFile = (content: string, filename: string, type: string) => {
+    const blob = new Blob([content], { type });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+
+    link.download = filename;
+    link.href = url;
+    link.click();
+
+    URL.revokeObjectURL(url);
+  };
+
+  const escapeCsvValue = (value: string | number | null | undefined): string => {
+    const stringValue = value == null ? '' : String(value);
+
+    if (/[",\n\r]/.test(stringValue)) {
+      return `"${stringValue.replace(/"/g, '""')}"`;
+    }
+
+    return stringValue;
+  };
+
+  const handleDownloadCSV = () => {
+    setOptionState('csv', 'loading');
+
+    try {
+      const exportedAt = new Date().toISOString();
+      const dailyActivity = exportData.activity ?? [];
+
+      const rows: Array<Array<string | number>> = [
+        ['field', 'value'],
+        ['username', username],
+        ['profileUrl', PROFILE_URL(username)],
+        ['exportedAt', exportedAt],
+        ['totalContributions', exportData.stats.totalContributions],
+        ['currentStreak', exportData.stats.currentStreak],
+        ['longestStreak', exportData.stats.peakStreak],
+        [],
+        ['date', 'dailyContributionCount', 'intensity'],
+        ...dailyActivity.map((day) => [day.date, day.count, day.intensity]),
+      ];
+
+      const csv = rows.map((row) => row.map(escapeCsvValue).join(',')).join('\n');
+
+      downloadTextFile(csv, `commitpulse-${username}-stats.csv`, 'text/csv;charset=utf-8');
+
+      setOptionState('csv', 'success');
+    } catch {
+      setOptionState('csv', 'error');
+    }
+  };
+
   const handleDownloadJSON = () => {
     setOptionState('json', 'loading');
+
     try {
+      const dailyContributions = (exportData.activity ?? []).map((day) => ({
+        date: day.date,
+        count: day.count,
+        intensity: day.intensity,
+      }));
+
       const payload = {
         username,
         profileUrl: PROFILE_URL(username),
         exportedAt: new Date().toISOString(),
+        totalContributions: exportData.stats.totalContributions,
         currentStreak: exportData.stats.currentStreak,
         longestStreak: exportData.stats.peakStreak,
-        totalContributions: exportData.stats.totalContributions,
+        contributionDates: dailyContributions.map((day) => day.date),
+        dailyContributions,
         topLanguages: exportData.languages,
       };
-      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.download = `commitpulse-${username}.json`;
-      link.href = url;
-      link.click();
-      URL.revokeObjectURL(url);
+
+      downloadTextFile(
+        JSON.stringify(payload, null, 2),
+        `commitpulse-${username}-stats.json`,
+        'application/json'
+      );
+
       setOptionState('json', 'success');
     } catch {
       setOptionState('json', 'error');
@@ -227,6 +288,7 @@ export function useShareActions(
     handleDownloadWEBP,
     handleDownloadSVG,
     handleCopyMarkdown,
+    handleDownloadCSV,
     handleDownloadJSON,
     handleNativeShare,
   };

--- a/types/dashboard.ts
+++ b/types/dashboard.ts
@@ -69,6 +69,7 @@ export interface CommitClockData {
 export interface DashboardExportData {
   stats: UserStats;
   languages: LanguageData[];
+  activity?: ActivityData[];
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Description
Added CSV and JSON export support for contribution statistics from the Share Pulse sheet.

This PR allows users to export their CommitPulse contribution stats with useful fields such as username, profile URL, total contributions, current streak, longest streak, daily contribution counts, and top languages.

Fixes #997 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — this PR adds CSV/JSON export functionality in the existing Share Pulse sheet and does not change SVG output or visual design.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

## What changed

- Added CSV export option in the Share Pulse sheet
- Improved JSON export payload with daily contribution data
- Added export support for activity data
- Passed activity data into share/export flow
- Added test coverage for CSV export
- Kept implementation dependency-free using browser Blob downloads

## Testing

- npm test -- components/dashboard/ShareSheet.test.tsx
- npm run typecheck
- npm run lint
   - Passed with 0 errors
   - 2 existing warnings in components/dashboard/ComparisonStatsCard.test.tsx, unrelated to this PR