### PR TITLE
fix: add error state for SVG badge fetch failures in app/page.tsx

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,7 +70,7 @@ export default function LandingPage() {
   const [username, setUsername] = useState('');
   const [copied, setCopied] = useState(false);
   const [svgContent, setSvgContent] = useState<string | null>(null);
-  const [svgState, setSvgState] = useState<'idle' | 'loading' | 'loaded'>('idle');
+  const [svgState, setSvgState] = useState<'idle' | 'loading' | 'loaded' | 'error'>('idle');
   const guideRef = useRef<HTMLDivElement>(null);
   const { searches, addSearch, clearSearches, removeSearch } = useRecentSearches();
   const trimmedUsername = username.trim();
@@ -109,7 +109,7 @@ export default function LandingPage() {
       })
       .catch((err) => {
         if (err.name === 'AbortError') return;
-        setSvgState('loaded'); // show nothing rather than hang on loading
+        setSvgState('error');
       });
 
     return () => controller.abort();
@@ -324,6 +324,16 @@ export default function LandingPage() {
                 <div className="w-full flex items-center justify-center">
                   {svgState === 'loading' && (
                     <div className="h-[200px] w-full max-w-[600px] rounded-xl bg-white/5 animate-pulse" />
+                  )}
+                  {svgState === 'error' && (
+                    <div className="flex flex-col items-center justify-center gap-2 text-center py-8">
+                      <p className="text-sm font-semibold text-red-500 dark:text-red-400">
+                        Failed to load badge
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-white/40">
+                        The API may be unavailable. Please try again.
+                      </p>
+                    </div>
                   )}
                   {svgState === 'loaded' && svgContent && (
                     <div


### PR DESCRIPTION
Fixes #1377 

## Description
When the SVG badge fetch failed in `app/page.tsx`, the error was silently swallowed and `svgState` was set to `'loaded'`:

.catch((err) => {
  if (err.name === 'AbortError') return;
  setSvgState('loaded'); // show nothing rather than hang on loading
});

Users saw a blank preview area with no indication that something went wrong — no error message, no retry prompt, no way to know if the API was down or their username was invalid.

Fixed by:
- Adding `'error'` to the `svgState` type union
- Setting `setSvgState('error')` on non-AbortError fetch failures instead of `'loaded'`
- Rendering a user-friendly error message in the preview area when `svgState === 'error'`

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
When the badge fetch fails, the preview area now shows:
**"Failed to load badge — The API may be unavailable. Please try again."**

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.