### PR TITLE
feat(dashboard): add visual tooltip to refresh button

### DIFF
--- a/components/dashboard/RefreshButton.tsx
+++ b/components/dashboard/RefreshButton.tsx
@@ -37,6 +37,7 @@ export default function RefreshButton({ username }: RefreshButtonProps) {
       disabled={isPending}
       onClick={handleRefresh}
       aria-label="Refresh dashboard contribution data"
+      title="Refresh dashboard contribution data"
       className="flex items-center gap-2 rounded-xl border border-black/10 dark:border-[rgba(255,255,255,0.15)] bg-black dark:bg-black px-4 py-2 text-sm font-semibold text-white dark:text-white transition-all duration-200 hover:bg-gray-800 dark:hover:bg-white/10 active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed"
     >
       <RefreshCw size={16} className={isPending ? 'animate-spin' : ''} />


### PR DESCRIPTION
Fixes #1795

## Description
Added a `title` attribute to the Refresh Data button in the dashboard.
Sighted users hovering over the button will now see a visual tooltip
"Refresh dashboard contribution data" instead of nothing.

## Changes Made
- Added `title="Refresh dashboard contribution data"` to the button element in `components/dashboard/RefreshButton.tsx`

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] `npm run format` and `npm run lint` pass locally ✅
- [x] `npm run test` passes locally ✅
- [x] My commits follow Conventional Commits format.
- [x] I have starred the repo.
- [x] I have only one commit in this PR.
- [x] (Recommended) I joined the CommitPulse Discord server.