### PR TITLE
feat: add rich tooltips to contribution visualizations

### DIFF
--- a/components/dashboard/ActivityLandscape.tsx
+++ b/components/dashboard/ActivityLandscape.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useState } from 'react';
-import { motion } from 'framer-motion';
-import { ActivityData } from '@/types/dashboard';
+import { useState, type SyntheticEvent } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import type { ActivityData } from '@/types/dashboard';
+import VisualizationTooltip from './VisualizationTooltip';
+import { formatTooltipDate, getActivityInsight, getContributionLabel } from './tooltipUtils';
 
 const tabs = ['1W', '1M', '3M', '1Y'];
 
@@ -19,12 +21,22 @@ export const getFilteredData = (data: ActivityData[], activeTab: string): Activi
     const step = Math.ceil(recent.length / 60);
     return recent.filter((_, i) => i % step === 0).slice(-60);
   }
+
   return recent;
 };
+
+interface TooltipState {
+  title: string;
+  metric: string;
+  insight: string;
+  x: number;
+  y: number;
+}
 
 export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
   const [activeTab, setActiveTab] = useState('3M');
   const [mode, setMode] = useState<'commits' | 'loc'>('commits');
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
 
   const displayData = getFilteredData(data, activeTab);
 
@@ -34,120 +46,153 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
 
   const maxCount = Math.max(...displayData.map(getValue), 1);
 
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.3 }}
-      className="p-6 rounded-xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)] overflow-hidden"
-    >
-      {/* Header */}
-      <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-8 gap-4">
-        <div>
-          <h2 className="text-base font-semibold text-gray-900 dark:text-white tracking-tight flex items-center gap-2">
-            Activity Landscape
-          </h2>
-          <p className="text-xs text-[#A1A1AA] mt-1">
-            {mode === 'loc' ? 'Lines of code modified over time' : 'Commit frequency over time'}
-          </p>
-        </div>
+  const showTooltip = (e: SyntheticEvent<HTMLDivElement>, day: ActivityData, value: number) => {
+    const rect = e.currentTarget.getBoundingClientRect();
 
-        <div className="flex flex-wrap items-center gap-3">
-          {/* Mode Toggle (Commits vs LoC) */}
-          <div className="flex items-center p-0.5 bg-gray-100 dark:bg-[#111] border border-black/5 dark:border-[rgba(255,255,255,0.08)] rounded-lg">
-            <button
-              onClick={() => setMode('commits')}
-              className={`px-3 py-1.5 text-xs font-semibold rounded-md transition-all ${
-                mode === 'commits'
-                  ? 'bg-white dark:bg-[#222] text-black dark:text-white shadow-sm border border-black/5 dark:border-white/5'
-                  : 'text-gray-500 hover:text-black dark:hover:text-white'
-              }`}
-            >
-              Commits
-            </button>
-            <button
-              onClick={() => setMode('loc')}
-              className={`px-3 py-1.5 text-xs font-semibold rounded-md transition-all ${
-                mode === 'loc'
-                  ? 'bg-white dark:bg-[#222] text-black dark:text-white shadow-sm border border-black/5 dark:border-white/5'
-                  : 'text-gray-500 hover:text-black dark:hover:text-white'
-              }`}
-            >
-              Lines of Code
-            </button>
+    setTooltip({
+      title: formatTooltipDate(day.date),
+      metric: mode === 'loc' ? `${value} lines modified` : getContributionLabel(day.count),
+      insight:
+        mode === 'loc'
+          ? value > 0
+            ? 'Code activity recorded'
+            : 'No code changes recorded'
+          : getActivityInsight(day.count, day.intensity),
+      x: rect.left + rect.width / 2,
+      y: rect.top - 10,
+    });
+  };
+
+  const hideTooltip = () => setTooltip(null);
+
+  return (
+    <>
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+        className="overflow-hidden rounded-xl border border-black/10 bg-white p-6 dark:border-[rgba(255,255,255,0.08)] dark:bg-[#0a0a0a]"
+      >
+        {/* Header */}
+        <div className="mb-8 flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
+          <div>
+            <h2 className="flex items-center gap-2 text-base font-semibold tracking-tight text-gray-900 dark:text-white">
+              Activity Landscape
+            </h2>
+            <p className="mt-1 text-xs text-[#A1A1AA]">
+              {mode === 'loc' ? 'Lines of code modified over time' : 'Commit frequency over time'}
+            </p>
           </div>
 
-          {/* Time Range Tabs */}
-          <div className="flex rounded-lg border border-black/10 dark:border-[rgba(255,255,255,0.08)] overflow-hidden">
-            {tabs.map((tab) => (
+          <div className="flex flex-wrap items-center gap-3">
+            {/* Mode Toggle (Commits vs LoC) */}
+            <div className="flex items-center rounded-lg border border-black/5 bg-gray-100 p-0.5 dark:border-[rgba(255,255,255,0.08)] dark:bg-[#111]">
               <button
-                key={tab}
-                onClick={() => setActiveTab(tab)}
-                className={`px-3.5 py-1.5 text-xs font-medium transition-all duration-200 border-r border-black/10 dark:border-[rgba(255,255,255,0.08)] last:border-r-0 ${
-                  activeTab === tab
-                    ? 'bg-black dark:bg-white text-white dark:text-black'
-                    : 'bg-gray-100 dark:bg-transparent text-gray-600 dark:text-[#A1A1AA] hover:bg-gray-200 dark:hover:bg-[rgba(255,255,255,0.05)] hover:text-black dark:hover:text-white'
+                onClick={() => setMode('commits')}
+                className={`rounded-md px-3 py-1.5 text-xs font-semibold transition-all ${
+                  mode === 'commits'
+                    ? 'border border-black/5 bg-white text-black shadow-sm dark:border-white/5 dark:bg-[#222] dark:text-white'
+                    : 'text-gray-500 hover:text-black dark:hover:text-white'
                 }`}
               >
-                {tab}
+                Commits
               </button>
-            ))}
+              <button
+                onClick={() => setMode('loc')}
+                className={`rounded-md px-3 py-1.5 text-xs font-semibold transition-all ${
+                  mode === 'loc'
+                    ? 'border border-black/5 bg-white text-black shadow-sm dark:border-white/5 dark:bg-[#222] dark:text-white'
+                    : 'text-gray-500 hover:text-black dark:hover:text-white'
+                }`}
+              >
+                Lines of Code
+              </button>
+            </div>
+
+            {/* Time Range Tabs */}
+            <div className="flex overflow-hidden rounded-lg border border-black/10 dark:border-[rgba(255,255,255,0.08)]">
+              {tabs.map((tab) => (
+                <button
+                  key={tab}
+                  onClick={() => setActiveTab(tab)}
+                  className={`border-r border-black/10 px-3.5 py-1.5 text-xs font-medium transition-all duration-200 last:border-r-0 dark:border-[rgba(255,255,255,0.08)] ${
+                    activeTab === tab
+                      ? 'bg-black text-white dark:bg-white dark:text-black'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-black dark:bg-transparent dark:text-[#A1A1AA] dark:hover:bg-[rgba(255,255,255,0.05)] dark:hover:text-white'
+                  }`}
+                >
+                  {tab}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
-      </div>
 
-      {/* Graph */}
-      <div
-        className="h-[200px] w-full flex items-end justify-between gap-[2px] relative"
-        role="img"
-        aria-label="Activity chart showing contribution frequency over time"
-      >
-        {displayData.map((day, i) => {
-          const val = getValue(day);
-          const heightPercent = Math.max((val / maxCount) * 100, 3);
+        {/* Graph */}
+        <div
+          className="relative flex h-[200px] w-full items-end justify-between gap-[2px]"
+          role="img"
+          aria-label="Activity chart showing contribution frequency over time"
+        >
+          {displayData.map((day, i) => {
+            const val = getValue(day);
+            const heightPercent = Math.max((val / maxCount) * 100, 3);
 
-          // Recalculate intensity for LoC mode visually
-          const isHigh = mode === 'loc' ? val > maxCount * 0.7 : day.intensity >= 3;
-          const isMedium = mode === 'loc' ? val > 0 : day.intensity > 0;
+            // Recalculate intensity for LoC mode visually
+            const isHigh = mode === 'loc' ? val > maxCount * 0.7 : day.intensity >= 3;
+            const isMedium = mode === 'loc' ? val > 0 : day.intensity > 0;
 
-          return (
-            <div
-              key={i}
-              className="relative flex-1 flex items-end group/bar h-full"
-              aria-label={`${day.date}: ${val} ${mode === 'loc' ? 'lines' : 'commits'}`}
-            >
-              {/* Tooltip */}
-              <div className="absolute -top-11 left-1/2 -translate-x-1/2 bg-white dark:bg-[#111] border border-black/10 dark:border-[rgba(255,255,255,0.1)] px-2.5 py-1.5 rounded-md opacity-0 group-hover/bar:opacity-100 transition-opacity duration-150 pointer-events-none z-20 flex flex-col items-center whitespace-nowrap shadow-[0_4px_12px_rgba(0,0,0,0.1)] dark:shadow-xl">
-                <span className="text-[10px] text-[#A1A1AA]">{day.date}</span>
-                <span className="text-xs font-semibold text-gray-900 dark:text-white">
-                  {val} {mode === 'loc' ? 'lines' : 'commits'}
-                </span>
-              </div>
-
-              {/* Bar */}
-              <motion.div
-                initial={{ height: 0 }}
-                animate={{ height: `${heightPercent}%` }}
-                transition={{ duration: 0.6, delay: i * 0.008, ease: [0.16, 1, 0.3, 1] }}
-                className={`w-full rounded-t-[2px] transition-all duration-200 ${
-                  isHigh
-                    ? mode === 'loc'
-                      ? 'bg-indigo-500 dark:bg-indigo-400'
-                      : 'bg-black dark:bg-white'
-                    : isMedium
+            return (
+              <div
+                key={`${day.date}-${i}`}
+                className="group/bar relative flex h-full flex-1 cursor-pointer items-end outline-none"
+                aria-label={`${
+                  mode === 'loc' ? `${val} lines modified` : getContributionLabel(day.count)
+                } on ${formatTooltipDate(day.date)}`}
+                tabIndex={0}
+                onMouseEnter={(e) => showTooltip(e, day, val)}
+                onFocus={(e) => showTooltip(e, day, val)}
+                onMouseLeave={hideTooltip}
+                onBlur={hideTooltip}
+              >
+                {/* Bar */}
+                <motion.div
+                  initial={{ height: 0 }}
+                  animate={{ height: `${heightPercent}%` }}
+                  transition={{
+                    duration: 0.6,
+                    delay: i * 0.008,
+                    ease: [0.16, 1, 0.3, 1],
+                  }}
+                  className={`w-full rounded-t-[2px] transition-all duration-200 ${
+                    isHigh
                       ? mode === 'loc'
-                        ? 'bg-indigo-300 dark:bg-indigo-500/50 hover:bg-indigo-400'
-                        : 'bg-zinc-500 dark:bg-zinc-600 hover:bg-zinc-700 dark:hover:bg-zinc-400'
-                      : 'bg-gray-200 dark:bg-zinc-800 hover:bg-gray-300 dark:hover:bg-zinc-700'
-                }`}
-              />
-            </div>
-          );
-        })}
-      </div>
+                        ? 'bg-indigo-500 dark:bg-indigo-400'
+                        : 'bg-black dark:bg-white'
+                      : isMedium
+                        ? mode === 'loc'
+                          ? 'bg-indigo-300 hover:bg-indigo-400 dark:bg-indigo-500/50'
+                          : 'bg-zinc-500 hover:bg-zinc-700 dark:bg-zinc-600 dark:hover:bg-zinc-400'
+                        : 'bg-gray-200 hover:bg-gray-300 dark:bg-zinc-800 dark:hover:bg-zinc-700'
+                  }`}
+                />
+              </div>
+            );
+          })}
+        </div>
 
-      {/* X axis */}
-      <div className="w-full h-px bg-black/10 dark:bg-[rgba(255,255,255,0.06)] mt-3" />
-    </motion.div>
+        {/* X axis */}
+        <div className="mt-3 h-px w-full bg-black/10 dark:bg-[rgba(255,255,255,0.06)]" />
+      </motion.div>
+
+      <AnimatePresence>
+        {tooltip && (
+          <VisualizationTooltip title={tooltip.title} x={tooltip.x} y={tooltip.y}>
+            <div>{tooltip.metric}</div>
+            <div>{tooltip.insight}</div>
+          </VisualizationTooltip>
+        )}
+      </AnimatePresence>
+    </>
   );
 }

--- a/components/dashboard/CommitClock.test.tsx
+++ b/components/dashboard/CommitClock.test.tsx
@@ -3,9 +3,11 @@ import { describe, it, expect, vi } from 'vitest';
 import type { ReactNode } from 'react';
 import CommitClock from './CommitClock';
 import type { CommitClockData } from '@/types/dashboard';
+import type React from 'react';
 
 // 1. Mock framer-motion to prevent animation errors during DOM testing
 vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   motion: {
     div: ({ children, className }: { children: ReactNode; className?: string }) => (
       <div className={className}>{children}</div>

--- a/components/dashboard/CommitClock.tsx
+++ b/components/dashboard/CommitClock.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import VisualizationTooltip from './VisualizationTooltip';
+import { getContributionLabel } from './tooltipUtils';
 import { CommitClockData } from '@/types/dashboard';
 
 export default function CommitClock({ data }: { data: CommitClockData[] }) {
@@ -10,38 +13,69 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
   const cy = 140;
   const r4 = (n: number) => Math.round(n * 1e4) / 1e4;
   const maxSpokeLength = 42;
+  const [tooltip, setTooltip] = useState<{
+    day: string;
+    commits: number;
+    insight: string;
+    x: number;
+    y: number;
+  } | null>(null);
 
   // Find the peak day index
   const peakIndex = data.reduce((peak, d, i) => (d.commits > data[peak].commits ? i : peak), 0);
   const hasData = data.length > 0 && data.some((d) => d.commits > 0);
+  const showTooltip = (
+    e: React.SyntheticEvent<SVGGElement>,
+    day: string,
+    commits: number,
+    isPeak: boolean
+  ) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+
+    setTooltip({
+      day,
+      commits,
+      insight:
+        commits === 0
+          ? 'No commits recorded for this weekday'
+          : isPeak
+            ? 'Peak weekday in this cycle'
+            : 'Weekly activity point',
+      x: rect.left + rect.width / 2,
+      y: rect.top - 10,
+    });
+  };
+
+  const hideTooltip = () => setTooltip(null);
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 12 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true }}
-      transition={{ duration: 0.3, delay: 0.1 }}
-      className="p-6 rounded-xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)] flex flex-col items-center min-h-[300px]"
-    >
-      <div className="w-full mb-1">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-white tracking-tight">
-          Commit Clock
-        </h3>
-        <p className="text-xs text-[#A1A1AA] mt-1">Weekly activity cycle</p>
-      </div>
+    <>
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.3, delay: 0.1 }}
+        className="p-6 rounded-xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)] flex flex-col items-center min-h-[300px]"
+      >
+        <div className="w-full mb-1">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white tracking-tight">
+            Commit Clock
+          </h3>
+          <p className="text-xs text-[#A1A1AA] mt-1">Weekly activity cycle</p>
+        </div>
 
-      <div className="relative w-[280px] h-[280px] flex items-center justify-center mt-4">
-        {hasData ? (
-          <svg width="280" height="280" className="overflow-visible rotate-[-90deg]">
-            <defs>
-              <filter id="spoke-glow" x="-50%" y="-50%" width="200%" height="200%">
-                <feGaussianBlur stdDeviation="3" result="blur" />
-                <feComposite in="SourceGraphic" in2="blur" operator="over" />
-              </filter>
-            </defs>
+        <div className="relative w-[280px] h-[280px] flex items-center justify-center mt-4">
+          {hasData ? (
+            <svg width="280" height="280" className="overflow-visible rotate-[-90deg]">
+              <defs>
+                <filter id="spoke-glow" x="-50%" y="-50%" width="200%" height="200%">
+                  <feGaussianBlur stdDeviation="3" result="blur" />
+                  <feComposite in="SourceGraphic" in2="blur" operator="over" />
+                </filter>
+              </defs>
 
-            <style>
-              {`
+              <style>
+                {`
     :root {
       --peak-spoke: #111111;
       --peak-dot: rgba(17,17,17,0.7);
@@ -54,155 +88,174 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
       --peak-label: #ffffff;
     }
   `}
-            </style>
+              </style>
 
-            {/* Base ring */}
-            <circle
-              cx={cx}
-              cy={cy}
-              r={radius}
-              fill="none"
-              stroke="rgba(120,120,120,0.15)"
-              strokeWidth="18"
-            />
+              {/* Base ring */}
+              <circle
+                cx={cx}
+                cy={cy}
+                r={radius}
+                fill="none"
+                stroke="rgba(120,120,120,0.15)"
+                strokeWidth="18"
+              />
 
-            {/* Outer boundary ring */}
-            <circle
-              cx={cx}
-              cy={cy}
-              r={radius + maxSpokeLength + 8}
-              fill="none"
-              stroke="rgba(120,120,120,0.22)"
-              strokeWidth="1"
-            />
+              {/* Outer boundary ring */}
+              <circle
+                cx={cx}
+                cy={cy}
+                r={radius + maxSpokeLength + 8}
+                fill="none"
+                stroke="rgba(120,120,120,0.22)"
+                strokeWidth="1"
+              />
 
-            {/* Subtle background dial (35 ticks = 7 days * 5 sub-intervals) */}
-            {Array.from({ length: 35 }).map((_, i) => {
-              const angle = (i * 360) / 35;
-              const rad = (angle * Math.PI) / 180;
-              const isMain = i % 5 === 0;
+              {/* Subtle background dial (35 ticks = 7 days * 5 sub-intervals) */}
+              {Array.from({ length: 35 }).map((_, i) => {
+                const angle = (i * 360) / 35;
+                const rad = (angle * Math.PI) / 180;
+                const isMain = i % 5 === 0;
 
-              // Main spokes get a full-length faint track, interval ticks are short
-              const tickLength = isMain ? maxSpokeLength : 4;
-              const innerOffset = isMain ? 0 : 4;
+                // Main spokes get a full-length faint track, interval ticks are short
+                const tickLength = isMain ? maxSpokeLength : 4;
+                const innerOffset = isMain ? 0 : 4;
 
-              return (
-                <line
-                  key={`bg-tick-${i}`}
-                  x1={r4(cx + (radius + innerOffset) * Math.cos(rad))}
-                  y1={r4(cy + (radius + innerOffset) * Math.sin(rad))}
-                  x2={r4(cx + (radius + tickLength) * Math.cos(rad))}
-                  y2={r4(cy + (radius + tickLength) * Math.sin(rad))}
-                  stroke={isMain ? 'rgba(120,120,120,0.28)' : 'rgba(120,120,120,0.14)'}
-                  strokeWidth={isMain ? '4' : '2'}
-                  strokeLinecap="round"
-                />
-              );
-            })}
-
-            {/* Spokes — one per day of week */}
-            {data.map((d, i) => {
-              const angle = (i * 360) / 7;
-              const length = Math.max((d.commits / maxCommits) * maxSpokeLength, 4);
-              const isHigh = d.commits > maxCommits * 0.7;
-              const isPeak = i === peakIndex && d.commits > 0;
-              const rad = (angle * Math.PI) / 180;
-
-              // Scale stroke width: 3px base, up to 6px for peak
-              const strokeW = isPeak ? 6 : isHigh ? 5 : 4;
-
-              const x1 = r4(cx + radius * Math.cos(rad));
-              const y1 = r4(cy + radius * Math.sin(rad));
-              const x2 = r4(cx + (radius + length) * Math.cos(rad));
-              const y2 = r4(cy + (radius + length) * Math.sin(rad));
-              const labelX = r4(cx + (radius + maxSpokeLength + 14) * Math.cos(rad));
-              const labelY = r4(cy + (radius + maxSpokeLength + 14) * Math.sin(rad));
-
-              const spokeColor = isPeak
-                ? 'var(--peak-spoke)'
-                : isHigh
-                  ? 'rgba(160,160,160,0.85)'
-                  : 'rgba(110,110,110,0.55)';
-
-              const dotColor = isPeak
-                ? 'var(--peak-dot)'
-                : isHigh
-                  ? 'rgba(180,180,180,0.75)'
-                  : 'rgba(120,120,120,0.55)';
-
-              const labelColor = isPeak
-                ? 'var(--peak-label)'
-                : isHigh
-                  ? 'rgba(180,180,180,0.75)'
-                  : 'rgba(120,120,120,0.6)';
-              return (
-                <motion.g
-                  key={d.day}
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  transition={{ delay: i * 0.08, duration: 0.3 }}
-                >
+                return (
                   <line
-                    x1={x1}
-                    y1={y1}
-                    x2={x2}
-                    y2={y2}
-                    stroke={spokeColor}
-                    strokeWidth={strokeW}
+                    key={`bg-tick-${i}`}
+                    x1={r4(cx + (radius + innerOffset) * Math.cos(rad))}
+                    y1={r4(cy + (radius + innerOffset) * Math.sin(rad))}
+                    x2={r4(cx + (radius + tickLength) * Math.cos(rad))}
+                    y2={r4(cy + (radius + tickLength) * Math.sin(rad))}
+                    stroke={isMain ? 'rgba(120,120,120,0.28)' : 'rgba(120,120,120,0.14)'}
+                    strokeWidth={isMain ? '4' : '2'}
                     strokeLinecap="round"
-                    filter={isPeak ? 'url(#spoke-glow)' : undefined}
                   />
+                );
+              })}
 
-                  {/* Dot at the end of each spoke */}
-                  {d.commits > 0 && (
-                    <circle
-                      cx={x2}
-                      cy={y2}
-                      r={isPeak ? 2.2 : 2}
-                      fill={dotColor}
+              {/* Spokes — one per day of week */}
+              {data.map((d, i) => {
+                const angle = (i * 360) / 7;
+                const length = Math.max((d.commits / maxCommits) * maxSpokeLength, 4);
+                const isHigh = d.commits > maxCommits * 0.7;
+                const isPeak = i === peakIndex && d.commits > 0;
+                const rad = (angle * Math.PI) / 180;
+
+                // Scale stroke width: 3px base, up to 6px for peak
+                const strokeW = isPeak ? 6 : isHigh ? 5 : 4;
+
+                const x1 = r4(cx + radius * Math.cos(rad));
+                const y1 = r4(cy + radius * Math.sin(rad));
+                const x2 = r4(cx + (radius + length) * Math.cos(rad));
+                const y2 = r4(cy + (radius + length) * Math.sin(rad));
+                const labelX = r4(cx + (radius + maxSpokeLength + 14) * Math.cos(rad));
+                const labelY = r4(cy + (radius + maxSpokeLength + 14) * Math.sin(rad));
+
+                const spokeColor = isPeak
+                  ? 'var(--peak-spoke)'
+                  : isHigh
+                    ? 'rgba(160,160,160,0.85)'
+                    : 'rgba(110,110,110,0.55)';
+
+                const dotColor = isPeak
+                  ? 'var(--peak-dot)'
+                  : isHigh
+                    ? 'rgba(180,180,180,0.75)'
+                    : 'rgba(120,120,120,0.55)';
+
+                const labelColor = isPeak
+                  ? 'var(--peak-label)'
+                  : isHigh
+                    ? 'rgba(180,180,180,0.75)'
+                    : 'rgba(120,120,120,0.6)';
+                return (
+                  <motion.g
+                    tabIndex={0}
+                    role="img"
+                    aria-label={`${d.day}: ${getContributionLabel(d.commits)}`}
+                    onMouseEnter={(e) => showTooltip(e, d.day, d.commits, isPeak)}
+                    onMouseMove={(e) => showTooltip(e, d.day, d.commits, isPeak)}
+                    onMouseLeave={hideTooltip}
+                    onFocus={(e) => showTooltip(e, d.day, d.commits, isPeak)}
+                    onBlur={hideTooltip}
+                    className="cursor-pointer outline-none"
+                    key={d.day}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    transition={{ delay: i * 0.08, duration: 0.3 }}
+                  >
+                    <line
+                      x1={x1}
+                      y1={y1}
+                      x2={x2}
+                      y2={y2}
+                      stroke={spokeColor}
+                      strokeWidth={strokeW}
+                      strokeLinecap="round"
                       filter={isPeak ? 'url(#spoke-glow)' : undefined}
                     />
-                  )}
 
-                  {/* Day and Commit Count Label (stacked vertically via tspan to avoid side overlaps) */}
-                  <text
-                    x={labelX}
-                    y={labelY}
-                    fill={isPeak ? 'var(--peak-label)' : 'rgba(120,120,120,0.55)'}
-                    fontSize="9"
-                    fontWeight={isPeak ? '700' : '400'}
-                    textAnchor="middle"
-                    transform={`rotate(90, ${labelX}, ${labelY})`}
-                  >
-                    <tspan x={labelX} dy="-2">
-                      {d.day}
-                    </tspan>
-                    <tspan
+                    {/* Dot at the end of each spoke */}
+                    {d.commits > 0 && (
+                      <circle
+                        cx={x2}
+                        cy={y2}
+                        r={isPeak ? 2.2 : 2}
+                        fill={dotColor}
+                        filter={isPeak ? 'url(#spoke-glow)' : undefined}
+                      />
+                    )}
+
+                    {/* Day and Commit Count Label (stacked vertically via tspan to avoid side overlaps) */}
+                    <text
                       x={labelX}
-                      dy="10"
-                      fill={isPeak ? 'var(--peak-label)' : labelColor}
-                      fontSize="7"
-                      fontWeight="700"
+                      y={labelY}
+                      fill={isPeak ? 'var(--peak-label)' : 'rgba(120,120,120,0.55)'}
+                      fontSize="9"
+                      fontWeight={isPeak ? '700' : '400'}
+                      textAnchor="middle"
+                      transform={`rotate(90, ${labelX}, ${labelY})`}
                     >
-                      {d.commits}
-                    </tspan>
-                  </text>
-                </motion.g>
-              );
-            })}
-          </svg>
-        ) : (
-          <div className="h-[280px] flex items-center justify-center w-full rounded-lg border border-dashed border-black/10 dark:border-[rgba(255,255,255,0.08)] text-sm text-[#A1A1AA]">
-            No recent activity to display
-          </div>
-        )}
+                      <tspan x={labelX} dy="-2">
+                        {d.day}
+                      </tspan>
+                      <tspan
+                        x={labelX}
+                        dy="10"
+                        fill={isPeak ? 'var(--peak-label)' : labelColor}
+                        fontSize="7"
+                        fontWeight="700"
+                      >
+                        {d.commits}
+                      </tspan>
+                    </text>
+                  </motion.g>
+                );
+              })}
+            </svg>
+          ) : (
+            <div className="h-[280px] flex items-center justify-center w-full rounded-lg border border-dashed border-black/10 dark:border-[rgba(255,255,255,0.08)] text-sm text-[#A1A1AA]">
+              No recent activity to display
+            </div>
+          )}
 
-        {/* Center label */}
-        <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
-          <span className="text-lg font-semibold text-gray-700 dark:text-white/60">7d</span>
-          <span className="text-[8px] text-gray-400 dark:text-white/20 mt-0.5">CYCLE</span>
+          {/* Center label */}
+          <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+            <span className="text-lg font-semibold text-gray-700 dark:text-white/60">7d</span>
+            <span className="text-[8px] text-gray-400 dark:text-white/20 mt-0.5">CYCLE</span>
+          </div>
         </div>
-      </div>
-    </motion.div>
+      </motion.div>
+
+      <AnimatePresence>
+        {tooltip && (
+          <VisualizationTooltip title={`${tooltip.day} activity`} x={tooltip.x} y={tooltip.y}>
+            <div>{getContributionLabel(tooltip.commits)}</div>
+            <div>{tooltip.insight}</div>
+          </VisualizationTooltip>
+        )}
+      </AnimatePresence>
+    </>
   );
 }

--- a/components/dashboard/Heatmap.tsx
+++ b/components/dashboard/Heatmap.tsx
@@ -1,15 +1,26 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import { ActivityData } from '@/types/dashboard';
+import { useEffect, useRef, useState, type SyntheticEvent } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import type { ActivityData } from '@/types/dashboard';
 import { getIntensityColor } from './heatmapUtils';
+import VisualizationTooltip from './VisualizationTooltip';
+import {
+  formatTooltipDate,
+  getActivityInsight,
+  getContributionLabel,
+  getLocalActiveStreak,
+  getStreakLabel,
+} from './tooltipUtils';
 
 const CELL = 14;
 const GAP = 3;
 
 interface TooltipState {
-  text: string;
+  count: number;
+  date: string;
+  insight: string;
+  streak: string;
   x: number;
   y: number;
 }
@@ -31,21 +42,31 @@ export default function Heatmap({ data }: { data: ActivityData[] }) {
   // Recalculate scale whenever the card resizes
   useEffect(() => {
     if (!containerRef.current) return;
+
     const observer = new ResizeObserver(([entry]) => {
       const available = entry.contentRect.width;
       if (available > 0) setScale(Math.min(1, available / naturalWidth));
     });
+
     observer.observe(containerRef.current);
     return () => observer.disconnect();
   }, [naturalWidth]);
 
-  const handleMouseEnter = (e: React.MouseEvent<HTMLDivElement>, day: ActivityData) => {
+  const handleMouseEnter = (
+    e: SyntheticEvent<HTMLDivElement>,
+    day: ActivityData,
+    index: number
+  ) => {
     const rect = e.currentTarget.getBoundingClientRect();
+    const streak = getLocalActiveStreak(data, index);
+
     setTooltip({
-      text: `${day.count} contribution${day.count !== 1 ? 's' : ''} on ${day.date}`,
-      // Centre the tooltip above the cell
+      count: day.count,
+      date: formatTooltipDate(day.date),
+      insight: getActivityInsight(day.count, day.intensity),
+      streak: getStreakLabel(streak),
       x: rect.left + rect.width / 2,
-      y: rect.top - 8,
+      y: rect.top - 10,
     });
   };
 
@@ -58,23 +79,25 @@ export default function Heatmap({ data }: { data: ActivityData[] }) {
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
         transition={{ duration: 0.5, delay: 0.2 }}
-        className="p-6 rounded-xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)]"
+        className="rounded-xl border border-black/10 bg-white p-6 dark:border-[rgba(255,255,255,0.08)] dark:bg-[#0a0a0a]"
       >
         {/* Header */}
-        <h3 className=" text-sm font-semibold text-gray-900 dark:text-white tracking-tight my-1">
+        <h3 className="my-1 text-sm font-semibold tracking-tight text-gray-900 dark:text-white">
           Contribution Heatmap
         </h3>
-        <div className="flex justify-between items-end mb-4">
+
+        <div className="mb-4 flex items-end justify-between">
           <div>
-            <p className="text-xs text-[#A1A1AA] mt-0.5">Last 365 days</p>
+            <p className="mt-0.5 text-xs text-[#A1A1AA]">Last 365 days</p>
           </div>
+
           <div className="flex items-center gap-2 text-xs text-[#A1A1AA]">
             <span>Less</span>
             <div className="flex gap-1">
               {[0, 1, 2, 3, 4].map((level) => (
                 <div
                   key={level}
-                  className={` h-2 w-2 xs:w-3 xs:h-3 rounded-sm ${getIntensityColor(level)}`}
+                  className={`h-2 w-2 rounded-sm xs:h-3 xs:w-3 ${getIntensityColor(level)}`}
                 />
               ))}
             </div>
@@ -93,25 +116,37 @@ export default function Heatmap({ data }: { data: ActivityData[] }) {
                 height: (7 * (CELL + GAP) - GAP) * scale,
               }}
             >
-              <div className="flex " style={{ gap: GAP }}>
+              <div className="flex" style={{ gap: GAP }}>
                 {weeks.map((week, wIndex) => (
                   <div key={wIndex} className="flex flex-col" style={{ gap: GAP }}>
-                    {week.map((day, dIndex) => (
-                      <div
-                        key={dIndex}
-                        onMouseEnter={(e) => handleMouseEnter(e, day)}
-                        onMouseLeave={handleMouseLeave}
-                        className={`rounded-sm cursor-pointer transition-all duration-150 hover:brightness-125 hover:scale-125 ${getIntensityColor(day.intensity)}`}
-                        style={{ width: CELL, height: CELL }}
-                      />
-                    ))}
+                    {week.map((day, dIndex) => {
+                      const originalIndex = wIndex * 7 + dIndex;
+
+                      return (
+                        <div
+                          key={day.date}
+                          aria-label={`${getContributionLabel(
+                            day.count
+                          )} on ${formatTooltipDate(day.date)}`}
+                          tabIndex={0}
+                          onMouseEnter={(e) => handleMouseEnter(e, day, originalIndex)}
+                          onFocus={(e) => handleMouseEnter(e, day, originalIndex)}
+                          onMouseLeave={handleMouseLeave}
+                          onBlur={handleMouseLeave}
+                          className={`cursor-pointer rounded-sm transition-all duration-150 hover:scale-125 hover:brightness-125 focus:outline-none focus:ring-2 focus:ring-white/70 dark:focus:ring-white ${getIntensityColor(
+                            day.intensity
+                          )}`}
+                          style={{ width: CELL, height: CELL }}
+                        />
+                      );
+                    })}
                   </div>
                 ))}
               </div>
             </div>
           </div>
         ) : (
-          <div className="h-[120px] flex items-center justify-center rounded-lg border border-dashed border-black/10 dark:border-[rgba(255,255,255,0.08)] text-sm text-[#A1A1AA]">
+          <div className="flex h-[120px] items-center justify-center rounded-lg border border-dashed border-black/10 text-sm text-[#A1A1AA] dark:border-[rgba(255,255,255,0.08)]">
             No recent activity to display
           </div>
         )}
@@ -120,21 +155,14 @@ export default function Heatmap({ data }: { data: ActivityData[] }) {
       {/* Tooltip rendered at viewport level — unaffected by scale/overflow */}
       <AnimatePresence>
         {tooltip && (
-          <motion.div
-            key="heatmap-tooltip"
-            initial={{ opacity: 0, y: 4 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 4 }}
-            transition={{ duration: 0.12 }}
-            className="fixed z-[9999] pointer-events-none -translate-x-1/2 -translate-y-full"
-            style={{ left: tooltip.x, top: tooltip.y }}
+          <VisualizationTooltip
+            title={`${getContributionLabel(tooltip.count)} on ${tooltip.date}`}
+            x={tooltip.x}
+            y={tooltip.y}
           >
-            <div className="bg-gray-100 dark:bg-[#111] border border-[rgba(255,255,255,0.1)] px-2.5 py-1.5 rounded-md text-[11px] text-gray-900 dark:text-white shadow-lg whitespace-nowrap">
-              {tooltip.text}
-            </div>
-            {/* Arrow */}
-            <div className="mx-auto w-2 h-2 bg-gray-100 dark:bg-[#111] border-r border-b border-black/10 dark:border-white/10 rotate-45 -mt-1" />
-          </motion.div>
+            <div>{tooltip.insight}</div>
+            <div>{tooltip.streak}</div>
+          </VisualizationTooltip>
         )}
       </AnimatePresence>
     </>

--- a/components/dashboard/VisualizationTooltip.tsx
+++ b/components/dashboard/VisualizationTooltip.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import type { ReactNode } from 'react';
+
+interface VisualizationTooltipProps {
+  title: string;
+  children: ReactNode;
+  x: number;
+  y: number;
+}
+
+export default function VisualizationTooltip({ title, children, x, y }: VisualizationTooltipProps) {
+  return (
+    <motion.div
+      role="tooltip"
+      initial={{ opacity: 0, scale: 0.96 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.96 }}
+      transition={{ duration: 0.15, ease: 'easeOut' }}
+      className="pointer-events-none fixed z-[9999] min-w-max max-w-xs -translate-x-1/2 -translate-y-full rounded-xl border border-black/10 bg-white/95 px-3 py-2 text-xs text-gray-800 shadow-2xl shadow-black/20 backdrop-blur-md dark:border-white/10 dark:bg-[#111]/95 dark:text-white"
+      style={{
+        left: x,
+        top: y,
+      }}
+    >
+      <div className="mb-1 font-semibold text-gray-950 dark:text-white">{title}</div>
+
+      <div className="space-y-0.5 text-[11px] leading-relaxed text-gray-600 dark:text-gray-300">
+        {children}
+      </div>
+    </motion.div>
+  );
+}

--- a/components/dashboard/tooltipUtils.test.ts
+++ b/components/dashboard/tooltipUtils.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import type { ActivityData } from '@/types/dashboard';
+import {
+  formatTooltipDate,
+  getActivityInsight,
+  getContributionLabel,
+  getLocalActiveStreak,
+  getStreakLabel,
+} from './tooltipUtils';
+
+describe('tooltipUtils', () => {
+  it('formats contribution labels correctly', () => {
+    expect(getContributionLabel(0)).toBe('0 contributions');
+    expect(getContributionLabel(1)).toBe('1 contribution');
+    expect(getContributionLabel(5)).toBe('5 contributions');
+  });
+
+  it('formats valid dates into readable tooltip dates', () => {
+    expect(formatTooltipDate('2024-01-15')).toBe('Jan 15, 2024');
+  });
+
+  it('returns original value for invalid date strings', () => {
+    expect(formatTooltipDate('invalid-date')).toBe('invalid-date');
+  });
+
+  it('returns activity insights based on count and intensity', () => {
+    expect(getActivityInsight(0, 0)).toBe('No activity recorded');
+    expect(getActivityInsight(1, 1)).toBe('Light activity day');
+    expect(getActivityInsight(3, 2)).toBe('Steady contribution day');
+    expect(getActivityInsight(6, 3)).toBe('High activity day');
+    expect(getActivityInsight(12, 4)).toBe('Peak activity day');
+  });
+
+  it('calculates active streak around a hovered day', () => {
+    const data: ActivityData[] = [
+      { date: '2024-01-01', count: 0, intensity: 0 },
+      { date: '2024-01-02', count: 2, intensity: 2 },
+      { date: '2024-01-03', count: 1, intensity: 1 },
+      { date: '2024-01-04', count: 3, intensity: 3 },
+      { date: '2024-01-05', count: 0, intensity: 0 },
+    ];
+
+    expect(getLocalActiveStreak(data, 2)).toBe(3);
+    expect(getLocalActiveStreak(data, 0)).toBe(0);
+  });
+
+  it('formats streak labels correctly', () => {
+    expect(getStreakLabel(0)).toBe('No active streak');
+    expect(getStreakLabel(4)).toBe('4-day active streak');
+  });
+});

--- a/components/dashboard/tooltipUtils.ts
+++ b/components/dashboard/tooltipUtils.ts
@@ -1,0 +1,53 @@
+import type { ActivityData } from '@/types/dashboard';
+
+export function formatTooltipDate(date: string) {
+  const parsed = new Date(`${date}T00:00:00Z`);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return date;
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(parsed);
+}
+
+export function getContributionLabel(count: number) {
+  return `${count} contribution${count === 1 ? '' : 's'}`;
+}
+
+export function getActivityInsight(count: number, intensity?: ActivityData['intensity']) {
+  if (count === 0) return 'No activity recorded';
+  if (intensity === 4 || count >= 10) return 'Peak activity day';
+  if (intensity === 3 || count >= 5) return 'High activity day';
+  if (intensity === 2 || count >= 2) return 'Steady contribution day';
+
+  return 'Light activity day';
+}
+
+export function getLocalActiveStreak(data: ActivityData[], index: number) {
+  if (!data[index] || data[index].count === 0) {
+    return 0;
+  }
+
+  let streak = 1;
+
+  for (let i = index - 1; i >= 0 && data[i].count > 0; i--) {
+    streak++;
+  }
+
+  for (let i = index + 1; i < data.length && data[i].count > 0; i++) {
+    streak++;
+  }
+
+  return streak;
+}
+
+export function getStreakLabel(streak: number) {
+  if (streak <= 0) return 'No active streak';
+
+  return `${streak}-day active streak`;
+}


### PR DESCRIPTION
## Description
Added rich, theme-aware hover tooltips to contribution visualizations across the dashboard.

This PR improves the tooltip experience for:
- Activity Landscape
- Contribution Heatmap
- Commit Clock

The updated tooltips now show clearer contextual information such as formatted dates, contribution counts, activity insights, active streak context, and weekday activity details. The tooltips also include smooth animations and consistent dark/light theme styling.

Fixes #263 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)
- Feature enhancement: added richer interactive hover tooltips for dashboard visualizations.

## Visual Preview
**Before: Activity Landscape only showed a basic date/count tooltip without richer activity insight.**
<img width="1896" height="941" alt="Screenshot 2026-05-30 005707" src="https://github.com/user-attachments/assets/b2e0fd6a-e831-42e3-a15e-e95c11c3b196" />
<br>

**Before: Contribution Heatmap only showed a basic contribution/date tooltip without detailed activity or streak context.**
<img width="1917" height="929" alt="Screenshot 2026-05-30 010219" src="https://github.com/user-attachments/assets/23eb288e-68c9-40ca-8a23-363d75f43837" />
<br>

**Before: Commit Clock did not show a detailed contextual hover tooltip.**
<img width="1919" height="939" alt="Screenshot 2026-05-30 010449" src="https://github.com/user-attachments/assets/fddb3a8e-0217-45fe-8358-bc1ebaae2cf2" />
<br>

**After: Activity Landscape tooltip now shows formatted date, contribution count, and activity insight.**
<img width="1919" height="943" alt="Screenshot 2026-05-30 015507" src="https://github.com/user-attachments/assets/47e1b330-13d5-4913-9018-b0f09d706e63" />
<br>

**After: Contribution Heatmap tooltip now shows contribution count, formatted date, activity insight, and active streak context.**
<img width="1919" height="944" alt="Screenshot 2026-05-30 015620" src="https://github.com/user-attachments/assets/0a43d272-4c5b-4176-a6e7-0156feab6772" />
<br>

**After: Commit Clock tooltip now shows weekday activity, contribution count, and peak weekday insight.**
<img width="1919" height="945" alt="Screenshot 2026-05-30 015725" src="https://github.com/user-attachments/assets/02e5e217-1818-480e-9918-6f242fa2cb86" />
<br>

## Testing

Tested locally on: [http://localhost:3000/dashboard/jhasourav07](http://localhost:3000/dashboard/jhasourav07)

Verified:
- Activity Landscape tooltip shows formatted date, contribution count, and activity insight
- Contribution Heatmap tooltip shows formatted date, contribution count, activity insight, and active streak context
- Commit Clock tooltip shows weekday activity, contribution count, and peak weekday insight
- Tooltips work on hover and keyboard focus
- Tooltip styling works with the existing dark dashboard UI
- Added tooltip utility tests

Commands run locally:
`npm run typecheck`
`npm run lint`
`npm test`


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
