### PR TITLE
test(i18n): verify locale labels are non-empty

### DIFF
--- a/lib/i18n/badgeLabels.test.ts
+++ b/lib/i18n/badgeLabels.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getLabels } from './badgeLabels';
+import { getLabels, labels } from './badgeLabels';
 
 describe('getLabels', () => {
   describe('supported locales', () => {
@@ -60,6 +60,14 @@ describe('getLabels', () => {
       expect(typeof labels.CURRENT_STREAK).toBe('string');
       expect(typeof labels.ANNUAL_SYNC_TOTAL).toBe('string');
       expect(typeof labels.PEAK_STREAK).toBe('string');
+    });
+    it('ensures all locale labels are non-empty strings', () => {
+      for (const locale of Object.values(labels)) {
+        for (const value of Object.values(locale)) {
+          expect(typeof value).toBe('string');
+          expect(value.length).toBeGreaterThan(0);
+        }
+      }
     });
   });
 });


### PR DESCRIPTION
## Description

Adds a test to verify that all locale label values are non-empty strings.

The test iterates through all locales dynamically using the exported `labels` object and ensures that every label value:
- Is a string
- Is not empty

Fixes #656

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change, no SVG/UI changes)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The change does not affect SVG output.
- [ ] (Recommended) I joined the CommitPulse Discord server.