### PR TITLE
fix(page): handle all HTTP error statuses in SVG badge fetch

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -104,7 +104,7 @@ export default function LandingPage() {
 
     fetch(badgeUrl, { signal: controller.signal })
       .then((res) => {
-        if (res.status === 404) {
+        if (!res.ok) {
           setSvgState('error');
           return;
         }


### PR DESCRIPTION
## Description

Fixes #1611 
In `app/page.tsx:107`, the SVG badge handler only checks for `res.status === 404` . Any other non OK response ( `500`, `403`, etc) falls through to the success branch: the raw response body gets passed to the `setSvgContent()` and `setSvgState('loaded')` is called. The preview area renders broken garbage instead of an error state.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

NA

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
