### PR TITLE
fix: use deterministic benchmark contribution data

### DIFF
--- a/scripts/benchmark-svg.ts
+++ b/scripts/benchmark-svg.ts
@@ -20,7 +20,7 @@ const baseParams = {
 
 const deterministicContributionCount = (
   weekIndex: number,
-  dayIndex: number
+  dayIndex: number,
 ): number => {
   return ((weekIndex * 7 + dayIndex) * 13) % 20;
 };

--- a/scripts/benchmark-svg.ts
+++ b/scripts/benchmark-svg.ts
@@ -21,7 +21,8 @@ const baseParams = {
 const deterministicContributionCount = (
   weekIndex: number,
   dayIndex: number,
-): number => {
+): 
+number => {
   return ((weekIndex * 7 + dayIndex) * 13) % 20;
 };
 

--- a/scripts/benchmark-svg.ts
+++ b/scripts/benchmark-svg.ts
@@ -18,11 +18,7 @@ const baseParams = {
   speed: sanitizeSpeed('8s'),
 };
 
-const deterministicContributionCount = (
-  weekIndex: number,
-  dayIndex: number,
-): 
-number => {
+const deterministicContributionCount = (weekIndex: number, dayIndex: number): number => {
   return ((weekIndex * 7 + dayIndex) * 13) % 20;
 };
 
@@ -30,7 +26,7 @@ const calendar = {
   totalContributions: 1240,
   weeks: Array.from({ length: 14 }, (_, weekIndex) => ({
     contributionDays: Array.from({ length: 7 }, (_, dayIndex) => ({
-      contributionCount:deterministicContributionCount(weekIndex,dayIndex),
+      contributionCount: deterministicContributionCount(weekIndex, dayIndex),
       date: `2026-05-${String(weekIndex * 7 + dayIndex + 1).padStart(2, '0')}`,
     })),
   })),

--- a/scripts/benchmark-svg.ts
+++ b/scripts/benchmark-svg.ts
@@ -29,7 +29,7 @@ const calendar = {
   totalContributions: 1240,
   weeks: Array.from({ length: 14 }, (_, weekIndex) => ({
     contributionDays: Array.from({ length: 7 }, (_, dayIndex) => ({
-      contributionCount: deterministicContributionCount(weekIndex,dayIndex),
+      contributionCount:deterministicContributionCount(weekIndex,dayIndex),
       date: `2026-05-${String(weekIndex * 7 + dayIndex + 1).padStart(2, '0')}`,
     })),
   })),

--- a/scripts/benchmark-svg.ts
+++ b/scripts/benchmark-svg.ts
@@ -18,11 +18,21 @@ const baseParams = {
   speed: sanitizeSpeed('8s'),
 };
 
+const deterministicContributionCount = (
+  weekIndex: number,
+  dayIndex: number
+): number => {
+  return ((weekIndex * 7 + dayIndex) * 13) % 20;
+};
+
 const calendar = {
   totalContributions: 1240,
   weeks: Array.from({ length: 14 }, (_, weekIndex) => ({
     contributionDays: Array.from({ length: 7 }, (_, dayIndex) => ({
-      contributionCount: Math.floor(Math.random() * 20),
+      contributionCount: deterministicContributionCount(
+        weekIndex,
+        dayIndex
+      ),
       date: `2026-05-${String(weekIndex * 7 + dayIndex + 1).padStart(2, '0')}`,
     })),
   })),

--- a/scripts/benchmark-svg.ts
+++ b/scripts/benchmark-svg.ts
@@ -29,10 +29,7 @@ const calendar = {
   totalContributions: 1240,
   weeks: Array.from({ length: 14 }, (_, weekIndex) => ({
     contributionDays: Array.from({ length: 7 }, (_, dayIndex) => ({
-      contributionCount: deterministicContributionCount(
-        weekIndex,
-        dayIndex
-      ),
+      contributionCount: deterministicContributionCount(weekIndex,dayIndex),
       date: `2026-05-${String(weekIndex * 7 + dayIndex + 1).padStart(2, '0')}`,
     })),
   })),


### PR DESCRIPTION
## Summary

This PR makes the benchmark dataset deterministic by replacing random contribution generation with a predictable calculation.

### Changes Made

* Added a deterministic contribution count generator
* Removed `Math.random()` from benchmark dataset creation
* Preserved variation in contribution values while ensuring reproducibility

### Problem

The benchmark previously generated a different dataset on every execution, making performance comparisons less reliable.

### Result

Benchmark runs now use a consistent dataset, improving reproducibility and regression tracking.

Closes #1678
