### PR TITLE
test(cache): reject empty cache keys

### DIFF
--- a/lib/cache.test.ts
+++ b/lib/cache.test.ts
@@ -410,6 +410,15 @@ describe('TTLCache', () => {
       cache.destroy();
     });
 
+    it('rejects an empty string cache key', () => {
+      const cache = new TTLCache<string>();
+
+      expect(() => cache.set('', 'value', 60_000)).toThrow('Cache key cannot be empty');
+      expect(cache.has('')).toBe(false);
+
+      cache.destroy();
+    });
+
     it('handles rapid get/set/delete cycles', () => {
       const cache = new TTLCache<number>();
       for (let i = 0; i < 100; i++) {

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -141,6 +141,7 @@ export class TTLCache<T> {
   }
 
   set(key: string, value: T, ttlMs: number): void {
+    if (key === '') throw new Error('Cache key cannot be empty');
     if (ttlMs <= 0) throw new RangeError(`ttlMs must be positive, got ${ttlMs}`);
 
     const maxSize = this.maxSize;


### PR DESCRIPTION
## Description

Fixes #1392

Added a focused boundary test for `TTLCache` to verify that empty string cache keys are rejected. Also added minimal validation in `TTLCache.set()` so an empty key cannot be stored.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable. This PR only updates cache validation and unit test coverage.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [ ] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.