### PR TITLE
docs(themes): add live SVG preview badge for all 19 preset themes in THEMES.md

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -1,91 +1,285 @@
 # 🎨 CommitPulse Themes
 
-All 13 available themes for your CommitPulse badge. Use the `?theme=<slug>` query parameter to apply a
-theme.
+All 19 available themes for your CommitPulse badge. Use the `?theme=<slug>` query parameter to apply a theme.
 
 ```
-https://commitpulse.vercel.app/api/badge?username=YOUR_USERNAME&theme=<slug>
+https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 ```
 
 ---
 
 ## Theme Gallery
 
-| Theme        | Background | Text      | Accent    |
-| ------------ | ---------- | --------- | --------- |
-| dark         | `#0d1117`  | `#c9d1d9` | `#58a6ff` |
-| light        | `#ffffff`  | `#24292f` | `#0969da` |
-| neon         | `#000000`  | `#00ffcc` | `#ff00ff` |
-| github       | `#0d1117`  | `#ffffff` | `#39d353` |
-| dracula      | `#282a36`  | `#f8f8f2` | `#bd93f9` |
-| ocean        | `#0a192f`  | `#ccd6f6` | `#64ffda` |
-| sunset       | `#1a0a0a`  | `#ffd6c0` | `#ff6b35` |
-| forest       | `#0d1f0d`  | `#c8f0c8` | `#39d353` |
-| rose         | `#1f0d14`  | `#f0c8d4` | `#ff6b9d` |
-| nord         | `#2e3440`  | `#d8dee9` | `#88c0d0` |
-| synthwave    | `#0d0221`  | `#f8f8f2` | `#ff2d78` |
-| gruvbox      | `#282828`  | `#ebdbb2` | `#fe8019` |
-| highcontrast | `#0a0a0a`  | `#ffffff` | `#ff4500` |
+| Theme            | Background | Text      | Accent    |
+| ---------------- | ---------- | --------- | --------- |
+| dark             | `#0d1117`  | `#c9d1d9` | `#58a6ff` |
+| light            | `#ffffff`  | `#24292f` | `#0969da` |
+| neon             | `#000000`  | `#00ffcc` | `#ff00ff` |
+| github           | `#0d1117`  | `#ffffff` | `#238636` |
+| dracula          | `#282a36`  | `#f8f8f2` | `#bd93f9` |
+| ocean            | `#0a192f`  | `#ccd6f6` | `#64ffda` |
+| sunset           | `#1a0a0a`  | `#ffd6c0` | `#ff6b35` |
+| forest           | `#0d1f0d`  | `#c8f0c8` | `#39d353` |
+| rose             | `#1f0d14`  | `#f0c8d4` | `#ff6b9d` |
+| nord             | `#2e3440`  | `#d8dee9` | `#88c0d0` |
+| synthwave        | `#0d0221`  | `#f8f8f2` | `#ff2d78` |
+| gruvbox          | `#282828`  | `#ebdbb2` | `#fe8019` |
+| aurora_cyberpunk | `#090B13`  | `#EAF2FF` | `#9D5CFF` |
+| highcontrast     | `#0a0a0a`  | `#ffffff` | `#ff4500` |
+| catppuccin_latte | `#eff1f5`  | `#4c4f69` | `#1e66f5` |
+| solarized_light  | `#fdf6e3`  | `#586e75` | `#268bd2` |
+| gruvbox_light    | `#fbf1c7`  | `#3c3836` | `#d65d0e` |
+| nord_light       | `#eceff4`  | `#2e3440` | `#5e81ac` |
+| cyber-pulse      | `#000000`  | `#ffffff` | `#00ffee` |
 
 ---
 
-## Preview URLs
+## Preview Gallery
 
-Use these URLs to preview each theme in your README:
+### 🌑 Dark (default)
 
-**dark**
+![dark](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=dark)
 
-![dark](https://commitpulse.vercel.app/api/badge?username=demo&theme=dark)
-
-**light**
-
-![light](https://commitpulse.vercel.app/api/badge?username=demo&theme=light)
-
-**neon**
-
-![neon](https://commitpulse.vercel.app/api/badge?username=demo&theme=neon)
-
-**github**
-
-![github](https://commitpulse.vercel.app/api/badge?username=demo&theme=github)
-
-**dracula**
-
-![dracula](https://commitpulse.vercel.app/api/badge?username=demo&theme=dracula)
-
-**ocean**
-
-![ocean](https://commitpulse.vercel.app/api/badge?username=demo&theme=ocean)
-
-**sunset**
-
-![sunset](https://commitpulse.vercel.app/api/badge?username=demo&theme=sunset)
-
-**forest**
-
-![forest](https://commitpulse.vercel.app/api/badge?username=demo&theme=forest)
-
-**rose**
-
-![rose](https://commitpulse.vercel.app/api/badge?username=demo&theme=rose)
-
-**nord**
-
-![nord](https://commitpulse.vercel.app/api/badge?username=demo&theme=nord)
-
-**synthwave**
-
-![synthwave](https://commitpulse.vercel.app/api/badge?username=demo&theme=synthwave)
-
-**gruvbox**
-
-![gruvbox](https://commitpulse.vercel.app/api/badge?username=demo&theme=gruvbox)
-
-**highcontrast**
-
-![highcontrast](https://commitpulse.vercel.app/api/badge?username=demo&theme=highcontrast)
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 0d1117 |
+| `text`    | c9d1d9 |
+| `accent`  | 58a6ff |
 
 ---
 
-> 💡 **Tip:** Use `?theme=auto` to automatically switch between `light` and `dark` based on the
-> viewer's OS setting.
+### ☀️ Light
+
+![light](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=light)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | ffffff |
+| `text`    | 24292f |
+| `accent`  | 0969da |
+
+---
+
+### ⚡ Neon
+
+![neon](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=neon)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 000000 |
+| `text`    | 00ffcc |
+| `accent`  | ff00ff |
+
+---
+
+### 🐙 GitHub
+
+![github](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=github)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 0d1117 |
+| `text`    | ffffff |
+| `accent`  | 238636 |
+
+---
+
+### 🧛 Dracula
+
+![dracula](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=dracula)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 282a36 |
+| `text`    | f8f8f2 |
+| `accent`  | bd93f9 |
+
+---
+
+### 🌊 Ocean
+
+![ocean](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=ocean)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 0a192f |
+| `text`    | ccd6f6 |
+| `accent`  | 64ffda |
+
+---
+
+### 🌅 Sunset
+
+![sunset](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=sunset)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 1a0a0a |
+| `text`    | ffd6c0 |
+| `accent`  | ff6b35 |
+
+---
+
+### 🌲 Forest
+
+![forest](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=forest)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 0d1f0d |
+| `text`    | c8f0c8 |
+| `accent`  | 39d353 |
+
+---
+
+### 🌸 Rose
+
+![rose](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=rose)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 1f0d14 |
+| `text`    | f0c8d4 |
+| `accent`  | ff6b9d |
+
+---
+
+### ❄️ Nord
+
+![nord](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=nord)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 2e3440 |
+| `text`    | d8dee9 |
+| `accent`  | 88c0d0 |
+
+---
+
+### 🎵 Synthwave
+
+![synthwave](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=synthwave)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 0d0221 |
+| `text`    | f8f8f2 |
+| `accent`  | ff2d78 |
+
+---
+
+### 🪵 Gruvbox
+
+![gruvbox](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=gruvbox)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 282828 |
+| `text`    | ebdbb2 |
+| `accent`  | fe8019 |
+
+---
+
+### 🔮 Aurora Cyberpunk
+
+![aurora_cyberpunk](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=aurora_cyberpunk)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 090B13 |
+| `text`    | EAF2FF |
+| `accent`  | 9D5CFF |
+
+---
+
+### 🔦 High Contrast
+
+![highcontrast](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=highcontrast)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 0a0a0a |
+| `text`    | ffffff |
+| `accent`  | ff4500 |
+
+---
+
+### 🐱 Catppuccin Latte
+
+![catppuccin_latte](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=catppuccin_latte)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | eff1f5 |
+| `text`    | 4c4f69 |
+| `accent`  | 1e66f5 |
+
+---
+
+### 🌞 Solarized Light
+
+![solarized_light](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=solarized_light)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | fdf6e3 |
+| `text`    | 586e75 |
+| `accent`  | 268bd2 |
+
+---
+
+### 🌻 Gruvbox Light
+
+![gruvbox_light](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=gruvbox_light)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | fbf1c7 |
+| `text`    | 3c3836 |
+| `accent`  | d65d0e |
+
+---
+
+### 🏔️ Nord Light
+
+![nord_light](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=nord_light)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | eceff4 |
+| `text`    | 2e3440 |
+| `accent`  | 5e81ac |
+
+---
+
+### 💠 Cyber Pulse
+
+![cyber-pulse](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=cyber-pulse)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 000000 |
+| `text`    | ffffff |
+| `accent`  | 00ffee |
+
+---
+
+## 🎛️ Custom Theme
+
+Not finding what you want? Build your own using raw color parameters — all values are hex codes **without** the `#` prefix:
+
+```
+https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&bg=1a1b27&text=a9b1d6&accent=7aa2f7
+```
+
+---
+
+## 🔄 Auto Theme
+
+Automatically switches between light and dark based on the viewer's OS setting — no hex values needed:
+
+```
+https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=auto
+```
+
+> 💡 **Tip:** You can combine `theme=` with individual overrides. For example, `theme=dracula&accent=ff79c6` applies the Dracula theme but swaps only the accent color.


### PR DESCRIPTION
## What does this PR do?

THEMES.md previously contained only a hex color table with no visual previews.
This PR adds a live rendered CommitPulse badge embed for every single preset 
theme so developers can compare all themes at a glance without manually testing 
each URL.

## Pillar
- [x] Other: Documentation improvement

## Fixes
Closes #1708 

## Changes

| File | Change |
|------|--------|
| `THEMES.md` | Added live badge preview for all 19 preset themes |
| `THEMES.md` | Kept hex color table under each preview for reference |
| `THEMES.md` | Added Custom Theme and Auto Theme usage sections |

## All 19 themes now have previews
dark, light, neon, github, dracula, ocean, sunset, forest, rose, nord,
synthwave, gruvbox, aurora_cyberpunk, highcontrast, catppuccin_latte,
solarized_light, gruvbox_light, nord_light, cyber-pulse

## Checklist
- [x] Zero code changes — Markdown only
- [x] npm run lint passes locally
- [x] npm run format passes locally
- [x] All 19 themes from lib/svg/themes.ts are represented
- [x] My commits follow the Conventional Commits format
- [x] No new dependencies added