### PR TITLE
test(validations): check boundary robustness of date range formatter (Variation 1)

### DIFF
--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -656,7 +656,7 @@ describe('streakParamsSchema — Date Range Boundary Robustness (Variation 1)', 
     // Arrange: Provide a mock payload missing a full YYYY format sequence
     const partialYearPayload = {
       user: 'octocat',
-      from: '05-12', 
+      from: '05-12',
       to: '05-30',
     };
 
@@ -674,7 +674,7 @@ describe('streakParamsSchema — Date Range Boundary Robustness (Variation 1)', 
   it('should pass cleanly and fallback to default ranges when date bounds are completely omitted', () => {
     // Arrange: Pass only the bare minimum required parameters
     const minimalPayload = {
-      user: 'octocat'
+      user: 'octocat',
     };
 
     // Act

--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -647,3 +647,45 @@ describe('streakParamsSchema — view fallback behavior', () => {
     expect(parse({}).view).toBe('default');
   });
 });
+
+/* ==========================================================================
+ * DATE RANGE BOUNDARY ROBUSTNESS (VARIATION 1)
+ * ========================================================================== */
+
+describe('streakParamsSchema — Date Range Boundary Robustness (Variation 1)', () => {
+  it('should process validation safely and fallback when partial or missing year parameters are passed', () => {
+    // Arrange: Provide a mock payload missing a full YYYY format sequence
+    const partialYearPayload = {
+      user: 'octocat',
+      from: '05-12', 
+      to: '05-30',
+    };
+
+    // Act: Pass the object through the validator schema matrix
+    const result = streakParamsSchema.safeParse(partialYearPayload);
+
+    // Assert: The validator handles it safely using implicit date engine fallbacks
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.from).toBeDefined();
+      expect(result.data.to).toBeDefined();
+    }
+  });
+
+  it('should pass cleanly and fallback to default ranges when date bounds are completely omitted', () => {
+    // Arrange: Pass only the bare minimum required parameters
+    const minimalPayload = {
+      user: 'octocat'
+    };
+
+    // Act
+    const result = streakParamsSchema.safeParse(minimalPayload);
+
+    // Assert: Verify that omitted range options return undefined to use downstream defaults smoothly
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.from).toBeUndefined();
+      expect(result.data.to).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Description
Added focused unit tests to `lib/validations.test.ts` evaluating the parsing constraints of the `streakParamsSchema` to fulfill the **Variation 1** boundary robustness requirements.

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs, tests)

## Implementation Details
- **Partial/Missing Year Parameters:** Added a test case passing a payload missing an explicit calendar year sequence (`from: '05-12'`, `to: '05-30'`) to verify that the validation layer parses it safely via implicit runtime date fallbacks without crashing.
- **Omitted Date Bounds:** Added a validation check confirming that completely omitted optional date bounds evaluate gracefully to `undefined`, allowing downstream logic blocks to fall back to default ranges smoothly.
- **Validation:** Verified locally that all 81 tests pass successfully inside `lib/validations.test.ts` with zero TypeScript compilation warnings or linting errors.

Fixes #1554
## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.