### PR TITLE
test(calculate): verify streak formulas for empty contribution calendar timeline (Variation 4)

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -271,6 +271,7 @@ describe('calculateStreak', () => {
     expect(result.currentStreak).toBe(5);
   });
 });
+
 it('handles massive single-day commit spike timeline', () => {
   const calendar = buildCalendar([
     0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 120, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1,
@@ -525,6 +526,27 @@ describe('calculateStreak — empty and sparse year edge cases', () => {
     const result = calculateStreak(calendar);
     expect(result.longestStreak).toBe(1);
     expect(result.totalContributions).toBe(2);
+  });
+
+  // =========================================================================
+  // ISSUE #1503 — Variation 4: Full year (52 weeks × 7 days) of 0 contributions
+  // =========================================================================
+  // Background: streak computation is susceptible to off-by-one errors when
+  // managing calendar offsets and date boundaries. A full year of zero commits
+  // is the most exhaustive boundary stress-test: the loop must traverse all 364
+  // days without incrementing either streak counter, and must not throw or return
+  // NaN/undefined due to boundary arithmetic on the first or last day.
+  it('returns all zeros for an entire year (52 weeks × 7 days) of empty contributions (Variation 4)', () => {
+    // 52 weeks × 7 days = 364 days, every day has 0 commits.
+    // buildCalendar groups them into 52 weeks automatically.
+    const emptyYearCounts = Array(364).fill(0);
+    const calendar = buildCalendar(emptyYearCounts);
+
+    const result = calculateStreak(calendar);
+
+    expect(result.currentStreak).toBe(0);
+    expect(result.longestStreak).toBe(0);
+    expect(result.totalContributions).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Description

Fixes #1503

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — test file only, no SVG changes.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npm run test` — 1010 tests passed across 72 test files).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format (`test(calculate): ...`).
- [x] I have NOT updated `README.md` (no new theme or URL parameter added).
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard (N/A — no SVG changes). 
