### PR TITLE
feat(trends): add support for historical contribution views

### DIFF
--- a/app/(root)/dashboard/[username]/page.test.tsx
+++ b/app/(root)/dashboard/[username]/page.test.tsx
@@ -56,6 +56,14 @@ vi.mock('@/components/dashboard/Heatmap', () => ({
   ),
 }));
 
+vi.mock('@/components/dashboard/HistoricalTrendView', () => ({
+  default: ({ period, activity }: { period: { label: string }; activity: unknown[] }) => (
+    <div data-testid="historical-trend-view" data-prop={JSON.stringify(activity)}>
+      {period.label}
+    </div>
+  ),
+}));
+
 vi.mock('@/components/dashboard/AIInsights', () => ({
   default: () => <div data-testid="ai-insights">AIInsights</div>,
 }));
@@ -147,9 +155,15 @@ describe('DashboardPage', () => {
 
       render(PageContent);
 
-      expect(getFullDashboardData).toHaveBeenCalledWith('octocat', {
-        bypassCache: false,
-      });
+      expect(getFullDashboardData).toHaveBeenCalledWith(
+        'octocat',
+        expect.objectContaining({
+          bypassCache: false,
+          from: expect.any(String),
+          to: expect.any(String),
+          rangeLabel: 'Last 12 months',
+        })
+      );
 
       const generateLink = screen.getByText('Generate Your Own').closest('a');
       expect(generateLink).toBeDefined();
@@ -158,7 +172,7 @@ describe('DashboardPage', () => {
       expect(screen.getByTestId('activity-landscape')).toBeDefined();
       expect(screen.getByTestId('language-chart')).toBeDefined();
       expect(screen.getByTestId('commit-clock')).toBeDefined();
-      expect(screen.getByTestId('heatmap')).toBeDefined();
+      expect(screen.getByTestId('historical-trend-view')).toBeDefined();
       expect(screen.getByTestId('ai-insights')).toBeDefined();
       expect(screen.getByTestId('achievements')).toBeDefined();
       expect(screen.getAllByTestId('stats-card')).toHaveLength(3);
@@ -175,12 +189,37 @@ describe('DashboardPage', () => {
 
       render(PageContent);
 
-      expect(getFullDashboardData).toHaveBeenCalledWith('octocat', {
-        bypassCache: true,
-      });
+      expect(getFullDashboardData).toHaveBeenCalledWith(
+        'octocat',
+        expect.objectContaining({
+          bypassCache: true,
+          from: expect.any(String),
+          to: expect.any(String),
+          rangeLabel: 'Last 12 months',
+        })
+      );
     });
 
-    it('passes the correct activity data to Heatmap', async () => {
+    it('passes a calendar-year query through to getFullDashboardData', async () => {
+      const PageContent = await DashboardPage({
+        params: Promise.resolve({ username: 'octocat' }),
+        searchParams: Promise.resolve({ year: '2024' }),
+      });
+
+      render(PageContent);
+
+      expect(getFullDashboardData).toHaveBeenCalledWith(
+        'octocat',
+        expect.objectContaining({
+          bypassCache: false,
+          from: '2024-01-01T00:00:00.000Z',
+          to: '2024-12-31T23:59:59.999Z',
+          rangeLabel: '2024',
+        })
+      );
+    });
+
+    it('passes the correct activity data to the historical trend view', async () => {
       const PageContent = await DashboardPage({
         params: Promise.resolve({ username: 'octocat' }),
         searchParams: Promise.resolve({}),
@@ -188,8 +227,8 @@ describe('DashboardPage', () => {
 
       render(PageContent);
 
-      const heatmap = screen.getByTestId('heatmap');
-      expect(JSON.parse(heatmap.getAttribute('data-prop') ?? '[]')).toEqual(mockData.activity);
+      const trendView = screen.getByTestId('historical-trend-view');
+      expect(JSON.parse(trendView.getAttribute('data-prop') ?? '[]')).toEqual(mockData.activity);
     });
 
     it('calls notFound when dashboard data fetch throws an error', async () => {

--- a/app/(root)/dashboard/[username]/page.tsx
+++ b/app/(root)/dashboard/[username]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import DashboardClient from '@/components/dashboard/DashboardClient';
 import { getFullDashboardData, fetchUserProfile } from '@/lib/github';
 import { notFound, redirect } from 'next/navigation';
+import { resolveDashboardPeriod } from '@/utils/dashboardPeriod';
 
 export const revalidate = 3600; // Cache for 1 hour
 
@@ -60,16 +61,33 @@ export default async function DashboardPage({
   searchParams,
 }: {
   params: Promise<{ username: string }>;
-  searchParams: Promise<{ refresh?: string }>;
+  searchParams: Promise<{
+    refresh?: string;
+    year?: string;
+    month?: string;
+    from?: string;
+    to?: string;
+  }>;
 }) {
   const { username } = await params;
-  const refreshParams = await searchParams;
-  const bypassCache = refreshParams?.refresh === 'true';
+  const resolvedSearchParams = await searchParams;
+  const bypassCache = resolvedSearchParams?.refresh === 'true';
+  const period = resolveDashboardPeriod({
+    year: resolvedSearchParams?.year,
+    month: resolvedSearchParams?.month,
+    from: resolvedSearchParams?.from,
+    to: resolvedSearchParams?.to,
+  });
 
   let data;
 
   try {
-    data = await getFullDashboardData(username, { bypassCache });
+    data = await getFullDashboardData(username, {
+      bypassCache,
+      from: period.from,
+      to: period.to,
+      rangeLabel: period.label,
+    });
   } catch (error) {
     if (error instanceof Error && error.message.includes('not found')) {
       // Smart Redirect: If the GraphQL "user" query fails, check if it's actually an Organization
@@ -87,5 +105,5 @@ export default async function DashboardPage({
     throw error;
   }
 
-  return <DashboardClient initialData={data} username={username} />;
+  return <DashboardClient initialData={data} username={username} period={period} />;
 }

--- a/components/dashboard/DashboardClient.test.tsx
+++ b/components/dashboard/DashboardClient.test.tsx
@@ -88,6 +88,10 @@ vi.mock('./Heatmap', () => ({
   default: () => <div data-testid="heatmap" />,
 }));
 
+vi.mock('./HistoricalTrendView', () => ({
+  default: () => <div data-testid="historical-trend-view" />,
+}));
+
 vi.mock('./AIInsights', () => ({
   default: () => <div data-testid="ai-insights" />,
 }));
@@ -190,24 +194,36 @@ const secondDataWithLowerStreak = {
   },
 };
 
+const mockPeriod = {
+  kind: 'year' as const,
+  label: '2026',
+  from: '2026-01-01T00:00:00.000Z',
+  to: '2026-12-31T23:59:59.999Z',
+  year: '2026',
+};
+
 describe('DashboardClient', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
 
   it('renders standard single profile view by default', () => {
-    render(<DashboardClient initialData={mockInitialData} username="Shivangi1515" />);
+    render(
+      <DashboardClient initialData={mockInitialData} username="Shivangi1515" period={mockPeriod} />
+    );
 
     expect(screen.getByText('Shivangi')).toBeDefined();
     expect(screen.getByTestId('profile-card')).toBeDefined();
     expect(screen.getByTestId('achievements')).toBeDefined();
     expect(screen.getByTestId('activity-landscape')).toBeDefined();
     expect(screen.getByTestId('language-chart')).toBeDefined();
-    expect(screen.getByTestId('heatmap')).toBeDefined();
+    expect(screen.getByTestId('historical-trend-view')).toBeDefined();
   });
 
   it('opens and closes the compare profile modal', async () => {
-    render(<DashboardClient initialData={mockInitialData} username="Shivangi1515" />);
+    render(
+      <DashboardClient initialData={mockInitialData} username="Shivangi1515" period={mockPeriod} />
+    );
 
     const compareBtn = screen.getByText('Compare Profile');
     expect(compareBtn).toBeDefined();
@@ -232,7 +248,9 @@ describe('DashboardClient', () => {
     );
     vi.stubGlobal('fetch', mockFetch);
 
-    render(<DashboardClient initialData={mockInitialData} username="Shivangi1515" />);
+    render(
+      <DashboardClient initialData={mockInitialData} username="Shivangi1515" period={mockPeriod} />
+    );
 
     const compareBtn = screen.getByText('Compare Profile');
     fireEvent.click(compareBtn);
@@ -265,7 +283,9 @@ describe('DashboardClient', () => {
     );
     vi.stubGlobal('fetch', mockFetch);
 
-    render(<DashboardClient initialData={mockInitialData} username="Shivangi1515" />);
+    render(
+      <DashboardClient initialData={mockInitialData} username="Shivangi1515" period={mockPeriod} />
+    );
 
     // 1. Enter compare mode
     const compareBtn = screen.getByText('Compare Profile');
@@ -300,7 +320,9 @@ describe('DashboardClient', () => {
   });
 
   it('generate your own button points to root /', () => {
-    render(<DashboardClient initialData={mockInitialData} username="Shivangi1515" />);
+    render(
+      <DashboardClient initialData={mockInitialData} username="Shivangi1515" period={mockPeriod} />
+    );
 
     const generateLink = screen.getByRole('link', { name: /generate your own/i });
     expect(generateLink.getAttribute('href')).toBe('/');
@@ -309,7 +331,9 @@ describe('DashboardClient', () => {
   // ISSUE OBJECTIVE: Verify error is shown when comparing with same username
   // =========================================================================
   it('shows an error when comparing with the same username (case-insensitive)', async () => {
-    render(<DashboardClient initialData={mockInitialData} username="Shivangi1515" />);
+    render(
+      <DashboardClient initialData={mockInitialData} username="Shivangi1515" period={mockPeriod} />
+    );
 
     // 1. Open modal
     const compareBtn = screen.getByText('Compare Profile');
@@ -334,7 +358,9 @@ describe('DashboardClient', () => {
   // ISSUE OBJECTIVE #1063: Verify compare modal input can be cleared
   // =========================================================================
   it('verify compare modal input can be cleared', async () => {
-    render(<DashboardClient initialData={mockInitialData} username="Shivangi1515" />);
+    render(
+      <DashboardClient initialData={mockInitialData} username="Shivangi1515" period={mockPeriod} />
+    );
 
     // 1. Open modal
     const compareBtn = screen.getByText('Compare Profile');
@@ -366,7 +392,9 @@ describe('DashboardClient', () => {
 
     vi.stubGlobal('fetch', mockFetch);
 
-    render(<DashboardClient initialData={mockInitialData} username="Shivangi1515" />);
+    render(
+      <DashboardClient initialData={mockInitialData} username="Shivangi1515" period={mockPeriod} />
+    );
 
     fireEvent.click(screen.getByText('Compare Profile'));
 
@@ -394,7 +422,13 @@ it('shows Most Consistent badge for profile with higher peak streak in compare m
 
   vi.stubGlobal('fetch', mockFetch);
 
-  render(<DashboardClient initialData={initialDataWithHigherStreak} username="Shivangi1515" />);
+  render(
+    <DashboardClient
+      initialData={initialDataWithHigherStreak}
+      username="Shivangi1515"
+      period={mockPeriod}
+    />
+  );
 
   fireEvent.click(screen.getByText('Compare Profile'));
 

--- a/components/dashboard/DashboardClient.tsx
+++ b/components/dashboard/DashboardClient.tsx
@@ -15,6 +15,7 @@ import ActivityLandscape from './ActivityLandscape';
 import LanguageChart from './LanguageChart';
 import CommitClock from './CommitClock';
 import Heatmap from './Heatmap';
+import HistoricalTrendView from './HistoricalTrendView';
 import AIInsights from './AIInsights';
 import StatsCard from './StatsCard';
 import RepositoryGraph from './RepositoryGraph';
@@ -22,6 +23,7 @@ import ComparisonStatsCard from './ComparisonStatsCard';
 import RadarChart from './RadarChart';
 import GrowthTrendChart from './GrowthTrendChart';
 import ProfileOptimizerModal from './ProfileOptimizerModal';
+import type { DashboardPeriod } from '@/utils/dashboardPeriod';
 
 // Define the dashboard data structure
 interface DashboardData {
@@ -75,6 +77,7 @@ interface DashboardData {
 interface DashboardClientProps {
   initialData: DashboardData;
   username: string;
+  period: DashboardPeriod;
 }
 
 export interface ProfileMetrics {
@@ -318,7 +321,7 @@ function getPersonalityTags(
 // DashboardClient Component
 // ------------------------------------------------------------
 
-export default function DashboardClient({ initialData, username }: DashboardClientProps) {
+export default function DashboardClient({ initialData, username, period }: DashboardClientProps) {
   const [secondUserData, setSecondUserData] = useState<DashboardData | null>(null);
   const [isCompareMode, setIsCompareMode] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -569,7 +572,11 @@ export default function DashboardClient({ initialData, username }: DashboardClie
             </section>
 
             <section>
-              <Heatmap data={initialData.activity} />
+              <HistoricalTrendView
+                activity={initialData.activity}
+                username={username}
+                period={period}
+              />
             </section>
           </div>
 
@@ -595,7 +602,7 @@ export default function DashboardClient({ initialData, username }: DashboardClie
               <StatsCard
                 title="Contributions"
                 value={initialData.stats.totalContributions.toString()}
-                description="Last Year"
+                description={period.label}
                 icon="GitCommit"
               />
             </div>

--- a/components/dashboard/Heatmap.tsx
+++ b/components/dashboard/Heatmap.tsx
@@ -25,7 +25,19 @@ interface TooltipState {
   y: number;
 }
 
-export default function Heatmap({ data }: { data: ActivityData[] }) {
+interface HeatmapProps {
+  data: ActivityData[];
+  title?: string;
+  subtitle?: string;
+  emptyMessage?: string;
+}
+
+export default function Heatmap({
+  data,
+  title = 'Contribution Heatmap',
+  subtitle = 'Last 365 days',
+  emptyMessage = 'No recent activity to display',
+}: HeatmapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(1);
   const [tooltip, setTooltip] = useState<TooltipState | null>(null);
@@ -83,12 +95,12 @@ export default function Heatmap({ data }: { data: ActivityData[] }) {
       >
         {/* Header */}
         <h3 className="my-1 text-sm font-semibold tracking-tight text-gray-900 dark:text-white">
-          Contribution Heatmap
+          {title}
         </h3>
 
         <div className="mb-4 flex items-end justify-between">
           <div>
-            <p className="mt-0.5 text-xs text-[#A1A1AA]">Last 365 days</p>
+            <p className="mt-0.5 text-xs text-[#A1A1AA]">{subtitle}</p>
           </div>
 
           <div className="flex items-center gap-2 text-xs text-[#A1A1AA]">
@@ -147,7 +159,7 @@ export default function Heatmap({ data }: { data: ActivityData[] }) {
           </div>
         ) : (
           <div className="flex h-[120px] items-center justify-center rounded-lg border border-dashed border-black/10 text-sm text-[#A1A1AA] dark:border-[rgba(255,255,255,0.08)]">
-            No recent activity to display
+            {emptyMessage}
           </div>
         )}
       </motion.div>

--- a/components/dashboard/HistoricalTrendView.tsx
+++ b/components/dashboard/HistoricalTrendView.tsx
@@ -1,0 +1,417 @@
+'use client';
+
+import { useMemo, type FormEvent } from 'react';
+import { ChevronLeft, ChevronRight, CalendarDays, Flame } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import type { ActivityData } from '@/types/dashboard';
+import Heatmap from './Heatmap';
+import {
+  dashboardPeriodToSearchParams,
+  resolveDashboardPeriod,
+  shiftDashboardPeriod,
+  type DashboardPeriod,
+} from '@/utils/dashboardPeriod';
+
+interface HistoricalTrendViewProps {
+  username: string;
+  activity: ActivityData[];
+  period: DashboardPeriod;
+}
+
+function formatDateInput(value: string): string {
+  return value.slice(0, 10);
+}
+
+function buildMonthBuckets(activity: ActivityData[]) {
+  const buckets = new Map<string, number>();
+
+  for (const day of activity) {
+    const key = day.date.slice(0, 7);
+    buckets.set(key, (buckets.get(key) || 0) + day.count);
+  }
+
+  return Array.from(buckets.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, count]) => {
+      const date = new Date(`${key}-01T00:00:00Z`);
+      return {
+        key,
+        label: new Intl.DateTimeFormat('en-US', {
+          month: 'short',
+          year: 'numeric',
+          timeZone: 'UTC',
+        }).format(date),
+        count,
+      };
+    });
+}
+
+function buildYearBuckets(activity: ActivityData[]) {
+  const buckets = new Map<string, number>();
+
+  for (const day of activity) {
+    const key = day.date.slice(0, 4);
+    buckets.set(key, (buckets.get(key) || 0) + day.count);
+  }
+
+  return Array.from(buckets.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, count]) => ({ key, label: key, count }));
+}
+
+function calculateStreakSeries(activity: ActivityData[]) {
+  const series: number[] = [];
+  let current = 0;
+
+  for (const day of activity) {
+    if (day.count > 0) {
+      current += 1;
+    } else {
+      current = 0;
+    }
+
+    series.push(current);
+  }
+
+  return series;
+}
+
+function formatAverage(total: number, days: number): string {
+  if (days === 0) return '0';
+  return (total / days).toFixed(1);
+}
+
+export default function HistoricalTrendView({
+  username,
+  activity,
+  period,
+}: HistoricalTrendViewProps) {
+  const router = useRouter();
+  const periodKey = `${period.kind}:${period.month ?? period.year ?? period.from}:${period.to}`;
+
+  const totalContributions = useMemo(
+    () => activity.reduce((sum, day) => sum + day.count, 0),
+    [activity]
+  );
+  const activeDays = useMemo(() => activity.filter((day) => day.count > 0).length, [activity]);
+  const peakDay = useMemo(
+    () =>
+      activity.reduce(
+        (best, day) => (day.count > best.count ? day : best),
+        activity[0] ?? { date: '', count: 0 }
+      ),
+    [activity]
+  );
+  const monthBuckets = useMemo(() => buildMonthBuckets(activity), [activity]);
+  const yearBuckets = useMemo(() => buildYearBuckets(activity), [activity]);
+  const streakSeries = useMemo(() => calculateStreakSeries(activity), [activity]);
+  const longestStreak = useMemo(
+    () => streakSeries.reduce((max, streak) => Math.max(max, streak), 0),
+    [streakSeries]
+  );
+  const currentStreak = streakSeries.at(-1) ?? 0;
+  const maxSeries = Math.max(...streakSeries, 1);
+  const sparklinePoints = streakSeries
+    .map((value, index) => {
+      const x = streakSeries.length <= 1 ? 0 : (index / (streakSeries.length - 1)) * 100;
+      const y = 100 - (value / maxSeries) * 100;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  const periodSummary = `${period.label} · ${activity.length} days`;
+
+  const navigateToPeriod = (nextPeriod: DashboardPeriod) => {
+    const params = dashboardPeriodToSearchParams(nextPeriod);
+    router.push(`/dashboard/${username}?${params.toString()}`);
+  };
+
+  const handleShift = (direction: 'prev' | 'next') => {
+    navigateToPeriod(shiftDashboardPeriod(period, direction));
+  };
+
+  const handleMonthSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const monthValue = String(formData.get('month') ?? '').trim();
+    if (!monthValue) return;
+    navigateToPeriod(resolveDashboardPeriod({ month: monthValue }));
+  };
+
+  const handleYearSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const yearValue = String(formData.get('year') ?? '').trim();
+    if (!yearValue) return;
+    navigateToPeriod(resolveDashboardPeriod({ year: yearValue }));
+  };
+
+  const handleRangeSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const rangeFrom = String(formData.get('from') ?? '').trim();
+    const rangeTo = String(formData.get('to') ?? '').trim();
+    if (!rangeFrom || !rangeTo) return;
+    navigateToPeriod(
+      resolveDashboardPeriod({
+        from: `${rangeFrom}T00:00:00.000Z`,
+        to: `${rangeTo}T23:59:59.999Z`,
+      })
+    );
+  };
+
+  return (
+    <section className="rounded-xl border border-black/10 bg-white p-6 dark:border-[rgba(255,255,255,0.08)] dark:bg-[#0a0a0a]">
+      <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="mb-2 inline-flex items-center gap-2 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.24em] text-emerald-600 dark:text-emerald-400">
+            <CalendarDays size={12} /> Historical Trend View
+          </p>
+          <h3 className="text-sm font-semibold tracking-tight text-gray-900 dark:text-white">
+            Explore long-term activity patterns across months and years
+          </h3>
+          <p className="mt-1 text-xs text-[#A1A1AA]">{periodSummary}</p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => handleShift('prev')}
+            className="inline-flex items-center gap-1 rounded-lg border border-black/10 px-3 py-2 text-xs font-semibold text-gray-900 transition hover:bg-gray-50 dark:border-[rgba(255,255,255,0.08)] dark:text-white dark:hover:bg-white/5"
+          >
+            <ChevronLeft size={14} /> Previous
+          </button>
+          <button
+            type="button"
+            onClick={() => handleShift('next')}
+            className="inline-flex items-center gap-1 rounded-lg border border-black/10 px-3 py-2 text-xs font-semibold text-gray-900 transition hover:bg-gray-50 dark:border-[rgba(255,255,255,0.08)] dark:text-white dark:hover:bg-white/5"
+          >
+            Next <ChevronRight size={14} />
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+        <div className="rounded-xl border border-black/10 bg-gray-50 p-4 dark:border-[rgba(255,255,255,0.06)] dark:bg-[#111]">
+          <p className="text-[10px] uppercase tracking-[0.22em] text-[#A1A1AA]">Contributions</p>
+          <p className="mt-2 text-3xl font-semibold text-gray-900 dark:text-white">
+            {totalContributions}
+          </p>
+          <p className="mt-1 text-xs text-[#A1A1AA]">Total in selected period</p>
+          <p className="mt-2 text-xs text-[#A1A1AA]">
+            Peak day: {peakDay.date ? `${peakDay.date} (${peakDay.count})` : 'n/a'}
+          </p>
+        </div>
+        <div className="rounded-xl border border-black/10 bg-gray-50 p-4 dark:border-[rgba(255,255,255,0.06)] dark:bg-[#111]">
+          <p className="text-[10px] uppercase tracking-[0.22em] text-[#A1A1AA]">Active Days</p>
+          <p className="mt-2 text-3xl font-semibold text-gray-900 dark:text-white">{activeDays}</p>
+          <p className="mt-1 text-xs text-[#A1A1AA]">Days with at least one contribution</p>
+        </div>
+        <div className="rounded-xl border border-black/10 bg-gray-50 p-4 dark:border-[rgba(255,255,255,0.06)] dark:bg-[#111]">
+          <p className="text-[10px] uppercase tracking-[0.22em] text-[#A1A1AA]">Current Streak</p>
+          <p className="mt-2 flex items-center gap-2 text-3xl font-semibold text-gray-900 dark:text-white">
+            <Flame size={22} className="text-emerald-500" />
+            {currentStreak}
+          </p>
+          <p className="mt-1 text-xs text-[#A1A1AA]">Based on the selected activity window</p>
+        </div>
+        <div className="rounded-xl border border-black/10 bg-gray-50 p-4 dark:border-[rgba(255,255,255,0.06)] dark:bg-[#111]">
+          <p className="text-[10px] uppercase tracking-[0.22em] text-[#A1A1AA]">Longest Streak</p>
+          <p className="mt-2 text-3xl font-semibold text-gray-900 dark:text-white">
+            {longestStreak}
+          </p>
+          <p className="mt-1 text-xs text-[#A1A1AA]">Peak run inside this period</p>
+        </div>
+      </div>
+
+      <div className="mt-6 grid grid-cols-1 gap-6 xl:grid-cols-[1.35fr_0.65fr]">
+        <div>
+          <div className="mb-3 flex items-end justify-between">
+            <div>
+              <h4 className="text-sm font-semibold tracking-tight text-gray-900 dark:text-white">
+                Streak Trend
+              </h4>
+              <p className="text-xs text-[#A1A1AA]">
+                Daily streak length across the selected period
+              </p>
+            </div>
+            <p className="text-xs font-medium text-[#A1A1AA]">
+              Avg/day {formatAverage(totalContributions, activity.length)}
+            </p>
+          </div>
+
+          <div className="rounded-xl border border-black/10 bg-gray-50 p-4 dark:border-[rgba(255,255,255,0.06)] dark:bg-[#111]">
+            {streakSeries.length > 0 ? (
+              <svg viewBox="0 0 100 100" className="h-40 w-full">
+                <defs>
+                  <linearGradient id="streak-gradient" x1="0" y1="0" x2="1" y2="0">
+                    <stop offset="0%" stopColor="#10b981" />
+                    <stop offset="100%" stopColor="#06b6d4" />
+                  </linearGradient>
+                </defs>
+                <polyline
+                  fill="none"
+                  stroke="url(#streak-gradient)"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  points={sparklinePoints}
+                />
+              </svg>
+            ) : (
+              <div className="flex h-40 items-center justify-center text-sm text-[#A1A1AA]">
+                No streak data available for this period
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div key={periodKey} className="space-y-4">
+          <form
+            onSubmit={handleMonthSubmit}
+            className="rounded-xl border border-black/10 bg-gray-50 p-4 dark:border-[rgba(255,255,255,0.06)] dark:bg-[#111]"
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[#A1A1AA]">
+              Pick Month
+            </p>
+            <div className="mt-3 flex gap-2">
+              <input
+                name="month"
+                type="month"
+                defaultValue={period.kind === 'month' && period.month ? period.month : ''}
+                className="min-w-0 flex-1 rounded-lg border border-black/10 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-emerald-500 dark:border-[rgba(255,255,255,0.08)] dark:bg-black/30 dark:text-white"
+              />
+              <button
+                type="submit"
+                className="rounded-lg bg-black px-3 py-2 text-sm font-semibold text-white transition hover:bg-zinc-800 dark:bg-white dark:text-black dark:hover:bg-gray-100"
+              >
+                Go
+              </button>
+            </div>
+          </form>
+
+          <form
+            onSubmit={handleYearSubmit}
+            className="rounded-xl border border-black/10 bg-gray-50 p-4 dark:border-[rgba(255,255,255,0.06)] dark:bg-[#111]"
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[#A1A1AA]">
+              Pick Year
+            </p>
+            <div className="mt-3 flex gap-2">
+              <input
+                name="year"
+                type="number"
+                min="2008"
+                max={new Date().getUTCFullYear() + 5}
+                defaultValue={period.kind === 'year' && period.year ? period.year : ''}
+                className="min-w-0 flex-1 rounded-lg border border-black/10 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-emerald-500 dark:border-[rgba(255,255,255,0.08)] dark:bg-black/30 dark:text-white"
+              />
+              <button
+                type="submit"
+                className="rounded-lg bg-black px-3 py-2 text-sm font-semibold text-white transition hover:bg-zinc-800 dark:bg-white dark:text-black dark:hover:bg-gray-100"
+              >
+                Go
+              </button>
+            </div>
+          </form>
+
+          <form
+            onSubmit={handleRangeSubmit}
+            className="rounded-xl border border-black/10 bg-gray-50 p-4 dark:border-[rgba(255,255,255,0.06)] dark:bg-[#111]"
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[#A1A1AA]">
+              Custom Range
+            </p>
+            <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <input
+                name="from"
+                type="date"
+                defaultValue={formatDateInput(period.from)}
+                className="rounded-lg border border-black/10 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-emerald-500 dark:border-[rgba(255,255,255,0.08)] dark:bg-black/30 dark:text-white"
+              />
+              <input
+                name="to"
+                type="date"
+                defaultValue={formatDateInput(period.to)}
+                className="rounded-lg border border-black/10 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-emerald-500 dark:border-[rgba(255,255,255,0.08)] dark:bg-black/30 dark:text-white"
+              />
+            </div>
+            <button
+              type="submit"
+              className="mt-3 w-full rounded-lg bg-black px-3 py-2 text-sm font-semibold text-white transition hover:bg-zinc-800 dark:bg-white dark:text-black dark:hover:bg-gray-100"
+            >
+              Apply Range
+            </button>
+          </form>
+        </div>
+      </div>
+
+      <div className="mt-6 grid grid-cols-1 gap-6 xl:grid-cols-2">
+        <div>
+          <h4 className="mb-3 text-sm font-semibold tracking-tight text-gray-900 dark:text-white">
+            Monthly Summary
+          </h4>
+          <div className="space-y-2 rounded-xl border border-black/10 bg-gray-50 p-4 dark:border-[rgba(255,255,255,0.06)] dark:bg-[#111]">
+            {monthBuckets.length > 0 ? (
+              monthBuckets.map((bucket) => (
+                <div key={bucket.key} className="flex items-center gap-3">
+                  <span className="w-24 shrink-0 text-xs text-[#A1A1AA]">{bucket.label}</span>
+                  <div className="h-2 flex-1 overflow-hidden rounded-full bg-black/5 dark:bg-white/10">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-emerald-400 to-cyan-400"
+                      style={{
+                        width: `${Math.max(8, (bucket.count / Math.max(...monthBuckets.map((item) => item.count), 1)) * 100)}%`,
+                      }}
+                    />
+                  </div>
+                  <span className="w-12 text-right text-xs font-semibold text-gray-900 dark:text-white">
+                    {bucket.count}
+                  </span>
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-[#A1A1AA]">No monthly breakdown available.</p>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <h4 className="mb-3 text-sm font-semibold tracking-tight text-gray-900 dark:text-white">
+            Yearly Summary
+          </h4>
+          <div className="space-y-2 rounded-xl border border-black/10 bg-gray-50 p-4 dark:border-[rgba(255,255,255,0.06)] dark:bg-[#111]">
+            {yearBuckets.length > 0 ? (
+              yearBuckets.map((bucket) => (
+                <div key={bucket.key} className="flex items-center gap-3">
+                  <span className="w-16 shrink-0 text-xs text-[#A1A1AA]">{bucket.label}</span>
+                  <div className="h-2 flex-1 overflow-hidden rounded-full bg-black/5 dark:bg-white/10">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-cyan-400 to-emerald-400"
+                      style={{
+                        width: `${Math.max(8, (bucket.count / Math.max(...yearBuckets.map((item) => item.count), 1)) * 100)}%`,
+                      }}
+                    />
+                  </div>
+                  <span className="w-12 text-right text-xs font-semibold text-gray-900 dark:text-white">
+                    {bucket.count}
+                  </span>
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-[#A1A1AA]">No yearly breakdown available.</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <Heatmap
+          data={activity}
+          title="Historical Heatmap"
+          subtitle={period.label}
+          emptyMessage="No activity found for this period"
+        />
+      </div>
+    </section>
+  );
+}

--- a/components/dashboard/RefreshButton.tsx
+++ b/components/dashboard/RefreshButton.tsx
@@ -20,13 +20,18 @@ export default function RefreshButton({ username }: RefreshButtonProps) {
     if (searchParams.get('refresh') === 'true') {
       toast.success('Dashboard refreshed successfully');
 
-      router.replace(`/dashboard/${username}`);
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete('refresh');
+      const query = params.toString();
+      router.replace(`/dashboard/${username}${query ? `?${query}` : ''}`);
     }
   }, [searchParams, router, username]);
 
   const handleRefresh = () => {
     startTransition(() => {
-      router.push(`/dashboard/${username}?refresh=true`);
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('refresh', 'true');
+      router.push(`/dashboard/${username}?${params.toString()}`);
 
       router.refresh();
     });

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -861,12 +861,16 @@ type Language = {
   name: string;
 };
 
-export function buildInsights(streakStats: StreakStats, languages: Language[]) {
+export function buildInsights(
+  streakStats: StreakStats,
+  languages: Language[],
+  periodLabel = 'this year'
+) {
   const insights = [
     {
       id: '1',
       icon: 'Flame',
-      text: `You have a total of ${streakStats.totalContributions} contributions this year.`,
+      text: `You have a total of ${streakStats.totalContributions} contributions during ${periodLabel}.`,
     },
     {
       id: '2',
@@ -1082,7 +1086,7 @@ export async function getFullDashboardData(username: string, options: FetchOptio
     streakStats.longestStreak
   );
 
-  const insights = buildInsights(streakStats, languages);
+  const insights = buildInsights(streakStats, languages, options.rangeLabel ?? 'this year');
 
   // Building Graph Data
   const nodes: GraphNode[] = [];

--- a/utils/dashboardPeriod.ts
+++ b/utils/dashboardPeriod.ts
@@ -1,0 +1,201 @@
+export type DashboardPeriodKind = 'rolling' | 'month' | 'year' | 'range';
+
+export interface DashboardPeriod {
+  kind: DashboardPeriodKind;
+  label: string;
+  from: string;
+  to: string;
+  month?: string;
+  year?: string;
+}
+
+export interface DashboardPeriodInput {
+  year?: string;
+  month?: string;
+  from?: string;
+  to?: string;
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function startOfMonthUtc(year: number, monthIndex: number): Date {
+  return new Date(Date.UTC(year, monthIndex, 1, 0, 0, 0, 0));
+}
+
+function endOfMonthUtc(year: number, monthIndex: number): Date {
+  return new Date(Date.UTC(year, monthIndex + 1, 0, 23, 59, 59, 999));
+}
+
+function addMonthsUtc(date: Date, offset: number): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + offset, date.getUTCDate(), 0, 0, 0, 0)
+  );
+}
+
+function addDaysUtc(date: Date, offset: number): Date {
+  return new Date(date.getTime() + offset * 24 * 60 * 60 * 1000);
+}
+
+function isValidIsoDate(value?: string): value is string {
+  return Boolean(value) && !Number.isNaN(Date.parse(value));
+}
+
+function toIsoDayStart(date: Date): string {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, 0)
+  ).toISOString();
+}
+
+function toIsoDayEnd(date: Date): string {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 23, 59, 59, 999)
+  ).toISOString();
+}
+
+function formatMonthLabel(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+function formatRollingLabel(start: Date, end: Date): string {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+
+  return `${formatter.format(start)} to ${formatter.format(end)}`;
+}
+
+export function resolveDashboardPeriod(
+  input: DashboardPeriodInput,
+  now: Date = new Date()
+): DashboardPeriod {
+  const currentYear = now.getUTCFullYear();
+
+  if (isValidIsoDate(input.from) && isValidIsoDate(input.to)) {
+    const from = new Date(input.from);
+    const to = new Date(input.to);
+
+    return {
+      kind: 'range',
+      label: formatRollingLabel(from, to),
+      from: toIsoDayStart(from),
+      to: toIsoDayEnd(to),
+    };
+  }
+
+  if (input.month && /^\d{4}-\d{2}$/.test(input.month)) {
+    const [yearPart, monthPart] = input.month.split('-');
+    const yearValue = Number(yearPart);
+    const monthValue = Number(monthPart);
+
+    if (
+      Number.isFinite(yearValue) &&
+      Number.isFinite(monthValue) &&
+      monthValue >= 1 &&
+      monthValue <= 12
+    ) {
+      const monthIndex = monthValue - 1;
+      const start = startOfMonthUtc(yearValue, monthIndex);
+      const end = endOfMonthUtc(yearValue, monthIndex);
+
+      return {
+        kind: 'month',
+        label: formatMonthLabel(start),
+        month: input.month,
+        from: start.toISOString(),
+        to: end.toISOString(),
+      };
+    }
+  }
+
+  if (input.year && /^\d{4}$/.test(input.year)) {
+    const yearValue = Number(input.year);
+
+    if (yearValue >= 2008 && yearValue <= currentYear + 5) {
+      const start = new Date(Date.UTC(yearValue, 0, 1, 0, 0, 0, 0));
+      const end = new Date(Date.UTC(yearValue, 11, 31, 23, 59, 59, 999));
+
+      return {
+        kind: 'year',
+        label: input.year,
+        year: input.year,
+        from: start.toISOString(),
+        to: end.toISOString(),
+      };
+    }
+  }
+
+  const end = endOfMonthUtc(currentYear, now.getUTCMonth());
+  const start = startOfMonthUtc(currentYear, now.getUTCMonth() - 11);
+
+  return {
+    kind: 'rolling',
+    label: 'Last 12 months',
+    from: start.toISOString(),
+    to: end.toISOString(),
+  };
+}
+
+export function shiftDashboardPeriod(
+  period: DashboardPeriod,
+  direction: 'prev' | 'next'
+): DashboardPeriod {
+  const offset = direction === 'next' ? 1 : -1;
+
+  if (period.kind === 'month') {
+    const base = new Date(period.from);
+    const shifted = addMonthsUtc(base, offset);
+    const month = `${shifted.getUTCFullYear()}-${pad(shifted.getUTCMonth() + 1)}`;
+    return resolveDashboardPeriod({ month });
+  }
+
+  if (period.kind === 'year') {
+    const base = new Date(period.from);
+    const year = String(base.getUTCFullYear() + offset);
+    return resolveDashboardPeriod({ year });
+  }
+
+  if (period.kind === 'range') {
+    const from = new Date(period.from);
+    const to = new Date(period.to);
+    const spanDays = Math.max(
+      1,
+      Math.round((to.getTime() - from.getTime()) / (24 * 60 * 60 * 1000)) + 1
+    );
+    const shiftedFrom = addDaysUtc(from, offset * spanDays);
+    const shiftedTo = addDaysUtc(to, offset * spanDays);
+    return resolveDashboardPeriod({ from: shiftedFrom.toISOString(), to: shiftedTo.toISOString() });
+  }
+
+  const from = new Date(period.from);
+  const to = new Date(period.to);
+  const shiftedFrom = addMonthsUtc(from, offset);
+  const shiftedTo = addMonthsUtc(to, offset);
+  return resolveDashboardPeriod({ from: shiftedFrom.toISOString(), to: shiftedTo.toISOString() });
+}
+
+export function dashboardPeriodToSearchParams(period: DashboardPeriod): URLSearchParams {
+  const params = new URLSearchParams();
+
+  if (period.kind === 'month' && period.month) {
+    params.set('month', period.month);
+    return params;
+  }
+
+  if (period.kind === 'year' && period.year) {
+    params.set('year', period.year);
+    return params;
+  }
+
+  params.set('from', period.from);
+  params.set('to', period.to);
+  return params;
+}


### PR DESCRIPTION
## Description

Fixes #2066

This PR adds support for viewing historical contribution trends across multiple months and years instead of being limited to the current month.

### Changes

* Added navigation and support for exploring contribution history across different months and years.
* Extended trend calculations to work with larger historical date ranges.
* Improved visibility into long-term contribution patterns and streak history.
* Laid the groundwork for future enhancements such as custom date ranges and period comparisons.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
