### PR TITLE
test(themes): verify theme record structure (#664)

### DIFF
--- a/lib/svg/themes.test.ts
+++ b/lib/svg/themes.test.ts
@@ -2,36 +2,40 @@ import { describe, expect, it } from 'vitest';
 import { themes, AUTO_THEME_LIGHT, AUTO_THEME_DARK } from './themes';
 
 describe('themes', () => {
-  it('should not use # prefix in background colors', () => {
-    Object.values(themes).forEach((theme) => {
-      expect(theme.bg.startsWith('#')).toBe(false);
+  it('validates every theme has bg, text, and accent as valid 6-character hex strings', () => {
+    const hexRegex = /^#[0-9a-f]{6}$/i;
+
+    Object.entries(themes).forEach(([name, theme]) => {
+      // Validate every theme has bg, text, and accent
+      expect(theme).toHaveProperty('bg');
+      expect(theme).toHaveProperty('text');
+      expect(theme).toHaveProperty('accent');
+
+      // Assert they are valid 6-character hex strings using the requested regex.
+      // We prepend '#' because the sanitizer strips it from the final object.
+      expect(`#${theme.bg}`, `Theme "${name}" bg is invalid`).toMatch(hexRegex);
+      expect(`#${theme.text}`, `Theme "${name}" text is invalid`).toMatch(hexRegex);
+      expect(`#${theme.accent}`, `Theme "${name}" accent is invalid`).toMatch(hexRegex);
     });
   });
 
-  it('should not use # prefix in text colors', () => {
-    Object.values(themes).forEach((theme) => {
-      expect(theme.text.startsWith('#')).toBe(false);
+  it('asserts no two themes are identical', () => {
+    const uniqueThemes = new Set<string>();
+
+    Object.entries(themes).forEach(([name, theme]) => {
+      // Create a unique fingerprint for each theme based on its colors
+      const fingerprint = `${theme.bg}-${theme.text}-${theme.accent}`;
+
+      // If the fingerprint already exists, this theme is a duplicate
+      expect(uniqueThemes.has(fingerprint), `Theme "${name}" is a duplicate`).toBe(false);
+
+      uniqueThemes.add(fingerprint);
     });
   });
 
-  it('should not use # prefix in accent colors', () => {
-    Object.values(themes).forEach((theme) => {
-      expect(theme.accent.startsWith('#')).toBe(false);
-    });
-  });
-  it('AUTO_THEME_LIGHT references themes.light', () => {
+  it('asserts auto themes match their respective light/dark counterparts', () => {
+    // Assert strictly equal (===)
     expect(AUTO_THEME_LIGHT).toBe(themes.light);
-  });
-
-  it('AUTO_THEME_DARK references themes.dark', () => {
     expect(AUTO_THEME_DARK).toBe(themes.dark);
-  });
-
-  it('AUTO_THEME_LIGHT bg matches themes.light.bg', () => {
-    expect(AUTO_THEME_LIGHT.bg).toBe(themes.light.bg);
-  });
-
-  it('AUTO_THEME_DARK accent matches themes.dark.accent', () => {
-    expect(AUTO_THEME_DARK.accent).toBe(themes.dark.accent);
   });
 });


### PR DESCRIPTION
## Description

Fixes #664

This PR implements the requested test suite for `lib/svg/themes.ts`. It validates the integrity and structure of the theme definitions.

- Overwrote the stub `lib/svg/themes.test.ts` with the full test suite.
- Validates that every theme has `bg`, `text`, and `accent` properties.
- Asserts that all color properties are valid 6-character hex strings using the strictly requested regex (`/^#[0-9a-f]{6}$/i`). 
  - *Implementation nuance: Because the source dictionary actually strips `#` strings during `hexColor` sanitization, the tests dynamically prepend `#` before running the regex assertion to strictly validate against the requested regex pattern without failing.*
- Asserts that no two themes in the record are exactly identical by comparing their color fingerprints.
- Asserts that `AUTO_THEME_LIGHT` and `AUTO_THEME_DARK` strictly equal `themes.light` and `themes.dark`.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test suite implementation only)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
