### PR TITLE
feat(customize): expose timezone control

### DIFF
--- a/app/customize/components/ControlsPanel.test.tsx
+++ b/app/customize/components/ControlsPanel.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ControlsPanel } from './ControlsPanel';
+import type { BadgeSize, DeltaFormat, Font, Language, Scale, Timezone, ViewMode } from '../types';
+
+const defaultProps = {
+  username: 'octocat',
+  theme: 'dark',
+  bgHex: '',
+  accentHex: '',
+  textHex: '',
+  scale: 'linear' as Scale,
+  speed: '8s',
+  font: '' as Font,
+  year: '',
+  radius: 8,
+  size: 'medium' as BadgeSize,
+  onUsernameChange: vi.fn(),
+  onThemeChange: vi.fn(),
+  onBgHexChange: vi.fn(),
+  onAccentHexChange: vi.fn(),
+  onTextHexChange: vi.fn(),
+  onScaleChange: vi.fn(),
+  onSpeedChange: vi.fn(),
+  onFontChange: vi.fn(),
+  onYearChange: vi.fn(),
+  onSizeChange: vi.fn(),
+  onClearOverrides: vi.fn(),
+  onRadiusChange: vi.fn(),
+  hideTitle: false,
+  hideBackground: false,
+  hideStats: false,
+  viewMode: 'default' as ViewMode,
+  deltaFormat: 'percent' as DeltaFormat,
+  badgeWidth: '' as const,
+  badgeHeight: '' as const,
+  grace: 1,
+  language: 'en' as Language,
+  timezone: 'UTC' as Timezone,
+  onHideTitleChange: vi.fn(),
+  onHideBackgroundChange: vi.fn(),
+  onHideStatsChange: vi.fn(),
+  onViewModeChange: vi.fn(),
+  onDeltaFormatChange: vi.fn(),
+  onBadgeWidthChange: vi.fn(),
+  onBadgeHeightChange: vi.fn(),
+  onGraceChange: vi.fn(),
+  onLanguageChange: vi.fn(),
+  onTimezoneChange: vi.fn(),
+} satisfies ComponentProps<typeof ControlsPanel>;
+
+describe('ControlsPanel timezone control', () => {
+  it('renders UTC as the default timezone option', () => {
+    render(<ControlsPanel {...defaultProps} />);
+
+    expect((screen.getByLabelText('Timezone') as HTMLSelectElement).value).toBe('UTC');
+  });
+
+  it('calls onTimezoneChange with the selected IANA timezone', () => {
+    const onTimezoneChange = vi.fn();
+    render(<ControlsPanel {...defaultProps} onTimezoneChange={onTimezoneChange} />);
+
+    fireEvent.change(screen.getByLabelText('Timezone'), {
+      target: { value: 'Asia/Kolkata' },
+    });
+
+    expect(onTimezoneChange).toHaveBeenCalledWith('Asia/Kolkata');
+  });
+});

--- a/app/customize/components/ControlsPanel.tsx
+++ b/app/customize/components/ControlsPanel.tsx
@@ -4,6 +4,7 @@ import {
   SIZES,
   SPEEDS,
   LANGUAGES,
+  TIMEZONES,
   VIEW_MODES,
   DELTA_FORMATS,
   type BadgeSize,
@@ -12,6 +13,7 @@ import {
   type ViewMode,
   type DeltaFormat,
   type Language,
+  type Timezone,
 } from '../types';
 import { isValidHex, stripHash } from '../utils';
 import { SectionLabel } from './SectionLabel';
@@ -123,6 +125,7 @@ export function ControlsPanel({
   badgeHeight,
   grace,
   language,
+  timezone,
   onHideTitleChange,
   onHideBackgroundChange,
   onHideStatsChange,
@@ -132,6 +135,7 @@ export function ControlsPanel({
   onBadgeHeightChange,
   onGraceChange,
   onLanguageChange,
+  onTimezoneChange,
 }: {
   username: string;
   theme: string;
@@ -165,6 +169,7 @@ export function ControlsPanel({
   badgeHeight: number | '';
   grace: number;
   language: Language;
+  timezone: Timezone;
   onHideTitleChange: (value: boolean) => void;
   onHideBackgroundChange: (value: boolean) => void;
   onHideStatsChange: (value: boolean) => void;
@@ -174,6 +179,7 @@ export function ControlsPanel({
   onBadgeHeightChange: (value: number | '') => void;
   onGraceChange: (value: number) => void;
   onLanguageChange: (value: Language) => void;
+  onTimezoneChange: (value: Timezone) => void;
 }): ReactElement {
   const hasOverrides = Boolean(bgHex || accentHex || textHex);
   const currentYear = new Date().getFullYear();
@@ -530,6 +536,23 @@ export function ControlsPanel({
                   {LANGUAGES.map((lang) => (
                     <option key={lang.value} value={lang.value}>
                       {lang.label}
+                    </option>
+                  ))}
+                </StyledSelect>
+              </div>
+            </ControlRow>
+
+            <ControlRow label="Timezone">
+              <div className="relative">
+                <StyledSelect
+                  id="timezone-select"
+                  ariaLabel="Timezone"
+                  value={timezone}
+                  onChange={(v) => onTimezoneChange(v as Timezone)}
+                >
+                  {TIMEZONES.map((tz) => (
+                    <option key={tz.value} value={tz.value}>
+                      {tz.label}
                     </option>
                   ))}
                 </StyledSelect>

--- a/app/customize/components/ThemeSelector.tsx
+++ b/app/customize/components/ThemeSelector.tsx
@@ -9,15 +9,18 @@ function StyledSelect({
   value,
   onChange,
   children,
+  ariaLabel,
 }: {
   id: string;
   value: string;
   onChange: (v: string) => void;
   children: ReactNode;
+  ariaLabel?: string;
 }): ReactElement {
   return (
     <select
       id={id}
+      aria-label={ariaLabel}
       value={value}
       onChange={(e) => onChange(e.target.value)}
       className="w-full bg-gray-100/80 backdrop-blur-md border border-black/10 dark:bg-white/[0.03] dark:border-white/10 rounded-xl px-4 py-2.5 text-sm text-black dark:text-white outline-none focus:border-emerald-500/50 transition-colors appearance-none cursor-pointer [color-scheme:light] dark:[color-scheme:dark] [&>option]:bg-white [&>option]:text-black dark:[&>option]:bg-[#0a0a0a] dark:[&>option]:text-white"

--- a/app/customize/page.test.tsx
+++ b/app/customize/page.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { AnchorHTMLAttributes, HTMLAttributes, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import CustomizePage from './page';
+
+type MockLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  children?: ReactNode;
+  href: string;
+};
+
+type MockContainerProps = HTMLAttributes<HTMLElement> & {
+  children?: ReactNode;
+};
+
+type MockControlsPanelProps = {
+  username: string;
+  timezone: string;
+  onUsernameChange: (value: string) => void;
+  onTimezoneChange: (value: string) => void;
+};
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: MockLinkProps) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    aside: ({ children, ...props }: MockContainerProps) => <aside {...props}>{children}</aside>,
+    div: ({ children, ...props }: MockContainerProps) => <div {...props}>{children}</div>,
+  },
+}));
+
+vi.mock('@/components/InteractiveViewer', () => ({
+  default: ({ children, ...props }: MockContainerProps) => <div {...props}>{children}</div>,
+}));
+
+vi.mock('./components/ControlsPanel', () => ({
+  ControlsPanel: ({
+    username,
+    timezone,
+    onUsernameChange,
+    onTimezoneChange,
+  }: MockControlsPanelProps) => (
+    <div>
+      <input
+        aria-label="Mock username"
+        value={username}
+        onChange={(event) => onUsernameChange(event.currentTarget.value)}
+      />
+      <select
+        aria-label="Mock timezone"
+        value={timezone}
+        onChange={(event) => onTimezoneChange(event.currentTarget.value)}
+      >
+        <option value="UTC">UTC</option>
+        <option value="Asia/Kolkata">Asia/Kolkata</option>
+      </select>
+    </div>
+  ),
+}));
+
+vi.mock('./components/ExportPanel', () => ({
+  ExportPanel: ({ snippet }: { snippet: string }) => (
+    <output aria-label="Mock export snippet">{snippet}</output>
+  ),
+}));
+
+describe('CustomizePage timezone query params', () => {
+  it('omits the default UTC timezone from export snippets', () => {
+    render(<CustomizePage />);
+
+    fireEvent.change(screen.getByLabelText('Mock username'), {
+      target: { value: 'octocat' },
+    });
+
+    const snippet = screen.getByLabelText('Mock export snippet').textContent;
+    expect(snippet).toContain('user=octocat');
+    expect(snippet).not.toContain('tz=');
+  });
+
+  it('adds a selected non-default timezone to export snippets', () => {
+    render(<CustomizePage />);
+
+    fireEvent.change(screen.getByLabelText('Mock username'), {
+      target: { value: 'octocat' },
+    });
+    fireEvent.change(screen.getByLabelText('Mock timezone'), {
+      target: { value: 'Asia/Kolkata' },
+    });
+
+    const snippet = screen.getByLabelText('Mock export snippet').textContent;
+    expect(snippet).toContain('user=octocat');
+    expect(snippet).toContain('tz=Asia%2FKolkata');
+  });
+});

--- a/app/customize/page.tsx
+++ b/app/customize/page.tsx
@@ -14,6 +14,7 @@ import type {
   ViewMode,
   DeltaFormat,
   Language,
+  Timezone,
 } from './types';
 import { getExportSnippet, stripHash } from './utils';
 
@@ -40,6 +41,7 @@ export default function CustomizePage(): ReactElement {
   const [badgeHeight, setBadgeHeight] = useState<number | ''>('');
   const [grace, setGrace] = useState<number>(1);
   const [language, setLanguage] = useState<Language>('en');
+  const [timezone, setTimezone] = useState<Timezone>('UTC');
   const [exportFormat, setExportFormat] = useState<ExportFormat>('markdown');
   const [copied, setCopied] = useState(false);
   const [copyStatusMessage, setCopyStatusMessage] = useState('');
@@ -123,6 +125,7 @@ export default function CustomizePage(): ReactElement {
     if (badgeHeight !== '') params.set('height', badgeHeight.toString());
     if (grace !== 1) params.set('grace', grace.toString());
     if (language !== 'en') params.set('lang', language);
+    if (timezone !== 'UTC') params.set('tz', timezone);
 
     return params.toString();
   }, [
@@ -148,6 +151,7 @@ export default function CustomizePage(): ReactElement {
     badgeHeight,
     grace,
     language,
+    timezone,
   ]);
 
   const queryString = buildQueryParams();
@@ -331,6 +335,7 @@ export default function CustomizePage(): ReactElement {
               badgeHeight={badgeHeight}
               grace={grace}
               language={language}
+              timezone={timezone}
               onHideTitleChange={setHideTitle}
               onHideBackgroundChange={setHideBackground}
               onHideStatsChange={setHideStats}
@@ -340,6 +345,7 @@ export default function CustomizePage(): ReactElement {
               onBadgeHeightChange={setBadgeHeight}
               onGraceChange={setGrace}
               onLanguageChange={setLanguage}
+              onTimezoneChange={setTimezone}
             />
           </motion.aside>
 

--- a/app/customize/types.test.ts
+++ b/app/customize/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { THEME_KEYS } from './types';
+import { THEME_KEYS, TIMEZONES } from './types';
 import { themes } from '../../lib/svg/themes';
 
 describe('Theme Keys Synchronization', () => {
@@ -13,5 +13,16 @@ describe('Theme Keys Synchronization', () => {
 
     // 3. Assert they are 100% identical (no missing keys, no extra obsolete keys)
     expect(sortedActual).toEqual(sortedExpected);
+  });
+});
+
+describe('Timezone options', () => {
+  it('uses UTC as the default timezone option', () => {
+    expect(TIMEZONES[0]).toEqual({ value: 'UTC', label: 'UTC (Default)' });
+  });
+
+  it('contains unique IANA timezone values', () => {
+    const values = TIMEZONES.map((tz) => tz.value);
+    expect(new Set(values).size).toBe(values.length);
   });
 });

--- a/app/customize/types.ts
+++ b/app/customize/types.ts
@@ -63,3 +63,16 @@ export const LANGUAGES = [
 ] as const satisfies readonly { value: string; label: string }[];
 
 export type Language = (typeof LANGUAGES)[number]['value'];
+
+export const TIMEZONES = [
+  { value: 'UTC', label: 'UTC (Default)' },
+  { value: 'America/New_York', label: 'New York' },
+  { value: 'America/Los_Angeles', label: 'Los Angeles' },
+  { value: 'Europe/London', label: 'London' },
+  { value: 'Europe/Berlin', label: 'Berlin' },
+  { value: 'Asia/Kolkata', label: 'Kolkata' },
+  { value: 'Asia/Tokyo', label: 'Tokyo' },
+  { value: 'Australia/Sydney', label: 'Sydney' },
+] as const satisfies readonly { value: string; label: string }[];
+
+export type Timezone = (typeof TIMEZONES)[number]['value'];


### PR DESCRIPTION
## Description

Adds a timezone control to the Customization Studio so users can configure the existing `tz` API parameter from the UI instead of manually editing generated badge URLs.

Fixes #1309

## Pillar

Pillar 3: Timezone logic optimization.

## Visual Preview

Customization Studio > Advanced Settings now includes a Timezone dropdown with UTC default and common IANA timezone presets such as Asia/Kolkata, America/New_York, and Europe/London. The generated export snippet behavior is covered by tests: `UTC` is omitted by default, and non-default selections append `tz=Asia%2FKolkata`.

## Checklist before requesting a review:

- [x] I have read the contributing guidelines.
- [x] I have linked the related issue.
- [x] I have kept the change scoped to one concern.
- [x] I have added focused tests for the change.
- [x] I have run the relevant verification commands.

## What

The Customization Studio now exposes a curated timezone selector in Advanced Settings and only emits `tz` in generated URLs when the selected timezone is not the default `UTC`.

## How

Added shared timezone options/types, wired timezone state through `CustomizePage` into `ControlsPanel`, extended the shared select wrapper with an optional accessible label, and added component/page tests for the default and non-default timezone query behavior.

## Testing

- `npm test -- app/customize/types.test.ts app/customize/components/ControlsPanel.test.tsx app/customize/page.test.tsx`
- `npm run typecheck`
- `npm run lint` passes with existing unrelated warnings in `components/dashboard/ComparisonStatsCard.test.tsx`
- `npm run format:check`
- `npm run build`

Full `npm test` is currently blocked by an existing unrelated navbar test failure: `app/components/navbar.test.tsx` throws `TypeError: Cannot read properties of undefined (reading 'getItem')` at `app/components/navbar.tsx:35`. This matches existing tracked navbar work (#1287 / #1292), so I did not broaden this PR into that fix.

## Risks / Notes

The selector intentionally uses a curated list of valid IANA timezone values rather than a free-form input, so users cannot generate invalid `tz` values from the UI. More timezone options can be added later without changing the query-string behavior.

Current Vercel check is blocked by deployment authorization (`Authorization required to deploy`), which is unrelated to this code change.
