### PR TITLE
feat: add Random Theme shuffle button to Customize UI (#136)

### DIFF
--- a/app/customize/components/ThemeSelector.tsx
+++ b/app/customize/components/ThemeSelector.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement, ReactNode } from 'react';
+import { Shuffle } from 'lucide-react';
 import { themes } from '../../../lib/svg/themes';
 import { THEME_KEYS, type ThemeKey } from '../types';
 import { SectionLabel } from './SectionLabel';
@@ -41,9 +42,25 @@ export function ThemeSelector({
   const isRandom = theme === 'random';
   const randomAccentColors = [themes.neon.accent, themes.ocean.accent, themes.sunset.accent];
 
+  const handleRandomTheme = () => {
+    const selectableThemes = THEME_KEYS.filter((k) => k !== 'auto' && k !== 'random');
+    const randomKey = selectableThemes[Math.floor(Math.random() * selectableThemes.length)];
+    onThemeChange(randomKey);
+  };
+
   return (
     <div className="flex flex-col gap-1.5">
-      <SectionLabel>Theme Preset</SectionLabel>
+      <div className="flex items-center justify-between">
+        <SectionLabel>Theme Preset</SectionLabel>
+        <button
+          onClick={handleRandomTheme}
+          title="Pick a random theme"
+          className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs text-white/50 hover:text-white hover:bg-white/10 transition-all"
+        >
+          <Shuffle className="w-3.5 h-3.5" />
+          Shuffle
+        </button>
+      </div>
 
       <ThemeQuickPresets theme={theme} onThemeChange={onThemeChange} />
 


### PR DESCRIPTION
Closes #136

## What I did
- Added a Shuffle button next to the "Theme Preset" label in ThemeSelector.tsx
- Imported Shuffle icon from lucide-react
- Wrote handleRandomTheme function that picks a random key from THEME_KEYS (excluding auto and random)
- Button has hover:bg-white/10 effect matching the dark UI
- Clicking instantly applies a random theme to the preview

## Screenshots
<img width="878" height="670" alt="image" src="https://github.com/user-attachments/assets/a1dd800f-4785-4581-b0c7-3abc4b57aa1c" />
<img width="844" height="712" alt="image" src="https://github.com/user-attachments/assets/e6250363-336c-4de6-8711-9fd1e017fadb" />


## Testing
- [x] Shuffle button renders next to Theme Preset label
- [x] Clicking picks a random theme instantly
- [x] Button has correct hover effect matching dark UI
- [x] Auto and Random themes excluded from shuffle pool