### PR TITLE
test(calculate): verify streak formulas for multiple weeks gaps timeline

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -54,6 +54,28 @@ describe('calculateStreak', () => {
     expect(result.totalContributions).toBe(0);
   });
 
+  it('handles multiple weeks of zero contributions separating active streaks', () => {
+    const calendar = buildCalendar([
+      // Week 1 - active streak
+      1, 1, 1, 1, 1, 1, 1,
+
+      // Week 2 - gap
+      0, 0, 0, 0, 0, 0, 0,
+
+      // Week 3 - gap
+      0, 0, 0, 0, 0, 0, 0,
+
+      // Week 4 - new streak
+      1, 1, 1, 1, 1, 1, 1,
+    ]);
+
+    const result = calculateStreak(calendar);
+
+    expect(result.currentStreak).toBe(7);
+    expect(result.longestStreak).toBe(7);
+    expect(result.totalContributions).toBe(14);
+  });
+
   it('counts an active streak when the last day has contributions', () => {
     // The last element represents "today" — committing today keeps the streak alive.
     const calendar = buildCalendar([


### PR DESCRIPTION
## Description

Fixes #1499

Added a new test case in `lib/calculate.test.ts` to verify streak calculations when multiple weeks with zero contributions separate two active contribution periods.

The test ensures that long inactive periods correctly break streaks and that current streak, longest streak, and total contribution calculations remain accurate after activity resumes.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Testing)

## Visual Preview

Not applicable — this PR only adds automated test coverage.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
* [x] (Recommended) I joined the CommitPulse Discord community.
