### PR TITLE
test(ReturnToTop): implement test file with 4 core test cases

### DIFF
--- a/components/ReturnToTop.test.tsx
+++ b/components/ReturnToTop.test.tsx
@@ -1,15 +1,98 @@
 import { render } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-
 import ReturnToTop from './ReturnToTop';
+import type React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+  motion: {
+    button: ({ children, ...props }: React.ComponentProps<'button'>) => (
+      <button {...props}>{children}</button>
+    ),
+  },
+}));
+
+vi.mock('lucide-react', () => ({
+  ChevronUp: () => <svg data-testid="chevron-up-icon" />,
+}));
 
 describe('ReturnToTop', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      configurable: true,
+      value: 2000,
+    });
+
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 1000,
+      writable: true,
+    });
+
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
+  // Test 1: Component does not render when not at bottom of page (initial state)
+  it('does not render when not at bottom of page', () => {
+    render(<ReturnToTop />);
+
+    expect(screen.queryByRole('button', { name: /return to top/i })).toBeNull();
+  });
+
+  // Test 2: 'Return to top' aria-label is on the button when visible
+  it('renders button with aria-label when visible', () => {
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 750,
+    });
+
+    render(<ReturnToTop />);
+
+    fireEvent.scroll(window);
+
+    expect(screen.getByRole('button', { name: /return to top/i })).toBeTruthy();
+  });
+
+  // Test 3: Clicking the button calls window.scrollTo
+  it('calls window.scrollTo when clicked', () => {
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 750,
+    });
+
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    render(<ReturnToTop />);
+
+    fireEvent.scroll(window);
+
+    fireEvent.click(screen.getByRole('button', { name: /return to top/i }));
+
+    expect(scrollToSpy).toHaveBeenCalledWith({
+      top: 0,
+      behavior: 'smooth',
+    });
+  });
+
+  // Test 4: ChevronUp icon is rendered inside the button
+  it('renders ChevronUp icon inside the button', () => {
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 750,
+    });
+
+    render(<ReturnToTop />);
+
+    fireEvent.scroll(window);
+
+    expect(screen.getByTestId('chevron-up-icon')).toBeTruthy();
   });
 
   it('adds scroll event listener on mount', () => {


### PR DESCRIPTION
## Description
Adds test coverage for the `ReturnToTop` component.

### Changes

* Added a test to verify the component is not rendered when the user is not near the bottom of the page.
* Added a test to verify the button is rendered with the `Return to top` aria-label when visible.
* Added a test to verify clicking the button calls `window.scrollTo` with smooth scrolling behavior.
* Added a test to verify the `ChevronUp` icon is rendered inside the button.
* Retained existing tests for scroll event listener registration and cleanup.

### Testing

* Verified the new `ReturnToTop` test cases pass.

Fixes #1008

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="1132" height="693" alt="image" src="https://github.com/user-attachments/assets/3b116d9d-b955-46e1-8836-20d680a7cac2" />

<img width="1206" height="933" alt="image" src="https://github.com/user-attachments/assets/5eeb56e9-8a69-4822-a78d-38deea753d75" />

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
