### PR TITLE
fix(api): return 500 when MONGODB_URI is missing in production

### DIFF
--- a/app/api/track-user/route.test.ts
+++ b/app/api/track-user/route.test.ts
@@ -23,13 +23,28 @@ function makeRequest(body: Record<string, unknown>): Request {
 }
 
 describe('POST /api/track-user', () => {
+  let originalNodeEnv: string | undefined;
+  let originalMongoUri: string | undefined;
+
   beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    originalMongoUri = process.env.MONGODB_URI;
     vi.clearAllMocks();
   });
 
   afterEach(() => {
-    // Clean up environment variables
-    delete process.env.MONGODB_URI;
+    // Restore environment variables
+    if (originalNodeEnv === undefined) {
+      Reflect.deleteProperty(process.env, 'NODE_ENV');
+    } else {
+      Reflect.set(process.env, 'NODE_ENV', originalNodeEnv);
+    }
+
+    if (originalMongoUri === undefined) {
+      delete process.env.MONGODB_URI;
+    } else {
+      process.env.MONGODB_URI = originalMongoUri;
+    }
   });
 
   describe('Validation', () => {

--- a/app/api/track-user/route.test.ts
+++ b/app/api/track-user/route.test.ts
@@ -33,6 +33,8 @@ describe('POST /api/track-user', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
+
     // Restore environment variables
     if (originalNodeEnv === undefined) {
       Reflect.deleteProperty(process.env, 'NODE_ENV');
@@ -109,17 +111,10 @@ describe('POST /api/track-user', () => {
         'MONGODB_URI is not set. Bypassing user tracking for local development.'
       );
       expect(dbConnect).not.toHaveBeenCalled();
-
-      consoleSpy.mockRestore();
     });
   });
 
   describe('Without MONGODB_URI (Production Environment)', () => {
-    afterEach(() => {
-      // Clean up NODE_ENV after production tests
-      delete (process.env as Record<string, string | undefined>).NODE_ENV;
-    });
-
     it('returns 500 error when MONGODB_URI is missing in production', async () => {
       (process.env as Record<string, string | undefined>).NODE_ENV = 'production';
       delete process.env.MONGODB_URI;
@@ -142,8 +137,6 @@ describe('POST /api/track-user', () => {
 
       // Verify database connection was never attempted
       expect(dbConnect).not.toHaveBeenCalled();
-
-      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -171,7 +164,7 @@ describe('POST /api/track-user', () => {
     });
 
     it('returns 500 when database connection fails', async () => {
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
       vi.mocked(dbConnect).mockRejectedValueOnce(new Error('DB Down'));
 
       const response = await POST(makeRequest({ username: 'octocat' }));
@@ -180,8 +173,6 @@ describe('POST /api/track-user', () => {
       const data = await response.json();
       expect(data.success).toBe(false);
       expect(data.error).toBe('Internal server error');
-
-      consoleErrorSpy.mockRestore();
     });
 
     it('gracefully handles concurrent duplicate key (code 11000) race conditions', async () => {
@@ -201,8 +192,6 @@ describe('POST /api/track-user', () => {
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(consoleErrorSpy).not.toHaveBeenCalled();
-
-      consoleErrorSpy.mockRestore();
     });
 
     it('rethrows duplicate key (code 11000) error if it is not related to username', async () => {
@@ -225,8 +214,6 @@ describe('POST /api/track-user', () => {
       expect(data.success).toBe(false);
       expect(data.error).toBe('Internal server error');
       expect(consoleErrorSpy).toHaveBeenCalled();
-
-      consoleErrorSpy.mockRestore();
     });
   });
 });

--- a/app/api/track-user/route.test.ts
+++ b/app/api/track-user/route.test.ts
@@ -99,6 +99,39 @@ describe('POST /api/track-user', () => {
     });
   });
 
+  describe('Without MONGODB_URI (Production Environment)', () => {
+    afterEach(() => {
+      // Clean up NODE_ENV after production tests
+      delete (process.env as Record<string, string | undefined>).NODE_ENV;
+    });
+
+    it('returns 500 error when MONGODB_URI is missing in production', async () => {
+      (process.env as Record<string, string | undefined>).NODE_ENV = 'production';
+      delete process.env.MONGODB_URI;
+
+      // Spy on console.error
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const response = await POST(makeRequest({ username: 'octocat' }));
+
+      expect(response.status).toBe(500);
+      const data = await response.json();
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Database configuration error');
+      expect(data.bypassed).toBeUndefined();
+
+      // Verify critical error was logged for monitoring/alerting
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'CRITICAL: MONGODB_URI is not set in production environment. User tracking is disabled.'
+      );
+
+      // Verify database connection was never attempted
+      expect(dbConnect).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
   describe('With MONGODB_URI', () => {
     beforeEach(() => {
       process.env.MONGODB_URI = 'mongodb://localhost:27017/test';

--- a/app/api/track-user/route.ts
+++ b/app/api/track-user/route.ts
@@ -37,8 +37,20 @@ export async function POST(req: Request) {
 
     const trimmedUsername = username.trim().toLowerCase();
 
-    // If MONGODB_URI is not set, skip tracking to allow local development without a DB
+    // If MONGODB_URI is not set, handle based on environment
     if (!process.env.MONGODB_URI) {
+      // In production, this is a critical configuration failure
+      if (process.env.NODE_ENV === 'production') {
+        console.error(
+          'CRITICAL: MONGODB_URI is not set in production environment. User tracking is disabled.'
+        );
+        return NextResponse.json(
+          { success: false, error: 'Database configuration error' },
+          { status: 500 }
+        );
+      }
+
+      // For development/non-production environments, bypass gracefully
       console.warn('MONGODB_URI is not set. Bypassing user tracking for local development.');
       return NextResponse.json({ success: true, bypassed: true });
     }


### PR DESCRIPTION
## Description

Fixes #1273

This PR resolves a production configuration handling issue in the `/api/track-user` endpoint.

Previously, when `MONGODB_URI` was not configured, the API silently returned a successful response (`200 OK`) with `{ success: true, bypassed: true }` regardless of environment. While this behavior is useful for local development, it can hide critical deployment misconfigurations in production and prevent monitoring systems from detecting failures.

### Changes Made

* Return **HTTP 500** when `MONGODB_URI` is missing in production (`NODE_ENV === 'production'`).
* Log a clear `console.error()` message for improved observability and monitoring.
* Preserve the existing bypass behavior for development and non-production environments.
* Added a regression test covering the production configuration failure scenario.
* Verified that no database connection is attempted when the configuration is missing.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A – Backend/API configuration handling fix.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable for this change).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
