### PR TITLE
style(contributors): fix contributor CTA contrast, opacity, and acces…

### DIFF
--- a/app/contributors/page.tsx
+++ b/app/contributors/page.tsx
@@ -225,7 +225,7 @@ export default async function ContributorsPage() {
                 <Link
                   href="https://github.com/JhaSourav07/commitpulse"
                   target="_blank"
-                  className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-cyan-500 via-blue-500 to-purple-500 px-8 py-4 font-semibold text-white transition-all duration-300 hover:scale-105"
+                  className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-cyan-500 via-blue-500 to-purple-500 px-8 py-4 font-semibold text-white transition-all duration-300 hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-zinc-900"
                 >
                   <Globe className="h-5 w-5" />
                   View Repository
@@ -234,7 +234,7 @@ export default async function ContributorsPage() {
                 <Link
                   href="https://github.com/JhaSourav07/commitpulse/issues"
                   target="_blank"
-                  className="inline-flex items-center gap-2 rounded-2xl border border-black/10 bg-white/60 dark:border-white/10 dark:bg-white/5 px-8 py-4 font-semibold text-zinc-700 dark:text-zinc-300 transition-all duration-300 hover:border-cyan-400/30 hover:bg-cyan-400/10 hover:text-white"
+                  className="inline-flex items-center gap-2 rounded-2xl border border-black/15 bg-white/90 dark:border-white/15 dark:bg-white/10 px-8 py-4 font-semibold text-zinc-700 dark:text-zinc-300 transition-all duration-300 hover:border-cyan-500 hover:bg-cyan-50 dark:hover:border-cyan-400 dark:hover:bg-cyan-950/30 hover:text-zinc-900 dark:hover:text-cyan-100 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-zinc-900"
                 >
                   Start Contributing
                   <ArrowRight className="h-5 w-5" />


### PR DESCRIPTION
## Description

Fixes #1635

This PR improves the visual contrast, theme consistency, and interactive feedback of the **Start Contributing** call-to-action button on the `/contributors` page.

### What was changed:
* **Opacity Adjustment**: Reduced the opacity transparency effect on the default state button by changing the background to `bg-white/90` (light theme) and `dark:bg-white/10` (dark theme) for consistent visibility.
* **Hover Contrast**: Replaced the low-contrast `hover:bg-cyan-400/10` and `hover:text-white` combination with a legible dark text color on hover in light theme (`hover:text-zinc-900` over `hover:bg-cyan-50`) and a theme-appropriate light text color in dark theme (`dark:hover:text-cyan-100` over `dark:hover:bg-cyan-950/30`).
* **Visual Polish**: Strengthened button borders slightly (`border-black/15` / `dark:border-white/15`) and added a premium `hover:shadow-lg` drop shadow on hover.
* **Accessibility Rings**: Added smooth `focus-visible:ring-2` focus rings for keyboard-only navigation accessibility.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Before : 
<img width="1227" height="627" alt="image" src="https://github.com/user-attachments/assets/5c5c02aa-2dae-4db0-bd20-7de3aecbdca5" />

After : 
<img width="1112" height="554" alt="image" src="https://github.com/user-attachments/assets/f6261931-98fc-4558-8849-ea329c99d972" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format (`style(contributors): fix contributor CTA contrast, opacity, and accessibility on hover`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
