### PR TITLE
test(ui): add responsive rendering coverage for InteractiveViewer

### DIFF
--- a/components/InteractiveViewer.test.tsx
+++ b/components/InteractiveViewer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import InteractiveViewer, { formatDate } from './InteractiveViewer';
 
 // getBoundingClientRect is not implemented in jsdom — mock it so mouse-position
@@ -552,5 +552,52 @@ describe('InteractiveViewer', () => {
     // Normalized coordinates: x = 900/1200 = 75% (0.75), y = 200/800 = 25% (0.25)
     expect(glow.style.left).toBe('75%');
     expect(glow.style.top).toBe('25%');
+  });
+
+  describe('InteractiveViewer responsive rendering', () => {
+    afterEach(() => {
+      window.innerWidth = 1024;
+      window.innerHeight = 768;
+    });
+
+    const resizeWindow = (width: number, height: number) => {
+      window.innerWidth = width;
+      window.innerHeight = height;
+
+      window.dispatchEvent(new Event('resize'));
+    };
+
+    it('renders correctly on mobile viewport', () => {
+      resizeWindow(375, 667);
+
+      render(
+        <InteractiveViewer>
+          <div data-testid="mobile-content">Mobile Content</div>
+        </InteractiveViewer>
+      );
+
+      expect(screen.getByTestId('mobile-content')).toBeTruthy();
+      expect(screen.getByTestId('parallax-bg-layer')).toBeTruthy();
+    });
+
+    it('renders correctly on desktop viewport with pointer interactions', () => {
+      resizeWindow(1440, 900);
+
+      render(
+        <InteractiveViewer>
+          <div data-testid="desktop-content">Desktop Content</div>
+        </InteractiveViewer>
+      );
+
+      const glowLayer = screen.getByTestId('parallax-cursor-glow');
+
+      fireEvent.pointerMove(glowLayer, {
+        clientX: 100,
+        clientY: 100,
+      });
+
+      expect(screen.getByTestId('desktop-content')).toBeTruthy();
+      expect(glowLayer).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixes #1541 
## Changes made

- Added responsive rendering tests for InteractiveViewer
- Verified component rendering on mobile and desktop viewport sizes
- Added pointer interaction coverage for desktop rendering
- Improved UI component test coverage

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
