### PR TITLE
Optimize GitHub API response caching by storing only required fields

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -517,6 +517,32 @@ describe('fetchUserProfile', () => {
     expect(result.avatar_url).toBe(mockProfile.avatar_url);
   });
 
+  it('sanitizes the profile by removing extra fields before returning', async () => {
+    const mockProfile = {
+      login: 'octocat',
+      name: 'The Octocat',
+      avatar_url: 'https://avatar.url',
+      public_repos: 8,
+      followers: 100,
+      following: 5,
+      created_at: '2011-01-25T18:44:36Z',
+      bio: 'GitHub mascot',
+      location: 'San Francisco',
+      extra_field: 'should be removed',
+      another_extra: 123,
+      plan: { name: 'pro', space: 1000 },
+    };
+
+    vi.mocked(fetch).mockResolvedValue(mockResponse(mockProfile));
+
+    const result = (await fetchUserProfile('octocat')) as unknown as Record<string, unknown>;
+
+    expect(result.login).toBe('octocat');
+    expect(result.extra_field).toBeUndefined();
+    expect(result.another_extra).toBeUndefined();
+    expect(result.plan).toEqual({ name: 'pro' });
+  });
+
   it('encodes the username before using it in the REST profile path', async () => {
     vi.mocked(fetch).mockResolvedValue(
       mockResponse({
@@ -561,6 +587,29 @@ describe('fetchUserRepos', () => {
     );
     const result = await fetchUserRepos('octocat');
     expect(result[0].stargazers_count).toBe(1);
+  });
+
+  it('sanitizes repo objects by removing extra fields before returning', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse([
+        {
+          name: 'some-repo',
+          stargazers_count: 10,
+          language: 'TypeScript',
+          id: 12345,
+          private: false,
+          owner: { login: 'octocat' },
+        },
+      ])
+    );
+
+    const result = (await fetchUserRepos('octocat')) as unknown as Record<string, unknown>[];
+
+    expect(result[0].stargazers_count).toBe(10);
+    expect(result[0].language).toBe('TypeScript');
+    expect(result[0].id).toBeUndefined();
+    expect(result[0].private).toBeUndefined();
+    expect(result[0].owner).toBeUndefined();
   });
 
   it('returns a full three-repo payload with the expected star counts and languages', async () => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -267,6 +267,41 @@ interface GitHubUserProfile {
   plan?: { name?: string } | null;
 }
 
+/**
+ * Sanitizes a GitHub user profile to only include required fields.
+ * This reduces the memory footprint of cached data.
+ */
+function sanitizeUserProfile(profile: GitHubUserProfile): GitHubUserProfile {
+  return {
+    login: profile.login,
+    name: profile.name,
+    avatar_url: profile.avatar_url,
+    public_repos: profile.public_repos,
+    followers: profile.followers,
+    following: profile.following,
+    created_at: profile.created_at,
+    bio: profile.bio,
+    location: profile.location,
+    type: profile.type,
+    plan: profile.plan ? { name: profile.plan.name } : null,
+  };
+}
+
+/**
+ * Sanitizes a GitHub repository object to only include required fields.
+ * This reduces the memory footprint of cached data.
+ */
+function sanitizeRepo(repo: GitHubRepo): GitHubRepo {
+  return {
+    name: repo.name,
+    stargazers_count: repo.stargazers_count,
+    language: repo.language,
+    fork: repo.fork,
+    forks_count: repo.forks_count,
+    updated_at: repo.updated_at,
+  };
+}
+
 export function cacheKey(
   kind: 'contributions' | 'profile' | 'repos',
   username: string,
@@ -581,8 +616,9 @@ export async function fetchUserProfile(
     }
 
     const profile = (await res.json()) as GitHubUserProfile;
-    if (!options.bypassCache) await profileCache.set(key, profile, GITHUB_CACHE_TTL_MS);
-    return profile;
+    const sanitizedProfile = sanitizeUserProfile(profile);
+    if (!options.bypassCache) await profileCache.set(key, sanitizedProfile, GITHUB_CACHE_TTL_MS);
+    return sanitizedProfile;
   };
 
   if (options.bypassCache) return load();
@@ -616,7 +652,7 @@ export async function fetchUserRepos(
     }
 
     const firstPageRepos = (await firstPageRes.json()) as GitHubRepo[];
-    const allRepos: GitHubRepo[] = [...firstPageRepos];
+    const allRepos: GitHubRepo[] = firstPageRepos.map(sanitizeRepo);
 
     const MAX_PAGES = 3;
 
@@ -643,7 +679,8 @@ export async function fetchUserRepos(
             throw new Error(`GitHub REST API error: ${response.status}`);
           }
 
-          return (await response.json()) as GitHubRepo[];
+          const repos = (await response.json()) as GitHubRepo[];
+          return repos.map(sanitizeRepo);
         })
       );
 


### PR DESCRIPTION
## Summary

This PR optimizes GitHub API response caching by storing only the fields required by the application instead of caching the entire GitHub REST API response.

## Changes Made

* Added `sanitizeUserProfile()` to retain only the required profile fields.
* Added `sanitizeRepo()` to retain only the repository fields used by the application.
* Updated `fetchUserProfile()` to sanitize profile data before caching and returning it.
* Updated `fetchUserRepos()` to sanitize repository data before caching and returning it.
* Added unit tests to verify that unnecessary fields are stripped before caching.

## Benefits

* Reduces cache memory footprint.
* Decreases cache storage requirements.
* Improves cache efficiency while preserving existing functionality.
* Prevents unnecessary GitHub API payload data from being stored.

## Testing

* Added sanitization tests for profile responses.
* Added sanitization tests for repository responses.
* Verified ESLint passes successfully.
* Verified all related tests pass locally.

Closes #1856 
