### PR TITLE
fix: generate valid calendar dates in benchmark by using Date object

### DIFF
--- a/scripts/benchmark-svg.ts
+++ b/scripts/benchmark-svg.ts
@@ -23,7 +23,7 @@ const calendar = {
   weeks: Array.from({ length: 14 }, (_, weekIndex) => ({
     contributionDays: Array.from({ length: 7 }, (_, dayIndex) => ({
       contributionCount: Math.floor(Math.random() * 20),
-      date: `2026-05-${String(weekIndex * 7 + dayIndex + 1).padStart(2, '0')}`,
+      date: new Date(2026, 4, weekIndex * 7 + dayIndex + 1).toISOString().slice(0, 10),
     })),
   })),
 };


### PR DESCRIPTION
Fixes #1677

Replaced manual date string construction (\weekIndex * 7 + dayIndex + 1\) with a proper \Date\ object so dates correctly roll over into subsequent months instead of producing invalid dates like \2026-05-32\.