### PR TITLE
Fix race condition in GitHub contribution cache during concurrent API calls

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -392,28 +392,49 @@ export async function fetchGitHubContributions(
   options: FetchOptions = {}
 ): Promise<ExtendedContributionData> {
   const key = cacheKey('contributions', username, options.from, options.to);
-  const cached = await contributionsCache.get(key);
 
-  const now = Date.now();
-  const isStale = cached?.calendar.lastSyncedAt
-    ? now - new Date(cached.calendar.lastSyncedAt).getTime() > GITHUB_CACHE_TTL_MS
-    : true;
-
-  if (cached && !isStale && !options.bypassCache) {
-    return cached;
+  if (options.bypassCache) {
+    return fetchContributionsUncached(username, key, options, null);
   }
 
-  const load = async () => {
-    const isDeltaSync = cached && cached.calendar.lastSyncedAt && !options.bypassCache;
-    let queryFrom = options.from;
+  // Wrap the entire cache-check + fetch pipeline in dedupeRequest so that
+  // concurrent calls for the same key share a single in-flight promise.
+  // This closes the TOCTOU window where two requests both miss the cache
+  // (during the async DistributedCache.get) and each fires its own API call.
+  const load = async (): Promise<ExtendedContributionData> => {
+    const cached = await contributionsCache.get(key);
 
-    if (isDeltaSync) {
-      const lastSyncedDate = new Date(cached.calendar.lastSyncedAt!);
-      lastSyncedDate.setUTCDate(lastSyncedDate.getUTCDate() - 1);
-      queryFrom = lastSyncedDate.toISOString();
+    const now = Date.now();
+    const isStale = cached?.calendar.lastSyncedAt
+      ? now - new Date(cached.calendar.lastSyncedAt).getTime() > GITHUB_CACHE_TTL_MS
+      : true;
+
+    if (cached && !isStale) {
+      return cached;
     }
 
-    const query = `
+    return fetchContributionsUncached(username, key, options, cached);
+  };
+
+  return dedupeRequest(pendingContributions, key, load);
+}
+
+async function fetchContributionsUncached(
+  username: string,
+  key: string,
+  options: FetchOptions,
+  cached: ExtendedContributionData | null
+): Promise<ExtendedContributionData> {
+  const isDeltaSync = cached && cached.calendar.lastSyncedAt && !options.bypassCache;
+  let queryFrom = options.from;
+
+  if (isDeltaSync) {
+    const lastSyncedDate = new Date(cached.calendar.lastSyncedAt!);
+    lastSyncedDate.setUTCDate(lastSyncedDate.getUTCDate() - 1);
+    queryFrom = lastSyncedDate.toISOString();
+  }
+
+  const query = `
       query($login: String!, $from: DateTime, $to: DateTime) {
         user(login: $login) {
           contributionsCollection(from: $from, to: $to) {
@@ -442,112 +463,108 @@ export async function fetchGitHubContributions(
       }
     `;
 
-    const res = await fetchGraphQLWithRetry(GITHUB_GRAPHQL_URL, {
-      method: 'POST',
-      headers: getHeaders(),
-      body: JSON.stringify({
-        query,
-        variables: { login: username, from: queryFrom, to: options.to },
-      }),
-      cache: 'no-store',
-      signal: options.signal,
-    });
+  const res = await fetchGraphQLWithRetry(GITHUB_GRAPHQL_URL, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify({
+      query,
+      variables: { login: username, from: queryFrom, to: options.to },
+    }),
+    cache: 'no-store',
+    signal: options.signal,
+  });
 
-    if (!res.ok) {
-      throwIfRateLimited(res);
-      if (res.status === 401) throw new Error('GitHub PAT is invalid or missing');
-      throw new Error(
-        `GitHub GraphQL API returned status ${res.status} after ${MAX_RETRIES} retries`
+  if (!res.ok) {
+    throwIfRateLimited(res);
+    if (res.status === 401) throw new Error('GitHub PAT is invalid or missing');
+    throw new Error(
+      `GitHub GraphQL API returned status ${res.status} after ${MAX_RETRIES} retries`
+    );
+  }
+
+  const data: GitHubGraphQLResponse = await res.json();
+
+  if (data.errors !== undefined) {
+    if (Array.isArray(data.errors)) {
+      const isRateLimit = data.errors.some(
+        (e) =>
+          e?.message?.toLowerCase().includes('rate limit') ||
+          (e as { type?: string })?.type === 'RATE_LIMITED'
       );
-    }
-
-    const data: GitHubGraphQLResponse = await res.json();
-
-    if (data.errors !== undefined) {
-      if (Array.isArray(data.errors)) {
-        const isRateLimit = data.errors.some(
-          (e) =>
-            e?.message?.toLowerCase().includes('rate limit') ||
-            (e as { type?: string })?.type === 'RATE_LIMITED'
-        );
-        if (isRateLimit) {
-          throw new Error('API Rate Limit Exceeded');
-        }
+      if (isRateLimit) {
+        throw new Error('API Rate Limit Exceeded');
       }
-      throw new Error(getGraphQLErrorMessage(data.errors));
     }
+    throw new Error(getGraphQLErrorMessage(data.errors));
+  }
 
-    if (!data.data?.user) {
-      throw new Error(`GitHub user "${username}" not found`);
-    }
+  if (!data.data?.user) {
+    throw new Error(`GitHub user "${username}" not found`);
+  }
 
-    let calendar = data.data.user.contributionsCollection?.contributionCalendar;
-    const repoContributions =
-      data.data.user.contributionsCollection?.commitContributionsByRepository || [];
+  let calendar = data.data.user.contributionsCollection?.contributionCalendar;
+  const repoContributions =
+    data.data.user.contributionsCollection?.commitContributionsByRepository || [];
 
-    if (!calendar || !calendar.weeks) {
-      calendar = {
-        totalContributions: 0,
-        weeks: [],
-      };
-    }
-
-    if (isDeltaSync && cached) {
-      calendar = mergeCalendars(cached.calendar, calendar);
-    }
-
-    // Inject deterministic Lines of Code (LoC) approximation
-    // Since GitHub's contributionCalendar doesn't provide native LoC metrics,
-    // we generate a consistent estimation based on the day's commit volume.
-    calendar.weeks.forEach((week) => {
-      week.contributionDays.forEach((day) => {
-        if (day.contributionCount > 0) {
-          let hash1 = 2166136261,
-            hash2 = 2166136261;
-          const seed1 = day.date + 'add',
-            seed2 = day.date + 'del';
-          for (let i = 0; i < seed1.length; i++) {
-            hash1 ^= seed1.charCodeAt(i);
-            hash1 = Math.imul(hash1, 16777619);
-          }
-          for (let i = 0; i < seed2.length; i++) {
-            hash2 ^= seed2.charCodeAt(i);
-            hash2 = Math.imul(hash2, 16777619);
-          }
-          const randAdd = (hash1 >>> 0) / 4294967296;
-          const randDel = (hash2 >>> 0) / 4294967296;
-
-          day.locAdditions = Math.floor(day.contributionCount * (25 + randAdd * 85));
-          day.locDeletions = Math.floor(day.contributionCount * (5 + randDel * 35));
-        } else {
-          day.locAdditions = 0;
-          day.locDeletions = 0;
-        }
-      });
-    });
-
-    calendar.lastSyncedAt = new Date().toISOString();
-
-    // Cache for 7 days to enable delta syncs, staleness is handled logically
-    const LONG_CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
-    if (!options.bypassCache) {
-      await contributionsCache.set(
-        key,
-        {
-          calendar,
-          repoContributions,
-        },
-        LONG_CACHE_TTL
-      );
-    }
-    return {
-      calendar,
-      repoContributions,
+  if (!calendar || !calendar.weeks) {
+    calendar = {
+      totalContributions: 0,
+      weeks: [],
     };
-  };
+  }
 
-  if (options.bypassCache) return load();
-  return dedupeRequest(pendingContributions, key, load);
+  if (isDeltaSync && cached) {
+    calendar = mergeCalendars(cached.calendar, calendar);
+  }
+
+  // Inject deterministic Lines of Code (LoC) approximation
+  // Since GitHub's contributionCalendar doesn't provide native LoC metrics,
+  // we generate a consistent estimation based on the day's commit volume.
+  calendar.weeks.forEach((week) => {
+    week.contributionDays.forEach((day) => {
+      if (day.contributionCount > 0) {
+        let hash1 = 2166136261,
+          hash2 = 2166136261;
+        const seed1 = day.date + 'add',
+          seed2 = day.date + 'del';
+        for (let i = 0; i < seed1.length; i++) {
+          hash1 ^= seed1.charCodeAt(i);
+          hash1 = Math.imul(hash1, 16777619);
+        }
+        for (let i = 0; i < seed2.length; i++) {
+          hash2 ^= seed2.charCodeAt(i);
+          hash2 = Math.imul(hash2, 16777619);
+        }
+        const randAdd = (hash1 >>> 0) / 4294967296;
+        const randDel = (hash2 >>> 0) / 4294967296;
+
+        day.locAdditions = Math.floor(day.contributionCount * (25 + randAdd * 85));
+        day.locDeletions = Math.floor(day.contributionCount * (5 + randDel * 35));
+      } else {
+        day.locAdditions = 0;
+        day.locDeletions = 0;
+      }
+    });
+  });
+
+  calendar.lastSyncedAt = new Date().toISOString();
+
+  // Cache for 7 days to enable delta syncs, staleness is handled logically
+  const LONG_CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
+  if (!options.bypassCache) {
+    await contributionsCache.set(
+      key,
+      {
+        calendar,
+        repoContributions,
+      },
+      LONG_CACHE_TTL
+    );
+  }
+  return {
+    calendar,
+    repoContributions,
+  };
 }
 
 export async function fetchUserProfile(
@@ -556,37 +573,46 @@ export async function fetchUserProfile(
 ): Promise<GitHubUserProfile> {
   const key = cacheKey('profile', username);
   const encodedUsername = encodeURIComponent(username);
-  if (!options.bypassCache) {
-    const cached = await profileCache.get(key);
-    if (cached) return cached;
+
+  if (options.bypassCache) {
+    return fetchProfileUncached(encodedUsername, key, options);
   }
 
-  const load = async () => {
-    const res = await fetchWithRetry(`${GITHUB_REST_URL}/users/${encodedUsername}`, {
-      headers: getHeaders(),
-      cache: 'no-store',
-      signal: options.signal,
-    });
-
-    if (!res.ok) {
-      throwIfRateLimited(res);
-      if (res.status === 404) throw new Error('User not found');
-      if (res.status === 403 && res.headers.get('x-ratelimit-remaining') === '0') {
-        throw new Error('API Rate Limit Exceeded');
-      }
-      if (res.status === 429) {
-        throw new Error('API Rate Limit Exceeded');
-      }
-      throw new Error(`GitHub REST API error: ${res.status}`);
-    }
-
-    const profile = (await res.json()) as GitHubUserProfile;
-    if (!options.bypassCache) await profileCache.set(key, profile, GITHUB_CACHE_TTL_MS);
-    return profile;
+  const load = async (): Promise<GitHubUserProfile> => {
+    const cached = await profileCache.get(key);
+    if (cached) return cached;
+    return fetchProfileUncached(encodedUsername, key, options);
   };
 
-  if (options.bypassCache) return load();
   return dedupeRequest(pendingProfiles, key, load);
+}
+
+async function fetchProfileUncached(
+  encodedUsername: string,
+  key: string,
+  options: FetchOptions
+): Promise<GitHubUserProfile> {
+  const res = await fetchWithRetry(`${GITHUB_REST_URL}/users/${encodedUsername}`, {
+    headers: getHeaders(),
+    cache: 'no-store',
+    signal: options.signal,
+  });
+
+  if (!res.ok) {
+    throwIfRateLimited(res);
+    if (res.status === 404) throw new Error('User not found');
+    if (res.status === 403 && res.headers.get('x-ratelimit-remaining') === '0') {
+      throw new Error('API Rate Limit Exceeded');
+    }
+    if (res.status === 429) {
+      throw new Error('API Rate Limit Exceeded');
+    }
+    throw new Error(`GitHub REST API error: ${res.status}`);
+  }
+
+  const profile = (await res.json()) as GitHubUserProfile;
+  if (!options.bypassCache) await profileCache.set(key, profile, GITHUB_CACHE_TTL_MS);
+  return profile;
 }
 
 export async function fetchUserRepos(
@@ -595,69 +621,78 @@ export async function fetchUserRepos(
 ): Promise<GitHubRepo[]> {
   const key = cacheKey('repos', username);
   const encodedUsername = encodeURIComponent(username);
-  if (!options.bypassCache) {
-    const cached = await reposCache.get(key);
-    if (cached) return cached;
+
+  if (options.bypassCache) {
+    return fetchReposUncached(encodedUsername, key, options);
   }
 
-  const load = async () => {
-    const firstPageRes = await fetchWithRetry(
-      `${GITHUB_REST_URL}/users/${encodedUsername}/repos?per_page=100&page=1&sort=pushed`,
-      {
-        headers: getHeaders(),
-        cache: 'no-store',
-        signal: options.signal,
-      }
-    );
-
-    if (!firstPageRes.ok) {
-      throwIfRateLimited(firstPageRes);
-      throw new Error(`GitHub REST API error: ${firstPageRes.status}`);
-    }
-
-    const firstPageRepos = (await firstPageRes.json()) as GitHubRepo[];
-    const allRepos: GitHubRepo[] = [...firstPageRepos];
-
-    const MAX_PAGES = 3;
-
-    if (firstPageRepos.length === 100) {
-      const remainingPages = Array.from({ length: MAX_PAGES - 1 }, (_, i) => i + 2);
-
-      const responses = await Promise.all(
-        remainingPages.map((page) =>
-          fetchWithRetry(
-            `${GITHUB_REST_URL}/users/${encodedUsername}/repos?per_page=100&page=${page}&sort=pushed`,
-            {
-              headers: getHeaders(),
-              cache: 'no-store',
-              signal: options.signal,
-            }
-          )
-        )
-      );
-
-      const pagesRepos = await Promise.all(
-        responses.map(async (response) => {
-          if (!response.ok) {
-            throwIfRateLimited(response);
-            throw new Error(`GitHub REST API error: ${response.status}`);
-          }
-
-          return (await response.json()) as GitHubRepo[];
-        })
-      );
-
-      for (const repos of pagesRepos) {
-        allRepos.push(...repos);
-      }
-    }
-
-    if (!options.bypassCache) await reposCache.set(key, allRepos, GITHUB_CACHE_TTL_MS);
-    return allRepos;
+  const load = async (): Promise<GitHubRepo[]> => {
+    const cached = await reposCache.get(key);
+    if (cached) return cached;
+    return fetchReposUncached(encodedUsername, key, options);
   };
 
-  if (options.bypassCache) return load();
   return dedupeRequest(pendingRepos, key, load);
+}
+
+async function fetchReposUncached(
+  encodedUsername: string,
+  key: string,
+  options: FetchOptions
+): Promise<GitHubRepo[]> {
+  const firstPageRes = await fetchWithRetry(
+    `${GITHUB_REST_URL}/users/${encodedUsername}/repos?per_page=100&page=1&sort=pushed`,
+    {
+      headers: getHeaders(),
+      cache: 'no-store',
+      signal: options.signal,
+    }
+  );
+
+  if (!firstPageRes.ok) {
+    throwIfRateLimited(firstPageRes);
+    throw new Error(`GitHub REST API error: ${firstPageRes.status}`);
+  }
+
+  const firstPageRepos = (await firstPageRes.json()) as GitHubRepo[];
+  const allRepos: GitHubRepo[] = [...firstPageRepos];
+
+  const MAX_PAGES = 3;
+
+  if (firstPageRepos.length === 100) {
+    const remainingPages = Array.from({ length: MAX_PAGES - 1 }, (_, i) => i + 2);
+
+    const responses = await Promise.all(
+      remainingPages.map((page) =>
+        fetchWithRetry(
+          `${GITHUB_REST_URL}/users/${encodedUsername}/repos?per_page=100&page=${page}&sort=pushed`,
+          {
+            headers: getHeaders(),
+            cache: 'no-store',
+            signal: options.signal,
+          }
+        )
+      )
+    );
+
+    const pagesRepos = await Promise.all(
+      responses.map(async (response) => {
+        if (!response.ok) {
+          throwIfRateLimited(response);
+          throw new Error(`GitHub REST API error: ${response.status}`);
+        }
+
+        return (await response.json()) as GitHubRepo[];
+      })
+    );
+
+    for (const repos of pagesRepos) {
+      allRepos.push(...repos);
+    }
+  }
+
+  if (!options.bypassCache) await reposCache.set(key, allRepos, GITHUB_CACHE_TTL_MS);
+  return allRepos;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## What this fixes

The GitHub contribution caching mechanism in `lib/github.ts` had a race condition where multiple concurrent requests for the same username could bypass the cache check and each fire its own API call to GitHub. This caused redundant API calls, rapid consumption of rate limits (5000 req/hour for authenticated users), and inconsistent contribution data during periods of high traffic. The issue was particularly severe for organization dashboards where dozens of member contributions are fetched simultaneously.

## Root cause

The three data-fetching functions (`fetchGitHubContributions`, `fetchUserProfile`, `fetchUserRepos`) performed the async cache lookup (`DistributedCache.get`) and the deduplication check (`dedupeRequest`) as separate sequential steps. During the `await` of the cache lookup, concurrent requests for the same key could all miss the cache and each independently proceed to make an API call before the first request's deduplication promise was stored in the pending map. This is a classic TOCTOU (time-of-check-to-time-of-use) race condition.

## What changed

- `lib/github.ts`: Moved the async cache lookup inside the `dedupeRequest` load function for all three data-fetching functions (`fetchGitHubContributions`, `fetchUserProfile`, `fetchUserRepos`). The entire cache-check + fetch pipeline is now wrapped in a single in-flight promise managed by `dedupeRequest`, so concurrent calls for the same key share one promise instead of each independently hitting the API.
- Extracted the actual API fetch logic into dedicated helper functions (`fetchContributionsUncached`, `fetchProfileUncached`, `fetchReposUncached`) for clarity and to keep the deduplication wrapper clean.

## How to verify

1. Run `npx vitest run lib/github.test.ts` — all 90 tests pass, including the four deduplication tests:
   - "dedupes concurrent contribution requests for the same cold cache key"
   - "dedupes rapid synchronous contribution requests until the delayed fetch resolves once"
   - "dedupes concurrent profile requests for the same cold cache key"
   - "dedupes concurrent repo requests for the same cold cache key"
2. Run `npx tsc --noEmit` — no type errors
3. Run `npx vitest run` — all 1289 tests pass across 81 test files

## Edge cases considered

- `bypassCache: true` skips deduplication intentionally (refresh requests should always fetch fresh data)
- Failed requests clean up the pending map via `.finally()`, so a failed request doesn't block future retries
- Stale cache entries correctly trigger a refetch through the deduplication pipeline
- The `getOrgDashboardData` function benefits from this fix since it calls `fetchGitHubContributions` for each org member concurrently

Closes #1223
