### PR TITLE
fix(rate-limit): use atomic incr for distributed rate limiting across serverless instances

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -47,3 +47,19 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 #   4. Replace <password> with your DB user's password
 # ------------------------------------------------------------
 # MONGODB_URI=mongodb+srv://<username>:<password>@cluster.mongodb.net/commitpulse?retryWrites=true&w=majority
+
+# ------------------------------------------------------------
+# OPTIONAL — Upstash Redis / Vercel KV (Distributed Rate Limiting)
+# ------------------------------------------------------------
+# Enables distributed rate limiting across all serverless instances.
+# Without these, rate limiting is per-instance (each Vercel function
+# gets its own counter), which allows N× the intended limit under load.
+#
+# How to get one (free):
+#   1. Create a free Upstash Redis database at https://console.upstash.com
+#   2. Copy the REST API URL and token
+#   3. If using Vercel KV, link it to your project in the Vercel dashboard
+#      — it sets KV_REST_API_URL and KV_REST_API_TOKEN automatically.
+# ------------------------------------------------------------
+# KV_REST_API_URL=https://<your-db>.upstash.io
+# KV_REST_API_TOKEN=<your-token>

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -371,6 +371,67 @@ export class DistributedCache<T> {
     this.localCache.clear();
   }
 
+  /**
+   * Atomically increments a numeric counter stored under `key` and returns the new value.
+   *
+   * When Redis is available, uses EVAL + Lua script for true atomicity.
+   * Falls back to the local TTLCache for non-Redis deployments (dev/test).
+   *
+   * @param key - Cache key holding a numeric counter.
+   * @param ttlMs - Time-to-live in milliseconds. Only applied when the key is first created (count == 1).
+   * @returns The incremented counter value.
+   */
+  async incr(key: string, ttlMs: number): Promise<number> {
+    if (!this.useRedis) {
+      const current = (this.localCache.get(key) as unknown as number) || 0;
+      const next = current + 1;
+      if (current === 0) {
+        this.localCache.set(key, next as unknown as T, ttlMs);
+      } else {
+        this.localCache.update(key, next as unknown as T);
+      }
+      return next;
+    }
+
+    try {
+      const ttlSec = Math.max(1, Math.ceil(ttlMs / 1000));
+      const luaScript = `local c = redis.call('INCR', KEYS[1])
+if c == 1 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return c`;
+
+      const res = await fetch(`${this.redisUrl}/`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.redisToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(['EVAL', luaScript, '1', key, ttlSec.toString()]),
+      });
+
+      if (!res.ok) {
+        throw new Error(`Redis HTTP error: ${res.status}`);
+      }
+
+      const data = await res.json();
+      const count = Number(data.result);
+
+      this.localCache.set(key, count as unknown as T, ttlMs);
+      return count;
+    } catch (err) {
+      console.error(`[DistributedCache] INCR failed for key "${key}":`, err);
+      const current = (this.localCache.get(key) as unknown as number) || 0;
+      const next = current + 1;
+      if (current === 0) {
+        this.localCache.set(key, next as unknown as T, ttlMs);
+      } else {
+        this.localCache.update(key, next as unknown as T);
+      }
+      return next;
+    }
+  }
+
   destroy(): void {
     this.localCache.destroy();
   }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -50,14 +50,8 @@ export class RateLimiter {
   async check(ip: string): Promise<boolean> {
     if (this.allowlist.has(ip)) return true;
     if (this.blocklist.has(ip)) return false;
-    const current = (await this.cache.get(ip)) ?? 0;
-    if (current >= this.limit) return false;
-    if (current === 0) {
-      await this.cache.set(ip, 1, this.windowMs);
-    } else {
-      await this.cache.update(ip, current + 1);
-    }
-    return true;
+    const count = await this.cache.incr(`ratelimit:${ip}`, this.windowMs);
+    return count <= this.limit;
   }
   async checkWithResult(ip: string): Promise<RateLimitResult> {
     if (this.allowlist.has(ip))
@@ -69,10 +63,11 @@ export class RateLimiter {
       };
     if (this.blocklist.has(ip))
       return { success: false, limit: this.limit, remaining: 0, reset: Date.now() + this.windowMs };
-    const now = Date.now();
-    const current = (await this.cache.get(ip)) ?? 0;
 
-    if (current >= this.limit) {
+    const now = Date.now();
+    const count = await this.cache.incr(`ratelimit:${ip}`, this.windowMs);
+
+    if (count > this.limit) {
       return {
         success: false,
         limit: this.limit,
@@ -81,15 +76,10 @@ export class RateLimiter {
       };
     }
 
-    if (current === 0) {
-      await this.cache.set(ip, 1, this.windowMs);
-    } else {
-      await this.cache.update(ip, current + 1);
-    }
     return {
       success: true,
       limit: this.limit,
-      remaining: this.limit - (current + 1),
+      remaining: this.limit - count,
       reset: now + this.windowMs,
     };
   }
@@ -105,7 +95,7 @@ export class RateLimiter {
    * rateLimiter.reset("192.168.1.1");
    */
   async reset(ip: string): Promise<void> {
-    await this.cache.delete(ip);
+    await this.cache.delete(`ratelimit:${ip}`);
   }
   /**
    * Returns the number of remaining requests allowed for a given IP
@@ -122,7 +112,7 @@ export class RateLimiter {
    * console.log(`You have ${left} requests left.`);
    */
   async remaining(ip: string): Promise<number> {
-    const current = (await this.cache.get(ip)) ?? 0;
+    const current = ((await this.cache.get(`ratelimit:${ip}`)) as unknown as number) ?? 0;
     return Math.max(0, this.limit - current);
   }
 
@@ -152,13 +142,14 @@ export const trackUserRateLimiter = new RateLimiter(5, 60000);
 export const notifyRateLimiter = new RateLimiter(5, 60000);
 
 /**
- * Lightweight in-memory rate limiter for Next.js Edge Middleware.
+ * Distributed rate limiter for Next.js Edge Middleware.
  *
- * Note: In a distributed edge environment, this is per-instance.
- * For global rate limiting, a distributed store like Redis would be required.
+ * When Upstash Redis / Vercel KV is configured, counters are shared across
+ * all serverless instances via atomic INCR + EXPIRE Lua scripts.
+ * Falls back to a local in-memory cache for development environments.
  */
 
-const trackers = new DistributedCache<{ count: number }>(2000, 60000);
+const trackers = new DistributedCache<number>(2000, 60000);
 
 /**
  * Checks if a request from a given IP should be rate limited.
@@ -180,22 +171,9 @@ export async function rateLimit(
   windowMs: number = 60000
 ): Promise<RateLimitResult> {
   const now = Date.now();
-  const tracker = await trackers.get(ip);
+  const count = await trackers.incr(ip, windowMs);
 
-  if (!tracker) {
-    await trackers.set(ip, { count: 1 }, windowMs);
-    return {
-      success: true,
-      limit,
-      remaining: limit - 1,
-      reset: now + windowMs,
-    };
-  }
-
-  tracker.count++;
-  await trackers.update(ip, tracker);
-
-  if (tracker.count > limit) {
+  if (count > limit) {
     return {
       success: false,
       limit,
@@ -207,7 +185,7 @@ export async function rateLimit(
   return {
     success: true,
     limit,
-    remaining: limit - tracker.count,
+    remaining: limit - count,
     reset: now + windowMs,
   };
 }


### PR DESCRIPTION
## Description

Fixes #1226

The rate limiting implementation in `middleware.ts` and `lib/rate-limit.ts` used a non-atomic read-modify-write pattern (`get` → increment → `update`) that caused cascading failures under concurrent load. On Vercel, each serverless instance maintained independent counters via in-memory `DistributedCache`, allowing N× the intended request limit across instances and exhausting GitHub API quotas.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — this is a backend infrastructure fix with no SVG or UI changes.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] I have run `npm run test` and all tests pass locally.
- [x] I have run `npm run test:coverage` and branch coverage is at or above 70%.
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.

---

### What changed

- **`lib/cache.ts`**: Added `incr(key, ttlMs)` method to `DistributedCache` that uses a Redis EVAL Lua script (`INCR` + conditional `EXPIRE`) for true atomic counter increment. Falls back to local `TTLCache` with proper TTL semantics when Redis is not configured.
- **`lib/rate-limit.ts`**: Replaced the non-atomic read-modify-write pattern in `rateLimit()` with a single `trackers.incr()` call. Updated `RateLimiter.check()`, `checkWithResult()`, `remaining()`, and `reset()` to use consistent key prefixes and atomic increment. Changed `trackers` cache type from `DistributedCache<{ count: number }>` to `DistributedCache<number>` to work with atomic increment.
- **`.env.local.example`**: Documented the optional Upstash Redis / Vercel KV configuration for distributed rate limiting.

### How to verify

1. Run `npm test` — all 1388 existing tests pass
2. Run `npx tsc --noEmit` — no type errors
3. Without Redis configured: rate limiting falls back to in-memory per-instance behavior (same as before)
4. With Upstash Redis configured (`KV_REST_API_URL` + `KV_REST_API_TOKEN`):
   - Rate limit counters are shared across all serverless instances
   - Concurrent requests from different instances correctly decrement the shared counter
   - After the limit is reached globally, all instances return 429

### Edge cases considered

- **No Redis configured**: Falls back to local in-memory cache with identical behavior to the previous implementation
- **Redis unavailable at runtime**: Catches errors and falls back to local cache, logging the failure
- **Concurrent requests from same instance**: The atomic `incr` prevents the TOCTOU race even within a single instance
- **Window expiry**: The Lua script sets TTL only on first creation (`INCR` returns 1), preserving fixed-window semantics
- **Key prefix collision**: `RateLimiter` uses `ratelimit:` prefix to avoid collisions with the middleware's `trackers` cache