### PR TITLE
test(documentation):add code-block clipboard interaction tests

### DIFF
--- a/app/documentation/code-block.test.tsx
+++ b/app/documentation/code-block.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { CodeBlock } from './code-block';
+
+describe('CodeBlock', () => {
+  const codeSnippet = "const status = 'ready';";
+  const writeTextMock = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: writeTextMock,
+      },
+      configurable: true,
+    });
+    writeTextMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the code prop inside a code element', () => {
+    const { container } = render(<CodeBlock code={codeSnippet} />);
+
+    const codeElement = container.querySelector('code');
+    expect(codeElement).toBeTruthy();
+    expect(codeElement?.textContent).toBe(codeSnippet);
+  });
+
+  it('renders the copy button with the correct label', () => {
+    render(<CodeBlock code={codeSnippet} />);
+
+    const copyButton = screen.getByRole('button', { name: /copy/i });
+    expect(copyButton).toBeTruthy();
+    expect(copyButton.textContent).toContain('Copy');
+  });
+
+  it('calls clipboard.writeText with the code when copy is clicked', async () => {
+    render(<CodeBlock code={codeSnippet} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /copy/i }));
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(codeSnippet);
+    });
+  });
+
+  it('changes the button label to Copied after clicking copy', async () => {
+    render(<CodeBlock code={codeSnippet} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /copy/i }));
+
+    const copiedButton = await screen.findByRole('button', { name: /copied/i });
+    expect(copiedButton.textContent).toContain('Copied');
+  });
+
+  it('reverts the button label to Copy after 2000ms', async () => {
+    vi.useFakeTimers();
+    render(<CodeBlock code={codeSnippet} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /copy/i }));
+    });
+
+    expect(writeTextMock).toHaveBeenCalledWith(codeSnippet);
+    expect(screen.getByRole('button', { name: /copied/i })).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByRole('button', { name: /copy/i })).toBeTruthy();
+  });
+});

--- a/app/documentation/code-block.test.tsx
+++ b/app/documentation/code-block.test.tsx
@@ -5,6 +5,7 @@ import { CodeBlock } from './code-block';
 describe('CodeBlock', () => {
   const codeSnippet = "const status = 'ready';";
   const writeTextMock = vi.fn().mockResolvedValue(undefined);
+  const originalClipboard = navigator.clipboard;
 
   beforeEach(() => {
     Object.defineProperty(navigator, 'clipboard', {
@@ -18,6 +19,10 @@ describe('CodeBlock', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+    });
   });
 
   it('renders the code prop inside a code element', () => {
@@ -61,13 +66,14 @@ describe('CodeBlock', () => {
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /copy/i }));
+      await Promise.resolve();
     });
 
     expect(writeTextMock).toHaveBeenCalledWith(codeSnippet);
     expect(screen.getByRole('button', { name: /copied/i })).toBeTruthy();
 
-    act(() => {
-      vi.advanceTimersByTime(2000);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
     });
 
     expect(screen.getByRole('button', { name: /copy/i })).toBeTruthy();


### PR DESCRIPTION
## Description
Adds a new test suite for the documentation codeblock component to verify clipboard and UI feedback behavior.

File added:
New file: app/documentation/code-block.test.tsx


Fixes #1032 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [ ] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
