### PR TITLE
fix(validation): use toBooleanFlag for hide_background in wrappedPara…

### DIFF
--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -364,7 +364,7 @@ export const wrappedParamsSchema = z.object({
     .transform((val) => sanitizeFont(val) || undefined),
   refresh: z.string().optional().transform(toRefreshFlag),
   hide_title: z.string().optional().transform(toBooleanFlag),
-  hide_background: z.string().optional().transform(toRefreshFlag),
+  hide_background: z.string().optional().transform(toBooleanFlag), // ✅ Fixed: was toRefreshFlag
   width: dimensionParam('width', 100, 1200),
   height: dimensionParam('height', 80, 800),
 });


### PR DESCRIPTION
Fixes #1873

## Description
Changed `hide_background` in `wrappedParamsSchema` to use `toBooleanFlag` instead of `toRefreshFlag`.

`toBooleanFlag` correctly accepts both `'true'` and `'1'` as truthy values, while `toRefreshFlag` only accepts `'true'`, causing `hide_background=1` to silently fail.

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes — this is a validation layer fix only.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community