### PR TITLE
fix(api): prevent org route crash for username requests

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -1189,4 +1189,18 @@ describe('GET /api/streak', () => {
       expect(response.headers.get('Cache-Control')).not.toContain('stale-while-revalidate=86400');
     });
   });
+
+  describe('org parameter validation', () => {
+    it('returns 400 when org parameter is a User instead of an Organization', async () => {
+      vi.mocked(getOrgDashboardData).mockRejectedValueOnce(
+        new Error('This endpoint is strictly for organizations.')
+      );
+
+      const response = await GET(makeRequest({ user: 'octocat', org: 'notanorg' }));
+      expect(response.status).toBe(400);
+
+      const body = await response.text();
+      expect(body).toContain('strictly for organizations');
+    });
+  });
 });

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -249,7 +249,8 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
   const isValidationError =
     (error instanceof Error && error.name === 'ValidationError') ||
     message.toLowerCase().includes('invalid') ||
-    message.toLowerCase().includes('validation');
+    message.toLowerCase().includes('validation') ||
+    message.toLowerCase().includes('strictly for organizations');
 
   const errBg = `#${(parseResult.success && parseResult.data.bg) || '0d1117'}`;
   const errAccent = `#${

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -513,15 +513,25 @@ export async function fetchOrgMembers(orgName: string): Promise<string[]> {
  * Generates an aggregated Organization Mega-Dashboard.
  */
 export async function getOrgDashboardData(orgName: string, options: FetchOptions = {}) {
-  const [profileData, reposData, members] = await Promise.all([
-    fetchUserProfile(orgName, options),
-    fetchUserRepos(orgName, options),
-    fetchOrgMembers(orgName),
+  const profilePromise = fetchUserProfile(orgName, options);
+  const reposPromise = fetchUserRepos(orgName, options);
+  const membersPromise = fetchOrgMembers(orgName).catch((err) => err as Error);
+
+  const [profileData, reposData, membersOrError] = await Promise.all([
+    profilePromise,
+    reposPromise,
+    membersPromise,
   ]);
 
   if (profileData.type !== 'Organization') {
     throw new Error('This endpoint is strictly for organizations.');
   }
+
+  if (membersOrError instanceof Error) {
+    throw membersOrError;
+  }
+
+  const members = membersOrError;
 
   // Fetch calendars for all members concurrently (Capped by member limit to avoid 429)
   const memberCalendarsPromises = members.map((member: string) =>


### PR DESCRIPTION
## Description

Fixes #1612 

This PR fixes a routing issue that could cause a 500 Internal Server Error when a username was provided in the `org` parameter.

Previously, username values could incorrectly enter the organization lookup flow and trigger a request to the organization members endpoint. When that request failed, the resulting promise rejection was not handled properly, causing the API to crash.

### Changes Made

* Added validation to prevent usernames from being processed as organizations.
* Improved error handling around organization member requests.
* Prevented unhandled promise rejections from propagating to the API layer.
* Ensured invalid organization requests return controlled responses instead of server errors.

### Result

* Username values no longer crash the API when passed through the organization route.
* Invalid organization requests return appropriate error responses.
* Organization dashboard data fetching is more resilient to invalid input and downstream failures.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

### Verification

* Tested requests using valid organization names.
* Tested requests using usernames in the `org` parameter.
* Confirmed invalid values no longer produce 500 errors.
* Verified proper error responses are returned.
* Confirmed organization dashboard data fetching continues to work correctly.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not affected by this change).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
