### PR TITLE
fix(useShareActions): replace hardcoded SSR fallback URL with NEXT_PU…

### DIFF
--- a/hooks/useShareActions.ts
+++ b/hooks/useShareActions.ts
@@ -5,10 +5,11 @@ import type { DashboardExportData } from '@/types/dashboard';
 
 type OptionState = 'idle' | 'loading' | 'success' | 'error';
 
-const PROFILE_URL = (username: string) =>
-  typeof window !== 'undefined'
-    ? `${window.location.origin}/dashboard/${username}`
-    : `https://commitpulse.vercel.app/dashboard/${username}`;
+const BASE_ORIGIN =
+  (typeof window !== 'undefined' ? window.location.origin : null) ??
+  process.env.NEXT_PUBLIC_SITE_URL ??
+  'https://commitpulse.vercel.app';
+const PROFILE_URL = (username: string) => `${BASE_ORIGIN}/dashboard/${username}`;
 
 export function useShareActions(
   username: string,


### PR DESCRIPTION
## Description
Fixes #1616 

`hooks/useShareActions.ts` had a hardcoded `https://commitpulse.vercel.app` SSR fallback in `PROFILE_URL`. When rendered server-side, all share links (Twitter, LinkedIn, Reddit, Copy Link, native share, JSON export) pointed to production regardless of the actual deployment environment: breaking staging and self-hosted forks.

This fix was originally merged as part of #1369  but was silently dropped during the merge. `git log -- hooks/useShareActions.ts` confirms the change never landed on main.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

NA

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
