### PR TITLE
test(cache): verify TTLCache throws RangeError for negative TTL (#1398)

### DIFF
--- a/lib/cache.test.ts
+++ b/lib/cache.test.ts
@@ -363,6 +363,13 @@ describe('TTLCache', () => {
   });
 
   describe('edge cases and error handling', () => {
+    // FIX: New test explicitly targeting the -5000 boundary for Issue #1398
+    it('throws RangeError when setting a value with -5000 TTL', () => {
+      const cache = new TTLCache<string>();
+      expect(() => cache.set('key', 'value', -5000)).toThrow(RangeError);
+      cache.destroy();
+    });
+
     it('throws RangeError when ttlMs is 0 or negative', () => {
       const cache = new TTLCache<string>();
       expect(() => cache.set('key', 'value', 0)).toThrow(RangeError);
@@ -401,6 +408,7 @@ describe('TTLCache', () => {
       expect([null, 'lived']).toContain(result);
       cache.destroy();
     });
+
     it('does not throw when ttlMs is Number.EPSILON', () => {
       const cache = new TTLCache<string>();
 


### PR DESCRIPTION
## Description
Added a specific test case in lib/cache.test.ts to verify that setting a cache value with a negative TTL (e.g., -5000) correctly throws a RangeError. This improves test coverage for boundary inputs and ensures the TTLCache implementation behaves safely under extreme values, satisfying all acceptance criteria for the issue.

Fixes #1398 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="947" height="420" alt="Screenshot 2026-05-31 005643" src="https://github.com/user-attachments/assets/15dd2a6f-f510-49cd-bccb-f76657b3f4e2" />


## Checklist before requesting a review:

[x] I have read the CONTRIBUTING.md file.

[x] I have tested these changes locally (localhost:3000/api/streak?user=YOUR_USERNAME).

[x] I have run npm run format and npm run lint locally and resolved all errors (CI will fail otherwise).

[x] My commits follow the Conventional Commits format (e.g., feat(themes): ..., fix(calculate): ...).

[x] I have updated README.md if I added a new theme or URL parameter.

[x] I have started the repo.

[x] I have made sure that i have only one commit to merge in this PR.

[x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).

[x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
