### PR TITLE
test(customize): add additional coverage for ThemeQuickPresets component

### DIFF
--- a/app/customize/components/ThemeQuickPresets.test.tsx
+++ b/app/customize/components/ThemeQuickPresets.test.tsx
@@ -49,4 +49,39 @@ describe('ThemeQuickPresets', () => {
     await user.click(inactiveBtn);
     expect(onThemeChange).toHaveBeenCalledWith(inactiveKey);
   });
+
+  it('each button has an aria-label starting with "Apply"', () => {
+    render(<ThemeQuickPresets theme="dark" onThemeChange={onThemeChange} />);
+    const buttons = screen.getAllByRole('button');
+    buttons.forEach((btn) => {
+      expect(btn.getAttribute('aria-label')).toMatch(/^Apply/i);
+    });
+  });
+
+  it('renders at least one button for each concrete theme excluding auto and random', () => {
+    render(<ThemeQuickPresets theme="dark" onThemeChange={onThemeChange} />);
+    validKeys.forEach((key) => {
+      const btn = screen.getByRole('button', {
+        name: new RegExp(`apply ${key} theme`, 'i'),
+      });
+      expect(btn).toBeTruthy();
+    });
+  });
+
+  it('switching active theme updates aria-pressed correctly', () => {
+    const { rerender } = render(<ThemeQuickPresets theme="dark" onThemeChange={onThemeChange} />);
+    const darkBtn = screen.getByRole('button', { name: /apply dark theme/i });
+    expect(darkBtn.getAttribute('aria-pressed')).toBe('true');
+
+    rerender(<ThemeQuickPresets theme="neon" onThemeChange={onThemeChange} />);
+    const neonBtn = screen.getByRole('button', { name: /apply neon theme/i });
+    expect(neonBtn.getAttribute('aria-pressed')).toBe('true');
+    expect(darkBtn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('does not render buttons for auto or random themes', () => {
+    render(<ThemeQuickPresets theme="dark" onThemeChange={onThemeChange} />);
+    expect(screen.queryByRole('button', { name: /apply auto theme/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /apply random theme/i })).toBeNull();
+  });
 });


### PR DESCRIPTION
## Description

Fixes #1030 

- `app/customize/components/ThemeQuickPresets.test.tsx` — added `4` additional tests: asserting every button has an `aria-label` starting with `"Apply"`, verifying a button exists for each concrete theme key excluding `auto` and `random`, confirming `aria-pressed` updates correctly when the active theme changes via rerender, and asserting no buttons are rendered for `auto` or `random` themes. 🚀

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.