### PR TITLE
refactor(dashboard): document allDays reuse

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -812,7 +812,10 @@ export async function getFullDashboardData(username: string, options: FetchOptio
     },
   };
 
+  // Flatten contribution days once and reuse across dashboard-derived
+  // computations such as activity and commit clock generation.
   const allDays = calendarData.weeks.flatMap((w) => w.contributionDays);
+
   const activity = allDays.map((day) => {
     let intensity: 0 | 1 | 2 | 3 | 4 = 0;
     if (day.contributionCount > 0) intensity = 1;


### PR DESCRIPTION
## Description

Fixes #371

Added a comment in `lib/github.ts` documenting that the flattened `allDays` contribution array is computed once and reused for dashboard-derived computations.

Verified that:

* `calendarData.weeks.flatMap(...)` is called once in `getFullDashboardData`
* Activity generation reuses `allDays`
* Commit clock generation reuses `allDays`

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (documentation/comment-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [ ] I have started the repo.
* [ ] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable)
* [ ] (Recommended) I joined the CommitPulse Discord community.
