### PR TITLE
fix(validation): validate lang parameter against supported languages keys

### DIFF
--- a/lib/i18n/badgeLabels.ts
+++ b/lib/i18n/badgeLabels.ts
@@ -72,6 +72,11 @@ export const labels: Record<string, BadgeLabels> = {
   },
 };
 
+export const supportedLanguages = Object.keys(labels) as [
+  keyof typeof labels,
+  ...(keyof typeof labels)[],
+];
+
 export function getLabels(lang: string = 'en'): BadgeLabels {
   return labels[lang.toLowerCase()] || labels['en'];
 }

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -1,5 +1,5 @@
 // lib/validations.ts
-
+import { supportedLanguages } from './i18n/badgeLabels';
 import { z } from 'zod';
 import {
   isValidHex,
@@ -173,7 +173,7 @@ export const streakParamsSchema = z.object({
   hide_title: z.string().optional().transform(toBooleanFlag),
   hide_background: z.string().optional().transform(toBooleanFlag),
   hide_stats: z.string().optional().transform(toBooleanFlag),
-  lang: z.string().optional().default('en'),
+  lang: z.enum(supportedLanguages).catch('en').default('en'),
   // Unknown view values fall back to the default dashboard view.
   view: z.enum(['default', 'monthly']).catch('default').default('default'),
   // Invalid delta formats fall back to percentage mode.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
       "devDependencies": {
         "@emnapi/core": "^1.10.0",
         "@emnapi/runtime": "^1.10.0",
-        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -2792,6 +2791,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2897,7 +2897,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3897,6 +3898,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4989,7 +4991,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.4.7",
@@ -7713,6 +7716,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8739,6 +8743,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8754,6 +8759,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8766,7 +8772,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",


### PR DESCRIPTION
## Description

Fixes #1796 

### Changes Made

- Added `supportedLanguages` derived from translation keys in `badgeLabels.ts`
- Updated `streakParamsSchema` to validate `lang` using `z.enum()`
- Added `.catch('en')` fallback behavior for unsupported language inputs
- Preserved default English fallback behavior

### Verification

- [x] npm run format
- [x] npm run lint
- [x] npm run test
- [x] npm run typecheck
- [x] Verified invalid lang values fall back to `en`

### Result

- Valid language inputs continue to work correctly
- Unsupported language values now safely fall back to English (`en`)
- Prevents downstream localization lookup failures during SVG generation