### PR TITLE
feat(themes): add glacier and lumos theme presets

### DIFF
--- a/lib/svg/themes.ts
+++ b/lib/svg/themes.ts
@@ -32,6 +32,8 @@ export const themes: Record<string, BadgeTheme> = {
   nord_light: makeTheme('eceff4', '2e3440', '5e81ac', 'bf616a'),
   obsidian: makeTheme('1a1a2e', 'e2e8f0', 'f59e0b'),
   'cyber-pulse': makeTheme('000000', 'ffffff', '00ffee', 'ff0055'),
+  glacier: makeTheme('e0f2fe', '0369a1', '06b6d4', 'ef4444'),
+  lumos: makeTheme('0a0a0a', 'a7f3d0', 'fbbf24', 'ef4444'),
 };
 
 // Auto-theme pairs: the SVG switches between these two palettes


### PR DESCRIPTION
## Description

Fixes #1940 

Added two new premium theme presets:
1. `glacier`: A frost-inspired theme with an ice-blue background and vivid cyan accents.
2. `lumos`: A magic-inspired cinematic theme with a void-dark background and glowing gold accents.

## Pillar

- [x] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="1919" height="972" alt="image" src="https://github.com/user-attachments/assets/9ab1a3b9-3af1-448b-bafa-227ff9d8e017" />
<img width="1919" height="913" alt="image" src="https://github.com/user-attachments/assets/21f34603-4764-4dca-a3e4-eed71be45c00" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.