### PR TITLE
test(generator): add isolated truncateUsername helper tests

### DIFF
--- a/lib/svg/generator.truncateUsername.test.ts
+++ b/lib/svg/generator.truncateUsername.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { truncateUsername } from './generator';
+
+describe('truncateUsername', () => {
+  it('returns original username when length is less than 12', () => {
+    expect(truncateUsername('sonal')).toBe('sonal');
+  });
+
+  it('returns original username when length is exactly 12', () => {
+    expect(truncateUsername('abcdefghijkl')).toBe('abcdefghijkl');
+  });
+
+  it('truncates username longer than 12 characters with ellipsis', () => {
+    expect(truncateUsername('abcdefghijklmnopqrstuvwxyz')).toBe('abcdefghijkl...');
+  });
+
+  it('handles empty string input', () => {
+    expect(truncateUsername('')).toBe('');
+  });
+
+  it('preserves spaces and special characters in the first 12 chars before ellipsis', () => {
+    expect(truncateUsername('john doe_user+tag')).toBe('john doe_use...');
+  });
+});


### PR DESCRIPTION
## Description\nAdds a focused helper test file for 	runcateUsername in lib/svg/generator.ts with 5 targeted cases:\n- shorter than 12 chars\n- exactly 12 chars\n- longer than 12 chars (ellipsis behavior)\n- empty string\n- spaces/special characters preservation before truncation\n\nFixes #2365\n\n## Pillar\nTesting reliability\n\n## Checklist\n- [x] I read the contributing guide\n- [x] I kept the change small and focused\n- [x] I added focused tests\n- [x] I ran local tests\n\n## Testing\n- 
pm test -- lib/svg/generator.truncateUsername.test.ts\n