### PR TITLE
fix: replace alert() with toast.error() on badge download failure in ExportPanel

### DIFF
--- a/app/customize/components/ExportPanel.tsx
+++ b/app/customize/components/ExportPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { toast } from 'sonner';
 import type { ReactElement } from 'react';
 import type { ExportFormat } from '../types';
 import { getPlaceholderSnippet } from '../utils';
@@ -114,7 +115,7 @@ export function ExportPanel({
       URL.revokeObjectURL(downloadUrl);
     } catch (error) {
       console.error('Failed to download custom vector badge image asset:', error);
-      alert('Failed to download the badge asset directly from the server pipeline.');
+      toast.error('Failed to download the badge. Please try again.');
     } finally {
       setIsDownloading(false);
     }


### PR DESCRIPTION
Fixes #1321

## Description
`ExportPanel.tsx` used a native browser `alert()` dialog when the badge download failed:

alert('Failed to download the badge asset directly from the server pipeline.');

`alert()` is a blocking browser dialog that is visually inconsistent with the rest of the application. Replaced with `toast.error()` from `sonner` which is already used elsewhere in the codebase (e.g. `RefreshButton.tsx` uses `toast.success()`).

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — error handling change, no SVG output affected.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.