### PR TITLE
fix: reuse timezone validation for stats params

### DIFF
--- a/app/api/stats/route.test.ts
+++ b/app/api/stats/route.test.ts
@@ -69,7 +69,8 @@ describe('GET /api/stats', () => {
     const response = await GET(makeRequest({ user: 'testuser', tz: 'Not/ATimezone' }));
     expect(response.status).toBe(400);
     const body = await response.json();
-    expect(body.error).toMatch(/Invalid "tz" parameter/);
+    expect(body.error).toBe('Invalid parameters');
+    expect(body.details.fieldErrors.tz[0]).toContain('Invalid timezone');
   });
 
   // ─── Successful responses ──────────────────────────────────────────────────

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -34,17 +34,9 @@ export async function GET(request: Request) {
   }
 
   const { user, refresh, tz } = parseResult.data;
-
-  // Validate the optional IANA timezone early so callers get a clear 400
-  // rather than a silent fallback or a 500.
-  let timezone = 'UTC';
-  if (tz) {
-    try {
-      timezone = new Intl.DateTimeFormat(undefined, { timeZone: tz }).resolvedOptions().timeZone;
-    } catch {
-      return NextResponse.json({ error: `Invalid "tz" parameter: "${tz}"` }, { status: 400 });
-    }
-  }
+  const timezone = tz
+    ? new Intl.DateTimeFormat(undefined, { timeZone: tz }).resolvedOptions().timeZone
+    : 'UTC';
 
   try {
     const userData = await fetchGitHubContributions(user, { bypassCache: refresh });

--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { githubParamsSchema, ogParamsSchema, streakParamsSchema } from './validations';
+import {
+  githubParamsSchema,
+  ogParamsSchema,
+  statsParamsSchema,
+  streakParamsSchema,
+} from './validations';
 
 describe('streakParamsSchema — grace fallback behavior', () => {
   it('accepts "0" as a valid grace value', () => {
@@ -878,6 +883,32 @@ describe('streakParamsSchema — tz IANA timezone validation (Variation 4)', () 
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.issues[0]?.message).toContain('Invalid timezone');
+    }
+  });
+});
+
+describe('statsParamsSchema — tz IANA timezone validation', () => {
+  it('rejects an invalid timezone before route handlers calculate stats', () => {
+    const result = statsParamsSchema.safeParse({
+      user: 'octocat',
+      tz: 'Mars/Cyonia',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain('Invalid timezone');
+    }
+  });
+
+  it('accepts a valid IANA timezone', () => {
+    const result = statsParamsSchema.safeParse({
+      user: 'octocat',
+      tz: 'America/New_York',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.tz).toBe('America/New_York');
     }
   });
 });

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -58,6 +58,24 @@ function dimensionParam(name: string, min: number, max: number) {
     .transform(toDimensionValue);
 }
 
+function timezoneParam() {
+  return z
+    .string()
+    .optional()
+    .refine(
+      (val) => {
+        if (!val) return true;
+        try {
+          new Intl.DateTimeFormat(undefined, { timeZone: val });
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { message: 'Invalid timezone. Must be a valid IANA timezone (e.g. America/New_York).' }
+    );
+}
+
 const GITHUB_USERNAME_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9]))*$/;
 
 const baseStreakParamsSchema = z.object({
@@ -179,21 +197,7 @@ const baseStreakParamsSchema = z.object({
       },
       { message: 'Invalid "date" format. Use ISO 8601.' }
     ),
-  tz: z
-    .string()
-    .optional()
-    .refine(
-      (val) => {
-        if (!val) return true;
-        try {
-          new Intl.DateTimeFormat(undefined, { timeZone: val });
-          return true;
-        } catch {
-          return false;
-        }
-      },
-      { message: 'Invalid timezone. Must be a valid IANA timezone (e.g. America/New_York).' }
-    ),
+  tz: timezoneParam(),
   refresh: z.string().optional().transform(toRefreshFlag),
   hide_title: z.string().optional().transform(toBooleanFlag),
   hide_background: z.string().optional().transform(toBooleanFlag),
@@ -332,7 +336,7 @@ export const statsParamsSchema = z.object({
       message: 'Invalid GitHub username',
     }),
   refresh: z.string().optional().transform(toRefreshFlag),
-  tz: z.string().optional(),
+  tz: timezoneParam(),
 });
 
 export const wrappedParamsSchema = z.object({


### PR DESCRIPTION
## Description

Fixes #2113.

- Extracts the IANA timezone validation into a reusable Zod helper.
- Applies the same validation to statsParamsSchema so /api/stats rejects invalid tz values at the schema layer.
- Removes the route-local timezone try/catch and updates route/schema coverage.

## Testing

- npm test -- lib/validations.test.ts app/api/stats/route.test.ts
- npm run typecheck
