### PR TITLE
test(models): verify user createdAt field has a Date default 

### DIFF
--- a/models/User.test.ts
+++ b/models/User.test.ts
@@ -30,6 +30,23 @@ describe('User Model', () => {
         expect(typeof result).toBe('number');
         expect(Number.isFinite(result)).toBe(true);
       });
+
+      it('has a defined defaultValue that is Date.now or returns a Date', () => {
+        const createdAtPath = User.schema.path('createdAt') as mongoose.SchemaType & {
+          defaultValue?: unknown;
+          options: { default?: unknown };
+        };
+
+        const defaultValue = createdAtPath.defaultValue ?? createdAtPath.options.default;
+
+        expect(defaultValue).toBeDefined();
+
+        if (defaultValue !== Date.now) {
+          expect(typeof defaultValue).toBe('function');
+          const value = (defaultValue as () => unknown)();
+          expect(value instanceof Date).toBe(true);
+        }
+      });
     });
     it('has trim: true on username path', () => {
       const usernamePath = User.schema.path('username') as mongoose.SchemaType & {


### PR DESCRIPTION
## Description

Fixes #697
Program: GSSoC 2026

This PR adds test coverage for ensuring that the `createdAt` field in the `User` schema has a proper, resilient default value. 

Previously, the default property was entirely untested. This update introduces explicit assertions to ensure schema integrity and prevent regressions in user documentation creation timestamps.

### Changes Made

* Added 1 new test case inside the `createdAt schema` describe block in `models/User.test.ts`.
* Verified that `User.schema.path('createdAt')` contains a defined `defaultValue`.
* Asserted that the default falls back correctly to `Date.now` or executes successfully as a callable function that yields a valid `Date` instance.

### Why this matters

Ensures the Mongoose user profile initialization workflow remains stable and dependable, guaranteeing that user accounts created on CommitPulse are automatically stamped with precise creation metrics without throwing runtime undefined issues.

---

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

---

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npm run test models/User.test.ts`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.