### PR TITLE
test(utils): verify default theme color fallbacks

### DIFF
--- a/lib/svg/sanitizer.test.ts
+++ b/lib/svg/sanitizer.test.ts
@@ -56,6 +56,12 @@ describe('SVG Sanitizer Utilities', () => {
       expect(hexColor('invalid', '000000')).toBe('000000');
     });
 
+    it('returns default theme colors for invalid hex names', () => {
+      expect(hexColor('not-a-background-color', '0d1117')).toBe('0d1117');
+      expect(hexColor('not-a-text-color', 'c9d1d9')).toBe('c9d1d9');
+      expect(hexColor('not-an-accent-color', '58a6ff')).toBe('58a6ff');
+    });
+
     it('returns default fallback for empty string', () => {
       expect(hexColor('')).toBe('000000');
     });


### PR DESCRIPTION


## Description

Added a utility-level test verifying that invalid hex color names fall back to the default dark theme background, text, and accent colors.

Fixes #1572 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable. This PR only adds a utility test.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run the relevant test, typecheck, and ESLint successfully.
- [x] My commit follows the Conventional Commits format.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] README update is not required because this PR only adds a test.
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
