### PR TITLE
fix(api): encode organization member lookup paths

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -1147,6 +1147,17 @@ describe('fetchOrgMembers', () => {
     expect(members[0]).toBe('alice');
     expect(members[1]).toBe('bob');
   });
+
+  it('encodes the organization name before using it in the members REST path', async () => {
+    vi.mocked(fetch).mockResolvedValue(mockResponse([]));
+
+    await fetchOrgMembers('octo/org');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.github.com/orgs/octo%2Forg/members?per_page=50',
+      expect.objectContaining({ cache: 'no-store' })
+    );
+  });
 });
 
 describe('getOrgDashboardData', () => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -496,10 +496,14 @@ export async function fetchUserRepos(
  * Fetches members of an organization. (Used for Org Dashboards).
  */
 export async function fetchOrgMembers(orgName: string): Promise<string[]> {
-  const res = await fetchWithRetry(`${GITHUB_REST_URL}/orgs/${orgName}/members?per_page=50`, {
-    headers: getHeaders(),
-    cache: 'no-store',
-  });
+  const encodedOrgName = encodeURIComponent(orgName);
+  const res = await fetchWithRetry(
+    `${GITHUB_REST_URL}/orgs/${encodedOrgName}/members?per_page=50`,
+    {
+      headers: getHeaders(),
+      cache: 'no-store',
+    }
+  );
   if (!res.ok) throw new Error(`Failed to fetch members for org ${orgName}`);
   const members = (await res.json()) as { login: string }[];
   return members.map((m) => m.login);


### PR DESCRIPTION
## Description

Fixes #1590

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed

`fetchOrgMembers()` was interpolating the raw organization name directly into the GitHub REST path:

```ts
/orgs/${orgName}/members
```

This PR encodes the organization name before building that URL, matching the existing behavior in `fetchUserProfile()` and `fetchUserRepos()`.

I also added a regression test that calls `fetchOrgMembers('octo/org')` and verifies the request goes to `/orgs/octo%2Forg/members`, so the org value is treated as one path segment.

This is a GSSoC 2026 API bug fix contribution. Please add the relevant GSSoC labels if they are missing.

## Visual Preview

N/A — this is an API URL construction fix.

## Local checks

```bash
npm run format:check
npm run lint
npm run test -- lib/github.test.ts
```

`npm run lint` reports one existing warning in `app/page.tsx`; there are no lint errors.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commit follows the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.
