### PR TITLE
test: add LoC mode generator test (issue #1081)

### DIFF
--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -355,6 +355,38 @@ describe('generateSVG', () => {
     expect(svg).toContain('CURRENT_STREAK');
   });
 
+  describe('LoC Mode', () => {
+    it('renders towers when LoC data exists (not ghost city)', () => {
+      const locCalendar: ContributionCalendar = {
+        totalContributions: 0,
+        weeks: [
+          {
+            contributionDays: [
+              {
+                contributionCount: 0,
+                locAdditions: 50,
+                locDeletions: 10,
+                date: '2024-06-10',
+              },
+            ],
+          },
+        ],
+      } as ContributionCalendar;
+
+      const svg = generateSVG(
+        mockStats,
+        { user: 'avi', mode: 'loc' } as unknown as BadgeParams,
+        locCalendar
+      );
+
+      // Should contain towers (LoC data exists, so it should not render the ghost city)
+      expect(svg).toContain('class="cp-tower');
+
+      // Should NOT contain stroke-width="0.5" (the ghost city marker)
+      expect(svg).not.toContain('stroke-width="0.5"');
+    });
+  });
+
   // ── Auto-theme (prefers-color-scheme) tests ──────────────────────────────
   // These verify that theme=auto produces an SVG that switches between light
   // and dark color palettes using CSS custom properties and a media query,


### PR DESCRIPTION
## Description

Fixes #1081

Added a generator test to verify that `generateSVG` correctly renders towers when `mode='loc'` and LoC data is present, even when the contribution count is zero.

### Changes Made

* Created a test calendar with:

  * `contributionCount: 0`
  * `locAdditions: 50`
  * `locDeletions: 10`
* Called `generateSVG` with `mode: 'loc'`
* Added an assertion to verify that towers are rendered
* Added an assertion to verify that the ghost city marker (`stroke-width="0.5"`) is not rendered

### Testing

* Verified that all existing generator tests pass
* Ran lint checks successfully (0 errors)

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run lint` locally.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
* [x] I joined the CommitPulse Discord community.
