### PR TITLE
test(utils): add boundary robustness test for rate limit TTL timers

### DIFF
--- a/utils/time.test.ts
+++ b/utils/time.test.ts
@@ -152,3 +152,31 @@ describe('getSecondsUntilMidnightInTimezone', () => {
     expect(getSecondsUntilMidnightInTimezone('Etc/GMT-14')).toBe(10 * 3600);
   });
 });
+
+describe('getSecondsUntilUTCMidnight — sliding window boundary robustness', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns correct TTL across a sliding window of times approaching UTC midnight', () => {
+    // Verifies that the utility guarantees keys expire exactly at the window limit.
+    // Each entry is [UTC time string, expected seconds until next midnight].
+    const cases: [string, number][] = [
+      ['2024-06-15T23:00:00.000Z', 3600], // 1 hour before midnight
+      ['2024-06-15T23:30:00.000Z', 1800], // 30 minutes before midnight
+      ['2024-06-15T23:45:00.000Z', 900], // 15 minutes before midnight
+      ['2024-06-15T23:59:00.000Z', 60], // 1 minute before midnight
+      ['2024-06-15T23:59:59.000Z', 1], // 1 second before midnight
+      ['2024-06-16T00:00:00.000Z', 86400], // exactly at midnight, resets to full day
+    ];
+
+    for (const [time, expected] of cases) {
+      vi.setSystemTime(new Date(time));
+      expect(getSecondsUntilUTCMidnight()).toBe(expected);
+    }
+  });
+});


### PR DESCRIPTION
## Description

Added a sliding window boundary robustness test for `getSecondsUntilUTCMidnight` in `utils/time.test.ts`. The test verifies that the utility returns the correct TTL value across a range of times approaching UTC midnight, ensuring keys expire exactly at the window limit.

Changes
- Added a new test in `utils/time.test.ts`
- Simulated a sliding window of times approaching UTC midnight
- Verified correct TTL is returned at each boundary point
- Verified the value resets to 86400 exactly at midnight

Fixes #1551

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

Visual Preview

N/A (test-only change)

## Checklist

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npm run test -- utils/time.test.ts`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `test(utils): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.