### PR TITLE
test: add ThemeSelector rendering and theme switch tests

### DIFF
--- a/app/customize/components/ThemeSelector.test.tsx
+++ b/app/customize/components/ThemeSelector.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ThemeSelector } from './ThemeSelector';
+
+describe('ThemeSelector', () => {
+  it('renders theme selector', () => {
+    render(<ThemeSelector theme="dracula" onThemeChange={vi.fn()} />);
+
+    expect(screen.getByLabelText(/apply dracula theme/i)).toBeTruthy();
+  });
+
+  it('calls onThemeChange when neon preset is clicked', () => {
+    const onThemeChange = vi.fn();
+
+    render(<ThemeSelector theme="dracula" onThemeChange={onThemeChange} />);
+
+    fireEvent.click(screen.getByLabelText(/apply neon theme/i));
+
+    expect(onThemeChange).toHaveBeenCalledWith('neon');
+  });
+});


### PR DESCRIPTION
## Description

Adds test coverage for the ThemeSelector component and verifies that theme switching interactions work correctly.

Fixes #1532

## Pillar

* [x] Testing

## Checklist

* [x] I have read the contributing guidelines.
* [x] I have tested my changes locally.
* [x] All existing tests pass.
* [x] This PR only includes changes relevant to the issue.

## Changes

* Added ThemeSelector.test.tsx
* Verified ThemeSelector renders correctly
* Verified switching from Dracula to Neon triggers the expected callback
* Increased component test coverage
