### PR TITLE
fix(api): classify stats route GitHub errors

### DIFF
--- a/app/api/stats/route.test.ts
+++ b/app/api/stats/route.test.ts
@@ -158,6 +158,28 @@ describe('GET /api/stats', () => {
     expect(body.error).toBe('GitHub API error');
   });
 
+  it('returns 404 when GitHub reports that the user does not exist', async () => {
+    vi.mocked(fetchGitHubContributions).mockRejectedValue(
+      new Error('GitHub user "missing-user" not found')
+    );
+
+    const response = await GET(makeRequest({ user: 'missing-user' }));
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe('User not found');
+  });
+
+  it('returns 403 when GitHub rate limiting bubbles up from the client', async () => {
+    vi.mocked(fetchGitHubContributions).mockRejectedValue(new Error('API Rate Limit Exceeded'));
+
+    const response = await GET(makeRequest({ user: 'testuser' }));
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe('GitHub API rate limit reached. Please configure GITHUB_TOKEN.');
+  });
+
   it('returns 500 with a generic message for non-Error throws', async () => {
     vi.mocked(fetchGitHubContributions).mockRejectedValue('something went wrong');
     const response = await GET(makeRequest({ user: 'testuser' }));

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -71,6 +71,25 @@ export async function GET(request: Request) {
     );
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'Unknown error';
+
+    if (
+      message.toLowerCase().includes('not found') ||
+      message.toLowerCase().includes('could not resolve')
+    ) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    if (
+      message.toLowerCase().includes('rate limit') ||
+      message.includes('API limit reached') ||
+      message.includes('status 403')
+    ) {
+      return NextResponse.json(
+        { error: 'GitHub API rate limit reached. Please configure GITHUB_TOKEN.' },
+        { status: 403 }
+      );
+    }
+
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Description

Fixes #2198

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed

The `/api/stats` route was returning `500 Internal Server Error` for every exception from `fetchGitHubContributions`, including normal GitHub-side cases like missing users and API rate limits.

This PR mirrors the error classification already used by the dashboard API route:

- GitHub not-found / could-not-resolve errors now return `404` with `User not found`
- GitHub rate-limit style errors now return `403` with the existing rate-limit message
- Unknown errors still fall back to `500`

I also added route tests for the new not-found and rate-limit branches so the behavior stays explicit.

## Visual Preview

N/A — JSON API status-code fix only.

## Local verification

- `npm run test -- app/api/stats/route.test.ts` passed
- `npm run format:check` passed
- `npm run lint` passed with one existing warning in `components/WallOfLove.tsx`
- `npm run typecheck` passed
- `npm run test` passed: 83 files, 1394 tests
- `npm run test:coverage` completed; current repo-wide branch coverage reports 66.98% on latest main
- `npm run build` currently fails on clean `origin/main` too with only `Build failed because of webpack errors`, so that appears unrelated to this PR

## GSSoC 2026

This is raised and fixed under GSSoC 2026. Please add the relevant GSSoC/level labels if they do not sync from the issue automatically.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` / `npm run format:check` and `npm run lint` locally.
- [x] I have run `npm run test` and all tests pass locally.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.
