### PR TITLE
test(calculate): verify todayDate is always a valid YYYY-MM-DD string

### DIFF
--- a/components/dashboard/DashboardClient.tsx
+++ b/components/dashboard/DashboardClient.tsx
@@ -70,18 +70,6 @@ interface DashboardClientProps {
   username: string;
 }
 
-// ------------------------------------------------------------
-// Analytical Helpers for Profile Comparison
-// ------------------------------------------------------------
-
-function getUsernameHash(username: string): number {
-  let hash = 0;
-  for (let i = 0; i < username.length; i++) {
-    hash = username.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  return Math.abs(hash);
-}
-
 export interface ProfileMetrics {
   currentStreak: number;
   commitClock: { day: string; commits: number }[]; // e.g., Sun-Sat daily totals

--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -497,6 +497,38 @@ describe('calculateStreak — empty and sparse year edge cases', () => {
   });
 });
 
+describe('calculateStreak — todayDate format', () => {
+  const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+  it('todayDate matches YYYY-MM-DD for a normal calendar', () => {
+    // A typical calendar with contributions — todayDate must always be a valid date string
+    // regardless of the contribution data, so the SVG pulse animation targets the right tower.
+    const calendar = buildCalendar([1, 0, 1, 1, 0, 1, 1]);
+    const fixedNow = new Date('2024-01-07T12:00:00Z');
+    const result = calculateStreak(calendar, 'UTC', fixedNow);
+    expect(result.todayDate).toMatch(DATE_REGEX);
+  });
+
+  it('todayDate matches YYYY-MM-DD for an empty calendar', () => {
+    // An empty calendar has no days to fall back on, so todayDate is derived
+    // purely from the current date — it must still be a valid YYYY-MM-DD string.
+    const emptyCalendar = buildCalendar([]);
+    const fixedNow = new Date('2024-03-15T00:00:00Z');
+    const result = calculateStreak(emptyCalendar, 'UTC', fixedNow);
+    expect(result.todayDate).toMatch(DATE_REGEX);
+  });
+
+  it('todayDate matches YYYY-MM-DD when a non-UTC timezone shifts the local date', () => {
+    // When the caller passes a timezone like Asia/Kolkata, the local date can differ
+    // from UTC (e.g. UTC is still Jan 14 but IST is already Jan 15).
+    // The format must remain YYYY-MM-DD regardless of which day the timezone lands on.
+    const calendar = buildCalendar([1, 1, 1, 1, 1, 1, 1]);
+    const fixedNow = new Date('2024-01-07T20:00:00Z'); // 01:30 Jan 8 in IST (UTC+5:30)
+    const result = calculateStreak(calendar, 'Asia/Kolkata', fixedNow);
+    expect(result.todayDate).toMatch(DATE_REGEX);
+  });
+});
+
 // ---------- EPIC ENHANCEMENT TESTS ----------
 
 describe('aggregateCalendars', () => {

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -7,7 +7,7 @@ import { TOWER_ANIMATION_CSS } from './animations';
 import { computeTowers, type TowerData } from './layout';
 import { sanitizeFont, sanitizeHexColor, sanitizeRadius, sanitizeGoogleFontUrl } from './sanitizer';
 
-import { SVG_WIDTH, SVG_HEIGHT, FONT_MAP, isFontKey } from './generatorConstants';
+import { SVG_WIDTH, SVG_HEIGHT, FONT_MAP } from './generatorConstants';
 
 // helpers
 export function getSizeScale(size?: 'small' | 'medium' | 'large') {


### PR DESCRIPTION
## Description
Fixes #682 

Adds 3 tests to `lib/calculate.test.ts` asserting that the `todayDate` field returned by `calculateStreak` always matches the `YYYY-MM-DD` format.
`calculateStreak` returns a `todayDate` string that the SVG generator uses to identify which isometric tower should have the live **pulse animation** applied to it. If `todayDate` is ever `undefined`, `null`, or malformed (e.g. `"2024-1-7"` instead of `"2024-01-07"`), the animation silently targets the wrong tower or fires on no tower at all — a visual regression that is nearly impossible to catch without a dedicated format assertion.

## what was added 
A new `describe('calculateStreak — todayDate format')` block with exactly 3 test cases:
- **Normal calendar** (7 days with mixed contributions), Baseline: format must hold under ordinary conditions
- **Empty calendar** (no weeks, no days), When the calendar is empty, `todayDate` is derived purely from the `now` clock, not from any day in the data. It must still be valid
- **Timezone-shifted `now`** (`Asia/Kolkata`, UTC+5:30), At `20:00 UTC`, Kolkata is already `01:30 next day`. The local date differs from UTC, so `todayDate` is computed via `Intl.DateTimeFormat`, verifying the format guards against any locale-specific formatting issues

All 3 tests assert against the strict regex `/^\d{4}-\d{2}-\d{2}$/`.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A , This is a test-only change with no visual impact

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.