### PR TITLE
fix(generator): align radar scan rect initial y with animation start

### DIFF
--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -1158,3 +1158,74 @@ describe('generateRateLimitSVG', () => {
     expect(svg).toContain('</svg>');
   });
 });
+
+describe('Radar Scan Line Animation Alignment', () => {
+  const mockStats: StreakStats = {
+    currentStreak: 5,
+    longestStreak: 10,
+    totalContributions: 100,
+    todayDate: '2024-06-12',
+  };
+  const mockCalendar = {
+    weeks: [
+      {
+        contributionDays: [
+          { contributionCount: 0, date: '2024-06-10' },
+          { contributionCount: 5, date: '2024-06-11' },
+          { contributionCount: 15, date: '2024-06-12' },
+        ],
+      },
+    ],
+  } as ContributionCalendar;
+
+  it('aligns the initial y position and translate values in static generateSVG', () => {
+    const svg = generateSVG(
+      mockStats,
+      { user: 'avi', size: 'medium', autoTheme: false } as unknown as BadgeParams,
+      mockCalendar
+    );
+
+    // Initial y on the rect must be 80 scaled (medium size = scale 1 -> 80)
+    expect(svg).toContain('y="80"');
+    // CSS scan-start must be 0px and scan-end must be 240px
+    expect(svg).toContain('--scan-start: 0px');
+    expect(svg).toContain('--scan-end: 240px');
+    // Keyframe translations should start at 0px and end at 240px
+    expect(svg).toContain('from { transform: translateY(var(--scan-start, 0px)); }');
+    expect(svg).toContain('to { transform: translateY(var(--scan-end, 240px)); }');
+  });
+
+  it('aligns the initial y position and translate values in auto-theme generateSVG', () => {
+    const svg = generateSVG(
+      mockStats,
+      { user: 'avi', size: 'medium', autoTheme: true } as unknown as BadgeParams,
+      mockCalendar
+    );
+
+    // Initial y on the rect must be 80 scaled
+    expect(svg).toContain('y="80"');
+    // CSS variables should be 0px and 240px
+    expect(svg).toContain('--scan-start: 0px');
+    expect(svg).toContain('--scan-end: 240px');
+    // Keyframe translations should start at 0px and end at 240px
+    expect(svg).toContain('from { transform: translateY(var(--scan-start, 0px)); }');
+    expect(svg).toContain('to { transform: translateY(var(--scan-end, 240px)); }');
+  });
+
+  it('aligns the initial y position and translate values in generateNotFoundSVG', () => {
+    const svg = generateNotFoundSVG('avi', '#0d1117', '#00ffaa', '#ffffff', 8, '8s');
+
+    // Initial y on the rect must be 80
+    expect(svg).toContain('rect x="100" y="80"');
+    // Keyframe translations should start at 0px and end at 240px
+    expect(svg).toContain('from { transform: translateY(0px); }');
+    expect(svg).toContain('to { transform: translateY(240px); }');
+  });
+
+  it('aligns the initial y position in generateRateLimitSVG', () => {
+    const svg = generateRateLimitSVG('#0d1117', '#00ffaa', '#ffffff', 8, '8s');
+
+    // Initial y on the rect must be 80
+    expect(svg).toContain('rect x="100" y="80"');
+  });
+});

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -195,8 +195,8 @@ function renderStyle(
     transform-origin: center;
   }
   @keyframes scan-sweep {
-    from { transform: translateY(var(--scan-start, ${fs(20)}px)); }
-    to { transform: translateY(var(--scan-end, ${fs(260)}px)); }
+    from { transform: translateY(var(--scan-start, ${fs(0)}px)); }
+    to { transform: translateY(var(--scan-end, ${fs(240)}px)); }
   }
   .title { font-family: ${selectedFont || '"Syncopate", sans-serif'}; fill: ${text}; font-size: ${fs(18)}px; letter-spacing: ${fs(6)}px; font-weight: 400; opacity: 0.8; }
   .stats { font-family: ${statsFont}; fill: ${text}; font-size: ${fs(42)}px; font-weight: 500; letter-spacing: 0; }
@@ -207,7 +207,7 @@ function renderStyle(
     .scan-line {
       animation: none !important;
       transition: none !important;
-      transform: translateY(var(--scan-start, ${fs(20)}px)) !important;
+      transform: translateY(var(--scan-start, ${fs(0)}px)) !important;
     }
   }
   .isometric-label { font-family: ${selectedFont || '"Roboto", sans-serif'}; font-size: ${fs(10)}px; font-weight: 400; letter-spacing: 1px; fill-opacity: 0.6; }
@@ -335,12 +335,12 @@ function renderFooter(
   ${!params.hide_title ? `<text x="${s(300)}" y="${s(50)}" text-anchor="middle" class="title">${truncateUsername(safeUser).toUpperCase()}</text>` : ''}
   <rect
     x="${s(100)}"
-    y="${s(60)}"
+    y="${s(80)}"
     width="${s(400)}"
     height="${sf}"
     class="cp-accent-fill scan-line"
     fill-opacity="0.3"
-    style="--scan-speed: ${params.speed || '8s'}; --scan-start: ${s(20)}px; --scan-end: ${s(260)}px;"
+    style="--scan-speed: ${params.speed || '8s'}; --scan-start: ${s(0)}px; --scan-end: ${s(240)}px;"
   />`;
 }
 
@@ -553,8 +553,8 @@ function generateAutoThemeSVG(
     transform-origin: center;
   }
   @keyframes scan-sweep {
-    from { transform: translateY(var(--scan-start, ${s(20)}px)); }
-    to { transform: translateY(var(--scan-end, ${s(260)}px)); }
+    from { transform: translateY(var(--scan-start, ${s(0)}px)); }
+    to { transform: translateY(var(--scan-end, ${s(240)}px)); }
   }
   .title { font-family: ${selectedFont || '"Syncopate", sans-serif'}; fill: var(--cp-text); font-size: ${fs(18)}px; letter-spacing: ${fs(6)}px; font-weight: 400; opacity: 0.8; }
   .stats { font-family: ${statsFont}; fill: var(--cp-text); font-size: ${fs(42)}px; font-weight: 500; letter-spacing: 0; }
@@ -567,7 +567,7 @@ function generateAutoThemeSVG(
     .scan-line {
       animation: none !important;
       transition: none !important;
-      transform: translateY(var(--scan-start, ${s(20)}px)) !important;
+      transform: translateY(var(--scan-start, ${s(0)}px)) !important;
     }
   }
   </style>
@@ -586,12 +586,12 @@ ${
 
   <rect
     x="${s(100)}"
-    y="${s(60)}"
+    y="${s(80)}"
     width="${s(400)}"
     height="${sf}"
     class="cp-accent-fill scan-line"
     fill-opacity="0.3"
-    style="--scan-speed: ${params.speed || '8s'}; --scan-start: ${s(20)}px; --scan-end: ${s(260)}px;"
+    style="--scan-speed: ${params.speed || '8s'}; --scan-start: ${s(0)}px; --scan-end: ${s(240)}px;"
   />
 </svg>
 `;
@@ -913,13 +913,13 @@ export function generateNotFoundSVG(
     .ghost-pulse { animation: gp 2.6s ease-in-out infinite; }
     .scan-line { animation: scan-sweep var(--scan-speed, 8s) linear infinite; }
     @keyframes gp { 0%,100%{opacity:.55} 50%{opacity:1} }
-    @keyframes scan-sweep { from { transform: translateY(20px); } to { transform: translateY(260px); } }
+    @keyframes scan-sweep { from { transform: translateY(0px); } to { transform: translateY(240px); } }
     @media (prefers-reduced-motion: reduce) {
       .ghost-pulse { animation: none !important; transition: none !important; }
       .scan-line {
         animation: none !important;
         transition: none !important;
-        transform: translateY(20px) !important;
+        transform: translateY(0px) !important;
       }
     }
   </style>
@@ -932,7 +932,7 @@ export function generateNotFoundSVG(
 
   <rect width="${SVG_WIDTH}" height="${SVG_HEIGHT}" rx="${radius}" fill="url(#ghostFade)"/>
 
-  <rect x="100" y="60" width="400" height="1" class="scan-line" fill="${accent}" fill-opacity="0.12" style="--scan-speed: ${speed};"/>
+  <rect x="100" y="80" width="400" height="1" class="scan-line" fill="${accent}" fill-opacity="0.12" style="--scan-speed: ${speed};"/>
 
   <text x="300" y="50" text-anchor="middle" class="title">${safeName}</text>
 
@@ -1158,8 +1158,8 @@ function generateAutoThemeVersusSVG(
     transform-origin: center;
   }
   @keyframes scan-sweep {
-    from { transform: translateY(var(--scan-start, ${s(20)}px)); }
-    to { transform: translateY(var(--scan-end, ${s(260)}px)); }
+    from { transform: translateY(var(--scan-start, ${s(0)}px)); }
+    to { transform: translateY(var(--scan-end, ${s(240)}px)); }
   }
   .title { font-family: ${selectedFont || '"Syncopate", sans-serif'}; fill: var(--cp-text); font-size: ${fs(18)}px; letter-spacing: ${fs(6)}px; font-weight: 400; opacity: 0.8; }
   .stats { font-family: ${statsFont}; fill: var(--cp-text); font-size: ${fs(42)}px; font-weight: 500; letter-spacing: 0; }
@@ -1172,7 +1172,7 @@ function generateAutoThemeVersusSVG(
     .scan-line {
       animation: none !important;
       transition: none !important;
-      transform: translateY(var(--scan-start, ${s(20)}px)) !important;
+      transform: translateY(var(--scan-start, ${s(0)}px)) !important;
     }
   }
   </style>
@@ -1298,7 +1298,7 @@ export function generateRateLimitSVG(
 
   <rect width="${SVG_WIDTH}" height="${SVG_HEIGHT}" rx="${radius}" fill="url(#ghostFade)"/>
 
-  <rect x="100" y="60" width="400" height="1" fill="${accent}" fill-opacity="0.12">
+  <rect x="100" y="80" width="400" height="1" fill="${accent}" fill-opacity="0.12">
     <animate attributeName="y" values="80;320;80" dur="${speed}" repeatCount="indefinite"/>
   </rect>
 


### PR DESCRIPTION
## Description

Fixes #1383 

The radar scan line was rendering with a visible jump on initial page load 
because the `<rect>` element's initial `y` attribute (60) didn't match the 
animation's starting position (80). This is now aligned across all SVG 
rendering functions.

## Changes

- Set initial `y="${s(80)}"` on radar scan `<rect>` in all render modes
- Updated CSS `--scan-start` and `--scan-end` variables 
- Updated `@keyframes scan-sweep` translations to match new baseline
- Added unit tests to verify alignment

## Pillar

- [x] 📐 Pillar 2 — Geometric SVG Improvement

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`)
- [x] I have run `npm run format` and `npm run lint` locally and all pass
- [x] My commits follow Conventional Commits format
- [x] I have only one commit to merge in this PR
- [x] SVG output verified in SVG Viewer — no flicker on load
- [x] All 98 unit tests passing

## Visual Preview

Tested on: Default, Neon, Auto, Dracula themes — scan line now renders smoothly 
without jump on initial load ✅