### PR TITLE
[CRITICAL] fix: sanitize compare route error messages and use locale-safe username comparison (#2250)

### DIFF
--- a/app/api/compare/route.test.ts
+++ b/app/api/compare/route.test.ts
@@ -98,7 +98,7 @@ describe('GET /api/compare', () => {
 
     expect(res.status).toBe(403);
     const data = await res.json();
-    expect(data.error).toBe('GitHub API rate limit reached. Please configure GITHUB_TOKEN.');
+    expect(data.error).toBe('GitHub API rate limit reached. Please try again later.');
   });
 
   it('returns 403 when the user2 fetch hits a GitHub rate limit', async () => {
@@ -110,18 +110,18 @@ describe('GET /api/compare', () => {
 
     expect(res.status).toBe(403);
     const data = await res.json();
-    expect(data.error).toBe('GitHub API rate limit reached. Please configure GITHUB_TOKEN.');
+    expect(data.error).toBe('GitHub API rate limit reached. Please try again later.');
   });
 
-  it('returns 500 for non-rate-limit upstream failures instead of reporting not found', async () => {
+  it('returns 502 for non-rate-limit upstream failures instead of reporting not found', async () => {
     vi.mocked(getFullDashboardData).mockRejectedValueOnce(
       new Error('GitHub GraphQL API returned status 500')
     );
 
     const res = await GET(makeRequest('user1=octocat&user2=torvalds'));
 
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(502);
     const data = await res.json();
-    expect(data.error).toContain('GitHub GraphQL API returned status 500');
+    expect(data.error).toContain('Unable to fetch GitHub data');
   });
 });

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -11,7 +11,7 @@ function buildCompareFetchErrorResponse(user: string, reason: unknown): NextResp
   if (lowerMessage.includes('not found') || lowerMessage.includes('could not resolve')) {
     return NextResponse.json(
       {
-        error: `Failed to fetch data for "${user}": ${message}`,
+        error: `GitHub user "${user}" was not found.`,
       },
       { status: 404 }
     );
@@ -23,16 +23,16 @@ function buildCompareFetchErrorResponse(user: string, reason: unknown): NextResp
     message.includes('status 403')
   ) {
     return NextResponse.json(
-      { error: 'GitHub API rate limit reached. Please configure GITHUB_TOKEN.' },
+      { error: 'GitHub API rate limit reached. Please try again later.' },
       { status: 403 }
     );
   }
 
   return NextResponse.json(
     {
-      error: `Failed to fetch data for "${user}": ${message}`,
+      error: `Unable to fetch GitHub data for "${user}". The upstream API returned an unexpected error.`,
     },
-    { status: 500 }
+    { status: 502 }
   );
 }
 

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -388,10 +388,13 @@ export const compareParamsSchema = z
       .max(39, { message: 'GitHub username cannot exceed 39 characters' })
       .regex(GITHUB_USERNAME_REGEX, { message: 'Invalid GitHub username for user2' }),
   })
-  .refine((data) => data.user1.toLowerCase() !== data.user2.toLowerCase(), {
-    message: 'Cannot compare a user with themselves.',
-    path: ['user2'],
-  });
+  .refine(
+    (data) => data.user1.localeCompare(data.user2, undefined, { sensitivity: 'base' }) !== 0,
+    {
+      message: 'Cannot compare a user with themselves.',
+      path: ['user2'],
+    }
+  );
 
 export const ogParamsSchema = z
   .object({


### PR DESCRIPTION
## Description

This PR closes #2250 by addressing the two remaining gaps not covered by the previous fix (PR #2093 which added Zod validation to /api/compare).

### Problem

Issue #2250 identified 4 security gaps in the /api/compare route:

1. **No input validation** - already fixed by PR #2093
2. **Error-based information disclosure** - still present: buildCompareFetchErrorResponse() leaked raw reason.message to the client
3. **Resource waste from unvalidated requests** - already fixed by PR #2093
4. **Locale-dependent self-comparison bypass** - still present: .toLowerCase() is locale-sensitive

### How I Fixed It

**Fix 1: Error message sanitization** - Replaced raw error messages with sanitized user-facing messages. 404 now returns "GitHub user was not found" instead of leaking internal error details. Rate limit messages no longer hint at env var names. 500 errors now return 502 (Bad Gateway) since the fault is upstream.

**Fix 2: Locale-safe comparison** - Replaced .toLowerCase() with localeCompare(undefined, { sensitivity: "base" }) which is case-insensitive and locale-agnostic, preventing Turkish i/I bypass.

### Changes

- `app/api/compare/route.ts` - Sanitized all error messages in buildCompareFetchErrorResponse
- `lib/validations.ts` - Replaced locale-sensitive .toLowerCase() with localeCompare

## Pillar

- [ ] Pillar 1 - New Theme Design
- [ ] Pillar 2 - Geometric SVG Improvement
- [ ] Pillar 3 - Timezone Logic Optimization
- [x] Other (Bug fix, security hardening)

## Checklist before requesting a review

- [x] I have read the CONTRIBUTING.md file
- [x] I have tested these changes locally (npm run format:check, npm run lint, npm run typecheck, npm run test, npm run build)
- [x] I have run npm run format and npm run lint locally and resolved all errors
- [x] My commits follow the Conventional Commits format
- [ ] I have updated README.md if I added a new theme or URL parameter (not applicable)
- [x] I have starred the repo

Closes #2250