### PR TITLE
fix(cache): cache contributed repositories requests

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -1191,6 +1191,83 @@ describe('GitHub API cache behavior', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
   });
+
+  it('cache hit: second fetchContributedRepos call uses cached value', async () => {
+    const mockNodes = [{ name: 'cached-repo' }];
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse({
+        data: {
+          user: {
+            repositoriesContributedTo: {
+              nodes: mockNodes,
+            },
+          },
+        },
+      })
+    );
+
+    await fetchContributedRepos('octocat');
+    await fetchContributedRepos('octocat');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes concurrent fetchContributedRepos requests for the same cold cache key', async () => {
+    let resolveFetch!: (response: Response) => void;
+    vi.mocked(fetch).mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    const requests = Promise.all([
+      fetchContributedRepos('octocat'),
+      fetchContributedRepos('octocat'),
+      fetchContributedRepos('octocat'),
+    ]);
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+
+    resolveFetch(
+      mockResponse({
+        data: {
+          user: {
+            repositoriesContributedTo: {
+              nodes: [{ name: 'deduped-repo' }],
+            },
+          },
+        },
+      })
+    );
+
+    const results = await requests;
+    expect(results.map((repos) => repos[0]?.name)).toEqual([
+      'deduped-repo',
+      'deduped-repo',
+      'deduped-repo',
+    ]);
+  });
+
+  it('refresh bypass: bypassCache=true forces fresh fetchContributedRepos fetch', async () => {
+    const mockNodes = [{ name: 'repo' }];
+    vi.mocked(fetch).mockImplementation(async () =>
+      mockResponse({
+        data: {
+          user: {
+            repositoriesContributedTo: {
+              nodes: mockNodes,
+            },
+          },
+        },
+      })
+    );
+
+    await fetchContributedRepos('octocat');
+    await fetchContributedRepos('octocat', { bypassCache: true });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('generateAchievements', () => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -249,9 +249,11 @@ export const GITHUB_CACHE_TTL_MS = 5 * 60 * 1000;
 const contributionsCache = new DistributedCache<ExtendedContributionData>(1000);
 const profileCache = new DistributedCache<GitHubUserProfile>(1000);
 const reposCache = new DistributedCache<GitHubRepo[]>(500);
+const contributedReposCache = new DistributedCache<Record<string, unknown>[]>(500);
 const pendingContributions = new Map<string, Promise<ExtendedContributionData>>();
 const pendingProfiles = new Map<string, Promise<GitHubUserProfile>>();
 const pendingRepos = new Map<string, Promise<GitHubRepo[]>>();
+const pendingContributedRepos = new Map<string, Promise<Record<string, unknown>[]>>();
 
 interface GitHubUserProfile {
   login: string;
@@ -268,18 +270,18 @@ interface GitHubUserProfile {
 }
 
 export function cacheKey(
-  kind: 'contributions' | 'profile' | 'repos',
+  kind: 'contributions' | 'profile' | 'repos' | 'repos:contributed',
   username: string,
   year?: string
 ): string;
 export function cacheKey(
-  kind: 'contributions' | 'profile' | 'repos',
+  kind: 'contributions' | 'profile' | 'repos' | 'repos:contributed',
   username: string,
   from?: string,
   to?: string
 ): string;
 export function cacheKey(
-  kind: 'contributions' | 'profile' | 'repos',
+  kind: 'contributions' | 'profile' | 'repos' | 'repos:contributed',
   username: string,
   yearOrFrom?: string,
   to?: string
@@ -296,9 +298,11 @@ export function clearGitHubApiCacheForTests(): void {
   contributionsCache.clear();
   profileCache.clear();
   reposCache.clear();
+  contributedReposCache.clear();
   pendingContributions.clear();
   pendingProfiles.clear();
   pendingRepos.clear();
+  pendingContributedRepos.clear();
 }
 
 function dedupeRequest<T>(
@@ -906,38 +910,54 @@ export async function fetchContributedRepos(
   username: string,
   options: FetchOptions = {}
 ): Promise<Record<string, unknown>[]> {
-  const query = `
-    query($login: String!) {
-      user(login: $login) {
-        repositoriesContributedTo(first: 100, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY], orderBy: {field: UPDATED_AT, direction: DESC}) {
-          nodes {
-            name
-            nameWithOwner
-            owner { login }
-            stargazerCount
-            forkCount
-            primaryLanguage { name }
-            updatedAt
+  const key = cacheKey('repos:contributed', username);
+  if (!options.bypassCache) {
+    const cached = await contributedReposCache.get(key);
+    if (cached) return cached;
+  }
+
+  const load = async () => {
+    const query = `
+      query($login: String!) {
+        user(login: $login) {
+          repositoriesContributedTo(first: 100, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY], orderBy: {field: UPDATED_AT, direction: DESC}) {
+            nodes {
+              name
+              nameWithOwner
+              owner { login }
+              stargazerCount
+              forkCount
+              primaryLanguage { name }
+              updatedAt
+            }
           }
         }
       }
+    `;
+
+    const res = await fetchWithRetry(GITHUB_GRAPHQL_URL, {
+      method: 'POST',
+      headers: getHeaders(),
+      body: JSON.stringify({
+        query,
+        variables: { login: username },
+      }),
+      cache: 'no-store',
+      signal: options.signal,
+    });
+
+    if (!res.ok) return [];
+    const data = await res.json();
+    const result = data?.data?.user?.repositoriesContributedTo?.nodes || [];
+
+    if (!options.bypassCache) {
+      await contributedReposCache.set(key, result, GITHUB_CACHE_TTL_MS);
     }
-  `;
+    return result;
+  };
 
-  const res = await fetchWithRetry(GITHUB_GRAPHQL_URL, {
-    method: 'POST',
-    headers: getHeaders(),
-    body: JSON.stringify({
-      query,
-      variables: { login: username },
-    }),
-    cache: 'no-store',
-    signal: options.signal,
-  });
-
-  if (!res.ok) return [];
-  const data = await res.json();
-  return data?.data?.user?.repositoriesContributedTo?.nodes || [];
+  if (options.bypassCache) return load();
+  return dedupeRequest(pendingContributedRepos, key, load);
 }
 
 export interface DeveloperScoreInput {


### PR DESCRIPTION
## Description

Fixes #<issue-number>

This PR adds caching support for `fetchContributedRepos()` to reduce unnecessary GitHub GraphQL requests and improve dashboard performance.

Previously, `getFullDashboardData()` cached user profiles, repositories, and contribution calendars, but `fetchContributedRepos()` always performed a live API request. As a result, repeated dashboard loads for the same user generated identical GitHub queries and consumed API rate limits unnecessarily.

This change introduces caching using a dedicated cache key:

```ts
repos:contributed:${username}
```

The implementation now follows the same caching strategy used by the other GitHub data fetchers:

* Check L1/L2 cache before making a GitHub request
* Return cached data when available
* Store fresh responses in cache after successful fetches

Benefits:

* Faster dashboard response times
* Reduced GitHub API usage
* Lower risk of rate-limit exhaustion
* Consistent caching behavior across dashboard data sources

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — backend caching improvement with no visual SVG/UI changes.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
