### PR TITLE
Boundary robustness of username

### DIFF
--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -7,6 +7,7 @@ import {
   particleCount,
   escapeXML,
   getSizeScale,
+  truncateUsername,
 } from './generator';
 import type { BadgeParams, ContributionCalendar, StreakStats, MonthlyStats } from '../../types';
 import { hexColor } from './sanitizer';
@@ -1244,5 +1245,23 @@ describe('Radar Scan Line Animation Alignment', () => {
 
     // Initial y on the rect must be 80
     expect(svg).toContain('rect x="100" y="80"');
+  });
+
+  it('safely truncates usernames longer than 30 chars with trailing dots', () => {
+    // 1. Arrange: Create a username strictly longer than 30 characters
+    const longUsername = 'ThisIsAVeryLongUsernameThatExceedsThirtyCharacters';
+
+    // 2. Act: Pass the string AND the max length of 30
+    const result = truncateUsername(longUsername);
+
+    // 3. Assert: Verify it contains the trailing dots
+    expect(result.endsWith('...')).toBe(true);
+
+    // 4. Assert: Verify the string was actually truncated
+    // If it caps at 30 chars and adds '...', the max length is 33.
+    expect(result.length).toBeLessThanOrEqual(33);
+
+    // 5. Assert: Ensure the original string was actually modified
+    expect(result).not.toEqual(longUsername);
   });
 });

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -16,7 +16,7 @@ export function getSizeScale(size?: 'small' | 'medium' | 'large') {
   return 1;
 }
 
-function truncateUsername(username: string): string {
+export function truncateUsername(username: string): string {
   return username.length > 12 ? `${username.slice(0, 12)}...` : username;
 }
 


### PR DESCRIPTION
## Description
test(utils): check boundary robustness of username length truncator (Variation 3)

Fixes #1573

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="1188" height="1323" alt="image" src="https://github.com/user-attachments/assets/c77f185c-2412-411a-9009-46db66428d52" />

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
