### PR TITLE
feat(i18n): add Tamil, Japanese, French languages and fix Korean labels

### DIFF
--- a/lib/i18n/badgeLabels.ts
+++ b/lib/i18n/badgeLabels.ts
@@ -44,10 +44,31 @@ export const labels: Record<string, BadgeLabels> = {
   },
   ko: {
     CURRENT_STREAK: '현재_연속',
-    ANNUAL_SYNC_TOTAL: '연간_총합',
+    ANNUAL_SYNC_TOTAL: '연간_총계',
     PEAK_STREAK: '최고_연속',
     COMMITS_THIS_MONTH: '이번 달 커밋',
     VS_LAST_MONTH: '지난달 대비',
+  },
+  ja: {
+    CURRENT_STREAK: '現在のストリーク',
+    ANNUAL_SYNC_TOTAL: '年間合計',
+    PEAK_STREAK: '最高ストリーク',
+    COMMITS_THIS_MONTH: '今月のコミット数',
+    VS_LAST_MONTH: '先月比',
+  },
+  fr: {
+    CURRENT_STREAK: 'SÉRIE_ACTUELLE',
+    ANNUAL_SYNC_TOTAL: 'TOTAL_ANNUEL',
+    PEAK_STREAK: 'SÉRIE_MAXIMALE',
+    COMMITS_THIS_MONTH: 'COMMITS CE MOIS',
+    VS_LAST_MONTH: 'vs mois dernier',
+  },
+  ta: {
+    CURRENT_STREAK: 'தற்போதைய_தொடர்',
+    ANNUAL_SYNC_TOTAL: 'ஆண்டு_மொத்தம்',
+    PEAK_STREAK: 'உச்ச_தொடர்',
+    COMMITS_THIS_MONTH: 'இம்மாத கமிட்கள்',
+    VS_LAST_MONTH: 'கடந்த மாதத்துடன்',
   },
   fr: {
     CURRENT_STREAK: 'SÉRIE_ACTUELLE',

--- a/lib/i18n/badgeLabels.ts
+++ b/lib/i18n/badgeLabels.ts
@@ -70,20 +70,6 @@ export const labels: Record<string, BadgeLabels> = {
     COMMITS_THIS_MONTH: 'இம்மாத கமிட்கள்',
     VS_LAST_MONTH: 'கடந்த மாதத்துடன்',
   },
-  fr: {
-    CURRENT_STREAK: 'SÉRIE_ACTUELLE',
-    ANNUAL_SYNC_TOTAL: 'TOTAL_ANNUEL',
-    PEAK_STREAK: 'SÉRIE_MAXIMALE',
-    COMMITS_THIS_MONTH: 'COMMITS CE MOIS',
-    VS_LAST_MONTH: 'vs mois dernier',
-  },
-  ja: {
-    CURRENT_STREAK: '現在_ストリーク',
-    ANNUAL_SYNC_TOTAL: '年間_合計',
-    PEAK_STREAK: '最高_ストリーク',
-    COMMITS_THIS_MONTH: '今月のコミット数',
-    VS_LAST_MONTH: '先月比',
-  },
   de: {
     CURRENT_STREAK: 'AKTUELLE_SERIE',
     ANNUAL_SYNC_TOTAL: 'JAHRES_GESAMT',


### PR DESCRIPTION
## Description
Fixes #2012

## Pillar
- [x] 🛠️ Other (New Functionality)

## Visual Preview
N/A (translation labels, no SVG structure changes)

## Checklist
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=janievinod`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] I have run `npm run test` and all tests pass locally.
- [x] I have run `npm run test:coverage` and branch coverage is at or above 70%.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.