### PR TITLE
fix(theme): case-insensitive theme matching for streak and wrapped pages

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -20,8 +20,7 @@
 #   Generate new token (classic)
 #   Required scope: read:user
 # ------------------------------------------------------------
-GITHUB_TOKEN=ghp_your_personal_access_token_here
-
+GITHUB_TOKEN=
 
 # ------------------------------------------------------------
 # REQUIRED — Public site URL

--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -766,6 +766,22 @@ describe('GET /api/streak', () => {
       expect(fieldError).toContain('light');
       expect(fieldError).toContain('neon');
     });
+
+    it('accepts capitalized or mixed-case theme parameter like "NEON" and maps it correctly', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', theme: 'NEON' }));
+      const body = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(body).toContain('ff00ff'); // Neon theme accent is #ff00ff — confirms the neon theme is applied
+    });
+
+    it('accepts mixed-case "random" or "auto" and resolves correctly', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', theme: 'aUtO' }));
+      const body = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(body).toContain('prefers-color-scheme: dark');
+    });
   });
 
   describe('custom colour overrides', () => {

--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -995,69 +995,47 @@ describe('streakParamsSchema — layout query validation boundaries (Variation 2
   });
 });
 
-/* ==========================================================================
- * LAYOUT PARAMETER — QUERY VALIDATION BOUNDARIES (VARIATION 2)
- * ========================================================================== */
-
-describe('streakParamsSchema — layout query validation boundaries (Variation 2)', () => {
-  it('rejects unsupported_layout and marks the parse as failed', () => {
+describe('streakParamsSchema — case-insensitive theme matching', () => {
+  it('accepts lowercase theme parameters', () => {
     const result = streakParamsSchema.safeParse({
       user: 'octocat',
-      layout: 'unsupported_layout',
+      theme: 'neon',
     });
-
-    expect(result.success).toBe(false);
-  });
-
-  it('surfaces a meaningful error message for unsupported_layout', () => {
-    const result = streakParamsSchema.safeParse({
-      user: 'octocat',
-      layout: 'unsupported_layout',
-    });
-
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const messages = result.error.issues.map((i) => i.message).join(' ');
-      expect(messages).toContain('Invalid layout format');
-    }
-  });
-
-  it('accepts "default" as a valid layout value', () => {
-    const result = streakParamsSchema.safeParse({
-      user: 'octocat',
-      layout: 'default',
-    });
-
-    expect(result.success).toBe(true);
-  });
-
-  it('accepts "compact" as a valid layout value', () => {
-    const result = streakParamsSchema.safeParse({
-      user: 'octocat',
-      layout: 'compact',
-    });
-
-    expect(result.success).toBe(true);
-  });
-
-  it('accepts "full" as a valid layout value', () => {
-    const result = streakParamsSchema.safeParse({
-      user: 'octocat',
-      layout: 'full',
-    });
-
-    expect(result.success).toBe(true);
-  });
-
-  it('treats omitted layout as undefined (no validation error)', () => {
-    const result = streakParamsSchema.safeParse({
-      user: 'octocat',
-    });
-
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.layout).toBeUndefined();
+      expect(result.data.theme).toBe('neon');
     }
+  });
+
+  it('accepts uppercase theme parameters and maps correctly', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      theme: 'NEON',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Maps capitalized input back to lowercase registry key
+      expect(result.data.theme).toBe('neon');
+    }
+  });
+
+  it('accepts mixed-case theme parameters and maps correctly', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      theme: 'DrAcUlA',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.theme).toBe('dracula');
+    }
+  });
+
+  it('rejects completely invalid theme name', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      theme: 'fictionaltheme',
+    });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -23,7 +23,13 @@ export function toEmptyStringAsUndefined(val?: string): string | undefined {
 }
 
 export function toValidTheme(val?: string): string | undefined {
-  return val && Object.hasOwn(themes, val) ? val : 'dark';
+  if (!val) return 'dark';
+  const normalized = val.toLowerCase();
+  if (normalized === 'auto' || normalized === 'random') {
+    return normalized;
+  }
+  const matchedKey = Object.keys(themes).find((key) => key.toLowerCase() === normalized);
+  return matchedKey || 'dark';
 }
 
 export function toValidHexColor(defaultColor: string) {
@@ -79,9 +85,17 @@ const baseStreakParamsSchema = z.object({
   theme: z
     .string()
     .optional()
+    .transform((val) => {
+      if (val === undefined || val === '') return 'dark';
+      const normalized = val.toLowerCase();
+      if (normalized === 'auto' || normalized === 'random') {
+        return normalized;
+      }
+      const matchedKey = Object.keys(themes).find((key) => key.toLowerCase() === normalized);
+      return matchedKey || val;
+    })
     .refine(
       (val) => {
-        if (val === undefined || val === '') return true;
         return val === 'auto' || val === 'random' || Object.hasOwn(themes, val);
       },
       {
@@ -391,7 +405,7 @@ export const wrappedParamsSchema = z.object({
         message: 'GitHub was founded in 2008. Please provide a year of 2008 or later.',
       }
     ),
-  theme: z.string().default('dark'),
+  theme: z.string().optional().transform(toValidTheme).default('dark'),
   bg: z
     .string()
     .optional()


### PR DESCRIPTION
## Description

Fixes #2032

This PR implements **Case-Insensitive Theme Preset Matching** across the CommitPulse schema validators and API routes.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
Querying `?theme=NEON` or other capitalized variants now successfully maps to the gorgeous neon theme rather than failing registry lookup and falling back to default.

<img width="1172" height="875" alt="image" src="https://github.com/user-attachments/assets/27bfa584-3de8-43ea-8c4f-7ed86bbf77b4" />

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
