### PR TITLE
test: add ThemeSelector rendering and theme switch tests

### DIFF
--- a/app/customize/components/ThemeSelector.test.tsx
+++ b/app/customize/components/ThemeSelector.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ThemeSelector } from './ThemeSelector';
+
+describe('ThemeSelector', () => {
+  it('renders theme selector', () => {
+    render(<ThemeSelector theme="dracula" onThemeChange={vi.fn()} />);
+
+    expect(screen.getByLabelText(/apply dracula theme/i)).toBeTruthy();
+  });
+
+  it('calls onThemeChange when neon preset is clicked', () => {
+    const onThemeChange = vi.fn();
+
+    render(<ThemeSelector theme="dracula" onThemeChange={onThemeChange} />);
+
+    fireEvent.click(screen.getByLabelText(/apply neon theme/i));
+
+    expect(onThemeChange).toHaveBeenCalledWith('neon');
+  });
+});


### PR DESCRIPTION
Fixes #1532

## Changes

* Added ThemeSelector component tests
* Verified ThemeSelector renders correctly
* Verified theme switching triggers the expected callback
* Added test coverage for Dracula and Neon theme interactions

## Testing

* All tests passing locally
* ThemeSelector.test.tsx passes successfully
* No existing tests were broken
