### PR TITLE
fix: handle private profiles and empty repositories during badge gene…

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -291,6 +291,54 @@ describe('GET /api/streak', () => {
     });
   });
 
+  describe('edge cases for empty/private profiles', () => {
+    it('Scenario 1: Normal active GitHub user', async () => {
+      const response = await GET(makeRequest({ user: 'octocat' }));
+      expect(response.status).toBe(200);
+      const body = await response.text();
+      expect(body).toContain('<svg');
+    });
+
+    it('Scenario 2 & 3: User with 0 public repositories or private profile (empty calendar)', async () => {
+      vi.mocked(fetchGitHubContributions).mockResolvedValue({
+        calendar: {
+          totalContributions: 0,
+          weeks: [],
+        },
+        repoContributions: [],
+      } as unknown as ExtendedContributionData);
+
+      const response = await GET(makeRequest({ user: 'private-user' }));
+      expect(response.status).toBe(200);
+      const body = await response.text();
+      expect(body).toContain('<svg');
+      // Should show 0 contributions and streaks
+      expect(body).toContain('>0<');
+    });
+
+    it('Scenario 4: Nonexistent username', async () => {
+      vi.mocked(fetchGitHubContributions).mockRejectedValue(
+        new Error('GitHub user "nonexistent" not found')
+      );
+
+      const response = await GET(makeRequest({ user: 'nonexistent' }));
+      expect(response.status).toBe(404);
+      const body = await response.text();
+      expect(body).toContain('<svg');
+      expect(body).toContain('NOT FOUND');
+    });
+
+    it('Scenario 5: GitHub API failure', async () => {
+      vi.mocked(fetchGitHubContributions).mockRejectedValue(new Error('API Rate Limit Exceeded'));
+
+      const response = await GET(makeRequest({ user: 'octocat' }));
+      expect(response.status).toBe(429);
+      const body = await response.text();
+      expect(body).toContain('<svg');
+      expect(body).toContain('API RATE LIMIT');
+    });
+  });
+
   describe('cache-control header', () => {
     it('caches until UTC midnight by default, using the value from getSecondsUntilUTCMidnight', async () => {
       const response = await GET(makeRequest({ user: 'octocat' }));

--- a/lib/calculate.ts
+++ b/lib/calculate.ts
@@ -28,8 +28,8 @@ export function calculateStreak(
   now: Date = new Date(),
   grace: number = 1
 ): StreakStats {
-  const weeks = calendar.weeks;
-  const days = weeks.flatMap((week) => week.contributionDays);
+  const weeks = calendar?.weeks || [];
+  const days = weeks.flatMap((week) => week?.contributionDays || []);
 
   let currentStreak = 0;
   let longestStreak = 0;
@@ -95,7 +95,8 @@ export function calculateMonthlyStats(
   timezone: string = 'UTC',
   now: Date = new Date()
 ): MonthlyStats {
-  const days = calendar.weeks.flatMap((week) => week.contributionDays);
+  const weeks = calendar?.weeks || [];
+  const days = weeks.flatMap((week) => week?.contributionDays || []);
 
   const localTodayStr = new Intl.DateTimeFormat('en-CA', { timeZone: timezone }).format(now);
   const [currentYearStr, currentMonthStr] = localTodayStr.split('-');
@@ -171,13 +172,13 @@ export function aggregateCalendars(calendars: ContributionCalendar[]): Contribut
   // Find the calendar with the most weeks to serve as our structural base
   let baseCalendar = calendars[0];
   for (const cal of calendars) {
-    if (cal.weeks.length > baseCalendar.weeks.length) {
+    if ((cal.weeks?.length || 0) > (baseCalendar.weeks?.length || 0)) {
       baseCalendar = cal;
     }
 
     // Populate the Map with all contributions from all calendars
-    cal.weeks.forEach((week) => {
-      week.contributionDays.forEach((day) => {
+    (cal.weeks || []).forEach((week) => {
+      (week?.contributionDays || []).forEach((day) => {
         const currentCount = dateMap.get(day.date) || 0;
         dateMap.set(day.date, currentCount + day.contributionCount);
       });
@@ -190,8 +191,8 @@ export function aggregateCalendars(calendars: ContributionCalendar[]): Contribut
   aggregatedBase.totalContributions = totalContributions;
 
   // Re-map the structural base using our aggregated date map
-  aggregatedBase.weeks.forEach((week) => {
-    week.contributionDays.forEach((day) => {
+  (aggregatedBase.weeks || []).forEach((week) => {
+    (week?.contributionDays || []).forEach((day) => {
       day.contributionCount = dateMap.get(day.date) || 0;
     });
   });
@@ -202,7 +203,8 @@ export function aggregateCalendars(calendars: ContributionCalendar[]): Contribut
  * Processes a calendar to generate deep insights for "GitHub Wrapped"
  */
 export function calculateWrappedStats(calendar: ContributionCalendar) {
-  const days = calendar.weeks.flatMap((w) => w.contributionDays);
+  const weeks = calendar?.weeks || [];
+  const days = weeks.flatMap((w) => w?.contributionDays || []);
 
   let mostActiveDay = { date: '', count: 0 };
   const monthCounts: Record<string, number> = {};

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -469,7 +469,16 @@ export async function fetchGitHubContributions(
       throw new Error(`GitHub user "${username}" not found`);
     }
 
-    let calendar = data.data.user.contributionsCollection.contributionCalendar;
+    let calendar = data.data.user.contributionsCollection?.contributionCalendar;
+    const repoContributions =
+      data.data.user.contributionsCollection?.commitContributionsByRepository || [];
+
+    if (!calendar || !calendar.weeks) {
+      calendar = {
+        totalContributions: 0,
+        weeks: [],
+      };
+    }
 
     if (isDeltaSync && cached) {
       calendar = mergeCalendars(cached.calendar, calendar);
@@ -514,14 +523,14 @@ export async function fetchGitHubContributions(
         key,
         {
           calendar,
-          repoContributions: data.data.user.contributionsCollection.commitContributionsByRepository,
+          repoContributions,
         },
         LONG_CACHE_TTL
       );
     }
     return {
       calendar,
-      repoContributions: data.data.user.contributionsCollection.commitContributionsByRepository,
+      repoContributions,
     };
   };
 


### PR DESCRIPTION
## Description
Fixes badge generation failures (HTTP 500) for GitHub users with private profiles, no public repositories, or no visible contribution data. 

I've added null-safe data handling for GraphQL responses in `lib/github.ts` and defensive validation across `lib/calculate.ts` so the system smoothly returns an empty-state badge instead of crashing. All 1,143 unit tests including the new edge-case scenarios passed successfully.

Fixes #1902

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
*(No visual changes to standard badges; empty users will now correctly render an empty state badge instead of crashing.)*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.