### PR TITLE
test(calculate): verify streak formulas for timezone shifts around midnight timeline

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -295,6 +295,35 @@ describe('calculateStreak — timezone awareness', () => {
     expect(result.currentStreak).toBe(0);
   });
 
+  it('handles commits around midnight correctly across timezone offsets', () => {
+    const calendar = {
+      totalContributions: 2,
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 0, date: '2024-06-12' },
+            { contributionCount: 1, date: '2024-06-13' },
+            { contributionCount: 1, date: '2024-06-14' },
+            { contributionCount: 0, date: '2024-06-15' },
+          ],
+        },
+      ],
+    };
+
+    const nowUTC = new Date('2024-06-14T23:59:00.000Z');
+
+    const utcResult = calculateStreak(calendar, 'UTC', nowUTC);
+    const aheadOffsetResult = calculateStreak(calendar, 'Etc/GMT-1', nowUTC);
+
+    expect(utcResult.todayDate).toBe('2024-06-14');
+    expect(utcResult.currentStreak).toBe(2);
+    expect(utcResult.longestStreak).toBe(2);
+
+    expect(aheadOffsetResult.todayDate).toBe('2024-06-15');
+    expect(aheadOffsetResult.currentStreak).toBe(2);
+    expect(aheadOffsetResult.longestStreak).toBe(2);
+  });
+
   it('preserves the streak when the local date (UTC-8) maps to a day with commits via grace period', () => {
     const result = calculateStreak(tzCalendar, 'Etc/GMT+8', nowUTC);
     expect(result.currentStreak).toBe(3);


### PR DESCRIPTION
## Description

Fixes #1500

Added a new test case in `lib/calculate.test.ts` to verify streak calculations when contribution activity occurs around midnight across different timezone offsets.

The test simulates a scenario where the same UTC timestamp maps to different local dates depending on the configured timezone and verifies that:

* `todayDate` is calculated correctly for each timezone.
* Active streaks remain accurate across date boundaries.
* Grace-period behavior works correctly when local midnight causes a day shift.
* Longest streak calculations remain unaffected by timezone changes.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [x] 🕐 Pillar 3 — Timezone Logic Optimization
* [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — this PR only adds automated test coverage.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
