### PR TITLE
test(themeSelector): add additional coverage for ThemeSelector component

### DIFF
--- a/app/customize/components/ThemeSelector.test.tsx
+++ b/app/customize/components/ThemeSelector.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { ThemeSelector } from './ThemeSelector';
 import { THEME_KEYS } from '../types';
+import userEvent from '@testing-library/user-event';
 
 describe('ThemeSelector', () => {
   const onThemeChange = vi.fn();
@@ -39,5 +40,36 @@ describe('ThemeSelector', () => {
   it('shows "bg · accent · text" text for a regular theme', () => {
     render(<ThemeSelector theme="dark" onThemeChange={onThemeChange} />);
     screen.getByText(/bg · accent · text/i);
+  });
+
+  it('renders the Shuffle button', () => {
+    render(<ThemeSelector theme="dark" onThemeChange={onThemeChange} />);
+    expect(screen.getByTitle('Pick a random theme')).toBeTruthy();
+  });
+
+  it('clicking Shuffle calls onThemeChange with a valid theme key', async () => {
+    const user = userEvent.setup();
+    render(<ThemeSelector theme="dark" onThemeChange={onThemeChange} />);
+    const shuffleBtn = screen.getByTitle('Pick a random theme');
+    await user.click(shuffleBtn);
+    expect(onThemeChange).toHaveBeenCalledTimes(1);
+    const calledWith = onThemeChange.mock.calls[0][0];
+    expect(THEME_KEYS).toContain(calledWith);
+    expect(calledWith).not.toBe('auto');
+    expect(calledWith).not.toBe('random');
+  });
+
+  it('changing the select calls onThemeChange with the selected value', async () => {
+    const user = userEvent.setup();
+    render(<ThemeSelector theme="dark" onThemeChange={onThemeChange} />);
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, 'neon');
+    expect(onThemeChange).toHaveBeenCalledWith('neon');
+  });
+
+  it('renders color swatches for a normal theme', () => {
+    render(<ThemeSelector theme="dark" onThemeChange={onThemeChange} />);
+    const swatches = screen.getAllByTitle(/^(bg|accent|text):/i);
+    expect(swatches.length).toBe(3);
   });
 });


### PR DESCRIPTION
## Description

Fixes #1029 

- `app/customize/components/ThemeSelector.test.tsx` — added `4` additional tests: asserting the Shuffle button renders correctly, verifying clicking Shuffle calls `onThemeChange` with a valid non-`auto` non-`random` theme key, confirming changing the select dropdown calls `onThemeChange` with the correct value, and asserting exactly 3 color swatches render for a normal theme with correct `title` attributes. 🚀

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.
