### PR TITLE
feat(themes): add obsidian preset — deep charcoal bg (#1a1a2e) with amber gold accent (#f59e0b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ URL Parameter > Theme Default > System Fallback
 | `random`           | Surprise theme on reload    | _varies_ | _varies_ | _varies_ |
 | `highcontrast`     | Accessibility high contrast | `0a0a0a` | `ff4500` | `ffffff` |
 | `cyber-pulse`      | AMOLED true-black & cyan    | `000000` | `00ffee` | `ffffff` |
+| `obsidian`         | Deep charcoal & amber gold  | `1a1a2e` | `f59e0b` | `e2e8f0` |
 
 > **`auto` uses CSS `@media (prefers-color-scheme)`** inside the SVG so the badge switches between the `light` and `dark` palettes based on the viewer's OS setting — no JavaScript required. This is ideal for GitHub profile READMEs where visitors may use either mode.
 

--- a/THEMES.md
+++ b/THEMES.md
@@ -1,6 +1,6 @@
 # 🎨 CommitPulse Themes
 
-All 19 available themes for your CommitPulse badge. Use the `?theme=<slug>` query parameter to apply a theme.
+All 20 available themes for your CommitPulse badge. Use the `?theme=<slug>` query parameter to apply a theme.
 
 ```
 https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
@@ -30,6 +30,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 | solarized_light  | `#fdf6e3`  | `#586e75` | `#268bd2` |
 | gruvbox_light    | `#fbf1c7`  | `#3c3836` | `#d65d0e` |
 | nord_light       | `#eceff4`  | `#2e3440` | `#5e81ac` |
+| obsidian         | `#1a1a2e`  | `#e2e8f0` | `#f59e0b` |
 | cyber-pulse      | `#000000`  | `#ffffff` | `#00ffee` |
 
 ---
@@ -261,6 +262,18 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 | `bg`      | 000000 |
 | `text`    | ffffff |
 | `accent`  | 00ffee |
+
+---
+
+### 🪨 Obsidian
+
+![obsidian](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=obsidian)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 1a1a2e |
+| `text`    | e2e8f0 |
+| `accent`  | f59e0b |
 
 ---
 

--- a/lib/svg/themes.ts
+++ b/lib/svg/themes.ts
@@ -30,6 +30,7 @@ export const themes: Record<string, BadgeTheme> = {
   solarized_light: makeTheme('fdf6e3', '586e75', '268bd2', 'dc322f'),
   gruvbox_light: makeTheme('fbf1c7', '3c3836', 'd65d0e', '9d0006'),
   nord_light: makeTheme('eceff4', '2e3440', '5e81ac', 'bf616a'),
+  obsidian: makeTheme('1a1a2e', 'e2e8f0', 'f59e0b'),
   'cyber-pulse': makeTheme('000000', 'ffffff', '00ffee', 'ff0055'),
 };
 


### PR DESCRIPTION
## What does this PR do?

Adds a new "obsidian" preset theme to CommitPulse — a sophisticated, premium 
dark neutral theme inspired by the Obsidian note-taking app aesthetic that is 
extremely popular in the developer community.

## Pillar
- [x] New Theme Design

## Fixes
Closes #1928 

## Palette

| Property | Value   | Role                              |
|----------|---------|-----------------------------------|
| `bg`     | 1a1a2e  | Deep navy-charcoal background     |
| `text`   | e2e8f0  | Cool off-white, readable at 11px  |
| `accent` | f59e0b  | Amber gold — towers, glow, labels |

## Visual Preview

![obsidian theme](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=obsidian)

## Why this palette works

- bg (#1a1a2e) is intentionally dark — the amber glow lands with depth on charcoal
- accent (#f59e0b amber) is saturated and vivid per CONTRIBUTING.md guidance
- text (#e2e8f0) contrast ratio against bg = ~13.5:1 (WCAG AA requires 4.5:1 ✅)
- All three values were chosen as a cohesive system — not arbitrary hex codes
- "obsidian" is unique, memorable, and does not conflict with any existing key

## Changes

| File | Change |
|------|--------|
| `lib/svg/themes.ts` | Added `obsidian: makeTheme('1a1a2e', 'e2e8f0', 'f59e0b')` |
| `README.md` | Added obsidian row to Theme Presets table |
| `THEMES.md` | Added 🪨 Obsidian section with live preview + hex table, updated count to 20 |

## Theme checklist (CONTRIBUTING.md)
- [x] Tested against all 5 label/stat text sizes in the SVG
- [x] Looks correct in both GitHub Dark and Light browser modes
- [x] Has a meaningful, memorable name
- [x] Added to theme table in README.md
- [x] Added to THEMES.md with live preview badge

## Code quality checklist
- [x] npm run test passes locally
- [x] npm run lint passes locally
- [x] npm run format passes locally
- [x] My commits follow the Conventional Commits format
- [x] Zero new dependencies added
- [x] No logic changes — theme data only