### PR TITLE
test(validation): check query validation boundaries for org param

### DIFF
--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -475,6 +475,18 @@ describe('streakParamsSchema — size fallback behavior', () => {
     }
   });
 
+  it('should fail when org contains invalid characters or spaces', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      org: 'invalid_org_name_with_spaces',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe('Invalid organization name format');
+    }
+  });
+
   it('should accept repo parameter when provided', () => {
     const result = streakParamsSchema.safeParse({
       user: 'octocat',


### PR DESCRIPTION
## Description

Fixes #1453
Program: GSSoC 2026

This PR handles the implementation of validation boundary unit testing for the incoming `?org=` query parameter under variation 4.

Previously, normal organization string mappings were checked, but format restrictions (alphanumeric and valid string bindings) required isolated boundary test coverage to guarantee input schema safety.

### Changes Made

* Added 1 target schema validation boundary test case inside `lib/validations.test.ts`.
* Mocked an invalid parameter payload passing an organization configuration value set to `'invalid_org_name_with_spaces'`.
* Asserted that the system validation layer catches the format violation and rejects it, matching expected format error requirements.

### Why this matters

Secures endpoint router bindings against parsing malformed organization parameters, preventing unexpected runtime errors or API fetch anomalies when interfacing with downstream GitHub query modules.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npm run test`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.