### PR TITLE
test(github): verify fetchUserRepos returns correct star count for a single repo 

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -456,6 +456,27 @@ describe('fetchUserRepos', () => {
     expect(result[0].stargazers_count).toBe(1);
   });
 
+  it('returns a full three-repo payload with the expected star counts and languages', async () => {
+    const mockedRepos = [
+      { stargazers_count: 7, language: 'TypeScript' },
+      { stargazers_count: 42, language: 'Rust' },
+      { stargazers_count: 128, language: 'JavaScript' },
+    ];
+
+    vi.mocked(fetch).mockResolvedValue(mockResponse(mockedRepos));
+
+    const result = await fetchUserRepos('octocat', { bypassCache: true });
+
+    expect(result).toHaveLength(3);
+    result.forEach((repo, index) => {
+      expect(repo).toHaveProperty('stargazers_count');
+      expect(repo).toHaveProperty('language');
+      expect(repo.stargazers_count).toBe(mockedRepos[index].stargazers_count);
+      expect(repo.language).toBe(mockedRepos[index].language);
+    });
+    expect(result).toEqual(mockedRepos);
+  });
+
   it('encodes the username before using it in the REST repos path', async () => {
     vi.mocked(fetch).mockResolvedValue(
       mockResponse([{ stargazers_count: 1, language: 'TypeScript' }])


### PR DESCRIPTION
## Description

Fixes #684
Program: GSSoC 2026

This PR introduces robust unit test coverage for the `fetchUserRepos` utility function within our GitHub GraphQL/REST client integration layer.

Previously, tests verified only the first item in a minimal layout. This update implements deep structural verification across a varied dataset array.

### Changes Made

* Added 1 comprehensive test case in `lib/github.test.ts` mocking network responses via global `fetch`.
* Structured a mock array payload containing 3 mock repositories with distinct star weights and languages.
* Added 3 core assertions validating length accuracy, property presence (`stargazers_count` & `language`), and data mapping parity.

### Why this matters

Ensures the repository parsing logic remains functional and correctly handles multiple project entries, protecting against broken metric calculations and rendering glitches across internal user dashboard modules.

---

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

---

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npm run test lib/github.test.ts`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.