### PR TITLE
test(calculate): verify streak formulas for different starting days of the week timeline (Variation 2) (#1486)

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -488,6 +488,35 @@ describe('calculateStreak', () => {
     expect(resultTuesday.currentStreak).toBe(0);
     expect(resultTuesday.longestStreak).toBe(2);
   });
+
+  it('verify streak formulas for different starting days of the week timeline (Variation 2)', () => {
+    // Week 1: 0, 0, 1, 1, 1, 1, 1 (Starts on Wednesday, 5 days)
+    // Week 2: 1, 1, 1, 1, 1, 1, 1 (7 days)
+    // Week 3: 1, 1, 1              // Ends on Wednesday (3 days)
+    // Total continuous streak = 15 days, ending on the last day.
+    const calendar = buildCalendar([
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+      1, // Week 1 (Starts Wed)
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1, // Week 2
+      1,
+      1,
+      1, // Week 3 (Ends Wed)
+    ]);
+    const result = calculateStreak(calendar);
+    expect(result.currentStreak).toBe(15);
+    expect(result.longestStreak).toBe(15);
+  });
 });
 
 it('handles massive single-day commit spike timeline', () => {


### PR DESCRIPTION
## Description

This PR adds test coverage to verify the streak formulas when commits are made starting on different days of the week (specifically starting on Wednesday), acting as Variation 2 of the starting days timeline tests.

Fixes #1486

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Tests only)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=boss477`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.