### PR TITLE
test(streak-calculator): Add Leap Year Leap-Day Tests

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -270,6 +270,159 @@ describe('calculateStreak', () => {
     expect(result.longestStreak).toBe(10);
     expect(result.currentStreak).toBe(5);
   });
+
+  it('correctly calculates current and longest streaks for Monday-through-Friday commits', () => {
+    // 2024-01-01 was a Monday.
+    // Week 1: 1, 1, 1, 1, 1, 0, 0 (Mon-Fri commit, Sat-Sun off)
+    // Week 2: 1, 1, 1, 1, 1, 0, 0 (Mon-Fri commit, Sat-Sun off)
+    const calendar = buildCalendar([
+      1,
+      1,
+      1,
+      1,
+      1,
+      0,
+      0, // Week 1 (Jan 1 - Jan 7)
+      1,
+      1,
+      1,
+      1,
+      1,
+      0,
+      0, // Week 2 (Jan 8 - Jan 14)
+    ]);
+
+    // Scenario A: Evaluated on Friday (Jan 12) -> Streak is active, last commit is today.
+    const fridayNow = new Date('2024-01-12T12:00:00Z');
+    const resultFriday = calculateStreak(calendar, 'UTC', fridayNow);
+    expect(resultFriday.currentStreak).toBe(5);
+    expect(resultFriday.longestStreak).toBe(5);
+
+    // Scenario B: Evaluated on Saturday (Jan 13) -> Today (Sat) has 0, yesterday (Fri) has 1.
+    // Grace period = 1 keeps it alive.
+    const saturdayNow = new Date('2024-01-13T12:00:00Z');
+    const resultSaturday = calculateStreak(calendar, 'UTC', saturdayNow);
+    expect(resultSaturday.currentStreak).toBe(5);
+    expect(resultSaturday.longestStreak).toBe(5);
+
+    // Scenario C: Evaluated on Sunday (Jan 14) -> Today (Sun) and yesterday (Sat) both have 0.
+    // Grace period = 1 cannot save the streak.
+    const sundayNow = new Date('2024-01-14T12:00:00Z');
+    const resultSunday = calculateStreak(calendar, 'UTC', sundayNow);
+    expect(resultSunday.currentStreak).toBe(0);
+    expect(resultSunday.longestStreak).toBe(5);
+  });
+
+  it('correctly calculates current and longest streaks for Saturday-and-Sunday commits', () => {
+    // 2024-01-01 was a Monday.
+    // Week 1: 0, 0, 0, 0, 0, 1, 1 (Mon-Fri off, Sat-Sun commits)
+    // Week 2: 0, 0, 0, 0, 0, 1, 1 (Mon-Fri off, Sat-Sun commits)
+    // Week 3: 0, 0, 0, 0, 0, 0, 0 (Buffer week)
+    const calendar = buildCalendar([
+      0,
+      0,
+      0,
+      0,
+      0,
+      1,
+      1, // Week 1 (Jan 1 - Jan 7)
+      0,
+      0,
+      0,
+      0,
+      0,
+      1,
+      1, // Week 2 (Jan 8 - Jan 14)
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0, // Week 3 (Jan 15 - Jan 21)
+    ]);
+
+    // Scenario A: Evaluated on Sunday (Jan 14) -> Streak is active, last commit is today.
+    const sundayNow = new Date('2024-01-14T12:00:00Z');
+    const resultSunday = calculateStreak(calendar, 'UTC', sundayNow);
+    expect(resultSunday.currentStreak).toBe(2);
+    expect(resultSunday.longestStreak).toBe(2);
+
+    // Scenario B: Evaluated on Monday (Jan 15) -> Today (Mon) has 0, yesterday (Sun) has 1.
+    // Grace period = 1 keeps it alive.
+    const mondayNow = new Date('2024-01-15T12:00:00Z');
+    const resultMonday = calculateStreak(calendar, 'UTC', mondayNow);
+    expect(resultMonday.currentStreak).toBe(2);
+    expect(resultMonday.longestStreak).toBe(2);
+
+    // Scenario C: Evaluated on Tuesday (Jan 16) -> Today (Tue) and yesterday (Mon) both have 0.
+    // Grace period = 1 cannot save the streak.
+    const tuesdayNow = new Date('2024-01-16T12:00:00Z');
+    const resultTuesday = calculateStreak(calendar, 'UTC', tuesdayNow);
+    expect(resultTuesday.currentStreak).toBe(0);
+    expect(resultTuesday.longestStreak).toBe(2);
+  });
+
+  it('correctly calculates streaks across Feb 28 → Mar 1 transitions in leap years vs non-leap years', () => {
+    // 1. Leap Year (2024): Feb 29 exists.
+    // Case A: Commit on Feb 28 and Mar 1, but NOT on Feb 29 (streak is broken at Feb 29)
+    const leapYearBrokenCalendar: ContributionCalendar = {
+      totalContributions: 2,
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 1, date: '2024-02-28' },
+            { contributionCount: 0, date: '2024-02-29' },
+            { contributionCount: 1, date: '2024-03-01' },
+          ],
+        },
+      ],
+    };
+    const leapYearBrokenNow = new Date('2024-03-01T12:00:00Z');
+    const resultLeapBroken = calculateStreak(leapYearBrokenCalendar, 'UTC', leapYearBrokenNow);
+    expect(resultLeapBroken.currentStreak).toBe(1);
+    expect(resultLeapBroken.longestStreak).toBe(1);
+
+    // Case B: Commit on Feb 28, Feb 29, and Mar 1 (streak is continuous: 3 days)
+    const leapYearContinuousCalendar: ContributionCalendar = {
+      totalContributions: 3,
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 1, date: '2024-02-28' },
+            { contributionCount: 1, date: '2024-02-29' },
+            { contributionCount: 1, date: '2024-03-01' },
+          ],
+        },
+      ],
+    };
+    const leapYearContinuousNow = new Date('2024-03-01T12:00:00Z');
+    const resultLeapContinuous = calculateStreak(
+      leapYearContinuousCalendar,
+      'UTC',
+      leapYearContinuousNow
+    );
+    expect(resultLeapContinuous.currentStreak).toBe(3);
+    expect(resultLeapContinuous.longestStreak).toBe(3);
+
+    // 2. Non-Leap Year (2023): Feb 29 does not exist.
+    // Commit on Feb 28 and Mar 1 (streak is continuous: 2 days)
+    const nonLeapYearCalendar: ContributionCalendar = {
+      totalContributions: 2,
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 1, date: '2023-02-28' },
+            { contributionCount: 1, date: '2023-03-01' },
+          ],
+        },
+      ],
+    };
+    const nonLeapYearNow = new Date('2023-03-01T12:00:00Z');
+    const resultNonLeap = calculateStreak(nonLeapYearCalendar, 'UTC', nonLeapYearNow);
+    expect(resultNonLeap.currentStreak).toBe(2);
+    expect(resultNonLeap.longestStreak).toBe(2);
+  });
 });
 it('handles massive single-day commit spike timeline', () => {
   const calendar = buildCalendar([


### PR DESCRIPTION
## Description

This PR introduces comprehensive unit tests in `lib/calculate.test.ts` to guard the streak calculation logic against off-by-one errors, calendar offsets, leap/non-leap year behaviors, and date boundary anomalies.

Specifically, it implements three new contribution timeline simulations:
1. **Monday-to-Friday Commits**: Verifies that weekday-only contributions yield a 5-day longest streak, are correctly kept alive on Saturday via the default grace period, and are safely terminated by Sunday.
2. **Saturday-and-Sunday Commits**: Verifies that weekend-only contributions correctly yield a 2-day longest streak, remain active on Monday due to the 1-day grace period, and are correctly ended by Tuesday.
3. **Leap vs Non-Leap Year Feb 28 -> Mar 1 Boundaries**: 
   - In Leap Years (e.g. 2024), verifies that a streak breaks if the user skips Feb 29 but continues if they commit on Feb 29.
   - In Non-Leap Years (e.g. 2023), verifies that Mar 1 is correctly treated as consecutive to Feb 28, resulting in a continuous streak without a gap.

These assertions ensure absolute mathematical precision across calendar day boundaries.

Fixes #1501

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [x] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
*N/A (Backend / Logic tests)*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.