### PR TITLE
test(utils): check date range formatter boundary robustness (#1564)

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -437,6 +437,16 @@ describe('GET /api/streak', () => {
       });
     });
 
+    it('passes correct from/to range when ?year=2008 is provided', async () => {
+      await GET(makeRequest({ user: 'octocat', year: '2008' }));
+
+      expect(fetchGitHubContributions).toHaveBeenCalledWith('octocat', {
+        bypassCache: false,
+        from: '2008-01-01T00:00:00Z',
+        to: '2008-12-31T23:59:59Z',
+      });
+    });
+
     it('functions normally when the year parameter is missing', async () => {
       const response = await GET(makeRequest({ user: 'octocat' }));
 


### PR DESCRIPTION
## Description

Fixes #1564

Added a boundary robustness test for year-based date range generation in the streak API route.

The new test verifies that when `?year=2008` is provided, the utility generates the correct lower-bound date range and passes the expected `from` and `to` values to contribution fetching logic.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable for test-only changes).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

## Test Validation

Command executed:

```bash
npx vitest run app/api/streak/route.test.ts
```

Result:

```text
✓ app/api/streak/route.test.ts

Test Files  1 passed (1)
Tests       114 passed (114)
```

## Files Changed

* app/api/streak/route.test.ts

## Notes

* Added one new boundary-focused test block.
* Verified correct `from` and `to` date range generation for the lower-bound year case (`2008`).
* No production code changes were made.