### PR TITLE
test: add CherryBlossom component tests

### DIFF
--- a/components/CherryBlossom.test.tsx
+++ b/components/CherryBlossom.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import CherryBlossom from './CherryBlossom';
+import type React from 'react';
+import '@testing-library/jest-dom';
+// Mock framer-motion
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>) => (
+      <div data-testid="motion-div" {...props}>
+        {children}
+      </div>
+    ),
+  },
+}));
+
+describe('CherryBlossom', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders without crashing after mount', async () => {
+    const { container } = render(<CherryBlossom />);
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeTruthy();
+    });
+  });
+
+  it('renders the cherry blossom container', async () => {
+    const { container } = render(<CherryBlossom />);
+
+    await waitFor(() => {
+      expect(container.querySelector('.fixed.inset-0')).toBeInTheDocument();
+    });
+  });
+
+  it('renders 25 falling petals', async () => {
+    render(<CherryBlossom />);
+
+    await waitFor(() => {
+      const petals = screen.getAllByTestId('motion-div');
+      expect(petals).toHaveLength(25);
+    });
+  });
+
+  it('renders decorative branch SVGs', async () => {
+    const { container } = render(<CherryBlossom />);
+
+    await waitFor(() => {
+      const svgs = container.querySelectorAll('svg');
+
+      // 2 branch SVGs + 25 petal SVGs
+      expect(svgs.length).toBeGreaterThanOrEqual(27);
+    });
+  });
+
+  it('unmounts cleanly without throwing errors', async () => {
+    const { unmount } = render(<CherryBlossom />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('motion-div')).toHaveLength(25);
+    });
+
+    expect(() => unmount()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Description
Adds a dedicated test suite for the CherryBlossom component to improve reliability and prevent regressions in rendering and animation-related behavior.

## Changes

- Added components/CherryBlossom.test.tsx
- Mocked framer-motion to simplify animation testing
- Added render validation tests
- Added petal generation/rendering assertions
- Added SVG rendering checks
- Added unmount/cleanup verification

Fixes #2270 

## Pillar

- [x] 📐 Pillar 2 — Geometric SVG Improvement
- [x] 🛠️ Other (Bug fix, refactoring, docs)


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
