### PR TITLE
test(api validation): check query validation boundaries for ?date= parameter (Variation 3)

### DIFF
--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -1013,3 +1013,34 @@ describe('streakParamsSchema — layout query validation boundaries (Variation 2
     }
   });
 });
+
+/* ==========================================================================
+ * LAYOUT PARAMETER — QUERY VALIDATION BOUNDARIES (VARIATION 3)
+ * ========================================================================== */
+
+describe('streakParamsSchema date validation boundaries (Variation 3)', () => {
+  it('rejects malformed or impossible ISO8601 date formats with a validation error', () => {
+    const invalidPayload = {
+      user: 'atharv96k',
+      from: '2026-15-40', // Impossible month (15) and day (40)
+    };
+
+    const parseResult = streakParamsSchema.safeParse(invalidPayload);
+
+    expect(parseResult.success).toBe(false);
+    if (!parseResult.success) {
+      const fieldErrors = parseResult.error.flatten().fieldErrors;
+      expect(fieldErrors.from).toBeDefined();
+    }
+  });
+
+  it('accepts perfectly structured valid ISO8601 calendar date formats', () => {
+    const validPayload = {
+      user: 'atharv96k',
+      from: '2026-05-31',
+    };
+
+    const parseResult = streakParamsSchema.safeParse(validPayload);
+    expect(parseResult.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1451

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Security / Input Validation Testing)

## Summary of Changes
- Added an explicit query validation boundary unit test under a dedicated layout block comment to `lib/validations.test.ts`.
- Verified that passing an invalid or impossible ISO8601 calendar date format combination (`2026-15-40`) correctly breaks schema parsing bounds and throws validation errors.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally using the isolated Vitest runner.
- [x] My commits follow the Conventional Commits format (`test(api validation): ...`).