### PR TITLE
fix: rename downloaded badge SVG from internal dev name to commitpulse-{username}.svg

### DIFF
--- a/app/customize/components/ExportPanel.test.tsx
+++ b/app/customize/components/ExportPanel.test.tsx
@@ -13,6 +13,7 @@ describe('ExportPanel', () => {
         copied
         copyStatusMessage="Markdown snippet copied to clipboard."
         hasUsername
+        username="octocat"
         onFormatChange={vi.fn()}
         onCopy={onCopy}
       />

--- a/app/customize/components/ExportPanel.tsx
+++ b/app/customize/components/ExportPanel.tsx
@@ -14,6 +14,7 @@ export function ExportPanel({
   copied,
   copyStatusMessage,
   hasUsername,
+  username,
   onFormatChange,
   onCopy,
 }: {
@@ -22,6 +23,7 @@ export function ExportPanel({
   copied: boolean;
   copyStatusMessage: string;
   hasUsername: boolean;
+  username: string;
   onFormatChange: (format: ExportFormat) => void;
   onCopy: () => void | Promise<void>;
 }): ReactElement {
@@ -105,7 +107,7 @@ export function ExportPanel({
       const downloadUrl = URL.createObjectURL(blob);
       const downloadLink = document.createElement('a');
       downloadLink.href = downloadUrl;
-      downloadLink.download = `perfect-centered-monolith-${Date.now()}.svg`;
+      downloadLink.download = `commitpulse-${username || 'badge'}.svg`;
       document.body.appendChild(downloadLink);
       downloadLink.click();
 

--- a/app/customize/page.tsx
+++ b/app/customize/page.tsx
@@ -384,6 +384,7 @@ export default function CustomizePage(): ReactElement {
               copied={copied}
               copyStatusMessage={copyStatusMessage}
               hasUsername={hasUsername}
+              username={trimmedUsername}
               onFormatChange={setExportFormat}
               onCopy={copyExportSnippet}
             />


### PR DESCRIPTION
Fixes #1319

## Description
The downloaded badge SVG file was named with an internal development artifact name:

downloadLink.download = `perfect-centered-monolith-${Date.now()}.svg`;

Users downloading their custom badge received a file named something like `perfect-centered-monolith-1748530432123.svg`. This was clearly a development name that was never cleaned up before shipping.

Fixed by adding a `username` prop to `ExportPanel`, passing `trimmedUsername` from the customize page, and using it to generate a meaningful filename: `commitpulse-{username}.svg` — consistent with how `useShareActions.ts` names its downloads (`{username}-commitpulse.svg`).

**Files changed:** `app/customize/components/ExportPanel.tsx`, `app/customize/page.tsx`, `app/customize/components/ExportPanel.test.tsx`

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — filename change only, no SVG output affected.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.