### PR TITLE
refactor(i18n): add Simplified Chinese locale support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ URL Parameter > Theme Default > System Fallback
 | `hide_background` | `boolean` | No         | `false`                        | Remove the background rect, letting the monolith float on the page                                                                                                        |
 | `hide_stats`      | `boolean` | No         | `false`                        | Hides the bottom row displaying Current Streak, Annual Sync Total, and Peak Streak stats when set to `true` or `1`.                                                       |
 | `tz`              | `string`  | No         | Omitted = UTC                  | IANA timezone (e.g. `Asia/Kolkata`, `America/New_York`) — aligns "today" with the user local midnight. Note: `?tz=UTC` is valid but cached separately from omitting `tz`. |
-| `lang`            | `string`  | No         | `en`                           | Language code for labels (`en`, `es`, `hi`, `fr`, `pt`, `ko`, `ja`, `de`)                                                                                                 |
+| `lang`            | `string`  | No         | `en`                           | Language code for labels (`en`, `es`, `hi`, `fr`, `pt`, `ko`, `ja`, `de`, `zh`)                                                                                           |
 | `view`            | `string`  | No         | `default`                      | Rendering mode: `default` (3D Monolith) or `monthly` (Compact monthly stats)                                                                                              |
 | `delta_format`    | `string`  | No         | `percent`                      | Format for month-over-month delta in monthly view: `percent` (e.g. +12%), `absolute` (e.g. +15 commits), or `both`                                                        |
 | `width`           | `number`  | No         | `300`                          | Custom width for the SVG canvas (currently only applies to `view=monthly`)                                                                                                |
@@ -288,6 +288,10 @@ Explore some of the built-in CommitPulse themes and quickly copy the style you l
 <!-- Render labels in Hindi -->
 
 ![](https://commitpulse.vercel.app/api/streak?user=jhasourav07&lang=hi)
+
+<!-- Render labels in Simplified Chinese -->
+
+![](https://commitpulse.vercel.app/api/streak?user=jhasourav07&lang=zh)
 
 <!-- Large badge size -->
 

--- a/lib/i18n/badgeLabels.ts
+++ b/lib/i18n/badgeLabels.ts
@@ -14,6 +14,13 @@ export const labels: Record<string, BadgeLabels> = {
     COMMITS_THIS_MONTH: 'COMMITS THIS MONTH',
     VS_LAST_MONTH: 'vs last month',
   },
+  zh: {
+    CURRENT_STREAK: '当前连续记录',
+    ANNUAL_SYNC_TOTAL: '年度总计',
+    PEAK_STREAK: '最长连续记录',
+    COMMITS_THIS_MONTH: '本月提交次数',
+    VS_LAST_MONTH: '较上个月',
+  },
   es: {
     CURRENT_STREAK: 'RACHA_ACTUAL',
     ANNUAL_SYNC_TOTAL: 'TOTAL_ANUAL',


### PR DESCRIPTION
## Description

Fixes #316 
## Summary

Adds Simplified Chinese (`zh`) locale support to `badgeLabels`.

## Changes Made

* Added `zh` locale entries in `lib/i18n/badgeLabels.ts`
* Added Simplified Chinese translations for badge labels
* Updated README documentation for `?lang=zh`
* Added a README example demonstrating Chinese label rendering

## Result

* `?lang=zh` now renders badge labels in Simplified Chinese
* Formatting, linting, and tests all pass successfully



## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
