### PR TITLE
fix(github): retry on GraphQL RATE_LIMITED errors returned with HTTP 200 (closes #1269)

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -316,6 +316,52 @@ describe('fetchGitHubContributions', () => {
     );
   });
 
+  // GitHub GraphQL returns HTTP 200 for rate limit errors — the error lives in the body.
+  // fetchGraphQLWithRetry must detect it and back off, not crash immediately.
+  describe('body-level RATE_LIMITED retry (HTTP 200)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('retries with backoff when GitHub returns RATE_LIMITED inside a 200 OK body', async () => {
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(
+          mockResponse({ errors: [{ type: 'RATE_LIMITED', message: 'API rate limit exceeded' }] })
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            data: { user: { contributionsCollection: { contributionCalendar: mockCalendar } } },
+          })
+        );
+
+      const promise = fetchGitHubContributions('octocat');
+      await vi.advanceTimersByTimeAsync(500);
+      const result = await promise;
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(result.totalContributions).toBe(mockCalendar.totalContributions);
+    });
+
+    it('throws after exhausting all retries on repeated body-level RATE_LIMITED errors', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        mockResponse({ errors: [{ type: 'RATE_LIMITED', message: 'API rate limit exceeded' }] })
+      );
+
+      const promise = fetchGitHubContributions('octocat');
+      // Register the rejection handler before advancing timers so the rejection
+      // is never "unhandled" during the timer callbacks.
+      const assertion = expect(promise).rejects.toThrow('API Rate Limit Exceeded');
+      // 500ms + 1000ms + 2000ms covers all 3 retry delays before attempt >= MAX_RETRIES
+      await vi.advanceTimersByTimeAsync(3500);
+      await assertion;
+      expect(fetch).toHaveBeenCalledTimes(4);
+    });
+  });
+
   it('throws a descriptive "user not found" error when the username does not exist on GitHub', async () => {
     vi.mocked(fetch).mockResolvedValue(mockResponse({ data: { user: null } }));
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -13,6 +13,7 @@ interface GitHubRepo {
 
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 500;
+const MAX_RETRY_DELAY_MS = 5000;
 const GRAPHQL_TIMEOUT_MS = 8000; // 8s for GraphQL endpoint
 const REST_TIMEOUT_MS = 5000; // 5s for REST endpoints
 
@@ -88,7 +89,7 @@ export async function fetchWithRetry(
 
     // If the delay is too long (e.g., > 5 seconds), it's a hard limit.
     // Return immediately to avoid serverless function timeouts.
-    if (delay > 5000) {
+    if (delay > MAX_RETRY_DELAY_MS) {
       return res;
     }
 
@@ -103,6 +104,38 @@ export async function fetchWithRetry(
   const delay = BASE_DELAY_MS * Math.pow(2, attempt);
   await new Promise((resolve) => setTimeout(resolve, delay));
   return fetchWithRetry(url, options, attempt + 1, timeoutMs);
+}
+
+// Wraps fetchWithRetry to also retry on GraphQL-level RATE_LIMITED errors
+// that GitHub returns with HTTP 200 OK instead of 429.
+async function fetchGraphQLWithRetry(
+  url: string | URL,
+  options: RequestInit,
+  attempt = 0,
+  timeoutMs?: number
+): Promise<Response> {
+  const res = await fetchWithRetry(url, options, attempt, timeoutMs);
+  if (!res.ok || attempt >= MAX_RETRIES) return res;
+
+  const body: unknown = await res
+    .clone()
+    .json()
+    .catch(() => null);
+  const isBodyRateLimited =
+    Array.isArray((body as { errors?: unknown })?.errors) &&
+    (body as { errors: unknown[] }).errors.some(
+      (e) =>
+        (e as { type?: string })?.type === 'RATE_LIMITED' ||
+        (e as { message?: string })?.message?.toLowerCase().includes('rate limit')
+    );
+
+  if (!isBodyRateLimited) return res;
+
+  const delay = BASE_DELAY_MS * Math.pow(2, attempt);
+  if (delay > MAX_RETRY_DELAY_MS) return res;
+
+  await new Promise((resolve) => setTimeout(resolve, delay));
+  return fetchGraphQLWithRetry(url, options, attempt + 1, timeoutMs);
 }
 
 const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql';
@@ -298,7 +331,7 @@ export async function fetchGitHubContributions(
       }
     `;
 
-    const res = await fetchWithRetry(GITHUB_GRAPHQL_URL, {
+    const res = await fetchGraphQLWithRetry(GITHUB_GRAPHQL_URL, {
       method: 'POST',
       headers: getHeaders(),
       body: JSON.stringify({


### PR DESCRIPTION
## Description

Closes #1269

GitHub's GraphQL API returns rate limit errors **with HTTP 200 OK**, embedding the error inside `data.errors` as `{ type: 'RATE_LIMITED' }`. Because `fetchWithRetry` only inspects HTTP status codes, it considers the 200 a success and returns immediately - `fetchGitHubContributions` then throws an unrecoverable error instead of backing off and retrying.

**Root cause:** `fetchWithRetry` has no visibility into the response body, so body-level GraphQL errors bypass all retry logic.

**Fix:** Adds a thin `fetchGraphQLWithRetry` wrapper around `fetchWithRetry`. After a 200 OK response, it clones and peeks the response body for `RATE_LIMITED` errors. If found, it applies the same `BASE_DELAY_MS * 2^attempt` exponential backoff used for HTTP 429, up to the same `MAX_RETRIES` cap and 5 000 ms delay guard. `fetchWithRetry` itself is unchanged - the fix is fully isolated.

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A - server-side API fix with no visual output changes.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).