### PR TITLE
feat: implement resilient cache fallbacks during rate limits and outages

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -196,6 +196,7 @@ export async function GET(request: Request) {
         .map((u) => u.trim())
         .filter(Boolean);
       let lastError: unknown = null;
+      let hasOfflineFallback = false;
       const fetchedCalendars = await Promise.all(
         users.map(async (u) => {
           try {
@@ -204,6 +205,9 @@ export async function GET(request: Request) {
               from,
               to,
             });
+            if (userData.isOfflineFallback) {
+              hasOfflineFallback = true;
+            }
             return userData.calendar;
           } catch (err) {
             lastError = err;
@@ -218,6 +222,9 @@ export async function GET(request: Request) {
         throw lastError || new Error('No successful calendars fetched');
       }
       calendar = aggregateCalendars(successfulCalendars);
+      if (hasOfflineFallback) {
+        params.isOfflineFallback = true;
+      }
     } else {
       const userData = await fetchGitHubContributions(user, {
         bypassCache: refresh,
@@ -225,6 +232,9 @@ export async function GET(request: Request) {
         to,
       });
       calendar = userData.calendar;
+      if (userData.isOfflineFallback) {
+        params.isOfflineFallback = true;
+      }
 
       if (versus) {
         const versusData = await fetchGitHubContributions(versus, {
@@ -233,6 +243,9 @@ export async function GET(request: Request) {
           to,
         });
         versusCalendar = versusData.calendar;
+        if (versusData.isOfflineFallback) {
+          params.isOfflineFallback = true;
+        }
       }
     }
 

--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -21,6 +21,7 @@ import {
   aggregateLanguages,
   buildInsights,
   buildActivityMap,
+  contributionsCache,
 } from './github';
 import type { ContributionCalendar } from '../types';
 
@@ -487,6 +488,58 @@ describe('fetchGitHubContributions', () => {
     });
     expect(r1.calendar.totalContributions).toBe(r2.calendar.totalContributions);
     expect(r1.calendar.weeks).toEqual(r2.calendar.weeks);
+  });
+
+  it('falls back to stale cache with isOfflineFallback: true when fetch fails and cache has data', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      mockResponse({
+        data: {
+          user: {
+            contributionsCollection: {
+              contributionCalendar: mockCalendar,
+              commitContributionsByRepository: [],
+            },
+          },
+        },
+      })
+    );
+    await fetchGitHubContributions('fallback-user');
+
+    // Expire the cache entry manually by changing lastSyncedAt to be 10 minutes in the past
+    const key = cacheKey('contributions', 'fallback-user');
+    const cachedData = await contributionsCache.get(key);
+    if (cachedData) {
+      cachedData.calendar.lastSyncedAt = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+      await contributionsCache.set(key, cachedData, 7 * 24 * 60 * 60 * 1000);
+    }
+
+    vi.mocked(fetch).mockRejectedValue(new Error('API rate limit exceeded'));
+
+    const result = await fetchGitHubContributions('fallback-user');
+    expect(result.calendar.totalContributions).toBe(mockCalendar.totalContributions);
+    expect(result.isOfflineFallback).toBe(true);
+  });
+
+  it('falls back to stale cache when bypassCache is true but fetch fails and cache has data', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      mockResponse({
+        data: {
+          user: {
+            contributionsCollection: {
+              contributionCalendar: mockCalendar,
+              commitContributionsByRepository: [],
+            },
+          },
+        },
+      })
+    );
+    await fetchGitHubContributions('bypass-fallback-user');
+
+    vi.mocked(fetch).mockRejectedValue(new Error('Failed to fetch'));
+
+    const result = await fetchGitHubContributions('bypass-fallback-user', { bypassCache: true });
+    expect(result.calendar.totalContributions).toBe(mockCalendar.totalContributions);
+    expect(result.isOfflineFallback).toBe(true);
   });
 });
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -249,7 +249,7 @@ type FetchOptions = {
 
 export const GITHUB_CACHE_TTL_MS = 5 * 60 * 1000;
 
-const contributionsCache = new DistributedCache<ExtendedContributionData>(1000);
+export const contributionsCache = new DistributedCache<ExtendedContributionData>(1000);
 const profileCache = new DistributedCache<GitHubUserProfile>(1000);
 const reposCache = new DistributedCache<GitHubRepo[]>(500);
 const contributedReposCache = new DistributedCache<Record<string, unknown>[]>(500);
@@ -389,8 +389,41 @@ export async function fetchGitHubContributions(
     return fetchContributionsUncached(username, key, options, cached);
   };
 
-  if (options.bypassCache) return load(null);
-  return contributionsCache.getOrSet(key, load, LONG_CACHE_TTL, shouldFetch);
+  if (options.bypassCache) {
+    try {
+      return await load(null);
+    } catch (err: unknown) {
+      const staleData = await contributionsCache.get(key);
+      if (staleData) {
+        console.warn(
+          `[GitHub API] Fetch failed for "${username}", falling back to stale cache:`,
+          err
+        );
+        return {
+          ...staleData,
+          isOfflineFallback: true,
+        };
+      }
+      throw err;
+    }
+  }
+
+  try {
+    return await contributionsCache.getOrSet(key, load, LONG_CACHE_TTL, shouldFetch);
+  } catch (err: unknown) {
+    const staleData = await contributionsCache.get(key);
+    if (staleData) {
+      console.warn(
+        `[GitHub API] Fetch failed for "${username}", falling back to stale cache:`,
+        err
+      );
+      return {
+        ...staleData,
+        isOfflineFallback: true,
+      };
+    }
+    throw err;
+  }
 }
 
 async function fetchContributionsUncached(

--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -775,6 +775,29 @@ describe('generateSVG', () => {
     });
   });
 
+  describe('isOfflineFallback parameter', () => {
+    it('appends [STALE CACHE] to the username when isOfflineFallback is true', () => {
+      const svg = generateSVG(
+        mockStats,
+        { user: 'octocat', isOfflineFallback: true } as unknown as BadgeParams,
+        mockCalendar
+      );
+
+      expect(svg).toContain('[STALE CACHE]');
+      expect(svg).toContain('fill="#ff9f43"');
+    });
+
+    it('does not append [STALE CACHE] when isOfflineFallback is false or omitted', () => {
+      const svg = generateSVG(
+        mockStats,
+        { user: 'octocat' } as unknown as BadgeParams,
+        mockCalendar
+      );
+
+      expect(svg).not.toContain('[STALE CACHE]');
+    });
+  });
+
   describe('SVG dimensions per size', () => {
     it('renders responsive width="100%" for medium size (default)', () => {
       const svg = generateSVG(

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -499,7 +499,7 @@ function renderFooter(
   const s = createScaler(sf);
   return `
   ${!params.hide_stats ? renderStatsSection(stats, labels, s, params) : ''}
-  ${!params.hide_title ? `<text x="${s(300)}" y="${s(50)}" text-anchor="middle" class="title">${truncateUsername(safeUser).toUpperCase()}</text>` : ''}
+  ${!params.hide_title ? `<text x="${s(300)}" y="${s(50)}" text-anchor="middle" class="title">${truncateUsername(safeUser).toUpperCase()}${params.isOfflineFallback ? '<tspan fill="#ff9f43" font-size="10px" font-weight="bold"> [STALE CACHE]</tspan>' : ''}</text>` : ''}
   <rect
     x="${s(100)}"
     y="${s(80)}"
@@ -767,7 +767,7 @@ function generateAutoThemeSVG(
   ${!params.hide_stats ? renderStatsSection(stats, labels, s, params) : ''}
 ${
   !params.hide_title
-    ? `<text x="${s(300)}" y="${s(50)}" text-anchor="middle" class="title">${truncateUsername(safeUser).toUpperCase()}</text>`
+    ? `<text x="${s(300)}" y="${s(50)}" text-anchor="middle" class="title">${truncateUsername(safeUser).toUpperCase()}${params.isOfflineFallback ? '<tspan fill="#ff9f43" font-size="10px" font-weight="bold"> [STALE CACHE]</tspan>' : ''}</text>`
     : ''
 }
 
@@ -1573,7 +1573,7 @@ export function generateHeatmapSVG(
 
   <rect width="${W}" height="${H}" rx="${radius}" fill="${params.hideBackground ? 'transparent' : bg}" ${borderAttr} />
 
-  ${!params.hide_title ? `<text x="${s(60)}" y="${s(30)}" class="hm-title">${truncateUsername(safeUser).toUpperCase()}</text>` : ''}
+  ${!params.hide_title ? `<text x="${s(60)}" y="${s(30)}" class="hm-title">${truncateUsername(safeUser).toUpperCase()}${params.isOfflineFallback ? '<tspan fill="#ff9f43" font-size="10px" font-weight="bold"> [STALE CACHE]</tspan>' : ''}</text>` : ''}
 
   ${grid}
 
@@ -1709,7 +1709,7 @@ function generateAutoThemeHeatmapSVG(
 
   <rect width="${W}" height="${H}" rx="${radius}" ${params.hideBackground ? 'fill="transparent"' : 'class="cp-bg-fill"'} />
 
-  ${!params.hide_title ? `<text x="${s(60)}" y="${s(30)}" class="hm-title">${truncateUsername(safeUser).toUpperCase()}</text>` : ''}
+  ${!params.hide_title ? `<text x="${s(60)}" y="${s(30)}" class="hm-title">${truncateUsername(safeUser).toUpperCase()}${params.isOfflineFallback ? '<tspan fill="#ff9f43" font-size="10px" font-weight="bold"> [STALE CACHE]</tspan>' : ''}</text>` : ''}
 
   ${grid}
 
@@ -2359,7 +2359,7 @@ export function generatePulseSVG(
   <line x1="${paddingX}" y1="${paddingYTop}" x2="${width - paddingX}" y2="${paddingYTop}" stroke="${text}" stroke-width="0.75" stroke-opacity="0.05" />
   <line x1="${paddingX}" y1="${paddingYTop + graphHeight}" x2="${width - paddingX}" y2="${paddingYTop + graphHeight}" stroke="${text}" stroke-width="0.75" stroke-opacity="0.05" />
 
-  ${!params.hide_title ? `<text x="30" y="38" class="title">${safeUser.toUpperCase()}</text>` : ''}
+  ${!params.hide_title ? `<text x="30" y="38" class="title">${safeUser.toUpperCase()}${params.isOfflineFallback ? '<tspan fill="#ff9f43" font-size="10px" font-weight="bold"> [STALE CACHE]</tspan>' : ''}</text>` : ''}
   ${
     !params.hide_stats
       ? `
@@ -2552,7 +2552,7 @@ function generateAutoThemePulseSVG(
   <line x1="${paddingX}" y1="${paddingYTop}" x2="${width - paddingX}" y2="${paddingYTop}" stroke="var(--cp-text)" stroke-width="0.75" stroke-opacity="0.05" />
   <line x1="${paddingX}" y1="${paddingYTop + graphHeight}" x2="${width - paddingX}" y2="${paddingYTop + graphHeight}" stroke="var(--cp-text)" stroke-width="0.75" stroke-opacity="0.05" />
 
-  ${!params.hide_title ? `<text x="30" y="38" class="title">${safeUser.toUpperCase()}</text>` : ''}
+  ${!params.hide_title ? `<text x="30" y="38" class="title">${safeUser.toUpperCase()}${params.isOfflineFallback ? '<tspan fill="#ff9f43" font-size="10px" font-weight="bold"> [STALE CACHE]</tspan>' : ''}</text>` : ''}
   ${
     !params.hide_stats
       ? `

--- a/types/index.ts
+++ b/types/index.ts
@@ -95,6 +95,7 @@ export interface RepoContribution {
 export interface ExtendedContributionData {
   calendar: ContributionCalendar;
   repoContributions: RepoContribution[];
+  isOfflineFallback?: boolean;
 }
 
 /**
@@ -228,6 +229,7 @@ export interface BadgeParams {
   disable_particles?: boolean;
   animate?: boolean;
   glow?: boolean;
+  isOfflineFallback?: boolean;
 
   /** @internal Temporary property to track custom gradient ID during SVG generation. */
   __customGradientId?: string;


### PR DESCRIPTION
## Description

Fixes #2185 

This PR implements robust cache fallbacks when the GitHub GraphQL or REST APIs degrade, return rate limit responses (HTTP 403/429), or experience network timeouts. Instead of rejecting the request and displaying a server error or rate-limited badge, CommitPulse now falls back to serving the user's stale cache data (from memory or MongoDB via Upstash/Vercel KV) even if it has exceeded the standard cache TTL. 

Additionally, a premium and subtle `[STALE CACHE]` status indicator tag is rendered next to the username title using an inline SVG `<tspan>` element so viewers are aware that the badge is rendering in offline/fallback mode.

Fixes #2185

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
When the offline/stale cache fallback is active, an elegant tag is appended directly to the username:
> **USER_NAME** `[STALE CACHE]`

It is self-contained within the SVG text element, preserving horizontal centering and alignment on auto-theme, isometric, heatmap, and pulse views.

---

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (N/A)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
