### PR TITLE
test(generator): add isolated getSizeScale helper tests

### DIFF
--- a/lib/svg/generator.getSizeScale.test.ts
+++ b/lib/svg/generator.getSizeScale.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { SVG_WIDTH } from './generatorConstants';
+import { getSizeScale } from './generator';
+
+describe('getSizeScale', () => {
+  it('returns small scale factor for size=small', () => {
+    expect(getSizeScale('small')).toBe(400 / SVG_WIDTH);
+  });
+
+  it('returns default scale factor for size=medium', () => {
+    expect(getSizeScale('medium')).toBe(1);
+  });
+
+  it('returns large scale factor for size=large', () => {
+    expect(getSizeScale('large')).toBe(800 / SVG_WIDTH);
+  });
+
+  it('returns default scale factor when size is undefined', () => {
+    expect(getSizeScale()).toBe(1);
+  });
+
+  it('falls back to default scale factor for unknown values', () => {
+    expect(getSizeScale('' as unknown as 'small')).toBe(1);
+    expect(getSizeScale('xlarge' as unknown as 'small')).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description\nAdds a focused helper test file for getSizeScale in lib/svg/generator.ts with 5 targeted unit cases:\n- small, medium, large expected outputs\n- undefined fallback\n- unknown-value fallback\n\nFixes #2364\n\n## Pillar\nTesting reliability\n\n## Checklist\n- [x] I read the contributing guide\n- [x] I kept the change small and focused\n- [x] I added focused tests\n- [x] I ran local tests\n\n## Testing\n- 
pm test -- lib/svg/generator.getSizeScale.test.ts\n