### PR TITLE
docs: replace mojibake in THEMES preview headings

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -1,4 +1,4 @@
-# 🎨 CommitPulse Themes
+# CommitPulse Themes
 
 All 20 available themes for your CommitPulse badge. Use the `?theme=<slug>` query parameter to apply a theme.
 
@@ -37,7 +37,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ## Preview Gallery
 
-### 🌑 Dark (default)
+### Dark (default)
 
 ![dark](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=dark)
 
@@ -49,7 +49,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### ☀️ Light
+### Light
 
 ![light](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=light)
 
@@ -61,7 +61,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### ⚡ Neon
+### Neon
 
 ![neon](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=neon)
 
@@ -73,7 +73,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🐙 GitHub
+### GitHub
 
 ![github](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=github)
 
@@ -85,7 +85,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🧛 Dracula
+### Dracula
 
 ![dracula](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=dracula)
 
@@ -97,7 +97,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🌊 Ocean
+### Ocean
 
 ![ocean](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=ocean)
 
@@ -109,7 +109,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🌅 Sunset
+### Sunset
 
 ![sunset](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=sunset)
 
@@ -121,7 +121,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🌲 Forest
+### Forest
 
 ![forest](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=forest)
 
@@ -133,7 +133,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🌸 Rose
+### Rose
 
 ![rose](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=rose)
 
@@ -145,7 +145,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### ❄️ Nord
+### Nord
 
 ![nord](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=nord)
 
@@ -157,7 +157,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🎵 Synthwave
+### Synthwave
 
 ![synthwave](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=synthwave)
 
@@ -169,7 +169,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🪵 Gruvbox
+### Gruvbox
 
 ![gruvbox](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=gruvbox)
 
@@ -181,7 +181,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🔮 Aurora Cyberpunk
+### Aurora Cyberpunk
 
 ![aurora_cyberpunk](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=aurora_cyberpunk)
 
@@ -193,7 +193,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🔦 High Contrast
+### High Contrast
 
 ![highcontrast](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=highcontrast)
 
@@ -205,7 +205,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🐱 Catppuccin Latte
+### Catppuccin Latte
 
 ![catppuccin_latte](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=catppuccin_latte)
 
@@ -217,7 +217,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🌞 Solarized Light
+### Solarized Light
 
 ![solarized_light](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=solarized_light)
 
@@ -229,7 +229,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🌻 Gruvbox Light
+### Gruvbox Light
 
 ![gruvbox_light](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=gruvbox_light)
 
@@ -241,7 +241,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🏔️ Nord Light
+### Nord Light
 
 ![nord_light](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=nord_light)
 
@@ -253,7 +253,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 💠 Cyber Pulse
+### Cyber Pulse
 
 ![cyber-pulse](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=cyber-pulse)
 
@@ -265,7 +265,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-### 🪨 Obsidian
+### Obsidian
 
 ![obsidian](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=obsidian)
 
@@ -277,9 +277,9 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ---
 
-## 🎛️ Custom Theme
+## Custom Theme
 
-Not finding what you want? Build your own using raw color parameters — all values are hex codes **without** the `#` prefix:
+Not finding what you want? Build your own using raw color parameters - all values are hex codes **without** the `#` prefix:
 
 ```
 https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&bg=1a1b27&text=a9b1d6&accent=7aa2f7
@@ -287,12 +287,12 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&bg=1a1b27&text=a9b1
 
 ---
 
-## 🔄 Auto Theme
+## Auto Theme
 
-Automatically switches between light and dark based on the viewer's OS setting — no hex values needed:
+Automatically switches between light and dark based on the viewer's OS setting - no hex values needed:
 
 ```
 https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=auto
 ```
 
-> 💡 **Tip:** You can combine `theme=` with individual overrides. For example, `theme=dracula&accent=ff79c6` applies the Dracula theme but swaps only the accent color.
+> **Tip:** You can combine `theme=` with individual overrides. For example, `theme=dracula&accent=ff79c6` applies the Dracula theme but swaps only the accent color.


### PR DESCRIPTION
## Description\nThis PR fixes mojibake/garbled text in THEMES.md preview headings and section labels by replacing broken prefixes with clean readable text.\n\nFixes #2372\n\n## Pillar\nDocumentation quality\n\n## Checklist\n- [x] I read the contributing guide\n- [x] I kept the change small and focused\n- [x] I verified the file renders correctly\n- [x] I did not change functional code\n