### PR TITLE
docs: sync THEMES.md catalog with current theme slugs (#2254)

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -1,6 +1,6 @@
 # 🎨 CommitPulse Themes
 
-All 20 available themes for your CommitPulse badge. Use the `?theme=<slug>` query parameter to apply a theme.
+All 22 available themes for your CommitPulse badge. Use the `?theme=<slug>` query parameter to apply a theme.
 
 ```
 https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
@@ -32,6 +32,8 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 | nord_light       | `#eceff4`  | `#2e3440` | `#5e81ac` |
 | obsidian         | `#1a1a2e`  | `#e2e8f0` | `#f59e0b` |
 | cyber-pulse      | `#000000`  | `#ffffff` | `#00ffee` |
+| glacier          | `#e0f2fe`  | `#0369a1` | `#06b6d4` |
+| lumos            | `#0a0a0a`  | `#a7f3d0` | `#fbbf24` |
 
 ---
 
@@ -274,6 +276,30 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 | `bg`      | 1a1a2e |
 | `text`    | e2e8f0 |
 | `accent`  | f59e0b |
+
+---
+
+### 🧊 Glacier
+
+![glacier](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=glacier)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | e0f2fe |
+| `text`    | 0369a1 |
+| `accent`  | 06b6d4 |
+
+---
+
+### 💡 Lumos
+
+![lumos](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=lumos)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 0a0a0a |
+| `text`    | a7f3d0 |
+| `accent`  | fbbf24 |
 
 ---
 

--- a/lib/svg/themes.test.ts
+++ b/lib/svg/themes.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { themes, AUTO_THEME_LIGHT, AUTO_THEME_DARK } from './themes';
 
@@ -143,6 +145,22 @@ describe('themes', () => {
         expect(theme.text.startsWith('#'), `theme "${name}" text starts with #`).toBe(false);
         expect(theme.accent.startsWith('#'), `theme "${name}" accent starts with #`).toBe(false);
       });
+    });
+  });
+
+  describe('THEMES.md sync guard', () => {
+    it('documents every theme slug defined in lib/svg/themes.ts', () => {
+      const docsPath = path.resolve(process.cwd(), 'THEMES.md');
+      const docs = fs.readFileSync(docsPath, 'utf8');
+
+      for (const themeSlug of Object.keys(themes)) {
+        expect(docs.includes(`theme=${themeSlug}`), `Missing preview for theme "${themeSlug}"`).toBe(
+          true
+        );
+        expect(docs.includes(`| ${themeSlug}`), `Missing table row for theme "${themeSlug}"`).toBe(
+          true
+        );
+      }
     });
   });
 });


### PR DESCRIPTION
## Description\nThis PR syncs THEMES.md with the actual theme registry in lib/svg/themes.ts.\n\n### What changed\n- Updated the documented theme count from **20** to **22**\n- Added missing glacier and lumos theme rows to the catalog table\n- Added preview + parameter blocks for glacier and lumos\n- Added a regression guard in lib/svg/themes.test.ts to ensure every theme slug in code is documented in THEMES.md\n\nFixes #2254\n\n## Pillar\nDocumentation + testing quality\n\n## Checklist\n- [x] Change is small and focused\n- [x] Added a guard test to prevent docs drift\n- [x] Verified lib/svg/themes.test.ts passes locally on this branch\n