### PR TITLE
test(ui): add responsive rendering tests for HeroSection 

### DIFF
--- a/app/components/HeroSection.test.tsx
+++ b/app/components/HeroSection.test.tsx
@@ -48,3 +48,42 @@ describe('HeroSection', () => {
     expect(screen.getByText(/isometric/i).textContent).toMatch(/isometric/i);
   });
 });
+
+describe('HeroSection responsive rendering and typography (Variation 3)', () => {
+  it('renders full typography heading with high contrast gradient', () => {
+    render(<HeroSection />);
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toBeDefined();
+    expect(heading.className).toMatch(/text-5xl|text-8xl|font-extrabold/);
+  });
+
+  it('renders all three stat badges', () => {
+    render(<HeroSection />);
+    expect(screen.getByText(/1,247 Contributions/i)).toBeDefined();
+    expect(screen.getByText(/83 Pull Requests/i)).toBeDefined();
+    expect(screen.getByText(/214 Commits/i)).toBeDefined();
+  });
+
+  it('renders GitHub username input field', () => {
+    render(<HeroSection />);
+    const input = screen.getByPlaceholderText(/Enter GitHub Username/i);
+    expect(input).toBeDefined();
+  });
+
+  it('renders Watch Dashboard button', () => {
+    render(<HeroSection />);
+    const button = screen.getByText(/Watch Dashboard/i);
+    expect(button).toBeDefined();
+  });
+
+  it('renders Copy Link button', () => {
+    render(<HeroSection />);
+    const button = screen.getByText(/Copy Link/i);
+    expect(button).toBeDefined();
+  });
+
+  it('renders descriptive paragraph with professional precision text', () => {
+    render(<HeroSection />);
+    expect(screen.getByText(/professional precision/i)).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description
Adds a new test suite `HeroSection responsive rendering and typography (Variation 3)` to `app/components/HeroSection.test.tsx` verifying the HeroSection component renders full typography headings, stat badges, input fields, and action buttons correctly.

Fixes #1537

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have made sure that i have only one commit to merge in this PR.