### PR TITLE
test: add weekday-only streak calculation test

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -134,6 +134,31 @@ describe('calculateStreak', () => {
     expect(result.totalContributions).toBe(13);
   });
 
+  it('counts weekday-only commits from Monday through Friday without spanning weekend gaps', () => {
+    // 2024-01-01 is a Monday. Commits happen only on weekdays across two work weeks.
+    const calendar = buildCalendar([
+      1,
+      1,
+      1,
+      1,
+      1,
+      0,
+      0, // Mon-Fri active, Sat-Sun inactive
+      1,
+      1,
+      1,
+      1,
+      1, // Mon-Fri active again, ending on Friday
+    ]);
+
+    const result = calculateStreak(calendar, 'UTC', new Date('2024-01-12T12:00:00Z'));
+
+    expect(result.currentStreak).toBe(5);
+    expect(result.longestStreak).toBe(5);
+    expect(result.totalContributions).toBe(10);
+    expect(result.todayDate).toBe('2024-01-12');
+  });
+
   it('keeps the streak alive via the grace period when only yesterday has contributions', () => {
     // Today is 0, but yesterday is 1 — the grace period treats the streak as still active.
     const calendar = buildCalendar([


### PR DESCRIPTION
## Description

Fixes #1495 

Added a new test case in `lib/calculate.test.ts` to simulate commits made exclusively from Monday through Friday. The test verifies streak calculations across weekday-only contribution patterns and ensures weekend gaps do not incorrectly extend streaks, preventing off-by-one errors in streak computation.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — test coverage update (no UI changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`)
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
