### PR TITLE
fix(api): escape validation error text in SVG responses

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -721,6 +721,17 @@ describe('GET /api/streak', () => {
       expect(body).toContain('garbage');
     });
 
+    it('escapes invalid timezone values before rendering the error SVG', async () => {
+      const response = await GET(
+        makeRequest({ user: 'octocat', tz: '</text><script>alert(1)</script>' })
+      );
+      const body = await response.text();
+
+      expect(response.status).toBe(400);
+      expect(body).toContain('&lt;/text&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
+      expect(body).not.toContain('</text><script>');
+    });
+
     it('returns 200 with a valid IANA timezone', async () => {
       const response = await GET(makeRequest({ user: 'octocat', tz: 'America/New_York' }));
 

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -26,6 +26,10 @@ export class ValidationError extends Error {
   }
 }
 
+function escapeSVGText(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 function getMonthlyReferenceDate(year: string | undefined, timezone: string): Date | undefined {
   if (!year) return undefined;
 
@@ -300,7 +304,7 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
       <svg xmlns="http://www.w3.org/2000/svg" width="400" height="150">
         <rect width="100%" height="100%" fill="#2d0000" rx="8"/>
         <text x="50%" y="50%" text-anchor="middle" fill="#ffcccc" font-family="sans-serif">
-          ${message}
+          ${escapeSVGText(message)}
         </text>
       </svg>
     `;


### PR DESCRIPTION
## Description

Fixes #1374

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed

The validation error SVG path in `app/api/streak/route.ts` was inserting the error message directly into a `<text>` node. That message can include user-controlled query values, such as an invalid `tz` parameter.

This PR escapes `&`, `<`, and `>` before rendering validation error text in the SVG, so invalid inputs are shown as text instead of being interpreted as SVG/XML markup.

I also added a regression test using an invalid timezone value containing `</text><script>...`, which verifies the generated SVG contains escaped text and not raw injected markup.

This is a GSSoC 2026 bug fix contribution. Please add the relevant GSSoC labels if they are missing.

## Visual Preview

N/A — this only changes the validation error SVG escaping behavior.

## Local checks

```bash
npm run format:check
npm run lint
npm run test -- app/api/streak/route.test.ts
```

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npm run test -- app/api/streak/route.test.ts`).
- [x] I have run formatting and linting locally and resolved all errors.
- [x] My commit follows the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.
