### PR TITLE
test: add sliding-window expiry test for utility

### DIFF
--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -84,6 +84,38 @@ describe('rateLimit', () => {
   });
 });
 
+it('keys expire exactly at the window limit with sliding time advances', async () => {
+  vi.useFakeTimers();
+  const ip = '9.9.9.9';
+  const windowMs = 1000;
+  const limit = 5;
+
+  // First request: creates the tracker with 1s TTL
+  let res = await rateLimit(ip, limit, windowMs);
+  expect(res.success).toBe(true);
+  expect(res.remaining).toBe(limit - 1);
+
+  // Advance half the window and make another request
+  vi.advanceTimersByTime(500);
+  res = await rateLimit(ip, limit, windowMs);
+  expect(res.success).toBe(true);
+
+  // Advance to exactly the original window boundary (total = 1000ms)
+  vi.advanceTimersByTime(500);
+
+  // At the exact boundary the entry should still be considered valid
+  res = await rateLimit(ip, limit, windowMs);
+  expect(res.success).toBe(true);
+
+  // Move just past the window expiry
+  vi.advanceTimersByTime(1);
+
+  // Now the key must have expired and a fresh window starts
+  res = await rateLimit(ip, limit, windowMs);
+  expect(res.success).toBe(true);
+  expect(res.remaining).toBe(limit - 1);
+});
+
 it('allows requests after many expired IP entries', async () => {
   const windowMs = 1000;
 


### PR DESCRIPTION
## Description
Added a test case for the sliding-window expiry utility to verify that keys expire exactly at the window boundary. This ensures the low-level time helper handles edge cases correctly and guarantees expiry precision for time-range inputs.

Fixes #1581 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [x] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
