### PR TITLE
fix(api): add CSP header to generic error SVGs

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -670,6 +670,17 @@ describe('GET /api/streak', () => {
       expect(response.headers.get('Cache-Control')).toBe('no-store');
     });
 
+    it('sets the SVG Content-Security-Policy header on generic error responses', async () => {
+      vi.mocked(fetchGitHubContributions).mockRejectedValue(new Error('Network failure'));
+
+      const response = await GET(makeRequest({ user: 'octocat' }));
+      const csp = response.headers.get('Content-Security-Policy');
+
+      expect(response.status).toBe(500);
+      expect(csp).toContain("default-src 'none'");
+      expect(csp).not.toContain('script-src');
+    });
+
     it('returns 429 with no-cache headers and rate limit SVG when rate limited', async () => {
       vi.mocked(fetchGitHubContributions).mockRejectedValue(new Error('API Rate Limit Exceeded'));
 

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -336,6 +336,7 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
     headers: {
       'Content-Type': 'image/svg+xml',
       'Cache-Control': 'no-store',
+      'Content-Security-Policy': SVG_CSP_HEADER,
     },
   });
 }


### PR DESCRIPTION
## Description

Fixes #1595

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed

The generic 500 SVG response in `app/api/streak/route.ts` was missing the same `Content-Security-Policy` header used by the other SVG responses from this route.

This PR adds `Content-Security-Policy: SVG_CSP_HEADER` to the catch-all error SVG response so the security headers stay consistent across success, validation, not-found, rate-limit, and generic failure paths.

I also added a route regression test that forces a generic fetch failure and verifies the 500 SVG response includes the CSP header.

This is a GSSoC 2026 API/security bug fix contribution. Please add the relevant GSSoC labels if they are missing.

## Visual Preview

N/A — this is a response header change only.

## Local checks

```bash
npm run format:check
npm run lint
npm run test -- app/api/streak/route.test.ts
```

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commit follows the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.
