### PR TITLE
fix(svg): escape ampersands in Google Fonts import URLs

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -1181,7 +1181,7 @@ describe('GET /api/streak', () => {
       const body = await response.text();
 
       expect(response.status).toBe(200);
-      expect(body).toContain('family=Inter&display=swap');
+      expect(body).toContain('family=Inter&amp;display=swap');
       expect(body).toContain('"Inter", sans-serif');
     });
   });

--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -486,7 +486,7 @@ describe('generateSVG', () => {
       );
 
       expect(svg).toContain(
-        "@import url('https://fonts.googleapis.com/css2?family=Inter&display=swap');"
+        "@import url('https://fonts.googleapis.com/css2?family=Inter&amp;display=swap');"
       );
       expect(svg).toContain('font-family: "Inter", sans-serif;');
     });
@@ -946,7 +946,7 @@ describe('generateMonthlySVG', () => {
     } as unknown as BadgeParams);
 
     expect(svg).toContain(
-      "@import url('https://fonts.googleapis.com/css2?family=Inter&display=swap');"
+      "@import url('https://fonts.googleapis.com/css2?family=Inter&amp;display=swap');"
     );
     expect(svg).toContain('font-family: "Inter", sans-serif;');
   });

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -526,7 +526,7 @@ function generateAutoThemeSVG(
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const googleFontUrlPart = sanitizedFont ? sanitizeGoogleFontUrl(sanitizedFont) : null;
   const googleFontsImport = googleFontUrlPart
-    ? `@import url('https://fonts.googleapis.com/css2?family=${googleFontUrlPart}&display=swap');`
+    ? `@import url('https://fonts.googleapis.com/css2?family=${googleFontUrlPart}&amp;display=swap');`
     : '';
   const sf = getSizeScale(params.size);
   const radius = sanitizeRadius(params.radius, 8) * sf;
@@ -1006,7 +1006,7 @@ function generateAutoThemeMonthlySVG(stats: MonthlyStats, params: BadgeParams): 
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const googleFontUrlPart = sanitizedFont ? sanitizeGoogleFontUrl(sanitizedFont) : null;
   const googleFontsImport = googleFontUrlPart
-    ? `@import url('https://fonts.googleapis.com/css2?family=${googleFontUrlPart}&display=swap');`
+    ? `@import url('https://fonts.googleapis.com/css2?family=${googleFontUrlPart}&amp;display=swap');`
     : '';
   const parsedRadius = Number(params.radius);
   const radius = Math.max(0, Math.min(Number.isNaN(parsedRadius) ? 8 : parsedRadius, 50));


### PR DESCRIPTION
## Description

Fixes #1705

This PR fixes an XML/SVG syntax issue in the auto-theme SVG generators.

When a custom Google Font is requested, `generateAutoThemeSVG` and `generateAutoThemeMonthlySVG` generate a Google Fonts `@import` URL containing a raw `&display=swap` parameter inside an SVG `<style>` block.

Because SVG is XML-based and the stylesheet is not wrapped in CDATA, raw ampersands are invalid XML and can cause parsing or rendering failures in strict SVG/XML parsers.

### Changes

* Replaced raw `&display=swap` with `&amp;display=swap`
* Updated:

  * `generateAutoThemeSVG`
  * `generateAutoThemeMonthlySVG`
* Aligned implementation with other SVG generators in the codebase that already use XML-safe escaped URLs

### Before

```css
@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
```

### After

```css
@import url('https://fonts.googleapis.com/css2?family=Roboto&amp;display=swap');
```

This preserves existing functionality while ensuring generated SVG output remains valid XML.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (No visual changes)

This change only affects XML escaping within generated SVG `<style>` blocks and does not alter the rendered output.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
