### PR TITLE
fix(api): validate usernames in JSON routes

### DIFF
--- a/app/api/github/route.test.ts
+++ b/app/api/github/route.test.ts
@@ -29,6 +29,15 @@ describe('GET /api/github', () => {
     expect(body.error).toContain('Invalid parameters');
   });
 
+  it('returns 400 and skips GitHub when username format is invalid', async () => {
+    const response = await GET(makeRequest({ username: 'bad user' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Invalid parameters');
+    expect(getFullDashboardData).not.toHaveBeenCalled();
+  });
+
   // Test 2 — valid username → 200
   it('returns 200 with JSON body for a valid username', async () => {
     vi.mocked(getFullDashboardData).mockResolvedValue({ profile: 'octocat' } as never);

--- a/app/api/stats/route.test.ts
+++ b/app/api/stats/route.test.ts
@@ -55,6 +55,13 @@ describe('GET /api/stats', () => {
     expect(fetchGitHubContributions).not.toHaveBeenCalled();
   });
 
+  it('returns 400 and skips GitHub when the username format is invalid', async () => {
+    const response = await GET(makeRequest({ user: 'octo/cat' }));
+
+    expect(response.status).toBe(400);
+    expect(fetchGitHubContributions).not.toHaveBeenCalled();
+  });
+
   it('returns 400 for an unknown timezone', async () => {
     const response = await GET(makeRequest({ user: 'testuser', tz: 'Not/ATimezone' }));
     expect(response.status).toBe(400);

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -58,13 +58,15 @@ function dimensionParam(name: string, min: number, max: number) {
     .transform(toDimensionValue);
 }
 
+const GITHUB_USERNAME_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9]))*$/;
+
 export const streakParamsSchema = z.object({
   // Required — missing user surfaces as "Missing" to match existing tests
   user: z
     .string({ error: 'Missing user parameter' })
     .min(1, { message: 'Missing user parameter' })
     .max(39, { message: 'GitHub username cannot exceed 39 characters' })
-    .regex(/^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9]))*$/, {
+    .regex(GITHUB_USERNAME_REGEX, {
       message: 'Invalid GitHub username',
     }),
 
@@ -218,7 +220,11 @@ export const streakParamsSchema = z.object({
 export const githubParamsSchema = z.object({
   username: z
     .string({ error: 'Missing "username" parameter' })
-    .min(1, { message: 'Username is required' }),
+    .min(1, { message: 'Username is required' })
+    .max(39, { message: 'GitHub username cannot exceed 39 characters' })
+    .regex(GITHUB_USERNAME_REGEX, {
+      message: 'Invalid GitHub username',
+    }),
   refresh: z.string().optional().transform(toRefreshFlag),
 });
 
@@ -258,7 +264,13 @@ export const ogParamsSchema = z
   }));
 
 export const statsParamsSchema = z.object({
-  user: z.string({ error: 'Missing user parameter' }).min(1, { message: 'Missing user parameter' }),
+  user: z
+    .string({ error: 'Missing user parameter' })
+    .min(1, { message: 'Missing user parameter' })
+    .max(39, { message: 'GitHub username cannot exceed 39 characters' })
+    .regex(GITHUB_USERNAME_REGEX, {
+      message: 'Invalid GitHub username',
+    }),
   refresh: z.string().optional().transform(toRefreshFlag),
   tz: z.string().optional(),
 });


### PR DESCRIPTION
## Description

Fixes #1609

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed

`/api/streak` already validates GitHub username syntax, but the JSON routes were only checking that usernames were non-empty.

This PR reuses the same GitHub username pattern across:

- `githubParamsSchema.username`
- `statsParamsSchema.user`
- the existing `streakParamsSchema.user`

Invalid values such as `octo/cat` or `bad user` now return a 400 validation response before any GitHub client call is made.

I added route tests for both `/api/github` and `/api/stats` to confirm malformed usernames are rejected and the mocked GitHub fetch functions are not called.

This is a GSSoC 2026 API/security bug fix contribution. Please add the relevant GSSoC labels if they are missing.

## Visual Preview

N/A — this is API validation behavior.

## Local checks

```bash
npm run format:check
npm run lint
npm run test -- app/api/stats/route.test.ts app/api/github/route.test.ts
```

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commit follows the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.
