### PR TITLE
test(utils): verify query parameter debouncing

### DIFF
--- a/hooks/useDebounce.test.ts
+++ b/hooks/useDebounce.test.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useDebounce } from './useDebounce';
+
+function useObservedDebounce(value: string, onResolved: (value: string) => void) {
+  const debouncedValue = useDebounce(value, 300);
+
+  useEffect(() => {
+    onResolved(debouncedValue);
+  }, [debouncedValue, onResolved]);
+}
+
+describe('useDebounce', () => {
+  it('resolves rapid synchronous query inputs exactly once after the timer expires', () => {
+    vi.useFakeTimers();
+    const onResolved = vi.fn();
+
+    try {
+      const { rerender } = renderHook(
+        ({ value }: { value: string }) => useObservedDebounce(value, onResolved),
+        { initialProps: { value: '' } }
+      );
+
+      onResolved.mockClear();
+
+      rerender({ value: 'o' });
+      rerender({ value: 'oc' });
+      rerender({ value: 'octocat' });
+
+      act(() => {
+        vi.advanceTimersByTime(299);
+      });
+      expect(onResolved).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(onResolved).toHaveBeenCalledTimes(1);
+      expect(onResolved).toHaveBeenCalledWith('octocat');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Description
Added a utility-level test verifying that rapid synchronous query inputs are debounced correctly. Only the final value resolves once after the timer expires.

Fixes #1557 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
Not applicable. This PR only adds a utility test.


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
