### PR TITLE
test(calculate): verify streak formulas for different starting days of the week timeline (Variation 3) (#1496)

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -708,6 +708,37 @@ describe('calculateStreak', () => {
     expect(result.longestStreak).toBe(15);
   });
 
+  it('verify streak formulas for different starting days of the week timeline (Variation 3)', () => {
+    // Week 1: 0, 0, 0, 0, 1, 1, 1 (Starts on Friday, 3 days)
+    // Week 2: 1, 1, 1, 1, 1, 1, 1 (7 days)
+    // Week 3: 1, 1, 1, 1, 1        // Ends on Friday (5 days)
+    // Total continuous streak = 15 days, ending on the last day.
+    const calendar = buildCalendar([
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1, // Week 1 (Starts Fri)
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1, // Week 2
+      1,
+      1,
+      1,
+      1,
+      1, // Week 3 (Ends Fri)
+    ]);
+    const result = calculateStreak(calendar);
+    expect(result.currentStreak).toBe(15);
+    expect(result.longestStreak).toBe(15);
+  });
+
   it('verify streak formulas for multiple weeks gaps timeline (Variation 3)', () => {
     // Streak 1: 5 days
     // Gap 1: 14 days (2 weeks of zeros)


### PR DESCRIPTION
## Description

This PR adds test coverage to verify the streak formulas when commits are made starting on different days of the week (specifically starting on Friday), acting as Variation 3 of the starting days timeline tests.

Fixes #1496

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Tests only)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=boss477`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.