### PR TITLE
fix: use production URL instead of localhost for social metadata

### DIFF
--- a/app/(root)/dashboard/[username]/page.tsx
+++ b/app/(root)/dashboard/[username]/page.tsx
@@ -8,8 +8,8 @@ import { notFound, redirect } from 'next/navigation';
 export const revalidate = 3600; // Cache for 1 hour
 
 const BASE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL ??
-  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'https://commitpulse.vercel.app');
 
 export async function generateMetadata({
   params,


### PR DESCRIPTION
## Description

Replaced the localhost fallback URL used in metadata generation with the production deployment URL.

### Changes
- Removed `http://localhost:3000` fallback.
- Added production URL fallback for Open Graph and Twitter metadata.

### Why
Using localhost in metadata results in broken social media previews when environment variables are not configured.

### Testing
- Verified metadata generation with missing environment variables.
- Confirmed generated URLs use a publicly accessible domain.

close #1732 