### PR TITLE
fix(cache): include both from and to dates in contribution cache key

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -1085,6 +1085,16 @@ describe('cacheKey', () => {
   it('creates key with year', () => {
     expect(cacheKey('contributions', 'DeepSikha', '2025')).toBe('contributions:deepsikha:2025');
   });
+
+  it('creates key with from and to date range', () => {
+    expect(cacheKey('contributions', 'octocat', '2024-01-01', '2024-06-30')).toBe('contributions:octocat:2024-01-01:2024-06-30');
+  });
+
+  it('collision test: different to dates produce different keys', () => {
+    const keyA = cacheKey('contributions', 'octocat', '2024-01-01', '2024-06-30');
+    const keyB = cacheKey('contributions', 'octocat', '2024-01-01', '2024-12-31');
+    expect(keyA).not.toBe(keyB);
+  });
 });
 describe('buildInsights', () => {
   it('uses active streak message when current streak > 3', () => {

--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -1087,7 +1087,9 @@ describe('cacheKey', () => {
   });
 
   it('creates key with from and to date range', () => {
-    expect(cacheKey('contributions', 'octocat', '2024-01-01', '2024-06-30')).toBe('contributions:octocat:2024-01-01:2024-06-30');
+    expect(cacheKey('contributions', 'octocat', '2024-01-01', '2024-06-30')).toBe(
+      'contributions:octocat:2024-01-01:2024-06-30'
+    );
   });
 
   it('collision test: different to dates produce different keys', () => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -212,8 +212,25 @@ export function cacheKey(
   kind: 'contributions' | 'profile' | 'repos',
   username: string,
   year?: string
+): string;
+export function cacheKey(
+  kind: 'contributions' | 'profile' | 'repos',
+  username: string,
+  from?: string,
+  to?: string
+): string;
+export function cacheKey(
+  kind: 'contributions' | 'profile' | 'repos',
+  username: string,
+  yearOrFrom?: string,
+  to?: string
 ): string {
-  return year ? `${kind}:${username.toLowerCase()}:${year}` : `${kind}:${username.toLowerCase()}`;
+  if (yearOrFrom && to) {
+    return `${kind}:${username.toLowerCase()}:${yearOrFrom.substring(0, 10)}:${to.substring(0, 10)}`;
+  }
+  return yearOrFrom
+    ? `${kind}:${username.toLowerCase()}:${yearOrFrom.substring(0, 4)}`
+    : `${kind}:${username.toLowerCase()}`;
 }
 
 export function clearGitHubApiCacheForTests(): void {
@@ -272,7 +289,7 @@ export async function fetchGitHubContributions(
   username: string,
   options: FetchOptions = {}
 ): Promise<ContributionCalendar> {
-  const key = cacheKey('contributions', username, options.from?.substring(0, 4));
+  const key = cacheKey('contributions', username, options.from, options.to);
   if (!options.bypassCache) {
     const cached = await contributionsCache.get(key);
     if (cached) return cached;


### PR DESCRIPTION
## Description

The `cacheKey` function for contributions only used the year portion of `options.from`, completely ignoring `options.to`. This meant requests with different date ranges but the same start year produced identical cache keys, causing data poisoning across queries.

Fixes #1367:
- Cache collision: `?from=2024-01-01&to=2024-06-30` and `?from=2024-01-01&to=2024-12-31` shared key `contributions:user:2024`
- Stale data: the first fetch's response was served to all subsequent queries regardless of their date range
- Hard to detect: no error surfaced, just silently wrong data for half-year projections

## Pillar

- [ ] Pillar 1 - New Theme Design
- [ ] Pillar 2 - Geometric SVG Improvement
- [ ] Pillar 3 - Timezone Logic Optimization
- [x] Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the CONTRIBUTING.md file.
- [x] I have tested these changes locally.
- [x] I have run npm run format and npm run lint locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.