### PR TITLE
fix: add visible focus states for keyboard navigation

### DIFF
--- a/app/components/CustomizeCTA.tsx
+++ b/app/components/CustomizeCTA.tsx
@@ -35,7 +35,11 @@ export function CustomizeCTA() {
           </div>
 
           <div className="shrink-0">
-            <Link href="/customize" id="open-customization-studio-cta">
+            <Link
+              href="/customize"
+              id="open-customization-studio-cta"
+              className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 rounded-2xl"
+            >
               <span className="relative inline-flex items-center gap-2 px-4 md:px-7 py-4 rounded-2xl border border-black/10 dark:border-white/10 font-bold text-sm text-black dark:text-black bg-gray-100 dark:bg-white hover:bg-gray-200 dark:hover:bg-zinc-100 hover:scale-[1.03] active:scale-[0.97] transition-all duration-200 shadow-[0_0_30px_-4px_rgba(255,255,255,0.12)] cursor-pointer select-none">
                 {/* Button shimmer */}
                 <span


### PR DESCRIPTION
## Description

This PR improves keyboard accessibility by adding visible focus states to the Customization Studio CTA.

### Changes Made
- Added `focus-visible` styles for keyboard navigation.
- Added a visible focus ring to improve focus indication.
- Improved accessibility for users navigating with the Tab key.

Fixes #77

## Pillar

- [x] Other (Bug fix, accessibility improvement)

## Checklist

- [x] I have read the CONTRIBUTING.md file.
- [x] I have tested these changes locally.
- [x] My commit follows the Conventional Commits format.
- [x] I verified keyboard navigation using the Tab key.

