### PR TITLE
[codex] Fix monthly stats month range handling

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -1048,6 +1048,48 @@ describe('GET /api/streak', () => {
       }
     });
 
+    it('ignores custom from/to when fetching data for monthly comparison stats', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-20T12:00:00Z'));
+
+      vi.mocked(fetchGitHubContributions).mockResolvedValueOnce({
+        calendar: {
+          totalContributions: 25,
+          weeks: [
+            { contributionDays: [{ date: '2026-04-15', contributionCount: 10 }] },
+            { contributionDays: [{ date: '2026-05-15', contributionCount: 15 }] },
+          ],
+        } as ContributionCalendar,
+        repoContributions: [],
+      } as unknown as ExtendedContributionData);
+
+      try {
+        const response = await GET(
+          makeRequest({
+            user: 'octocat',
+            view: 'monthly',
+            from: '2026-05-15',
+            to: '2026-05-20',
+            delta_format: 'both',
+          })
+        );
+
+        expect(response.status).toBe(200);
+        expect(fetchGitHubContributions).toHaveBeenCalledWith('octocat', {
+          bypassCache: false,
+          from: '2026-04-01T00:00:00.000Z',
+          to: '2026-05-31T23:59:59.000Z',
+        });
+
+        const body = await response.text();
+        expect(body).toContain('MAY');
+        expect(body).toContain('class="stats">15</text>');
+        expect(body).toContain('+50% (+5)');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('uses valid custom width and height in monthly SVG output', async () => {
       const response = await GET(
         makeRequest({ user: 'octocat', view: 'monthly', width: '400', height: '200' })

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -36,6 +36,21 @@ function getMonthlyReferenceDate(year: string | undefined, timezone: string): Da
   return selectedYear < currentYear ? new Date(`${year}-12-15T12:00:00Z`) : undefined;
 }
 
+function getMonthlyComparisonRange(referenceDate: Date, timezone: string) {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+  }).formatToParts(referenceDate);
+  const year = Number(parts.find((part) => part.type === 'year')?.value);
+  const month = Number(parts.find((part) => part.type === 'month')?.value);
+
+  const from = new Date(Date.UTC(year, month - 2, 1, 0, 0, 0)).toISOString();
+  const to = new Date(Date.UTC(year, month, 0, 23, 59, 59)).toISOString();
+
+  return { from, to };
+}
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
 
@@ -99,16 +114,6 @@ export async function GET(request: Request) {
     } = parseResult.data;
 
     const themeName = theme || 'dark';
-    const from = customFrom
-      ? new Date(customFrom).toISOString()
-      : year
-        ? `${year}-01-01T00:00:00Z`
-        : undefined;
-    const to = customTo
-      ? new Date(customTo).toISOString()
-      : year
-        ? `${year}-12-31T23:59:59Z`
-        : undefined;
     const currentYear = new Date().getUTCFullYear();
     const isHistoricalYear = !!year && Number(year) < currentYear;
 
@@ -117,6 +122,22 @@ export async function GET(request: Request) {
       timezone = new Intl.DateTimeFormat(undefined, { timeZone: tzParam }).resolvedOptions()
         .timeZone;
     }
+
+    const monthlyReferenceDate = getMonthlyReferenceDate(year, timezone) ?? new Date();
+    const customMonthlyRange =
+      view === 'monthly' && (customFrom || customTo)
+        ? getMonthlyComparisonRange(monthlyReferenceDate, timezone)
+        : undefined;
+    const from =
+      customMonthlyRange?.from ??
+      (customFrom
+        ? new Date(customFrom).toISOString()
+        : year
+          ? `${year}-01-01T00:00:00Z`
+          : undefined);
+    const to =
+      customMonthlyRange?.to ??
+      (customTo ? new Date(customTo).toISOString() : year ? `${year}-12-31T23:59:59Z` : undefined);
 
     const isAutoTheme = themeName === 'auto';
     const isRandomTheme = themeName === 'random';
@@ -203,11 +224,7 @@ export async function GET(request: Request) {
     // ─── JSON output mode ──────────────────────────────────────────────────
     if (format === 'json') {
       const stats = calculateStreak(calendar, timezone, undefined, grace);
-      const monthlyStats = calculateMonthlyStats(
-        calendar,
-        timezone,
-        getMonthlyReferenceDate(year, timezone)
-      );
+      const monthlyStats = calculateMonthlyStats(calendar, timezone, monthlyReferenceDate);
 
       const secondsToMidnight = tzParam
         ? getSecondsUntilMidnightInTimezone(timezone)
@@ -238,11 +255,7 @@ export async function GET(request: Request) {
     // ─── SVG output mode (default) ──────────────────────────────────────────
     let svg = '';
     if (view === 'monthly') {
-      const stats = calculateMonthlyStats(
-        calendar,
-        timezone,
-        getMonthlyReferenceDate(year, timezone)
-      );
+      const stats = calculateMonthlyStats(calendar, timezone, monthlyReferenceDate);
       svg = generateMonthlySVG(stats, params);
     } else if (view === 'heatmap') {
       const stats = calculateStreak(calendar, timezone, undefined, grace);

--- a/components/dashboard/GithubWrapped.tsx
+++ b/components/dashboard/GithubWrapped.tsx
@@ -11,6 +11,16 @@ interface GithubWrappedProps {
   wrappedData: WrappedStats;
 }
 
+function formatBusiestMonth(month: string): string {
+  const [year, monthNumber] = month.split('-').map(Number);
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(Date.UTC(year, monthNumber - 1, 1)));
+}
+
 export default function GithubWrapped({ profile, wrappedData }: GithubWrappedProps) {
   const isWeekendGrinder = wrappedData.weekendRatio > 25;
 
@@ -106,12 +116,7 @@ export default function GithubWrapped({ profile, wrappedData }: GithubWrappedPro
           >
             <Calendar className="text-purple-400 mb-2" size={24} />
             <p className="text-sm text-white/60">Busiest Month</p>
-            <p className="text-2xl font-bold">
-              {new Date(wrappedData.busiestMonth + '-01').toLocaleString('default', {
-                month: 'long',
-                year: 'numeric',
-              })}
-            </p>
+            <p className="text-2xl font-bold">{formatBusiestMonth(wrappedData.busiestMonth)}</p>
           </motion.div>
 
           <motion.div


### PR DESCRIPTION
## Summary

Fixes the monthly badge comparison window so `view=monthly` no longer calculates month-over-month stats from a caller-provided partial `from`/`to` range.

When the monthly view receives custom date bounds such as `from=2026-05-15&to=2026-05-20`, the route now fetches the complete previous and current months needed for comparison stats. This keeps the rendered monthly totals and percent deltas based on complete month data instead of partial ranges.

This also fixes Wrapped's busiest-month formatting by formatting `YYYY-MM` values in UTC. Without that, users in negative UTC offsets can see a month like `2026-04` render as March because `new Date('2026-04-01')` is interpreted at UTC midnight and then displayed in local time.

Fixes #2110.

## Changes

- Add a monthly comparison fetch range helper in `app/api/streak/route.ts`.
- Use the shared monthly reference date for monthly SVG and JSON stats.
- Add a regression test for `view=monthly` with custom `from`/`to` parameters.
- Format Wrapped busiest-month values using UTC to avoid local timezone month rollover.

## Verification

- `npm run test -- app/api/streak/route.test.ts components/dashboard/GithubWrapped.test.tsx`
- `npm run typecheck`
- `npm run lint` (passes with one existing warning in `components/WallOfLove.tsx`)
- `npx prettier --check app/api/streak/route.ts app/api/streak/route.test.ts components/dashboard/GithubWrapped.tsx`
- `git diff --check`
- `npm run test` (83 files passed, 1436 tests passed, 1 expected failure)
