### PR TITLE
Fix: Rate Limiter Bypassed via X-Forwarded-For Spoofing

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -15,9 +15,11 @@ import { rateLimit } from './lib/rate-limit';
  * Limit: 60 requests per minute per IP.
  */
 export async function middleware(request: NextRequest) {
-  // Use Vercel's ip property if available, fallback to headers, then localhost
+  // Use Vercel's verified ip property first, then the rightmost proxy-appended
+  // X-Forwarded-For entry (client cannot spoof), then fallback to localhost
   const ip =
-    request.headers.get('x-forwarded-for')?.split(',')[0] ??
+    request.ip ??
+    request.headers.get('x-forwarded-for')?.split(',').at(-1)?.trim() ??
     request.headers.get('x-real-ip') ??
     '127.0.0.1';
 


### PR DESCRIPTION
Closes #1604

**Root cause**: `middleware.ts:19-22` extracted the client IP from the **leftmost** `X-Forwarded-For` entry (`split(',')[0]`). Since `X-Forwarded-For` is fully user-controlled, an attacker can rotate spoofed IPs on every request to get a fresh rate limit quota, bypassing the 60 req/min limit entirely.

**Fix**: 
- Use `request.ip` first (Vercel's verified real IP, set by infrastructure — cannot be spoofed)
- Fallback to `x-forwarded-for` **rightmost** entry (`.at(-1)`), which is appended by the trusted proxy and cannot be forged by the client
- Preserve `x-real-ip` and `127.0.0.1` as final fallbacks

This ensures rate limit keys always reflect the actual client origin, regardless of spoofed headers.
