### PR TITLE
leap streak

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -501,6 +501,70 @@ describe('calculateStreak', () => {
     expect(resultLeapGap.longestStreak).toBe(1);
   });
 
+  it('handles leap years vs non-leap years Feb 28 to Mar 1 timeline and asserts correct current/longest streaks', () => {
+    const buildCustomCalendar = (
+      daysData: { date: string; count: number }[]
+    ): ContributionCalendar => {
+      const weeks = [];
+      for (let i = 0; i < daysData.length; i += 7) {
+        const slice = daysData.slice(i, i + 7);
+        weeks.push({
+          contributionDays: slice.map((day) => ({
+            contributionCount: day.count,
+            date: day.date,
+          })),
+        });
+      }
+      return {
+        totalContributions: daysData.reduce((sum, d) => sum + d.count, 0),
+        weeks,
+      };
+    };
+
+    // 1. Non-Leap Year (2021): Feb 28 to Mar 1
+    // Calendar doesn't have Feb 29.
+    const nonLeapCalendar = buildCustomCalendar([
+      { date: '2021-02-28', count: 1 },
+      { date: '2021-03-01', count: 1 },
+    ]);
+
+    const resultNonLeap = calculateStreak(nonLeapCalendar, 'UTC', new Date('2021-03-01T12:00:00Z'));
+    expect(resultNonLeap.currentStreak).toBe(2);
+    expect(resultNonLeap.longestStreak).toBe(2);
+
+    // 2. Leap Year (2020) with missed leap day (Feb 29 has 0 commits)
+    const leapCalendarWithGap = buildCustomCalendar([
+      { date: '2020-02-28', count: 1 },
+      { date: '2020-02-29', count: 0 },
+      { date: '2020-03-01', count: 1 },
+    ]);
+
+    const resultLeapGap = calculateStreak(
+      leapCalendarWithGap,
+      'UTC',
+      new Date('2020-03-01T12:00:00Z')
+    );
+    // Since Feb 29 has 0 commits, the streak of consecutive active days is broken.
+    // However, grace period = 1 keeps current streak alive but only for the continuous active days ending today (Mar 1).
+    expect(resultLeapGap.currentStreak).toBe(1);
+    expect(resultLeapGap.longestStreak).toBe(1);
+
+    // 3. Leap Year (2020) with active leap day (Feb 29 has 1 commit)
+    const leapCalendarContinuous = buildCustomCalendar([
+      { date: '2020-02-28', count: 1 },
+      { date: '2020-02-29', count: 1 },
+      { date: '2020-03-01', count: 1 },
+    ]);
+
+    const resultLeapContinuous = calculateStreak(
+      leapCalendarContinuous,
+      'UTC',
+      new Date('2020-03-01T12:00:00Z')
+    );
+    expect(resultLeapContinuous.currentStreak).toBe(3);
+    expect(resultLeapContinuous.longestStreak).toBe(3);
+  });
+
   it('correctly calculates current and longest streaks when commits are made exclusively on Saturdays and Sundays', () => {
     // 2024-01-01 is a Monday.
     // Days in a week: Mon, Tue, Wed, Thu, Fri, Sat, Sun


### PR DESCRIPTION
## Description

This pull request introduces a highly specific unit test suite in `lib/calculate.test.ts` to validate timezone boundaries and calendar offsets during the February 28 to March 1 transition. 

By comparing leap years (e.g., 2020) and non-leap years (e.g., 2021) with both active and inactive leap days, the new test ensures that streak calculations are resilient against off-by-one errors and gap boundary misalignments.

### Scenarios Covered in the Test:
1. **Non-Leap Year (2021)**: Verifies that a user committing on Feb 28 and Mar 1 achieves a continuous **2-day** streak since Feb 29 does not exist.
2. **Leap Year (2020) with a Missed Leap Day**: Verifies that when Feb 29 has 0 commits, the streak correctly breaks, resulting in a current and longest streak of **1 day** on Mar 1.
3. **Leap Year (2020) with an Active Leap Day**: Verifies that committing on Feb 28, Feb 29, and Mar 1 results in a seamless **3-day** streak.

fixes #1501 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [x] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Unit testing)

## Visual Preview

*(N/A - This is a pure logic & unit testing addition)*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.