### PR TITLE
test(api validation): check query validation boundaries for ?accent= parameter (Variation 4)

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -715,6 +715,11 @@ describe('GET /api/streak', () => {
 
       expect(response.status).toBe(400);
     });
+    it('returns 400 when another invalid hex color is passed as accent (Variation 4)', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', accent: '#ZZZZZZ' }));
+
+      expect(response.status).toBe(400);
+    });
   });
 
   describe('hide parameters', () => {

--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -727,6 +727,15 @@ describe('streakParamsSchema — accent parameter HEX color validation', () => {
     expect(result.success).toBe(false);
   });
 
+  it('rejects an invalid hex color like "#ZZZZZZ" for accent (Variation 4)', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      accent: '#ZZZZZZ',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('accepts a valid 6-character hex color for accent', () => {
     const result = streakParamsSchema.safeParse({
       user: 'octocat',


### PR DESCRIPTION
## Description

Fixes #1458

This PR adds unit tests and route integration tests to verify validation boundaries for the `?accent=` query parameter when passing an invalid color hex value like `#ZZZZZZ`.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

None (Validation changes)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
