### PR TITLE
add JSDoc to dbConnect() function [ GSSOC'26 ]

### DIFF
--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -13,7 +13,19 @@ let cached = global.mongoose;
 if (!cached) {
   cached = global.mongoose = { conn: null, promise: null };
 }
-
+/**
+ * Connects to the MongoDB database and returns the cached connection.
+ *
+ * Reuses an existing connection if one is already established.
+ * Automatically resets the cache if the connection drops.
+ *
+ * @throws {Error} If called from the Edge runtime.
+ * @throws {Error} If `MONGODB_URI` environment variable is not defined.
+ * @returns The active Mongoose connection instance.
+ *
+ * @example
+ * const db = await dbConnect();
+ */
 async function dbConnect() {
   if (process.env.NEXT_RUNTIME === 'edge') {
     throw new Error('MongoDB is not supported in the Edge runtime. Use the Node.js runtime.');


### PR DESCRIPTION
## Description

Adds JSDoc to `dbConnect()` documenting the Edge runtime restriction,
the `MONGODB_URI` requirement, return value, and usage example.
Brings it in line with the `dbDisconnect()` documentation style
already present in the same file.

Fixes #2001 

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — documentation only, no behavioural changes.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.