### PR TITLE
test(utils): add boundary robustness tests for date range formatter

### DIFF
--- a/utils/dateRange.test.ts
+++ b/utils/dateRange.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { formatDateRange, DEFAULT_DATE_RANGE } from './dateRange';
+
+describe('formatDateRange', () => {
+  it('returns full date range for valid 4-digit year', () => {
+    const result = formatDateRange('2024');
+    expect(result).toEqual({
+      from: '2024-01-01T00:00:00Z',
+      to: '2024-12-31T23:59:59Z',
+    });
+  });
+
+  it('handles partial year with 2 digits - prepends 20', () => {
+    const result = formatDateRange('24');
+    expect(result).toEqual({
+      from: '2024-01-01T00:00:00Z',
+      to: '2024-12-31T23:59:59Z',
+    });
+  });
+
+  it('handles partial year with 1 digit - maps to 202x', () => {
+    const result = formatDateRange('4');
+    expect(result).toEqual({
+      from: '2024-01-01T00:00:00Z',
+      to: '2024-12-31T23:59:59Z',
+    });
+  });
+
+  it('returns fallback default range for empty string year', () => {
+    const result = formatDateRange('');
+    const currentYear = new Date().getUTCFullYear();
+    expect(result).toEqual({
+      from: `${currentYear}-01-01T00:00:00Z`,
+      to: `${currentYear}-12-31T23:59:59Z`,
+    });
+  });
+
+  it('returns fallback default range for undefined year', () => {
+    const result = formatDateRange(undefined);
+    const currentYear = new Date().getUTCFullYear();
+    expect(result).toEqual({
+      from: `${currentYear}-01-01T00:00:00Z`,
+      to: `${currentYear}-12-31T23:59:59Z`,
+    });
+  });
+
+  it('returns fallback default range for whitespace-only year', () => {
+    const result = formatDateRange('   ');
+    const currentYear = new Date().getUTCFullYear();
+    expect(result).toEqual({
+      from: `${currentYear}-01-01T00:00:00Z`,
+      to: `${currentYear}-12-31T23:59:59Z`,
+    });
+  });
+
+  it('returns fallback default range for year before GitHub founding (2008)', () => {
+    const result = formatDateRange('2007');
+    const currentYear = new Date().getUTCFullYear();
+    expect(result).toEqual({
+      from: `${currentYear}-01-01T00:00:00Z`,
+      to: `${currentYear}-12-31T23:59:59Z`,
+    });
+  });
+
+  it('returns fallback default range for far future year', () => {
+    const result = formatDateRange('3000');
+    const currentYear = new Date().getUTCFullYear();
+    expect(result).toEqual({
+      from: `${currentYear}-01-01T00:00:00Z`,
+      to: `${currentYear}-12-31T23:59:59Z`,
+    });
+  });
+
+  it('returns fallback default range for non-numeric year', () => {
+    const result = formatDateRange('abc');
+    const currentYear = new Date().getUTCFullYear();
+    expect(result).toEqual({
+      from: `${currentYear}-01-01T00:00:00Z`,
+      to: `${currentYear}-12-31T23:59:59Z`,
+    });
+  });
+
+  it('returns fallback default range for invalid numeric year', () => {
+    const result = formatDateRange('-1');
+    const currentYear = new Date().getUTCFullYear();
+    expect(result).toEqual({
+      from: `${currentYear}-01-01T00:00:00Z`,
+      to: `${currentYear}-12-31T23:59:59Z`,
+    });
+  });
+
+  it('returns correct range for GitHub founding year (2008)', () => {
+    const result = formatDateRange('2008');
+    expect(result).toEqual({
+      from: '2008-01-01T00:00:00Z',
+      to: '2008-12-31T23:59:59Z',
+    });
+  });
+
+  it('returns result object matching DateRange interface', () => {
+    const result = formatDateRange('2025');
+    expect(result).toHaveProperty('from');
+    expect(result).toHaveProperty('to');
+    expect(typeof result.from).toBe('string');
+    expect(typeof result.to).toBe('string');
+  });
+
+  it('DEFAULT_DATE_RANGE uses current UTC year', () => {
+    const currentYear = new Date().getUTCFullYear();
+    expect(DEFAULT_DATE_RANGE.from).toBe(`${currentYear}-01-01T00:00:00Z`);
+    expect(DEFAULT_DATE_RANGE.to).toBe(`${currentYear}-12-31T23:59:59Z`);
+  });
+});

--- a/utils/dateRange.ts
+++ b/utils/dateRange.ts
@@ -1,0 +1,63 @@
+/**
+ * Default fallback date range when year is missing or invalid.
+ * Uses current year as fallback.
+ */
+export const DEFAULT_DATE_RANGE = {
+  from: `${new Date().getUTCFullYear()}-01-01T00:00:00Z`,
+  to: `${new Date().getUTCFullYear()}-12-31T23:59:59Z`,
+};
+
+/**
+ * Date range with from and to ISO strings for GitHub API queries.
+ */
+export interface DateRange {
+  from: string;
+  to: string;
+}
+
+/**
+ * Formats a year into a date range for GitHub contributions query.
+ * Returns fallback default ranges when year is missing, partial, or invalid.
+ *
+ * @param year - The year as string (e.g., "2024", "24", "2", "", undefined)
+ * @returns DateRange object with from and to ISO date strings
+ *
+ * @example
+ * formatDateRange("2024") // { from: "2024-01-01T00:00:00Z", to: "2024-12-31T23:59:59Z" }
+ * formatDateRange("24") // { from: "2024-01-01T00:00:00Z", to: "2024-12-31T23:59:59Z" }
+ * formatDateRange("") // returns DEFAULT_DATE_RANGE
+ * formatDateRange(undefined) // returns DEFAULT_DATE_RANGE
+ */
+export function formatDateRange(year?: string): DateRange {
+  if (!year || year.trim() === '') {
+    return { ...DEFAULT_DATE_RANGE };
+  }
+
+  const trimmedYear = year.trim();
+
+  // Handle partial years (1 or 2 digits): assume 20xx
+  // For 2-digit: '24' -> 2024
+  // For 1-digit: '4' -> 2024 (not 2004, to stay in reasonable range)
+  let fullYear: number;
+  if (trimmedYear.length === 2) {
+    fullYear = parseInt('20' + trimmedYear, 10);
+  } else if (trimmedYear.length === 1) {
+    // 1-digit: map to 2020 + digit (4 -> 2024, 9 -> 2029)
+    fullYear = 2020 + parseInt(trimmedYear, 10);
+  } else {
+    fullYear = parseInt(trimmedYear, 10);
+  }
+
+  // Validate parsed year – must be >= 2008 (GitHub founding year) and reasonable future limit
+  const currentYear = new Date().getUTCFullYear();
+  const isValidYear = !isNaN(fullYear) && fullYear >= 2008 && fullYear <= currentYear + 5;
+
+  if (!isValidYear) {
+    return { ...DEFAULT_DATE_RANGE };
+  }
+
+  return {
+    from: `${fullYear}-01-01T00:00:00Z`,
+    to: `${fullYear}-12-31T23:59:59Z`,
+  };
+}


### PR DESCRIPTION
## Description

Fixes #1574

Added a reusable `formatDateRange` utility with boundary robustness handling for partial, missing, and invalid year inputs.

### Supported Cases

* Full 4-digit years: `2024`
* Partial 2-digit years: `24` → `2024`
* Partial 1-digit years: `4` → `2024`
* Missing, empty, or invalid inputs fallback safely to the current year range

### Changes Made

* Added `utils/dateRange.ts`
* Added `utils/dateRange.test.ts`
* Added 13 boundary-condition test cases
* Ensured all existing tests continue to pass successfully

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — utility and test changes only.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] All tests pass successfully.
