### PR TITLE
test: add personality tag coverage in compare mode

### DIFF
--- a/components/dashboard/DashboardClient.test.tsx
+++ b/components/dashboard/DashboardClient.test.tsx
@@ -354,6 +354,37 @@ describe('DashboardClient', () => {
     // 5. Assert input value is empty
     expect((input as HTMLInputElement).value).toBe('');
   });
+
+  // =========================================================================
+  // ISSUE OBJECTIVE: Verify personality tags render in compare mode
+  // =========================================================================
+  it('renders personality tags for both profiles in compare mode', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockSecondData,
+    });
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    render(<DashboardClient initialData={mockInitialData} username="Shivangi1515" />);
+
+    fireEvent.click(screen.getByText('Compare Profile'));
+
+    fireEvent.change(screen.getByPlaceholderText('Enter GitHub Username'), {
+      target: { value: 'JhaSourav07' },
+    });
+
+    fireEvent.click(screen.getByText('Compare'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Exit Compare Mode')).toBeDefined();
+    });
+
+    // Both profiles have stats that generate the "Consistency Beast 🔥" tag
+    // Using Regex /.../i to match the text even if there is an emoji next to it!
+    const tags = screen.getAllByText(/Consistency Beast/i);
+    expect(tags).toHaveLength(2);
+  });
 });
 it('shows Most Consistent badge for profile with higher peak streak in compare mode', async () => {
   const mockFetch = vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Description

Fixes #1066 

Adds test coverage for personality tags rendered in compare mode within `DashboardClient`.

### Changes

* Added a new test case in `components/dashboard/DashboardClient.test.tsx`
* Verifies personality tags are displayed when comparing two GitHub profiles
* Reuses existing compare mode mock data and test patterns
* No production code changes

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
