### PR TITLE
test(calculate): verify streak across Dec 31 to Jan 1 year boundary

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -550,6 +550,46 @@ describe('calculateStreak — todayDate format', () => {
   });
 });
 
+describe('calculateStreak — year boundary transition (Dec 31 → Jan 1)', () => {
+  // Streak math relies on the flattened day array being chronologically ordered,
+  // so a run that crosses from December into January must be counted as a single
+  // continuous streak. This guards against off-by-one bugs where the calendar
+  // year rollover (e.g. 2024-12-31 → 2025-01-01) is mistakenly treated as a gap.
+  it('counts a streak that spans the Dec 31 → Jan 1 boundary as one continuous run', () => {
+    const calendar: ContributionCalendar = {
+      totalContributions: 7,
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 0, date: '2024-12-26' }, // gap before the streak begins
+            { contributionCount: 1, date: '2024-12-27' },
+            { contributionCount: 1, date: '2024-12-28' },
+            { contributionCount: 1, date: '2024-12-29' },
+            { contributionCount: 1, date: '2024-12-30' },
+            { contributionCount: 1, date: '2024-12-31' }, // last day of the year
+            { contributionCount: 1, date: '2025-01-01' }, // first day of the new year
+          ],
+        },
+        {
+          contributionDays: [
+            { contributionCount: 1, date: '2025-01-02' }, // "today"
+          ],
+        },
+      ],
+    };
+
+    // Pin "now" to Jan 2 so the final day is treated as today and the streak is live.
+    const now = new Date('2025-01-02T12:00:00Z');
+    const result = calculateStreak(calendar, 'UTC', now);
+
+    // The 7-day run (Dec 27 → Jan 2) must not be split by the year rollover.
+    expect(result.currentStreak).toBe(7);
+    expect(result.longestStreak).toBe(7);
+    expect(result.totalContributions).toBe(7);
+    expect(result.todayDate).toBe('2025-01-02');
+  });
+});
+
 // ---------- EPIC ENHANCEMENT TESTS ----------
 
 describe('aggregateCalendars', () => {


### PR DESCRIPTION
## Description

Fixes #1482

Adds a unit test in `lib/calculate.test.ts` simulating a contribution streak that spans the **Dec 31 → Jan 1** year boundary. It verifies that `calculateStreak` treats the calendar year rollover (`2024-12-31` → `2025-01-01`) as one continuous run rather than splitting the streak — guarding against off-by-one bugs at the year boundary.

Assertions:
- `currentStreak === 7` (Dec 27 → Jan 2)
- `longestStreak === 7`
- `totalContributions === 7`
- `todayDate === '2025-01-02'`

No production code changed — this is purely additional test coverage.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — test-only change, no SVG/UI output affected.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.