### PR TITLE
test(svg): add fallback color boundary test

### DIFF
--- a/lib/svg/sanitizer.test.ts
+++ b/lib/svg/sanitizer.test.ts
@@ -49,6 +49,11 @@ describe('SVG Sanitizer Utilities', () => {
       expect(sanitizeHexColor('"><script>', '000000')).toBe('000000');
     });
 
+    it('uses fallback color for unrecognized hex strings', () => {
+      expect(sanitizeHexColor('not-a-color', '808080')).toBe('808080');
+      expect(sanitizeHexColor('xyz123', '808080')).toBe('808080');
+    });
+
     it('returns fallback for invalid hex names', () => {
       expect(sanitizeHexColor('red', '000000')).toBe('000000');
       expect(sanitizeHexColor('blue', '000000')).toBe('000000');

--- a/utils/tracking.test.ts
+++ b/utils/tracking.test.ts
@@ -47,6 +47,20 @@ describe('trackUser', () => {
     });
   });
 
+  it('handles empty username without crashing', () => {
+    const sendBeaconMock = vi.fn().mockReturnValue(true);
+
+    Object.defineProperty(navigator, 'sendBeacon', {
+      value: sendBeaconMock,
+      configurable: true,
+    });
+
+    trackUser('');
+
+    expect(sendBeaconMock).toHaveBeenCalledTimes(1);
+    expect(sendBeaconMock).toHaveBeenCalledWith('/api/track-user', expect.any(Blob));
+  });
+
   it('falls back to fetch when sendBeacon returns false', () => {
     const sendBeaconMock = vi.fn().mockReturnValue(false);
 


### PR DESCRIPTION
## Description

Fixes #1575

Added a boundary test for SVG color sanitization to verify that unrecognized hex strings correctly fall back to the provided default color value. This helps ensure robust handling of invalid color inputs.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
