### PR TITLE
Test layout helper functions

### DIFF
--- a/lib/svg/layout.test.ts
+++ b/lib/svg/layout.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { computeTowers } from './layout';
+import { computeTowers, computeFaceOpacity, computeTowerHeight } from './layout';
 import type { ContributionCalendar } from '../../types';
+import {
+  GHOST_HEIGHT_PX,
+  LOG_SCALE_MULTIPLIER,
+  LINEAR_SCALE_MULTIPLIER,
+  MAX_LOG_HEIGHT,
+  MAX_LINEAR_HEIGHT,
+} from './layoutConstants';
 
 describe('computeTowers edge cases', () => {
   it('adds TODAY prefix for today tower with commits', () => {
@@ -98,7 +105,7 @@ describe('computeTowers edge cases', () => {
     } as unknown as ContributionCalendar;
     const towers = computeTowers(calendar, 'linear', '2024-06-10');
     expect(towers[0].isGhost).toBe(true);
-    expect(towers[0].h).toBe(4); // GHOST_HEIGHT_PX
+    expect(towers[0].h).toBe(GHOST_HEIGHT_PX); // GHOST_HEIGHT_PX
     expect(towers[0].strokeOpacity).toBe(0.3);
     expect(towers[0].strokeWidth).toBe(0.5);
     expect(towers[0].faceOpacity.top).toBe(0.08);
@@ -126,7 +133,7 @@ describe('computeTowers edge cases', () => {
 
     towers.forEach((tower) => {
       expect(tower.isGhost).toBe(true);
-      expect(tower.h).toBe(4); // GHOST_HEIGHT_PX
+      expect(tower.h).toBe(GHOST_HEIGHT_PX); // GHOST_HEIGHT_PX
       expect(tower.faceOpacity.top).toBe(0.08);
     });
   });
@@ -228,4 +235,68 @@ it('assigns correct row and col values based on week/day position', () => {
 
   expect(towers[3].row).toBe(1);
   expect(towers[3].col).toBe(0);
+});
+
+describe('computeFaceOpacity', () => {
+  it('returns ghost opacity in ghost city mode', () => {
+    expect(computeFaceOpacity(10, true)).toEqual({
+      left: 0,
+      right: 0,
+      top: 0.08,
+    });
+  });
+
+  it('returns ghost opacity for zero contributions', () => {
+    expect(computeFaceOpacity(0, false)).toEqual({
+      left: 0,
+      right: 0,
+      top: 0.08,
+    });
+  });
+
+  it('returns active opacity for low contribution count', () => {
+    expect(computeFaceOpacity(1, false)).toEqual({
+      left: 0.35,
+      right: 0.21,
+      top: 0.7,
+    });
+  });
+
+  it('returns active opacity for high contribution count', () => {
+    expect(computeFaceOpacity(999, false)).toEqual({
+      left: 0.35,
+      right: 0.21,
+      top: 0.7,
+    });
+  });
+});
+
+describe('computeTowerHeight', () => {
+  it('returns ghost height when ghost city mode is enabled', () => {
+    expect(computeTowerHeight(0, 'linear', true)).toBe(GHOST_HEIGHT_PX);
+  });
+
+  it('returns zero height when count is zero and ghost city mode is disabled', () => {
+    expect(computeTowerHeight(0, 'linear', false)).toBe(0);
+  });
+
+  it('computes linear scale height correctly', () => {
+    const expected = Math.min(5 * LINEAR_SCALE_MULTIPLIER, MAX_LINEAR_HEIGHT);
+
+    expect(computeTowerHeight(5, 'linear', false)).toBe(expected);
+  });
+
+  it('caps linear scale height at maximum', () => {
+    expect(computeTowerHeight(9999, 'linear', false)).toBe(MAX_LINEAR_HEIGHT);
+  });
+
+  it('computes logarithmic scale height correctly', () => {
+    const expected = Math.min(Math.log2(8 + 1) * LOG_SCALE_MULTIPLIER, MAX_LOG_HEIGHT);
+
+    expect(computeTowerHeight(8, 'log', false)).toBeCloseTo(expected);
+  });
+
+  it('caps logarithmic scale height at maximum', () => {
+    expect(computeTowerHeight(999999, 'log', false)).toBe(MAX_LOG_HEIGHT);
+  });
 });

--- a/lib/svg/layout.ts
+++ b/lib/svg/layout.ts
@@ -35,7 +35,7 @@ export interface TowerData {
   intensityLevel: number; // Quartile level (0 for no commits, 1 to 4 based on contribution intensity)
 }
 
-function computeTowerHeight(
+export function computeTowerHeight(
   count: number,
   scale: 'linear' | 'log',
   shouldShowGhostCity: boolean
@@ -47,7 +47,7 @@ function computeTowerHeight(
     : Math.min(count * LINEAR_SCALE_MULTIPLIER, MAX_LINEAR_HEIGHT);
 }
 
-function computeFaceOpacity(count: number, isGhostCityMode: boolean): FaceOpacity {
+export function computeFaceOpacity(count: number, isGhostCityMode: boolean): FaceOpacity {
   if (isGhostCityMode) {
     return { left: 0, right: 0, top: 0.08 };
   }


### PR DESCRIPTION
## Description

Fixes #294 
## Summary

Adds focused unit test coverage for `computeFaceOpacity` and `computeTowerHeight` in `lib/svg/layout.ts`.

## Changes Made

* Exported `computeFaceOpacity` and `computeTowerHeight` from `layout.ts`
* Added direct helper-level unit tests in `layout.test.ts`
* Added coverage for:

  * ghost city mode
  * zero contribution count
  * low/high contribution counts
  * linear scaling
  * logarithmic scaling
  * max-height clamping behavior

## Test Coverage Added

### `computeFaceOpacity`

* ghost opacity in ghost city mode
* zero-count opacity handling
* active opacity for low counts
* active opacity for high counts

### `computeTowerHeight`

* ghost height behavior
* zero-height behavior
* linear scale calculation
* linear scale clamping
* logarithmic scale calculation
* logarithmic scale clamping

## Result

* Added 8+ focused helper tests
* Existing integration tests preserved
* All tests passing successfully


## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
