### PR TITLE
test: expand sanitizeRadius coverage for string parsing and edge cases

### DIFF
--- a/components/dashboard/ComparisonStatsCard.test.tsx
+++ b/components/dashboard/ComparisonStatsCard.test.tsx
@@ -138,12 +138,6 @@ describe('ComparisonStatsCard', () => {
       />
     );
 
-    const progressSegments = container.querySelectorAll(
-      '.w-full.bg-gray-700\\/50 div, .relative div'
-    );
-
-    const allDivs = Array.from(container.querySelectorAll('div'));
-
     const emeraldElement =
       container.querySelector('[className*="emerald"]') ||
       container.querySelector('.text-emerald-400');

--- a/lib/svg/sanitizer.test.ts
+++ b/lib/svg/sanitizer.test.ts
@@ -88,6 +88,14 @@ describe('SVG Sanitizer Utilities', () => {
     it('returns fallback for invalid input', () => {
       expect(sanitizeRadius('invalid', 8)).toBe(8);
     });
+
+    it('handles float strings, extreme negative values, leading zeros, and boundaries', () => {
+      expect(sanitizeRadius('8.7', 8)).toBe(8);
+      expect(sanitizeRadius('-999', 8)).toBe(0);
+      expect(sanitizeRadius('50', 8)).toBe(50);
+      expect(sanitizeRadius('51', 8)).toBe(50);
+      expect(sanitizeRadius('00', 8)).toBe(0);
+    });
   });
 
   describe('sanitizeFont', () => {

--- a/lib/svg/sanitizer.test.ts
+++ b/lib/svg/sanitizer.test.ts
@@ -34,6 +34,12 @@ describe('SVG Sanitizer Utilities', () => {
       expect(isValidHex('ff')).toBe(false);
       expect(isValidHex('fffff')).toBe(false);
     });
+
+    it('returns false for undefined, null, or empty string', () => {
+      expect(isValidHex(undefined)).toBe(false);
+      expect(isValidHex(null as unknown as string)).toBe(false);
+      expect(isValidHex('')).toBe(false);
+    });
   });
 
   describe('sanitizeHexColor', () => {
@@ -72,6 +78,11 @@ describe('SVG Sanitizer Utilities', () => {
       expect(sanitizeSpeed('8', '8s')).toBe('8s');
       expect(sanitizeSpeed('s', '8s')).toBe('8s');
     });
+
+    it('returns fallback for null or undefined speed', () => {
+      expect(sanitizeSpeed(undefined, '8s')).toBe('8s');
+      expect(sanitizeSpeed(null, '8s')).toBe('8s');
+    });
   });
 
   describe('sanitizeRadius', () => {
@@ -95,6 +106,11 @@ describe('SVG Sanitizer Utilities', () => {
       expect(sanitizeRadius('50', 8)).toBe(50);
       expect(sanitizeRadius('51', 8)).toBe(50);
       expect(sanitizeRadius('00', 8)).toBe(0);
+    });
+
+    it('returns fallback for null or undefined input', () => {
+      expect(sanitizeRadius(undefined, 8)).toBe(8);
+      expect(sanitizeRadius(null, 8)).toBe(8);
     });
   });
 


### PR DESCRIPTION
##Description

## fixes #344 

Expanded test coverage for sanitizeRadius in lib/svg/sanitizer.test.ts to better validate string parsing behavior and edge-case handling.

Added test cases for:

Float string input: '8.7' → 8
Extreme negative value: '-999' → 0
Valid numeric string: '50' → 50
Upper bound clamping: '51' → 50
Leading zero string: '00' → 0

These tests improve confidence around parseInt behavior, bounds enforcement, and sanitization consistency.

##Pillar

📐 Pillar 2 — Geometric SVG Improvement

Visual Preview

N/A — test coverage update only.

##Checklist before requesting a review:

[x] I have read the CONTRIBUTING.md file.
[x] I have tested these changes locally (localhost:3000/api/streak?user=YOUR_USERNAME).
[x] I have run npm run format and npm run lint locally and resolved all errors (CI will fail otherwise).
[x] My commits follow the Conventional Commits format (e.g., feat(themes): ..., fix(calculate): ...).
[x] I have starred the repo.
[x] I have made sure that I have only one commit to merge in this PR.