### PR TITLE
test(api): reject fictitious tz value Mars/Cyonia with 400 Bad Request

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -820,6 +820,20 @@ describe('GET /api/streak', () => {
 
       expect(getSecondsUntilMidnightInTimezone).toHaveBeenCalledWith('Australia/Sydney');
     });
+
+    // =========================================================================
+    // ISSUE OBJECTIVE: Reject fictitious planetary timezone (Variation 4)
+    // =========================================================================
+    it('returns 400 when a fictitious planetary timezone Mars/Cyonia is supplied', async () => {
+      // Mars/Cyonia is structurally plausible (Region/City format) but does not
+      // exist in the IANA tz database — the schema must reject it before the
+      // request reaches the GitHub API.
+      const response = await GET(makeRequest({ user: 'octocat', tz: 'Mars/Cyonia' }));
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.details.fieldErrors.tz[0]).toContain('Invalid timezone');
+    });
   });
 
   describe('hide_background parameter', () => {

--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -713,3 +713,24 @@ describe('streakParamsSchema — Date Range Boundary Robustness (Variation 1)', 
     }
   });
 });
+
+/* ==========================================================================
+ * TZ PARAMETER — IANA TIMEZONE VALIDATION (VARIATION 4)
+ * ========================================================================== */
+
+describe('streakParamsSchema — tz IANA timezone validation (Variation 4)', () => {
+  it('rejects a fictitious planetary timezone that is not a valid IANA zone', () => {
+    // Mars/Cyonia looks structurally plausible (Region/City format) but does not
+    // exist in the IANA tz database, so Intl.DateTimeFormat must throw and the
+    // schema must surface a field-level validation error.
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      tz: 'Mars/Cyonia',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain('Invalid timezone');
+    }
+  });
+});


### PR DESCRIPTION
## Description

Fixes  #1457 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A - test only change, no SVG output modified.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
