### PR TITLE
fix(api): dedupe concurrent GitHub cache misses

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -781,6 +781,37 @@ describe('GitHub API cache behavior', () => {
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
+  it('dedupes concurrent contribution requests for the same cold cache key', async () => {
+    let resolveFetch!: (response: Response) => void;
+    vi.mocked(fetch).mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    const requests = Promise.all([
+      fetchGitHubContributions('octocat'),
+      fetchGitHubContributions('octocat'),
+      fetchGitHubContributions('octocat'),
+    ]);
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+
+    resolveFetch(
+      mockResponse({
+        data: {
+          user: {
+            contributionsCollection: { contributionCalendar: mockCalendar },
+          },
+        },
+      })
+    );
+
+    const results = await requests;
+    expect(results.map((result) => result.totalContributions)).toEqual([42, 42, 42]);
+  });
+
   it('refresh bypass: bypassCache=true forces a fresh fetch', async () => {
     vi.mocked(fetch).mockImplementation(async () =>
       mockResponse({
@@ -829,6 +860,29 @@ describe('GitHub API cache behavior', () => {
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
+  it('dedupes concurrent profile requests for the same cold cache key', async () => {
+    let resolveFetch!: (response: Response) => void;
+    vi.mocked(fetch).mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    const requests = Promise.all([
+      fetchUserProfile('octocat'),
+      fetchUserProfile('octocat'),
+      fetchUserProfile('octocat'),
+    ]);
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+
+    resolveFetch(mockResponse({ login: 'octocat', name: 'The Octocat' }));
+
+    const results = await requests;
+    expect(results.map((profile) => profile.login)).toEqual(['octocat', 'octocat', 'octocat']);
+  });
+
   it('refresh bypass: bypassCache=true forces fresh profile fetch', async () => {
     vi.mocked(fetch).mockImplementation(async () =>
       mockResponse({ login: 'octocat', name: 'The Octocat' })
@@ -838,6 +892,29 @@ describe('GitHub API cache behavior', () => {
     await fetchUserProfile('octocat', { bypassCache: true });
 
     expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('dedupes concurrent repo requests for the same cold cache key', async () => {
+    let resolveFetch!: (response: Response) => void;
+    vi.mocked(fetch).mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    const requests = Promise.all([
+      fetchUserRepos('octocat'),
+      fetchUserRepos('octocat'),
+      fetchUserRepos('octocat'),
+    ]);
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+
+    resolveFetch(mockResponse([{ stargazers_count: 7, language: 'TypeScript' }]));
+
+    const results = await requests;
+    expect(results.map((repos) => repos[0]?.stargazers_count)).toEqual([7, 7, 7]);
   });
 
   it('normalizes username casing for cache keys', async () => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -190,6 +190,9 @@ export const GITHUB_CACHE_TTL_MS = 5 * 60 * 1000;
 const contributionsCache = new DistributedCache<ContributionCalendar>(1000);
 const profileCache = new DistributedCache<GitHubUserProfile>(1000);
 const reposCache = new DistributedCache<GitHubRepo[]>(500);
+const pendingContributions = new Map<string, Promise<ContributionCalendar>>();
+const pendingProfiles = new Map<string, Promise<GitHubUserProfile>>();
+const pendingRepos = new Map<string, Promise<GitHubRepo[]>>();
 
 interface GitHubUserProfile {
   login: string;
@@ -217,6 +220,24 @@ export function clearGitHubApiCacheForTests(): void {
   contributionsCache.clear();
   profileCache.clear();
   reposCache.clear();
+  pendingContributions.clear();
+  pendingProfiles.clear();
+  pendingRepos.clear();
+}
+
+function dedupeRequest<T>(
+  pendingRequests: Map<string, Promise<T>>,
+  key: string,
+  load: () => Promise<T>
+): Promise<T> {
+  const pending = pendingRequests.get(key);
+  if (pending) return pending;
+
+  const request = load().finally(() => {
+    pendingRequests.delete(key);
+  });
+  pendingRequests.set(key, request);
+  return request;
 }
 
 function getGitHubToken(): string {
@@ -257,99 +278,104 @@ export async function fetchGitHubContributions(
     if (cached) return cached;
   }
 
-  const query = `
-    query($login: String!, $from: DateTime, $to: DateTime) {
-      user(login: $login) {
-        contributionsCollection(from: $from, to: $to) {
-          contributionCalendar {
-            totalContributions
-            weeks {
-              contributionDays {
-                contributionCount
-                date
-                color
+  const load = async () => {
+    const query = `
+      query($login: String!, $from: DateTime, $to: DateTime) {
+        user(login: $login) {
+          contributionsCollection(from: $from, to: $to) {
+            contributionCalendar {
+              totalContributions
+              weeks {
+                contributionDays {
+                  contributionCount
+                  date
+                  color
+                }
               }
             }
           }
         }
       }
-    }
-  `;
+    `;
 
-  const res = await fetchWithRetry(GITHUB_GRAPHQL_URL, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify({
-      query,
-      variables: { login: username, from: options.from, to: options.to },
-    }),
-    cache: 'no-store',
-    signal: options.signal,
-  });
-
-  if (!res.ok) {
-    throwIfRateLimited(res);
-    if (res.status === 401) throw new Error('GitHub PAT is invalid or missing');
-    throw new Error(
-      `GitHub GraphQL API returned status ${res.status} after ${MAX_RETRIES} retries`
-    );
-  }
-
-  const data: GitHubContributionResponse = await res.json();
-
-  if (data.errors !== undefined) {
-    if (Array.isArray(data.errors)) {
-      const isRateLimit = data.errors.some(
-        (e) =>
-          e?.message?.toLowerCase().includes('rate limit') ||
-          (e as { type?: string })?.type === 'RATE_LIMITED'
-      );
-      if (isRateLimit) {
-        throw new Error('API Rate Limit Exceeded');
-      }
-    }
-    throw new Error(getGraphQLErrorMessage(data.errors));
-  }
-
-  if (!data.data?.user) {
-    throw new Error(`GitHub user "${username}" not found`);
-  }
-
-  const calendar = data.data.user.contributionsCollection.contributionCalendar;
-
-  // Inject deterministic Lines of Code (LoC) approximation
-  // Since GitHub's contributionCalendar doesn't provide native LoC metrics,
-  // we generate a consistent estimation based on the day's commit volume.
-  calendar.weeks.forEach((week) => {
-    week.contributionDays.forEach((day) => {
-      if (day.contributionCount > 0) {
-        let hash1 = 2166136261,
-          hash2 = 2166136261;
-        const seed1 = day.date + 'add',
-          seed2 = day.date + 'del';
-        for (let i = 0; i < seed1.length; i++) {
-          hash1 ^= seed1.charCodeAt(i);
-          hash1 = Math.imul(hash1, 16777619);
-        }
-        for (let i = 0; i < seed2.length; i++) {
-          hash2 ^= seed2.charCodeAt(i);
-          hash2 = Math.imul(hash2, 16777619);
-        }
-        const randAdd = (hash1 >>> 0) / 4294967296;
-        const randDel = (hash2 >>> 0) / 4294967296;
-
-        day.locAdditions = Math.floor(day.contributionCount * (25 + randAdd * 85));
-        day.locDeletions = Math.floor(day.contributionCount * (5 + randDel * 35));
-      } else {
-        day.locAdditions = 0;
-        day.locDeletions = 0;
-      }
+    const res = await fetchWithRetry(GITHUB_GRAPHQL_URL, {
+      method: 'POST',
+      headers: getHeaders(),
+      body: JSON.stringify({
+        query,
+        variables: { login: username, from: options.from, to: options.to },
+      }),
+      cache: 'no-store',
+      signal: options.signal,
     });
-  });
 
-  if (!options.bypassCache) await contributionsCache.set(key, calendar, GITHUB_CACHE_TTL_MS);
+    if (!res.ok) {
+      throwIfRateLimited(res);
+      if (res.status === 401) throw new Error('GitHub PAT is invalid or missing');
+      throw new Error(
+        `GitHub GraphQL API returned status ${res.status} after ${MAX_RETRIES} retries`
+      );
+    }
 
-  return calendar;
+    const data: GitHubContributionResponse = await res.json();
+
+    if (data.errors !== undefined) {
+      if (Array.isArray(data.errors)) {
+        const isRateLimit = data.errors.some(
+          (e) =>
+            e?.message?.toLowerCase().includes('rate limit') ||
+            (e as { type?: string })?.type === 'RATE_LIMITED'
+        );
+        if (isRateLimit) {
+          throw new Error('API Rate Limit Exceeded');
+        }
+      }
+      throw new Error(getGraphQLErrorMessage(data.errors));
+    }
+
+    if (!data.data?.user) {
+      throw new Error(`GitHub user "${username}" not found`);
+    }
+
+    const calendar = data.data.user.contributionsCollection.contributionCalendar;
+
+    // Inject deterministic Lines of Code (LoC) approximation
+    // Since GitHub's contributionCalendar doesn't provide native LoC metrics,
+    // we generate a consistent estimation based on the day's commit volume.
+    calendar.weeks.forEach((week) => {
+      week.contributionDays.forEach((day) => {
+        if (day.contributionCount > 0) {
+          let hash1 = 2166136261,
+            hash2 = 2166136261;
+          const seed1 = day.date + 'add',
+            seed2 = day.date + 'del';
+          for (let i = 0; i < seed1.length; i++) {
+            hash1 ^= seed1.charCodeAt(i);
+            hash1 = Math.imul(hash1, 16777619);
+          }
+          for (let i = 0; i < seed2.length; i++) {
+            hash2 ^= seed2.charCodeAt(i);
+            hash2 = Math.imul(hash2, 16777619);
+          }
+          const randAdd = (hash1 >>> 0) / 4294967296;
+          const randDel = (hash2 >>> 0) / 4294967296;
+
+          day.locAdditions = Math.floor(day.contributionCount * (25 + randAdd * 85));
+          day.locDeletions = Math.floor(day.contributionCount * (5 + randDel * 35));
+        } else {
+          day.locAdditions = 0;
+          day.locDeletions = 0;
+        }
+      });
+    });
+
+    if (!options.bypassCache) await contributionsCache.set(key, calendar, GITHUB_CACHE_TTL_MS);
+
+    return calendar;
+  };
+
+  if (options.bypassCache) return load();
+  return dedupeRequest(pendingContributions, key, load);
 }
 
 export async function fetchUserProfile(
@@ -363,27 +389,32 @@ export async function fetchUserProfile(
     if (cached) return cached;
   }
 
-  const res = await fetchWithRetry(`${GITHUB_REST_URL}/users/${encodedUsername}`, {
-    headers: getHeaders(),
-    cache: 'no-store',
-    signal: options.signal,
-  });
+  const load = async () => {
+    const res = await fetchWithRetry(`${GITHUB_REST_URL}/users/${encodedUsername}`, {
+      headers: getHeaders(),
+      cache: 'no-store',
+      signal: options.signal,
+    });
 
-  if (!res.ok) {
-    throwIfRateLimited(res);
-    if (res.status === 404) throw new Error('User not found');
-    if (res.status === 403 && res.headers.get('x-ratelimit-remaining') === '0') {
-      throw new Error('API Rate Limit Exceeded');
+    if (!res.ok) {
+      throwIfRateLimited(res);
+      if (res.status === 404) throw new Error('User not found');
+      if (res.status === 403 && res.headers.get('x-ratelimit-remaining') === '0') {
+        throw new Error('API Rate Limit Exceeded');
+      }
+      if (res.status === 429) {
+        throw new Error('API Rate Limit Exceeded');
+      }
+      throw new Error(`GitHub REST API error: ${res.status}`);
     }
-    if (res.status === 429) {
-      throw new Error('API Rate Limit Exceeded');
-    }
-    throw new Error(`GitHub REST API error: ${res.status}`);
-  }
 
-  const profile = (await res.json()) as GitHubUserProfile;
-  if (!options.bypassCache) await profileCache.set(key, profile, GITHUB_CACHE_TTL_MS);
-  return profile;
+    const profile = (await res.json()) as GitHubUserProfile;
+    if (!options.bypassCache) await profileCache.set(key, profile, GITHUB_CACHE_TTL_MS);
+    return profile;
+  };
+
+  if (options.bypassCache) return load();
+  return dedupeRequest(pendingProfiles, key, load);
 }
 
 export async function fetchUserRepos(
@@ -397,59 +428,64 @@ export async function fetchUserRepos(
     if (cached) return cached;
   }
 
-  const firstPageRes = await fetchWithRetry(
-    `${GITHUB_REST_URL}/users/${encodedUsername}/repos?per_page=100&page=1&sort=pushed`,
-    {
-      headers: getHeaders(),
-      cache: 'no-store',
-      signal: options.signal,
+  const load = async () => {
+    const firstPageRes = await fetchWithRetry(
+      `${GITHUB_REST_URL}/users/${encodedUsername}/repos?per_page=100&page=1&sort=pushed`,
+      {
+        headers: getHeaders(),
+        cache: 'no-store',
+        signal: options.signal,
+      }
+    );
+
+    if (!firstPageRes.ok) {
+      throwIfRateLimited(firstPageRes);
+      throw new Error(`GitHub REST API error: ${firstPageRes.status}`);
     }
-  );
 
-  if (!firstPageRes.ok) {
-    throwIfRateLimited(firstPageRes);
-    throw new Error(`GitHub REST API error: ${firstPageRes.status}`);
-  }
+    const firstPageRepos = (await firstPageRes.json()) as GitHubRepo[];
+    const allRepos: GitHubRepo[] = [...firstPageRepos];
 
-  const firstPageRepos = (await firstPageRes.json()) as GitHubRepo[];
-  const allRepos: GitHubRepo[] = [...firstPageRepos];
+    const MAX_PAGES = 3;
 
-  const MAX_PAGES = 3;
+    if (firstPageRepos.length === 100) {
+      const remainingPages = Array.from({ length: MAX_PAGES - 1 }, (_, i) => i + 2);
 
-  if (firstPageRepos.length === 100) {
-    const remainingPages = Array.from({ length: MAX_PAGES - 1 }, (_, i) => i + 2);
-
-    const responses = await Promise.all(
-      remainingPages.map((page) =>
-        fetchWithRetry(
-          `${GITHUB_REST_URL}/users/${encodedUsername}/repos?per_page=100&page=${page}&sort=pushed`,
-          {
-            headers: getHeaders(),
-            cache: 'no-store',
-            signal: options.signal,
-          }
+      const responses = await Promise.all(
+        remainingPages.map((page) =>
+          fetchWithRetry(
+            `${GITHUB_REST_URL}/users/${encodedUsername}/repos?per_page=100&page=${page}&sort=pushed`,
+            {
+              headers: getHeaders(),
+              cache: 'no-store',
+              signal: options.signal,
+            }
+          )
         )
-      )
-    );
+      );
 
-    const pagesRepos = await Promise.all(
-      responses.map(async (response) => {
-        if (!response.ok) {
-          throwIfRateLimited(response);
-          throw new Error(`GitHub REST API error: ${response.status}`);
-        }
+      const pagesRepos = await Promise.all(
+        responses.map(async (response) => {
+          if (!response.ok) {
+            throwIfRateLimited(response);
+            throw new Error(`GitHub REST API error: ${response.status}`);
+          }
 
-        return (await response.json()) as GitHubRepo[];
-      })
-    );
+          return (await response.json()) as GitHubRepo[];
+        })
+      );
 
-    for (const repos of pagesRepos) {
-      allRepos.push(...repos);
+      for (const repos of pagesRepos) {
+        allRepos.push(...repos);
+      }
     }
-  }
 
-  if (!options.bypassCache) await reposCache.set(key, allRepos, GITHUB_CACHE_TTL_MS);
-  return allRepos;
+    if (!options.bypassCache) await reposCache.set(key, allRepos, GITHUB_CACHE_TTL_MS);
+    return allRepos;
+  };
+
+  if (options.bypassCache) return load();
+  return dedupeRequest(pendingRepos, key, load);
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Description

Fixes #1588

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed

The GitHub client already cached completed responses, but concurrent cold misses for the same cache key could still trigger duplicate upstream GitHub requests before the first response populated the cache.

This PR adds small in-flight request maps for contribution, profile, and repo fetches. Normal cacheable requests now share a pending promise for the same key, and the pending entry is removed once the request settles.

`bypassCache` is intentionally unchanged: refresh requests still skip both the completed cache and in-flight deduping so an explicit refresh remains a real fresh request.

I also added regression tests for concurrent cold misses across all three GitHub data paths.

This is a GSSoC 2026 performance/API bug fix contribution. Please add the relevant GSSoC labels if they are missing.

## Visual Preview

N/A — this is an API/client caching behavior change.

## Local checks

```bash
npm run format:check
npm run lint
npm run test -- lib/github.test.ts
```

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commit follows the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.
