### PR TITLE
fix: replace share alert with toast notification

### DIFF
--- a/components/dashboard/DashboardClient.tsx
+++ b/components/dashboard/DashboardClient.tsx
@@ -487,7 +487,7 @@ export default function DashboardClient({ initialData, username }: DashboardClie
           <button
             onClick={() => {
               navigator.clipboard.writeText(window.location.href);
-              alert('Link copied to clipboard!');
+              toast.success('Link copied to clipboard!');
             }}
             className="flex items-center gap-2 rounded-xl border border-black/10 px-4 py-2 text-sm font-semibold hover:bg-gray-100 dark:hover:bg-zinc-800 transition"
           >


### PR DESCRIPTION
## Description

Fixes #1917 

Replaces the browser-native `alert()` shown after clicking the Share button with a non-blocking Sonner toast notification.

### Changes Made

* Removed `alert('Link copied to clipboard!')`
* Added `toast.success('Link copied to clipboard!')`
* Preserved existing clipboard copy functionality
* Aligned the Share action with the project's existing notification system

### Why

The Share action currently displays a blocking browser alert after successfully copying the dashboard URL. This interrupts the user experience and is inconsistent with the application's modern UI patterns.

Using the existing Sonner toast system provides a smoother and more consistent experience across desktop and mobile devices.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

**Before**

* Clicking Share copied the URL and displayed a browser-native alert dialog.

**After**

* Clicking Share copies the URL and displays a non-blocking success toast notification.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000`).
* [x] I have run `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
