### PR TITLE
fix(validation): validate tz parameter through Zod schema instead of raw searchParams

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -731,26 +731,27 @@ describe('GET /api/streak', () => {
       const response = await GET(makeRequest({ user: 'octocat', tz: 'Not/ATimezone' }));
 
       expect(response.status).toBe(400);
-      const body = await response.text();
-      expect(body).toContain('Invalid "tz" parameter');
+      const body = await response.json();
+      expect(body.details.fieldErrors.tz[0]).toContain('Invalid timezone');
     });
 
-    it('returns 400 and names the bad value in the error message', async () => {
+    it('returns 400 and names the bad value in the field error', async () => {
       const response = await GET(makeRequest({ user: 'octocat', tz: 'garbage' }));
-      const body = await response.text();
+      const body = await response.json();
 
-      expect(body).toContain('garbage');
+      expect(response.status).toBe(400);
+      expect(body.details.fieldErrors.tz[0]).toContain('Invalid timezone');
     });
 
-    it('escapes invalid timezone values before rendering the error SVG', async () => {
+    it('is not vulnerable to XSS via tz parameter', async () => {
       const response = await GET(
         makeRequest({ user: 'octocat', tz: '</text><script>alert(1)</script>' })
       );
-      const body = await response.text();
+      const body = await response.json();
 
       expect(response.status).toBe(400);
-      expect(body).toContain('&lt;/text&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
-      expect(body).not.toContain('</text><script>');
+      // Zod validates the input and returns a JSON error — no raw user input reflected
+      expect(body.details.fieldErrors.tz[0]).toContain('Invalid timezone');
     });
 
     it('returns 200 with a valid IANA timezone', async () => {

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -96,6 +96,7 @@ export async function GET(request: Request) {
       versus,
       shading,
       gradient,
+      tz: tzParam,
     } = parseResult.data;
 
     const themeName = theme || 'dark';
@@ -110,16 +111,10 @@ export async function GET(request: Request) {
         ? `${year}-12-31T23:59:59Z`
         : undefined;
 
-    const tzParam = searchParams.get('tz');
     let timezone = 'UTC';
     if (tzParam) {
-      try {
-        timezone = new Intl.DateTimeFormat(undefined, { timeZone: tzParam }).resolvedOptions()
-          .timeZone;
-      } catch {
-        // We throw our new ValidationError here instead of returning directly
-        throw new ValidationError(`Invalid "tz" parameter: "${tzParam}"`);
-      }
+      timezone = new Intl.DateTimeFormat(undefined, { timeZone: tzParam }).resolvedOptions()
+        .timeZone;
     }
 
     const isAutoTheme = themeName === 'auto';

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -169,6 +169,21 @@ export const streakParamsSchema = z.object({
       },
       { message: 'Invalid "to" date format. Use ISO 8601 (e.g. 2023-12-31).' }
     ),
+  tz: z
+    .string()
+    .optional()
+    .refine(
+      (val) => {
+        if (!val) return true;
+        try {
+          new Intl.DateTimeFormat(undefined, { timeZone: val });
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { message: 'Invalid timezone. Must be a valid IANA timezone (e.g. America/New_York).' }
+    ),
   refresh: z.string().optional().transform(toRefreshFlag),
   hide_title: z.string().optional().transform(toBooleanFlag),
   hide_background: z.string().optional().transform(toBooleanFlag),


### PR DESCRIPTION
## Description

The `tz` parameter was extracted directly from raw `searchParams` (bypassing Zod validation entirely) and interpolated into error responses without escaping. While `escapeSVGText()` mitigated reflected XSS in the SVG path, the root cause was an architectural gap: `tz` was the only query parameter not validated through `streakParamsSchema`.

Fixes #1368:
- Reflected content injection: non-IANA tz values appeared verbatim in error responses
- Validation bypass: `tz` was the sole parameter extracted from raw searchParams, not from Zod-parsed data
- Architecture inconsistency: all other params go through Zod; tz had custom validation outside the schema

## Pillar

- [ ] Pillar 1 - New Theme Design
- [ ] Pillar 2 - Geometric SVG Improvement
- [ ] Pillar 3 - Timezone Logic Optimization
- [x] Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the CONTRIBUTING.md file.
- [x] I have tested these changes locally.
- [x] I have run npm run format and npm run lint locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.