### PR TITLE
test(i18n): verify getLabels returns COMMITS_THIS_MONTH for all supported locales

### DIFF
--- a/lib/i18n/badgeLabels.test.ts
+++ b/lib/i18n/badgeLabels.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { getLabels } from './badgeLabels';
+
+describe('getLabels', () => {
+  describe('COMMITS_THIS_MONTH', () => {
+    it('returns correct label for en', () => {
+      expect(getLabels('en').COMMITS_THIS_MONTH).toBe('COMMITS THIS MONTH');
+    });
+
+    it('returns correct label for es', () => {
+      expect(getLabels('es').COMMITS_THIS_MONTH).toBe('COMMITS ESTE MES');
+    });
+
+    it('returns correct label for de', () => {
+      expect(getLabels('de').COMMITS_THIS_MONTH).toBe('COMMITS DIESEN MONAT');
+    });
+
+    it('returns correct label for ja', () => {
+      expect(getLabels('ja').COMMITS_THIS_MONTH).toBe('今月のコミット数');
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1079 

Added 4 dedicated unit tests to `lib/i18n/badgeLabels.test.ts` to verify the behavior of the `getLabels` function. This ensures the function correctly returns the newly added `COMMITS_THIS_MONTH` locale-specific text for English (`en`), Spanish (`es`), German (`de`), and Japanese (`ja`).

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs, tests)

## Visual Preview
N/A (Unit tests only).

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions.