### PR TITLE
test(utils): check unrecognized hex string applies standard gray glow…

### DIFF
--- a/lib/svg/sanitizer.test.ts
+++ b/lib/svg/sanitizer.test.ts
@@ -65,34 +65,37 @@ describe('SVG Sanitizer Utilities', () => {
     it('returns default fallback for empty string', () => {
       expect(hexColor('')).toBe('000000');
     });
+
+    it('applies standard gray fallback for unrecognized hex strings', () => {
+      expect(hexColor('ZZZZZZ', '808080')).toBe('808080');
+      expect(hexColor('GGGGGG', '808080')).toBe('808080');
+      expect(hexColor('xyz999', '808080')).toBe('808080');
+      expect(hexColor('------', '808080')).toBe('808080');
+    });
   });
 
   describe('sanitizeHexColor', () => {
     it('returns sanitized hex without #', () => {
       expect(sanitizeHexColor('#ff00ff', '000000')).toBe('ff00ff');
       expect(sanitizeHexColor('ff00ff', '000000')).toBe('ff00ff');
-      // Handles multiple leading hashes gracefully
       expect(sanitizeHexColor('##ff00ff', '000000')).toBe('ff00ff');
     });
 
     it('returns valid 3-digit hex without #', () => {
       expect(sanitizeHexColor('#f0f', '000000')).toBe('f0f');
       expect(sanitizeHexColor('f0f', '000000')).toBe('f0f');
-      // Handles multiple leading hashes gracefully
       expect(sanitizeHexColor('##f0f', '000000')).toBe('f0f');
     });
 
     it('returns valid 8-digit hex without #', () => {
       expect(sanitizeHexColor('#ff00ff00', '000000')).toBe('ff00ff00');
       expect(sanitizeHexColor('ff00ff00', '000000')).toBe('ff00ff00');
-      // Handles multiple leading hashes gracefully
       expect(sanitizeHexColor('##ff00ff00', '000000')).toBe('ff00ff00');
     });
 
     it('returns valid 4-digit hex without #', () => {
       expect(sanitizeHexColor('#f0f0', '000000')).toBe('f0f0');
       expect(sanitizeHexColor('f0f0', '000000')).toBe('f0f0');
-      // Handles multiple leading hashes gracefully
       expect(sanitizeHexColor('##f0f0', '000000')).toBe('f0f0');
     });
 


### PR DESCRIPTION
## Description
Adds a new test case to verify that `hexColor()` applies a standard gray fallback when passed unrecognized hex strings (e.g. `ZZZZZZ`, `GGGGGG`, `xyz999`).

Fixes #1555

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist
- [x] I have read the CONTRIBUTING.md file.
- [x] I have tested these changes locally.
- [x] My commits follow the Conventional Commits format.
- [x] I have made sure that i have only one commit to merge in this PR.