### PR TITLE
test(calculate): verify calculateStreak with a 365-day all-contributi…

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -957,6 +957,16 @@ describe('calculateStreak — empty and sparse year edge cases', () => {
     expect(result.longestStreak).toBe(0);
     expect(result.totalContributions).toBe(0);
   });
+
+  it('verifies calculateStreak with a 365-day all-contribution calendar', () => {
+    const calendar = buildCalendar(Array(365).fill(1));
+
+    const result = calculateStreak(calendar);
+
+    expect(result.currentStreak).toBe(365);
+    expect(result.longestStreak).toBe(365);
+    expect(result.totalContributions).toBe(365);
+  });
 });
 
 describe('calculateStreak — todayDate format', () => {


### PR DESCRIPTION
## Description

Adds a new test case to verify the maximum streak scenario in `calculateStreak`.

The test creates a 365-day contribution calendar where every day has `contributionCount: 1` and validates that:

- `currentStreak === 365`
- `longestStreak === 365`
- `totalContributions === 365`

This ensures the streak calculation logic correctly handles a full year of continuous contributions and covers a previously untested edge case.

Fixes #681

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] My commits follow the Conventional Commits format.
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.