### PR TITLE
fix(rate-limiter): prevent TTL reset on every request allowing window bypass

### DIFF
--- a/lib/cache.test.ts
+++ b/lib/cache.test.ts
@@ -260,6 +260,46 @@ describe('TTLCache', () => {
     });
   });
 
+  describe('update()', () => {
+    it('updates the value without resetting TTL', () => {
+      vi.useFakeTimers();
+      const cache = new TTLCache<number>();
+      cache.set('count', 1, 5_000);
+
+      vi.advanceTimersByTime(3_000);
+      cache.update('count', 2);
+
+      // Another 3s: total 6s from set — would be expired if TTL had been reset
+      vi.advanceTimersByTime(3_000);
+      expect(cache.get('count')).toBeNull();
+
+      cache.destroy();
+    });
+
+    it('returns true when the key exists and is not expired', () => {
+      const cache = new TTLCache<number>();
+      cache.set('count', 1, 60_000);
+      expect(cache.update('count', 2)).toBe(true);
+      expect(cache.get('count')).toBe(2);
+      cache.destroy();
+    });
+
+    it('returns false for a missing key', () => {
+      const cache = new TTLCache<number>();
+      expect(cache.update('missing', 99)).toBe(false);
+      cache.destroy();
+    });
+
+    it('returns false for an expired key', () => {
+      vi.useFakeTimers();
+      const cache = new TTLCache<number>();
+      cache.set('count', 1, 1_000);
+      vi.advanceTimersByTime(2_000);
+      expect(cache.update('count', 2)).toBe(false);
+      cache.destroy();
+    });
+  });
+
   describe('overwriting keys resets TTL', () => {
     it('resets TTL when overwriting an existing key', () => {
       vi.useFakeTimers();

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -126,6 +126,20 @@ export class TTLCache<T> {
    * @example
    * cache.set("user:1", userData, 5000);
    */
+  /**
+   * Updates the value of an existing, non-expired cache entry without resetting its TTL.
+   *
+   * @param key - Cache key.
+   * @param value - New value to store.
+   * @returns `true` if the entry existed and was updated, `false` if missing or expired.
+   */
+  update(key: string, value: T): boolean {
+    const hit = this.store.get(key);
+    if (!hit || Date.now() > hit.expiresAt) return false;
+    hit.value = value;
+    return true;
+  }
+
   set(key: string, value: T, ttlMs: number): void {
     if (ttlMs <= 0) throw new RangeError(`ttlMs must be positive, got ${ttlMs}`);
 
@@ -301,6 +315,34 @@ export class DistributedCache<T> {
       return value !== null;
     } catch {
       return false;
+    }
+  }
+
+  async update(key: string, value: T): Promise<boolean> {
+    const updated = this.localCache.update(key, value);
+    if (!updated) return false;
+
+    if (!this.useRedis) {
+      return true;
+    }
+
+    try {
+      const res = await fetch(`${this.redisUrl}/`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.redisToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(['SET', key, JSON.stringify(value), 'KEEPTTL']),
+      });
+
+      if (!res.ok) {
+        throw new Error(`Redis HTTP error: ${res.status}`);
+      }
+      return true;
+    } catch (err) {
+      console.error(`[DistributedCache] UPDATE failed for key "${key}":`, err);
+      return true;
     }
   }
 

--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -48,6 +48,28 @@ describe('rateLimit', () => {
     expect(result.remaining).toBe(59);
   });
 
+  it('does not reset the window TTL on each request (fixed window)', async () => {
+    const ip = '4.5.6.7';
+    const windowMs = 60000;
+    const limit = 5;
+
+    // Make 3 requests spread across the window
+    await rateLimit(ip, limit, windowMs);
+    vi.advanceTimersByTime(20000);
+    await rateLimit(ip, limit, windowMs);
+    vi.advanceTimersByTime(20000);
+    await rateLimit(ip, limit, windowMs);
+
+    // Advance past original window start (60s from first request)
+    // If TTL was resetting, the window would still be open; it should now be closed
+    vi.advanceTimersByTime(21000); // total: 61s from first request
+
+    // Window should have expired — count resets
+    const result = await rateLimit(ip, limit, windowMs);
+    expect(result.success).toBe(true);
+    expect(result.remaining).toBe(limit - 1);
+  });
+
   it('tracks different IPs separately', async () => {
     const ip1 = '11.11.11.11';
     const ip2 = '22.22.22.22';
@@ -118,5 +140,24 @@ describe('RateLimiter', () => {
     vi.advanceTimersByTime(windowMs + 1);
 
     expect(await limiter.check('5.5.5.5')).toBe(true);
+  });
+
+  it('does not reset the window TTL on each request (fixed window)', async () => {
+    const windowMs = 60000;
+    const limiter = new RateLimiter(5, windowMs);
+    const ip = '6.6.6.6';
+
+    // Make 3 requests spread across the window
+    await limiter.check(ip);
+    vi.advanceTimersByTime(20000);
+    await limiter.check(ip);
+    vi.advanceTimersByTime(20000);
+    await limiter.check(ip);
+
+    // Advance past original window start (60s from first request)
+    vi.advanceTimersByTime(21000); // total: 61s from first request
+
+    // Window should have expired — count resets, request is allowed
+    expect(await limiter.check(ip)).toBe(true);
   });
 });

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -55,7 +55,7 @@ export class RateLimiter {
     if (current === 0) {
       await this.cache.set(ip, 1, this.windowMs);
     } else {
-      await this.cache.set(ip, current + 1, this.windowMs);
+      await this.cache.update(ip, current + 1);
     }
     return true;
   }
@@ -84,7 +84,7 @@ export class RateLimiter {
     if (current === 0) {
       await this.cache.set(ip, 1, this.windowMs);
     } else {
-      await this.cache.set(ip, current + 1, this.windowMs);
+      await this.cache.update(ip, current + 1);
     }
     return {
       success: true,
@@ -172,7 +172,7 @@ export async function rateLimit(
   }
 
   tracker.count++;
-  await trackers.set(ip, tracker, windowMs);
+  await trackers.update(ip, tracker);
 
   if (tracker.count > limit) {
     return {


### PR DESCRIPTION
## Description

The rate limiter could be bypassed indefinitely by staying just under the request limit. Every allowed request called cache.set() to increment the counter, which also reset the TTL window from that moment. Since the window kept extending with each request, it never closed as long as the attacker stayed below the limit.

Fixes #1371 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
-  [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A. Backend-only change, no UI output affected.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
