### PR TITLE
test(utils): check rate limit TTL boundary robustness (#1561)

### DIFF
--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -70,6 +70,30 @@ describe('rateLimit', () => {
     expect(result.remaining).toBe(limit - 1);
   });
 
+  it('expires at the window boundary after sliding requests', async () => {
+    const ip = '7.7.7.7';
+    const windowMs = 60000;
+    const limit = 3;
+
+    vi.setSystemTime(0);
+    await rateLimit(ip, limit, windowMs);
+    vi.advanceTimersByTime(20000);
+    await rateLimit(ip, limit, windowMs);
+    vi.advanceTimersByTime(20000);
+    await rateLimit(ip, limit, windowMs);
+
+    // Still within the same fixed window, before the boundary
+    vi.advanceTimersByTime(19999);
+    expect((await rateLimit(ip, limit, windowMs)).success).toBe(false);
+
+    // Move just past the window limit. The old entry should have expired.
+    vi.advanceTimersByTime(2);
+
+    const result = await rateLimit(ip, limit, windowMs);
+    expect(result.success).toBe(true);
+    expect(result.remaining).toBe(limit - 1);
+  });
+
   it('tracks different IPs separately', async () => {
     const ip1 = '11.11.11.11';
     const ip2 = '22.22.22.22';


### PR DESCRIPTION
## Description

Fixes #1561

Added a boundary robustness test for the rate limit utility to verify that keys expire exactly at the configured window limit when requests occur across sliding time ranges.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable for test-only changes).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

## Test Validation

Command executed:

```bash
npx vitest run lib/rate-limit.test.ts
```

Result:

```text
✓ lib/rate-limit.test.ts

Test Files  1 passed (1)
Tests       12 passed (12)
```

### Implementation Notes

* Updated `lib/rate-limit.test.ts`
* Added a boundary-focused test:

  * `expires at the window boundary after sliding requests`
* Verified expiration behavior at the configured window limit for sliding request timings.
* No production code changes were made.
