### PR TITLE
fix: correct Customization Studio navigation from contributors page

### DIFF
--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -16,7 +16,7 @@ function GithubMark() {
 const NAV_LINKS = [
   {
     label: 'Customization Studio',
-    href: '#customization-studio',
+    href: '/#customization-studio',
     isExternal: false,
   },
   {


### PR DESCRIPTION
## Description

This PR fixes the navigation issue where the **Customization Studio** button in the navbar did not work correctly when accessed from the **Contributors** page.

The issue was caused by the navigation link using a relative anchor (`#customization-studio`), which redirected users to `/contributors#customization-studio` instead of navigating back to the homepage customization section.

### Changes Made

* Updated the Customization Studio navigation link in the navbar.
* Fixed cross-page navigation behavior.
* Ensured users can access the Customization Studio section from any page.

Fixes #1372

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

### Before

* Clicking **Customization Studio** from the Contributors page redirected to:

  * `/contributors#customization-studio`
* The Customization Studio section was not accessible from the Contributors page.

### After

* Clicking **Customization Studio** from the Contributors page correctly redirects to:

  * `/#customization-studio`
* The Customization Studio section is accessible from any page.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format.
* [x] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The changes maintain the existing UI/UX and do not affect the application's functionality.
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
