### PR TITLE
test(api): add dedicated integration tests for refresh parameter

### DIFF
--- a/app/api/streak/tests/refresh.test.ts
+++ b/app/api/streak/tests/refresh.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createRequest } from 'node-mocks-http';
+import { GET } from '../route';
+
+vi.mock('../../../../lib/github', () => ({
+  fetchGitHubContributions: vi.fn(),
+  getOrgDashboardData: vi.fn(),
+}));
+
+vi.mock('../../../../utils/time', () => ({
+  getSecondsUntilUTCMidnight: vi.fn(),
+  getSecondsUntilMidnightInTimezone: vi.fn(),
+}));
+
+import { fetchGitHubContributions } from '../../../../lib/github';
+import { getSecondsUntilUTCMidnight } from '../../../../utils/time';
+import type { ExtendedContributionData } from '../../../../types';
+
+const mockCalendar = {
+  totalContributions: 10,
+  weeks: [],
+};
+
+describe('GET /api/streak - refresh parameter group', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchGitHubContributions).mockResolvedValue({
+      calendar: mockCalendar,
+      repoContributions: [],
+    } as unknown as ExtendedContributionData);
+    vi.mocked(getSecondsUntilUTCMidnight).mockReturnValue(3600);
+  });
+
+  it('returns status 200 for valid requests with custom refresh values', async () => {
+    const req = createRequest({
+      method: 'GET',
+      url: 'http://localhost/api/streak?user=octocat&refresh=true',
+    });
+    const response = await GET(req as unknown as Request);
+    expect(response.status).toBe(200);
+  });
+
+  it('correctly reflects changes dictated by the parameter by forwarding bypassCache to the fetcher', async () => {
+    const req = createRequest({
+      method: 'GET',
+      url: 'http://localhost/api/streak?user=octocat&refresh=true',
+    });
+    await GET(req as unknown as Request);
+    expect(fetchGitHubContributions).toHaveBeenCalledWith(
+      'octocat',
+      expect.objectContaining({ bypassCache: true })
+    );
+  });
+
+  it('tests negative and fallback edge cases for invalid inputs of refresh', async () => {
+    const invalidInputs = ['false', '1', 'yes', 'random', ''];
+
+    for (const val of invalidInputs) {
+      vi.clearAllMocks();
+      const req = createRequest({
+        method: 'GET',
+        url: `http://localhost/api/streak?user=octocat&refresh=${val}`,
+      });
+      const response = await GET(req as unknown as Request);
+
+      expect(response.status).toBe(200);
+      expect(fetchGitHubContributions).toHaveBeenCalledWith(
+        'octocat',
+        expect.objectContaining({ bypassCache: false })
+      );
+      expect(response.headers.get('X-Cache-Status')).toBe('HIT');
+    }
+  });
+
+  it('asserts that appropriate HTTP headers are returned in responses (cache bypass)', async () => {
+    const req = createRequest({
+      method: 'GET',
+      url: 'http://localhost/api/streak?user=octocat&refresh=true',
+    });
+    const response = await GET(req as unknown as Request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-cache, no-store, must-revalidate');
+    expect(response.headers.get('X-Cache-Status')).toMatch(/^BYPASS/);
+  });
+
+  it('asserts that appropriate HTTP headers are returned in responses (normal cache fallback)', async () => {
+    const req = createRequest({
+      method: 'GET',
+      url: 'http://localhost/api/streak?user=octocat',
+    });
+    const response = await GET(req as unknown as Request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe(
+      'public, s-maxage=3600, stale-while-revalidate=86400'
+    );
+    expect(response.headers.get('X-Cache-Status')).toBe('HIT');
+  });
+});


### PR DESCRIPTION
## Description
 Creates `app/api/streak/tests/refresh.test.ts` using `node-mocks-http`.
- Adds 5 integration test cases validating parameter parsing, edge-case fallback, cache bypass logic, and HTTP header configuration.

Fixes #2345 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Implementation details
- **Mock Framework:** Set up a mock request framework using `node-mocks-http` to simulate `NextRequest` behavior.
- **Valid Inputs:** Validated that requesting with `?refresh=true` returns an HTTP `200` response.
- **Cache Bypassing:** Asserted that passing `refresh=true` accurately forwards the `bypassCache` directive to the underlying `fetchGitHubContributions` data fetcher.
- **Edge Cases & Fallbacks:** Added strict negative edge case testing for invalid parameter inputs (e.g., `'false'`, `'1'`, `'random'`) to ensure they gracefully fall back to the standard stale-while-revalidate caching behavior.
- **HTTP Headers:** Validated that `Cache-Control` and `X-Cache-Status` headers dynamically and appropriately shift between `BYPASS` rules and standard `HIT` cache rules depending on the parameter state.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.