### PR TITLE
test(i18n): verify all locales have COMMITS_THIS_MONTH and VS_LAST_MONTH keys

### DIFF
--- a/lib/i18n/badgeLabels.test.ts
+++ b/lib/i18n/badgeLabels.test.ts
@@ -70,4 +70,16 @@ describe('getLabels', () => {
       }
     });
   });
+
+  describe('monthly view keys', () => {
+    it.each(Object.keys(labels))('locale %s has a non-empty COMMITS_THIS_MONTH', (lang) => {
+      const locale = getLabels(lang);
+      expect(locale.COMMITS_THIS_MONTH).toEqual(expect.stringMatching(/\S/));
+    });
+
+    it.each(Object.keys(labels))('locale %s has a non-empty VS_LAST_MONTH', (lang) => {
+      const locale = getLabels(lang);
+      expect(locale.VS_LAST_MONTH).toEqual(expect.stringMatching(/\S/));
+    });
+  });
 });


### PR DESCRIPTION
## Description
Extends lib/i18n/badgeLabels.test.ts with a dynamic monthly view keys describe block that asserts COMMITS_THIS_MONTH and VS_LAST_MONTH are present and non-empty in every supported locale. Uses it.each(Object.keys(labels)) so the tests automatically cover any locale added in the future without needing to touch the test file.

Fixes #1078

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
