### PR TITLE
fix: add GitHub token auth header to contributors page API fetchfix: add GitHub token auth header to contributors page API fetch

### DIFF
--- a/app/contributors/page.tsx
+++ b/app/contributors/page.tsx
@@ -15,8 +15,13 @@ interface Contributor {
 
 async function getContributors(): Promise<Contributor[]> {
   try {
+    const token = process.env.GITHUB_PAT || process.env.GITHUB_TOKEN;
     const res = await fetch('https://api.github.com/repos/JhaSourav07/commitpulse/contributors', {
       next: { revalidate: 3600 },
+      headers: {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        Accept: 'application/vnd.github+json',
+      },
     });
 
     if (!res.ok) {


### PR DESCRIPTION
Fixes #1373 

## Description
`app/contributors/page.tsx` fetched the GitHub REST API without an `Authorization` header:

const res = await fetch('https://api.github.com/repos/JhaSourav07/commitpulse/contributors', {
  next: { revalidate: 3600 },
});

Unauthenticated GitHub API requests are limited to 60 requests per hour per IP. Since this is a server-side fetch, all requests from the same Vercel deployment share this limit. Under moderate traffic, the rate limit is hit, `res.ok` becomes false, and the page silently shows 0 contributors and 0 contributions with no error message.

Fixed by adding the `GITHUB_PAT` or `GITHUB_TOKEN` authorization header when available, consistent with the `getGitHubToken()` pattern already used in `lib/github.ts`. The auth header is skipped gracefully if no token is configured, preserving existing behavior in local development.

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — server-side fetch fix, no UI change.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.