### PR TITLE
test(validation): check query validation boundaries for theme param

### DIFF
--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -663,6 +663,15 @@ describe('ogParamsSchema', () => {
     const result = ogParamsSchema.parse({});
     expect(result.user).toBe('unknown');
   });
+
+  it('should fallback to "dark" when an invalid theme is provided', () => {
+    const result = ogParamsSchema.safeParse({ theme: 'nonexistent_theme_name' });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.theme).toBe('dark');
+    }
+  });
 });
 
 describe('streakParamsSchema — view fallback behavior', () => {


### PR DESCRIPTION
## Description

Fixes #1455
Program: GSSoC 2026

This PR handles the implementation of validation boundary unit testing for the incoming `?theme=` query parameter under variation 4.

Previously, normal custom color overrides and known presets were evaluated, but unknown string assignments required isolated boundary test coverage to guarantee system stability.

### Changes Made

* Added 1 target schema validation boundary test case inside `lib/validations.test.ts`.
* Mocked an invalid parameter payload passing a theme configuration value set to `'nonexistent_theme_name'`.
* Asserted that the system boundary validation layer processes the unknown string parameter safely without crashing, validating alignment with application defaults.

### Why this matters

Secures internal configuration mapping engines against structural failures when handling undefined aesthetic descriptors, guaranteeing that arbitrary text payloads degrade gracefully to standard themes.

---

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

---

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npm run test`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.