### PR TITLE
test(utils): check boundary robustness of JSON response serializer

### DIFF
--- a/utils/tracking.test.ts
+++ b/utils/tracking.test.ts
@@ -176,3 +176,35 @@ describe('trackUser', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });
+
+//JSON RESPONSE SERIALIZER BOUNDARY ROBUSTNESS
+
+describe('trackUser — JSON response serializer boundary robustness (Variation 2)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+
+    Object.defineProperty(navigator, 'sendBeacon', {
+      value: originalSendBeacon,
+      configurable: true,
+    });
+  });
+
+  it('does not throw or send a beacon when JSON.stringify fails', () => {
+    vi.spyOn(JSON, 'stringify').mockImplementationOnce(() => {
+      throw new TypeError('Converting circular structure to JSON');
+    });
+
+    const sendBeaconMock = vi.fn();
+    Object.defineProperty(navigator, 'sendBeacon', {
+      value: sendBeaconMock,
+      configurable: true,
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(() => trackUser('testuser')).not.toThrow();
+    expect(sendBeaconMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description
Adds a new describe block in utils/tracking.test.ts to verify the boundary robustness of the JSON response serializer inside trackUser.
The test simulates a serialization failure by mocking JSON.stringify to throw a TypeError.
Asserts that:
The function does not throw or propagate the exception to the caller.
No beacon is dispatched.
No fetch fallback is triggered.

Fixes #1566

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
