### PR TITLE
test(export3d): verify STL output skips ghost towers

### DIFF
--- a/lib/export3d.test.ts
+++ b/lib/export3d.test.ts
@@ -100,3 +100,34 @@ it('always includes a base plate even with no tower data', () => {
   expect(stl).toContain('endsolid commitpulse_monolith');
   expect(stl).toContain('facet normal');
 });
+it('skips ghost towers (h=0) while still generating the base plate', () => {
+  const ghostTowers: TowerData[] = [
+    {
+      x: 0,
+      y: 0,
+      h: 0,
+      hasCommits: false,
+      isGhost: true,
+      isToday: false,
+      isTodayWithCommits: false,
+      tooltip: '',
+      contributionCount: 0,
+      faceOpacity: { left: 1, right: 1, top: 1 },
+      strokeOpacity: 1,
+      strokeWidth: 1,
+      row: 0,
+      col: 0,
+      intensityLevel: 0,
+    },
+  ];
+
+  const stl = generateMonolithSTL(ghostTowers);
+
+  expect(stl).toContain('solid commitpulse_monolith');
+  expect(stl).toContain('endsolid commitpulse_monolith');
+
+  const facetCount = (stl.match(/facet normal/g) ?? []).length;
+
+  // Base plate only = 12 facets
+  expect(facetCount).toBe(12);
+});


### PR DESCRIPTION
## Description

Fixes #1024 
Added a test to verify that  generateMonolithSTL  skips ghost towers (h = 0) while still generating the base plate.

The test:
- Verifies STL output contains valid STL structure
- Counts generated facets using facet normal
- Asserts only the base plate facets (12 facets) are present
- Confirms ghost towers do not generate additional geometry

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
