### PR TITLE
test(user): cover connecting-state failure and timeout scenarios

### DIFF
--- a/models/User.test.ts
+++ b/models/User.test.ts
@@ -149,27 +149,55 @@ describe('User Model', () => {
       const collectionWrapper = User.collection as unknown as { queue: unknown[] };
       expect(collectionWrapper.queue.length).toBe(0);
     });
-  });
 
-  describe('Database Connection State 99 Handling', () => {
-    it('triggers a lazy initialization fallback for database operations when uninitialized', async () => {
-      const { vi } = await import('vitest');
+    it('handles connection failure while connecting without leaving operations stuck', async (): Promise<void> => {
+      let currentReadyState = 2;
 
-      const readyStateSpy = vi
+      readyStateSpy = vi
         .spyOn(mongoose.connection, 'readyState', 'get')
-        .mockReturnValue(99 as unknown as typeof mongoose.connection.readyState);
+        .mockImplementation(() => currentReadyState as typeof mongoose.connection.readyState);
 
-      expect(mongoose.connection.readyState).toBe(99);
+      expect(mongoose.connection.readyState).toBe(2);
 
-      const fallbackUser = { username: 'buffered_user' };
-      const findOneSpy = vi.spyOn(User, 'findOne').mockResolvedValue(fallbackUser as never);
+      const connectionError = new Error('Database connection lost');
+      connectionError.name = 'ConnectionError';
 
-      const result = await User.findOne({ username: 'buffered_user' });
-      expect(result).toEqual(fallbackUser);
-      expect(findOneSpy).toHaveBeenCalledTimes(1);
+      const findOneSpy = vi.spyOn(User, 'findOne').mockRejectedValue(connectionError);
 
-      readyStateSpy.mockRestore();
+      // Simulate connection dropping before it becomes connected
+      currentReadyState = 0;
+
+      expect(mongoose.connection.readyState).toBe(0);
+
+      await expect(User.findOne({ username: 'failure-user' })).rejects.toThrow(
+        'Database connection lost'
+      );
+
+      await expect(User.findOne({ username: 'failure-user' })).rejects.toMatchObject({
+        name: 'ConnectionError',
+      });
+
       findOneSpy.mockRestore();
+    });
+
+    it('times out cleanly when the connection remains stuck in state 2 too long', async (): Promise<void> => {
+      readyStateSpy = vi
+        .spyOn(mongoose.connection, 'readyState', 'get')
+        .mockReturnValue(2 as unknown as typeof mongoose.connection.readyState);
+
+      expect(mongoose.connection.readyState).toBe(2);
+
+      const query = User.findOne({ username: 'timeout-user' }).exec();
+
+      const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Connection timeout: state 2 did not resolve')), 50)
+      );
+
+      await expect(Promise.race([query, timeoutPromise])).rejects.toThrow(
+        'Connection timeout: state 2 did not resolve'
+      );
+
+      query.catch(() => undefined);
     });
   });
 
@@ -245,7 +273,7 @@ describe('User Model', () => {
     });
   });
 
-  describe('Database Connection State 99 Handling (Lazy Initialization Tracking)', () => {
+  describe('Database Connection State 99 Handling', () => {
     it('triggers lazy initialization exactly once and uses the correct connection URI', async (): Promise<void> => {
       const readyStateSpy = vi
         .spyOn(mongoose.connection, 'readyState', 'get')
@@ -268,20 +296,6 @@ describe('User Model', () => {
 
       readyStateSpy.mockRestore();
       connectSpy.mockRestore();
-    });
-  });
-
-  describe('Database Connection State 1 Handling', () => {
-    it('keeps the User model usable while mongoose is connected', async (): Promise<void> => {
-      const readyStateSpy = vi
-        .spyOn(mongoose.connection, 'readyState', 'get')
-        .mockReturnValue(1 as unknown as typeof mongoose.connection.readyState);
-
-      expect(mongoose.connection.readyState).toBe(1);
-      expect(User).toBeDefined();
-      expect(User.modelName).toBe('User');
-
-      readyStateSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes #1413 

Adds coverage for database connection edge cases while Mongoose is in readyState 2 (connecting).

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [X] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes

## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [X] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [X] I have started the repo.
- [X] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [X] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
