### PR TITLE
fix: add accessible labels to social share links

### DIFF
--- a/components/ShareButtons.tsx
+++ b/components/ShareButtons.tsx
@@ -11,11 +11,17 @@ export default function ShareButtons({ url, title = '' }: ShareButtonsProps) {
 
   return (
     <div className="flex gap-3">
-      <a href={linkedinUrl} target="_blank" rel="noopener noreferrer">
-        <FaLinkedin size={24} />
+      <a
+        href={linkedinUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Share on LinkedIn"
+      >
+        <FaLinkedin size={24} aria-hidden="true" />
       </a>
-      <a href={twitterUrl} target="_blank" rel="noopener noreferrer">
-        <FaXTwitter size={24} />
+
+      <a href={twitterUrl} target="_blank" rel="noopener noreferrer" aria-label="Share on X">
+        <FaXTwitter size={24} aria-hidden="true" />
       </a>
     </div>
   );


### PR DESCRIPTION
## Description

Fixes #2374 

Improves accessibility in the `ShareButtons` component by adding descriptive labels to icon-only social sharing links.

### Changes Made

* Added `aria-label="Share on LinkedIn"` to the LinkedIn share link
* Added `aria-label="Share on X"` to the X share link
* Added `aria-hidden="true"` to decorative social media icons

### Benefits

* Improves screen reader accessibility
* Provides meaningful labels for icon-only links
* Aligns with accessibility best practices
* No visual or functional changes to the UI

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No visual changes. This PR improves accessibility for assistive technologies by providing descriptive labels for icon-only social sharing links.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [x] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
