### PR TITLE
fix(streak): replace hash-based random theme with Math.random() for true randomness

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -119,9 +119,8 @@ export async function GET(request: Request) {
       if (isAutoTheme) return themes.light;
       if (isRandomTheme) {
         const keys = Object.keys(themes);
-        const hash = user.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
-        const stableKey = keys[hash % keys.length];
-        return themes[stableKey] || themes.dark;
+        const randomKey = keys[Math.floor(Math.random() * keys.length)];
+        return themes[randomKey] || themes.dark;
       }
       return themes[theme] || themes.dark;
     })();


### PR DESCRIPTION
## Description

Fixes #2170 

- `app/api/streak/route.ts` — replaced the `hash-based` theme selection in the `isRandomTheme` block with `Math.random()`. The previous implementation derived a deterministic key from the username hash, causing `?theme=random` to always return the same theme for the same user. Using `Math.random()` ensures a genuinely different theme is picked on every request as intended.

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
https://collection.cloudinary.com/dqvm8dce2/6465bd0681a3db8305ceaff2f9528020

## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.
