### PR TITLE
fix(validation): add max-length and regex validation to org parameter in streakParamsSchema

### DIFF
--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -183,7 +183,13 @@ export const streakParamsSchema = z.object({
   grace: z.string().optional().transform(toGraceValue).default(1),
   mode: z.enum(['commits', 'loc']).catch('commits').default('commits'),
   repo: z.string().optional(),
-  org: z.string().optional(),
+  org: z
+    .string()
+    .optional()
+    .max(39, { message: 'Organization name cannot exceed 39 characters' })
+    .regex(GITHUB_USERNAME_REGEX, {
+      message: 'Invalid organization name format',
+    }),
   labels: z.string().optional().transform(toBooleanFlag),
   labelColor: z
     .string()

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -185,11 +185,11 @@ export const streakParamsSchema = z.object({
   repo: z.string().optional(),
   org: z
     .string()
-    .optional()
     .max(39, { message: 'Organization name cannot exceed 39 characters' })
     .regex(GITHUB_USERNAME_REGEX, {
       message: 'Invalid organization name format',
-    }),
+    })
+    .optional(),
   labels: z.string().optional().transform(toBooleanFlag),
   labelColor: z
     .string()


### PR DESCRIPTION
## Description

The `org` parameter in `streakParamsSchema` at `lib/validations.ts:186` had zero validation (`org: z.string().optional()`) -- no min, no max, no regex. Any arbitrary string of any length was accepted and directly interpolated into GitHub REST API URL paths. This enabled path-traversal attacks against the GitHub API, bypassing the strict validation enforced on the `user` parameter.

Fixes #1366:
- SSRF: path-traversal sequences in org parameter could reach unintended GitHub API endpoints
- Injection: unvalidated string length could create enormous URL strings stressing the server
- Inconsistency: org had no validation while user on the same schema had strict regex + max(39)

## Pillar

- [ ] Pillar 1 - New Theme Design
- [ ] Pillar 2 - Geometric SVG Improvement
- [ ] Pillar 3 - Timezone Logic Optimization
- [x] Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the CONTRIBUTING.md file.
- [x] I have tested these changes locally.
- [x] I have run npm run format and npm run lint locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.