### PR TITLE
refactor(svg): move FONT_MAP out of generator.ts into a dedicated lib/…

### DIFF
--- a/lib/svg/fonts.test.ts
+++ b/lib/svg/fonts.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import FONT_MAP, { resolveFont } from './fonts';
+
+describe('fonts.resolveFont', () => {
+  it('returns predefined stack for known keys (case-insensitive)', () => {
+    expect(resolveFont('jetbrains')).toBe(FONT_MAP.jetbrains);
+    expect(resolveFont('JetBrains')).toBe(FONT_MAP.jetbrains);
+    expect(resolveFont('FIRA')).toBe(FONT_MAP.fira);
+  });
+
+  it('returns a dynamic font-family for custom font names', () => {
+    expect(resolveFont('Inter')).toBe('"Inter", sans-serif');
+    expect(resolveFont('Space Mono')).toBe('"Space Mono", sans-serif');
+  });
+
+  it('returns null for invalid or empty inputs', () => {
+    expect(resolveFont(undefined)).toBeNull();
+    expect(resolveFont(null)).toBeNull();
+    expect(resolveFont('')).toBeNull();
+    expect(resolveFont('   ')).toBeNull();
+    // strings made only of disallowed characters should sanitize to null
+    expect(resolveFont(';;;')).toBeNull();
+  });
+});

--- a/lib/svg/fonts.ts
+++ b/lib/svg/fonts.ts
@@ -1,0 +1,28 @@
+import { sanitizeFont } from './sanitizer';
+
+export const FONT_MAP = {
+  jetbrains: '"JetBrains Mono", monospace',
+  fira: '"Fira Code", monospace',
+  roboto: '"Roboto", sans-serif',
+} as const;
+
+/**
+ * Resolve a font name to a CSS font-family string.
+ * - If `font` matches a predefined key in `FONT_MAP` (case-insensitive), returns that stack.
+ * - If `font` is a valid custom font name, returns `"<Font>", sans-serif`.
+ * - Otherwise returns `null`.
+ */
+export function resolveFont(font?: string | null): string | null {
+  const sanitized = sanitizeFont(font ?? undefined);
+  if (!sanitized) return null;
+
+  const key = sanitized.toLowerCase();
+  const predefined = (FONT_MAP as Record<string, string>)[key];
+  if (predefined) return predefined;
+
+  return `"${sanitized}", sans-serif`;
+}
+
+export type FontKey = keyof typeof FONT_MAP;
+
+export default FONT_MAP;

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -15,7 +15,10 @@ import {
   getGradientCoordinates,
 } from './sanitizer';
 
-import { SVG_WIDTH, SVG_HEIGHT, FONT_MAP } from './generatorConstants';
+import { SVG_WIDTH, SVG_HEIGHT } from './generatorConstants';
+import { FONT_MAP, resolveFont } from './fonts';
+
+export { FONT_MAP, resolveFont } from './fonts';
 
 // helpers
 export function getSizeScale(size?: 'small' | 'medium' | 'large') {
@@ -619,15 +622,10 @@ export function generateSVG(
   const borderAttr = params.border ? `stroke="#${params.border}" stroke-width="2"` : '';
 
   const sanitizedFont = sanitizeFont(params.font);
-  const predefinedFont = sanitizedFont
-    ? (FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP] ?? null)
-    : null;
-  const isPredefinedFont = Boolean(predefinedFont);
-  const selectedFont = isPredefinedFont
-    ? predefinedFont
-    : sanitizedFont
-      ? `"${sanitizedFont}", sans-serif`
-      : null;
+  const selectedFont = resolveFont(sanitizedFont);
+  const isPredefinedFont = sanitizedFont
+    ? Boolean(FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP])
+    : false;
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const googleFontUrlPart =
     sanitizedFont && !isPredefinedFont ? sanitizeGoogleFontUrl(sanitizedFont) : null;
@@ -688,10 +686,7 @@ function generateAutoThemeSVG(
   const darkLabelOpacity = getLuminance(dark.bg) > 0.5 ? '0.8' : '0.7';
   const safeUser = escapeXML(params.user || 'GitHub User');
   const sanitizedFont = sanitizeFont(params.font);
-  const selectedFont = sanitizedFont
-    ? (FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP] ?? null) ||
-      `"${sanitizedFont}", sans-serif`
-    : null;
+  const selectedFont = resolveFont(sanitizedFont);
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const googleFontUrlPart = sanitizedFont ? sanitizeGoogleFontUrl(sanitizedFont) : null;
   const googleFontsImport = googleFontUrlPart
@@ -806,16 +801,10 @@ export function generateMonthlySVG(stats: MonthlyStats, params: BadgeParams): st
   const text = `#${sanitizeHexColor(params.text, 'ffffff')}`;
 
   const sanitizedFont = sanitizeFont(params.font);
-  const predefinedFont = sanitizedFont
-    ? (FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP] ?? null)
-    : null;
-  const isPredefinedFont = Boolean(predefinedFont);
-  const selectedFont = isPredefinedFont
-    ? predefinedFont
-    : sanitizedFont
-      ? `"${sanitizedFont}", sans-serif`
-      : null;
-
+  const selectedFont = resolveFont(sanitizedFont);
+  const isPredefinedFont = sanitizedFont
+    ? Boolean(FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP])
+    : false;
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const radius = sanitizeRadius(params.radius, 8);
   const labels = getLabels(params.lang);
@@ -935,16 +924,10 @@ export function generateWrappedSVG(
   const text = `#${sanitizeHexColor(params.text, 'ffffff')}`;
 
   const sanitizedFont = sanitizeFont(params.font);
-  const predefinedFont = sanitizedFont
-    ? (FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP] ?? null)
-    : null;
-  const isPredefinedFont = Boolean(predefinedFont);
-  const selectedFont = isPredefinedFont
-    ? predefinedFont
-    : sanitizedFont
-      ? `"${sanitizedFont}", sans-serif`
-      : null;
-
+  const selectedFont = resolveFont(sanitizedFont);
+  const isPredefinedFont = sanitizedFont
+    ? Boolean(FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP])
+    : false;
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const radius = sanitizeRadius(params.radius, 8);
 
@@ -1194,10 +1177,7 @@ function generateAutoThemeMonthlySVG(stats: MonthlyStats, params: BadgeParams): 
   const dark = AUTO_THEME_DARK;
   const safeUser = escapeXML(params.user || 'GitHub User');
   const sanitizedFont = sanitizeFont(params.font);
-  const selectedFont = sanitizedFont
-    ? (FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP] ?? null) ||
-      `"${sanitizedFont}", sans-serif`
-    : null;
+  const selectedFont = resolveFont(sanitizedFont);
 
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const googleFontUrlPart = sanitizedFont ? sanitizeGoogleFontUrl(sanitizedFont) : null;
@@ -1481,12 +1461,10 @@ export function generateHeatmapSVG(
   const predefinedFont = sanitizedFont
     ? (FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP] ?? null)
     : null;
-  const isPredefinedFont = Boolean(predefinedFont);
-  const selectedFont = isPredefinedFont
-    ? predefinedFont
-    : sanitizedFont
-      ? `"${sanitizedFont}", sans-serif`
-      : null;
+  const selectedFont = resolveFont(sanitizedFont);
+  const isPredefinedFont = sanitizedFont
+    ? Boolean(FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP])
+    : false;
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const googleFontUrlPart =
     sanitizedFont && !isPredefinedFont ? sanitizeGoogleFontUrl(sanitizedFont) : null;
@@ -1618,10 +1596,7 @@ function generateAutoThemeHeatmapSVG(
   const safeUser = escapeXML(params.user || 'GitHub User');
 
   const sanitizedFont = sanitizeFont(params.font);
-  const selectedFont = sanitizedFont
-    ? (FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP] ?? null) ||
-      `"${sanitizedFont}", sans-serif`
-    : null;
+  const selectedFont = resolveFont(sanitizedFont);
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const googleFontUrlPart = sanitizedFont ? sanitizeGoogleFontUrl(sanitizedFont) : null;
   const googleFontsImport = googleFontUrlPart
@@ -1940,15 +1915,10 @@ export function generateVersusSVG(
   const text = `#${sanitizeHexColor(params.text, 'ffffff')}`;
 
   const sanitizedFont = sanitizeFont(params.font);
-  const predefinedFont = sanitizedFont
-    ? (FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP] ?? null)
-    : null;
-  const isPredefinedFont = Boolean(predefinedFont);
-  const selectedFont = isPredefinedFont
-    ? predefinedFont
-    : sanitizedFont
-      ? `"${sanitizedFont}", sans-serif`
-      : null;
+  const selectedFont = resolveFont(sanitizedFont);
+  const isPredefinedFont = sanitizedFont
+    ? Boolean(FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP])
+    : false;
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const googleFontUrlPart =
     sanitizedFont && !isPredefinedFont ? sanitizeGoogleFontUrl(sanitizedFont) : null;
@@ -2026,10 +1996,7 @@ function generateAutoThemeVersusSVG(
   const safeUser1 = escapeXML(params.user || 'User 1');
   const safeUser2 = escapeXML(params.versus || 'User 2');
   const sanitizedFont = sanitizeFont(params.font);
-  const selectedFont = sanitizedFont
-    ? (FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP] ?? null) ||
-      `"${sanitizedFont}", sans-serif`
-    : null;
+  const selectedFont = resolveFont(sanitizedFont);
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const sf = getSizeScale(params.size);
   const radius = sanitizeRadius(params.radius, 8) * sf;

--- a/lib/svg/generatorConstants.test.ts
+++ b/lib/svg/generatorConstants.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { SVG_WIDTH, SVG_HEIGHT, FONT_MAP, isFontKey } from './generatorConstants';
+import { SVG_WIDTH, SVG_HEIGHT, isFontKey } from './generatorConstants';
+import { FONT_MAP } from './fonts';
 
 describe('generatorConstants', () => {
   it('SVG_WIDTH equals 600', () => {

--- a/lib/svg/generatorConstants.ts
+++ b/lib/svg/generatorConstants.ts
@@ -1,11 +1,7 @@
 export const SVG_WIDTH = 600;
 export const SVG_HEIGHT = 420;
 
-export const FONT_MAP = {
-  jetbrains: '"JetBrains Mono", monospace',
-  fira: '"Fira Code", monospace',
-  roboto: '"Roboto", sans-serif',
-} as const;
+import { FONT_MAP } from './fonts';
 
 export type FontKey = keyof typeof FONT_MAP;
 


### PR DESCRIPTION
## Description

Fixes #292

## Changes Made
- Moved FONT_MAP and font-resolution logic into lib/svg/fonts.ts
- re-exported it from generator.ts.
- Added unit tests for resolveFont covering predefined, dynamic, and invalid inputs.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

closes(#292)