### PR TITLE
fix(api): return bad request for malformed notify JSON

### DIFF
--- a/app/api/notify/route.test.ts
+++ b/app/api/notify/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { GET, POST } from './route';
+import dbConnect from '@/lib/mongodb';
 
 // Mock dependencies
 vi.mock('@/lib/mongodb', () => ({ default: vi.fn() }));
@@ -88,6 +89,7 @@ describe('POST /api/notify', () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.message).toContain('Malformed JSON');
+    expect(dbConnect).not.toHaveBeenCalled();
   });
 
   // ── Rate limiting ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Closes #2057

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed

`POST /api/notify` was parsing `await req.json()` inside the same broad `try/catch` used for database and persistence failures. When the request body was malformed JSON, the route returned the generic 500 response even though the request itself was invalid.

This PR moves JSON parsing into a narrow `try/catch` before validation. Malformed JSON now returns a 400 response with a clear message, while the existing database/server error path is left unchanged.

I also added a route regression test that verifies malformed JSON returns 400 and does not attempt a database connection.

This is a GSSoC 2026 API bug fix contribution. Please add the relevant GSSoC labels if they are missing.

## Visual Preview

N/A — this is API error handling behavior.

## Local checks

```bash
npm run test -- app/api/notify/route.test.ts
npm run format:check
npm run lint
npm run typecheck
npm run test
```

`npm run lint` reports one existing warning outside the touched files; there are no lint errors.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commit follows the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.
