### PR TITLE
feat(mongodb): add dbDisconnect() for graceful connection teardown

### DIFF
--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -43,5 +43,20 @@ async function dbConnect() {
 
   return cached.conn;
 }
+/**
+ * Disconnects from the MongoDB database and clears the cached connection.
+ *
+ * Useful for graceful shutdown in tests or serverless teardown.
+ *
+ * @example
+ * await dbDisconnect();
+ */
+export async function dbDisconnect(): Promise<void> {
+  if (!cached.conn) return;
+
+  await mongoose.disconnect();
+  cached.conn = null;
+  cached.promise = null;
+}
 
 export default dbConnect;


### PR DESCRIPTION
## Description

Adds a `dbDisconnect()` utility that calls `mongoose.disconnect()` and
clears the cached connection state. Useful for graceful shutdown in
tests or serverless teardown where leaving connections open causes
resource leaks.

Fixes #1745 

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — database utility, no visual output.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.