### PR TITLE
test(utils): add invalid hex color fallback tests

### DIFF
--- a/lib/svg/sanitizer.test.ts
+++ b/lib/svg/sanitizer.test.ts
@@ -49,6 +49,12 @@ describe('SVG Sanitizer Utilities', () => {
       expect(sanitizeHexColor('"><script>', '000000')).toBe('000000');
     });
 
+    it('returns fallback for invalid hex names', () => {
+      expect(sanitizeHexColor('red', '000000')).toBe('000000');
+      expect(sanitizeHexColor('blue', '000000')).toBe('000000');
+      expect(sanitizeHexColor('green', '000000')).toBe('000000');
+    });
+
     it('returns fallback for null/undefined', () => {
       expect(sanitizeHexColor(null, '000000')).toBe('000000');
       expect(sanitizeHexColor(undefined, '000000')).toBe('000000');


### PR DESCRIPTION
## Description

Fixes #1582

Added test cases to verify that invalid hex/color-name inputs gracefully fall back to the default theme colors. This improves boundary robustness for theme color parsing utilities.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design 
* [ ] 📐 Pillar 2 — Geometric SVG Improvement 
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable – test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (Not applicable – test-only change).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
