### PR TITLE
fix(frontend): sanitize recent searches from localStorage

### DIFF
--- a/hooks/useRecentSearches.test.ts
+++ b/hooks/useRecentSearches.test.ts
@@ -134,6 +134,28 @@ describe('useRecentSearches', () => {
     expect(result2.current.searches[0]).toBe('octocat');
   });
 
+  it('ignores valid JSON from localStorage when it is not an array', () => {
+    store[STORAGE_KEY] = JSON.stringify({ value: 'octocat' });
+
+    const { result } = renderHook(() => useRecentSearches());
+
+    expect(result.current.searches).toEqual([]);
+
+    act(() => {
+      result.current.addSearch('torvalds');
+    });
+
+    expect(result.current.searches).toEqual(['torvalds']);
+  });
+
+  it('filters non-string entries loaded from localStorage', () => {
+    store[STORAGE_KEY] = JSON.stringify(['octocat', null, 42, 'torvalds']);
+
+    const { result } = renderHook(() => useRecentSearches());
+
+    expect(result.current.searches).toEqual(['octocat', 'torvalds']);
+  });
+
   it('is safe under Strict Mode double invocation', () => {
     const setItemSpy = vi.spyOn(window.localStorage, 'setItem');
     const removeItemSpy = vi.spyOn(window.localStorage, 'removeItem');

--- a/hooks/useRecentSearches.ts
+++ b/hooks/useRecentSearches.ts
@@ -11,7 +11,12 @@ function loadFromStorage(): string[] {
   let saved: string[] = [];
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) saved = JSON.parse(stored) as string[];
+    if (stored) {
+      const parsed: unknown = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        saved = parsed.filter((item): item is string => typeof item === 'string');
+      }
+    }
   } catch {
     // ignore malformed storage
   }


### PR DESCRIPTION
## Description

Fixes #2263

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed

`useRecentSearches()` already handled malformed JSON in `localStorage`, but it still trusted any valid JSON value as a `string[]`. If `recentSearches` contained a valid object/string/number instead of an array, the hook could later crash when `addSearch()` called `.filter()` on it.

This PR makes the storage load path validate the parsed value before using it:

- non-array JSON values are ignored
- array values are kept, but only string entries are retained
- malformed JSON still falls back safely as before

I added regression tests for a non-array storage value and a mixed array with non-string entries.

## Visual Preview

N/A - hook/data validation fix only.

## Local verification

- `npm run test -- hooks/useRecentSearches.test.ts` passed
- `npm run format:check` passed
- `npm run lint` passed with existing warnings only
- `npm run typecheck` passed
- `npm run test` passed: 86 files, 1523 passed, 1 expected fail
- `npm run build` still fails locally with the existing opaque webpack error; no file-level diagnostics were emitted, and this same local build behavior has not reproduced in CI on recent PRs

## GSSoC 2026

This issue and PR are raised under GSSoC 2026. Please add the relevant GSSoC/level labels if they do not sync from the issue automatically.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` / `npm run format:check` and `npm run lint` locally.
- [x] I have run `npm run test` locally.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.
