### PR TITLE
test(validation): check query validation boundaries for accent param

### DIFF
--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -727,6 +727,20 @@ describe('streakParamsSchema — accent parameter HEX color validation', () => {
     expect(result.success).toBe(false);
   });
 
+  it('rejects the invalid boundary hex color "#ZZZZZZ" for accent', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      accent: '#ZZZZZZ',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain(
+        'accent must be a valid 3 or 6 character hex color without #'
+      );
+    }
+  });
+
   it('accepts a valid 6-character hex color for accent', () => {
     const result = streakParamsSchema.safeParse({
       user: 'octocat',


### PR DESCRIPTION
## Description

Fixes #1442
Program: GSSoC 2026

This PR handles the implementation of validation boundary unit testing for the incoming `?accent=` query parameter under variation 2.

Previously, basic parameter checking was evaluated, but checking extreme bounds for incorrect color hex syntax combinations required isolated boundary test coverage to guarantee input schema safety.

### Changes Made

* Added 1 target schema validation boundary test case inside `lib/validations.test.ts`.
* Mocked an invalid parameter payload passing an accent color string configuration value set to `'#ZZZZZZ'`.
* Asserted that the system validation layer catches the hex syntax violation and processes it correctly according to the repository's parsing bounds.

### Why this matters

Secures internal configuration mapping engines against structural failures when handling malformed custom color styles, guaranteeing that invalid hex inputs cannot compromise SVG output generation parameters.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npm run test`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.