### PR TITLE
feat(ui): Add GitHub Action workflow generator to Export Panel

### DIFF
--- a/app/customize/components/ExportPanel.tsx
+++ b/app/customize/components/ExportPanel.tsx
@@ -6,6 +6,7 @@ import { getPlaceholderSnippet } from '../utils';
 const EXPORT_FORMATS: { value: ExportFormat; label: string }[] = [
   { value: 'markdown', label: 'Markdown' },
   { value: 'html', label: 'HTML' },
+  { value: 'action', label: 'GitHub Action' },
 ];
 
 export function ExportPanel({
@@ -26,9 +27,12 @@ export function ExportPanel({
   onCopy: () => void | Promise<void>;
 }): ReactElement {
   const activeSnippet = hasUsername ? snippet : getPlaceholderSnippet(format);
-  const formatLabel = format === 'markdown' ? 'Markdown' : 'HTML';
+  const formatLabel =
+    format === 'markdown' ? 'Markdown' : format === 'action' ? 'GitHub Action' : 'HTML';
   const copyButtonLabel = hasUsername
-    ? `Copy ${formatLabel} export snippet to clipboard`
+    ? format === 'action'
+      ? 'Copy GitHub Action workflow to clipboard'
+      : `Copy ${formatLabel} export snippet to clipboard`
     : `Add a GitHub username to enable copying the ${formatLabel} export snippet`;
 
   // Track async server download states
@@ -242,7 +246,7 @@ export function ExportPanel({
                   <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
                   <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
                 </svg>
-                Copy {formatLabel}
+                Copy {format === 'action' ? 'workflow' : formatLabel}
               </>
             )}
           </button>
@@ -265,11 +269,58 @@ export function ExportPanel({
         </code>
       </div>
 
-      <p className="mt-4 text-[11px] text-gray-500 dark:text-white/20 leading-relaxed">
-        Paste this into your GitHub profile&apos;s{' '}
-        <code className="text-gray-700 dark:text-white/35">README.md</code>. The badge renders
-        server-side, no script required.
-      </p>
+      <div className="mt-4 text-[11px] text-gray-500 dark:text-white/20 leading-relaxed space-y-3">
+        {format === 'action' ? (
+          <>
+            <p>
+              <strong>Step 1:</strong> Save the workflow snippet above as{' '}
+              <code className="text-gray-700 dark:text-white/35">
+                .github/workflows/commitpulse.yml
+              </code>{' '}
+              to automatically fetch and commit your customized badge.
+            </p>
+            <p>
+              <strong>Step 2:</strong> Embed the generated SVG into your{' '}
+              <code className="text-gray-700 dark:text-white/35">README.md</code> using the markdown
+              below:
+            </p>
+            <div className="mt-2 bg-gray-100/80 dark:bg-white/[0.03] border border-black/10 dark:border-white/10 rounded-lg px-3 py-2 flex items-center justify-between group">
+              <code className="text-emerald-600 dark:text-emerald-300 font-mono select-all">
+                ![CommitPulse](commitpulse.svg)
+              </code>
+              <button
+                type="button"
+                onClick={() => {
+                  navigator.clipboard.writeText('![CommitPulse](commitpulse.svg)');
+                }}
+                className="text-gray-400 hover:text-emerald-500 transition-colors"
+                title="Copy Step 2 markdown"
+                aria-label="Copy Step 2 markdown snippet"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-3.5 w-3.5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                </svg>
+              </button>
+            </div>
+          </>
+        ) : (
+          <p>
+            Paste this into your GitHub profile&apos;s{' '}
+            <code className="text-gray-700 dark:text-white/35">README.md</code>. The badge renders
+            server-side, no script required.
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/app/customize/types.ts
+++ b/app/customize/types.ts
@@ -2,7 +2,7 @@ import { themes } from '../../lib/svg/themes';
 
 export type Scale = 'linear' | 'log';
 
-export type ExportFormat = 'markdown' | 'html';
+export type ExportFormat = 'markdown' | 'html' | 'action';
 
 export type ThemeKey = Extract<keyof typeof themes, string>;
 

--- a/app/customize/utils.test.ts
+++ b/app/customize/utils.test.ts
@@ -25,6 +25,16 @@ describe('Export Snippet utilities', () => {
       expect(result).toBe(`<img src="${EXPECTED_BASE_URL}?${queryString}" alt="CommitPulse" />`);
     });
 
+    it('generates action snippet', () => {
+      const queryString = 'user=testuser&theme=dark';
+      const result = getExportSnippet('action', queryString);
+
+      expect(typeof result).toBe('string');
+      expect(result.startsWith('name: CommitPulse Streak Badge')).toBe(true);
+      expect(result).toContain(EXPECTED_BASE_URL);
+      expect(result).toContain(`curl -o commitpulse.svg "${EXPECTED_BASE_URL}?${queryString}"`);
+    });
+
     it('handles empty query string', () => {
       const emptyQuery = '';
       const markdownResult = getExportSnippet('markdown', emptyQuery);
@@ -44,6 +54,11 @@ describe('Export Snippet utilities', () => {
       expect(result).toContain(complexQuery);
       expect(result).toBe(`![CommitPulse](${EXPECTED_BASE_URL}?${complexQuery})`);
     });
+
+    it('throws error for unknown format', () => {
+      // @ts-expect-error Testing invalid format at runtime
+      expect(() => getExportSnippet('unknown', '')).toThrow('Unsupported export format: unknown');
+    });
   });
 
   describe('getPlaceholderSnippet', () => {
@@ -59,6 +74,14 @@ describe('Export Snippet utilities', () => {
       const result = getPlaceholderSnippet('html');
 
       expect(result.startsWith('<img src=')).toBe(true);
+      expect(result).toContain('your-github-username');
+      expect(result).toContain(EXPECTED_BASE_URL);
+    });
+
+    it('includes placeholder username in action', () => {
+      const result = getPlaceholderSnippet('action');
+
+      expect(result.startsWith('name: CommitPulse Streak Badge')).toBe(true);
       expect(result).toContain('your-github-username');
       expect(result).toContain(EXPECTED_BASE_URL);
     });

--- a/app/customize/utils.ts
+++ b/app/customize/utils.ts
@@ -30,7 +30,36 @@ export function getExportSnippet(format: ExportFormat, queryString: string): str
     return `<img src="${badgeUrl}" alt="CommitPulse" />`;
   }
 
-  return `![CommitPulse](${badgeUrl})`;
+  if (format === 'action') {
+    return [
+      'name: CommitPulse Streak Badge',
+      '',
+      'on:',
+      '  schedule:',
+      "    - cron: '0 0 * * *' # Runs daily at midnight",
+      '  workflow_dispatch:',
+      '',
+      'jobs:',
+      '  update-badge:',
+      '    runs-on: ubuntu-latest',
+      '    steps:',
+      '      - uses: actions/checkout@v4',
+      '      - name: Fetch CommitPulse Badge',
+      `        run: curl -o commitpulse.svg "${badgeUrl}"`,
+      '      - name: Commit Badge',
+      '        uses: stefanzweifel/git-auto-commit-action@v5',
+      '        with:',
+      '          commit_message: "chore: update CommitPulse badge"',
+      '          file_pattern: commitpulse.svg',
+    ].join('\n');
+  }
+
+  if (format === 'markdown') {
+    return `![CommitPulse](${badgeUrl})`;
+  }
+
+  // Defensive fallback for any unexpected formats (though TS should catch this)
+  throw new Error(`Unsupported export format: ${format}`);
 }
 
 export function getPlaceholderSnippet(format: ExportFormat): string {


### PR DESCRIPTION
## Description

Adds a "GitHub Action" tab to the Customization Studio Export Panel. This allows users to easily generate a ready-to-use `.github/workflows/commitpulse.yml` script that uses `curl` on a cron schedule to fetch their configured badge and commit the static SVG directly into their repo, saving Vercel serverless executions and GitHub API quota.

Fixes #583 

**Key updates:**
- Added the `action` format to `ExportFormat` in `types.ts`.
- Updated `getExportSnippet()` in `utils.ts` to output a properly indented YAML workflow template.
- Separated the export instructions into two distinct steps (save workflow vs. embed in README) in `ExportPanel.tsx`.
- Refined the copy functionality to include a dedicated copy button for the Markdown embed step, and renamed the primary copy button to "Copy workflow" for a cleaner layout.
- Added comprehensive unit tests in `utils.test.ts` to cover the new YAML format and unknown format fallbacks.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

<img width="1075" height="1163" alt="image" src="https://github.com/user-attachments/assets/cdbbd3ff-8844-45f3-b644-93994ca31266" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
