### PR TITLE
fix(loc): use LoC count for tower intensity calculation

### DIFF
--- a/lib/svg/layout.test.ts
+++ b/lib/svg/layout.test.ts
@@ -201,6 +201,8 @@ describe('computeTowers edge cases', () => {
     expect(testTower.contributionCount).toBe(60);
     // Assert h > 0 (not ghost despite 0 normal contributions)
     expect(testTower.h).toBeGreaterThan(0);
+    // Assert intensityLevel is calculated correctly based on lines of code (60/60 = 100%, so intensity 4)
+    expect(testTower.intensityLevel).toBe(4);
   });
 });
 

--- a/lib/svg/layout.ts
+++ b/lib/svg/layout.ts
@@ -127,9 +127,9 @@ export function computeTowers(
       let intensityLevel = 0;
       if (hasCommits) {
         if (maxCommits <= 4) {
-          intensityLevel = Math.min(4, day.contributionCount);
+          intensityLevel = Math.min(4, count);
         } else {
-          const ratio = day.contributionCount / maxCommits;
+          const ratio = count / maxCommits;
           if (ratio <= 0.25) intensityLevel = 1;
           else if (ratio <= 0.5) intensityLevel = 2;
           else if (ratio <= 0.75) intensityLevel = 3;


### PR DESCRIPTION
## Description

Fixes #1600 

This PR fixes a rendering logic issue in Lines of Code (LoC) mode where tower color intensity was calculated using commit counts instead of LoC values.

Previously, the intensity level for a day's tower was derived from the number of commits, causing days with high LoC activity but few commits to appear with low or flat shading. This resulted in a visualization that did not accurately represent code volume.

### Changes Made

* Updated LoC mode intensity calculations to use the day's LoC value.
* Removed the dependency on commit counts when determining LoC tower shading.
* Preserved existing behavior for commit-based rendering modes.

### Result

* Tower intensity now accurately reflects Lines of Code activity.
* High-LoC days receive stronger visual emphasis.
* LoC mode provides a more meaningful and accurate representation of coding activity.

## Pillar

* [ ] 🎨 Pillar 1 - New Theme Design
* [ ] 📐 Pillar 2 - Geometric SVG Improvement
* [ ] 🕐 Pillar 3 - Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

### Verification

* Generated SVG output in LoC mode using varying LoC values.
* Confirmed tower intensity scales according to LoC counts.
* Verified days with high LoC and low commit counts now render with appropriate intensity.
* Confirmed non-LoC rendering modes remain unchanged.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
