### PR TITLE
Test(sanitizer): Added test to handle all valid hex lengths

### DIFF
--- a/lib/svg/sanitizer.test.ts
+++ b/lib/svg/sanitizer.test.ts
@@ -69,6 +69,27 @@ describe('SVG Sanitizer Utilities', () => {
       expect(sanitizeHexColor('##ff00ff', '000000')).toBe('ff00ff');
     });
 
+    it('returns valid 3-digit hex without #', () => {
+      expect(sanitizeHexColor('#f0f', '000000')).toBe('f0f');
+      expect(sanitizeHexColor('f0f', '000000')).toBe('f0f');
+      // Handles multiple leading hashes gracefully
+      expect(sanitizeHexColor('##f0f', '000000')).toBe('f0f');
+    });
+
+    it('returns valid 8-digit hex without #', () => {
+      expect(sanitizeHexColor('#ff00ff00', '000000')).toBe('ff00ff00');
+      expect(sanitizeHexColor('ff00ff00', '000000')).toBe('ff00ff00');
+      // Handles multiple leading hashes gracefully
+      expect(sanitizeHexColor('##ff00ff00', '000000')).toBe('ff00ff00');
+    });
+
+    it('returns valid 4-digit hex without #', () => {
+      expect(sanitizeHexColor('#f0f0', '000000')).toBe('f0f0');
+      expect(sanitizeHexColor('f0f0', '000000')).toBe('f0f0');
+      // Handles multiple leading hashes gracefully
+      expect(sanitizeHexColor('##f0f0', '000000')).toBe('f0f0');
+    });
+
     it('returns fallback for invalid input', () => {
       expect(sanitizeHexColor('invalid', '000000')).toBe('000000');
       expect(sanitizeHexColor('"><script>', '000000')).toBe('000000');


### PR DESCRIPTION
## Description
- isValidHex already accepts 3, 4, 6, and 8-character hex codes, but sanitizeHexColor only had tests for the 6-char case.
- Added test cases to verify that sanitizeHexColor correctly passes through 3-char (f0f), 4-char (f0f0), and 8-char (ff00ff00) hex values without falling back to the default.
- Each new test covers input with #, without #, and with ## (multiple leading hashes), consistent with the existing 6-char test pattern.
- 
Fixes #736 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
