### PR TITLE
fix(contributors): trim search input before filtering

### DIFF
--- a/app/contributors/ContributorsSearch.test.tsx
+++ b/app/contributors/ContributorsSearch.test.tsx
@@ -53,6 +53,15 @@ describe('ContributorsSearch', () => {
     expect(screen.queryByText('bob')).toBeNull();
   });
 
+  it('ignores leading and trailing whitespace when filtering', async () => {
+    const user = userEvent.setup();
+    render(<ContributorsSearch contributors={mockContributors} />);
+    const input = screen.getByPlaceholderText(/search contributors by name/i);
+    await user.type(input, ' alice ');
+    screen.getByText('alice');
+    expect(screen.queryByText('bob')).toBeNull();
+  });
+
   it('shows "No contributors found" when search has no matches', async () => {
     const user = userEvent.setup();
     render(<ContributorsSearch contributors={mockContributors} />);

--- a/app/contributors/ContributorsSearch.tsx
+++ b/app/contributors/ContributorsSearch.tsx
@@ -16,7 +16,8 @@ interface Contributor {
 export default function ContributorsSearch({ contributors }: { contributors: Contributor[] }) {
   const [search, setSearch] = useState('');
 
-  const filtered = contributors.filter((c) => c.login.toLowerCase().includes(search.toLowerCase()));
+  const normalizedSearch = search.trim().toLowerCase();
+  const filtered = contributors.filter((c) => c.login.toLowerCase().includes(normalizedSearch));
 
   return (
     <>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4525,8 +4525,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",


### PR DESCRIPTION
## Description

Fixes #1351

This PR fixes the contributor search bug where leading or trailing whitespace in the search query causes valid contributors to disappear from the filtered results.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

### Before
Searching with leading/trailing whitespace could return no contributors.

### After
Leading/trailing whitespace is trimmed before filtering, and matching contributors are displayed correctly.

## Checklist before requesting a review:

- [x] I have read the CONTRIBUTING.md file.
- [x] I have tested these changes locally.
- [ ] I have run npm run format and npm run lint locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated README.md if required.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse premium quality aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord server.