### PR TITLE
fix: replace hardcoded production URL in PROFILE_URL with NEXT_PUBLIC_SITE_URL env var

### DIFF
--- a/hooks/useShareActions.ts
+++ b/hooks/useShareActions.ts
@@ -5,10 +5,11 @@ import type { DashboardExportData } from '@/types/dashboard';
 
 type OptionState = 'idle' | 'loading' | 'success' | 'error';
 
-const PROFILE_URL = (username: string) =>
-  typeof window !== 'undefined'
-    ? `${window.location.origin}/dashboard/${username}`
-    : `https://commitpulse.vercel.app/dashboard/${username}`;
+const BASE_ORIGIN =
+  (typeof window !== 'undefined' ? window.location.origin : null) ??
+  process.env.NEXT_PUBLIC_SITE_URL ??
+  'https://commitpulse.vercel.app';
+const PROFILE_URL = (username: string) => `${BASE_ORIGIN}/dashboard/${username}`;
 
 export function useShareActions(
   username: string,


### PR DESCRIPTION
Fixes #1364

## Description
`hooks/useShareActions.ts` had a hardcoded production URL as the SSR fallback for `PROFILE_URL`:

const PROFILE_URL = (username: string) =>
  typeof window !== 'undefined'
    ? `${window.location.origin}/dashboard/${username}`
    : `https://commitpulse.vercel.app/dashboard/${username}`;

When rendered server-side, share links (Twitter, LinkedIn, Reddit, native share, copy link, JSON export) always pointed to `commitpulse.vercel.app` regardless of the deployment environment. This means shared links generated on staging or fork deployments incorrectly point to production.

Fixed by extracting a `BASE_ORIGIN` constant that prefers `window.location.origin` on the client, falls back to `NEXT_PUBLIC_SITE_URL`, and finally falls back to the production URL — consistent with how `BASE_URL` is defined in `app/(root)/dashboard/[username]/page.tsx`.

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — URL generation fix, no UI change.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.