### PR TITLE
test(useRecentSearches): ignore blank input

### DIFF
--- a/hooks/useRecentSearches.test.ts
+++ b/hooks/useRecentSearches.test.ts
@@ -34,6 +34,35 @@ describe('useRecentSearches', () => {
     });
     expect(result.current.searches[0]).toBe('torvalds');
   });
+  it('ignores empty string input', () => {
+    const { result } = renderHook(() => useRecentSearches());
+
+    act(() => {
+      result.current.addSearch('');
+    });
+
+    expect(result.current.searches).toEqual([]);
+  });
+
+  it('ignores whitespace-only input', () => {
+    const { result } = renderHook(() => useRecentSearches());
+
+    act(() => {
+      result.current.addSearch('   ');
+    });
+
+    expect(result.current.searches).toEqual([]);
+  });
+
+  it('ignores newline-only input', () => {
+    const { result } = renderHook(() => useRecentSearches());
+
+    act(() => {
+      result.current.addSearch('\n');
+    });
+
+    expect(result.current.searches).toEqual([]);
+  });
 
   it('deduplicates — moves existing to front', () => {
     const { result } = renderHook(() => useRecentSearches());


### PR DESCRIPTION
## Description

Fixes #716

Added tests for `useRecentSearches` to verify that `addSearch` ignores blank inputs.

### Covered cases

* Empty string: `''`
* Whitespace-only string: `'   '`
* Newline-only string: `'\n'`

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix/calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
