### PR TITLE
fix: handle initial commit and shallow clone scenarios in vercel-ignore.sh

### DIFF
--- a/vercel-ignore.sh
+++ b/vercel-ignore.sh
@@ -1,3 +1,8 @@
+# Handle initial commits and shallow clones
+if ! git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+  exit 1
+fi
+
 CHANGED_FILES=$(git diff --name-only HEAD^ HEAD)
 
 if [ -z "$CHANGED_FILES" ]; then


### PR DESCRIPTION
## Description

Fixes #2201 

This PR addresses an edge case in `vercel-ignore.sh` where the script assumes that `HEAD^` is always available.

In scenarios such as:

* Initial repository commits
* Shallow clones
* CI/CD environments with limited Git history

the command:

```bash
git diff --name-only HEAD^ HEAD
```

may fail because Git cannot resolve the parent commit.

To prevent unexpected failures, this PR adds a guard using `git rev-parse --verify HEAD^` and defaults to triggering a build when a parent commit cannot be determined.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A – Build script reliability improvement.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
