### PR TITLE
fix: null cache key

### DIFF
--- a/lib/cache.test.ts
+++ b/lib/cache.test.ts
@@ -447,6 +447,17 @@ describe('TTLCache', () => {
       cache.destroy();
     });
 
+    it('throws TypeError when setting a null key', () => {
+      const cache = new TTLCache<string>();
+
+      expect(() => {
+        cache.set(null as unknown as string, 'value', 60_000);
+      }).toThrow(TypeError);
+      expect(cache.size()).toBe(0);
+
+      cache.destroy();
+    });
+
     it('throws RangeError when ttlMs is 0 or negative', () => {
       const cache = new TTLCache<string>();
       expect(() => cache.set('key', 'value', 0)).toThrow(RangeError);

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -19,6 +19,12 @@ export class TTLCache<T> {
   private cleanupInterval: ReturnType<typeof setInterval> | null = null;
   private readonly maxSize?: number;
 
+  private static assertValidKey(key: unknown): asserts key is string {
+    if (typeof key !== 'string') {
+      throw new TypeError('Cache key must be a string');
+    }
+  }
+
   /**
    * Creates a new TTL cache instance.
    *
@@ -62,6 +68,8 @@ export class TTLCache<T> {
    * const user = cache.get("user:1");
    */
   get(key: string): T | null {
+    TTLCache.assertValidKey(key);
+
     const hit = this.store.get(key);
     if (!hit) return null;
 
@@ -87,6 +95,8 @@ export class TTLCache<T> {
    * }
    */
   has(key: string): boolean {
+    TTLCache.assertValidKey(key);
+
     const hit = this.store.get(key);
     if (!hit) return false;
 
@@ -109,6 +119,8 @@ export class TTLCache<T> {
    * cache.delete("user:1");
    */
   delete(key: string): boolean {
+    TTLCache.assertValidKey(key);
+
     return this.store.delete(key);
   }
 
@@ -134,6 +146,8 @@ export class TTLCache<T> {
    * @returns `true` if the entry existed and was updated, `false` if missing or expired.
    */
   update(key: string, value: T): boolean {
+    TTLCache.assertValidKey(key);
+
     const hit = this.store.get(key);
     if (!hit || Date.now() > hit.expiresAt) return false;
     hit.value = value;
@@ -141,6 +155,7 @@ export class TTLCache<T> {
   }
 
   set(key: string, value: T, ttlMs: number): void {
+    TTLCache.assertValidKey(key);
     if (key === '') throw new Error('Cache key cannot be empty');
     if (ttlMs <= 0) throw new RangeError(`ttlMs must be positive, got ${ttlMs}`);
 


### PR DESCRIPTION
## Description

Fixes #1391

Adds runtime validation for `TTLCache` keys so `null` keys are rejected with a `TypeError`, and adds a focused boundary test to verify the cache remains unchanged after the rejected write.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — this PR only updates cache validation and unit tests.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [ ] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [ ] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.