### PR TITLE
test(types-index): create type safety assertion tests for types/index.ts

### DIFF
--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,0 +1,62 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type {
+  StreakStats,
+  BadgeTheme,
+  ContributionDay,
+  BadgeParams,
+  NotificationPreferences,
+  HexColor,
+  SpeedString,
+  NotificationFrequency,
+} from './index';
+
+describe('Type Safety Assertions for types/index.ts', () => {
+  it('Test 1: StreakStats should strictly require number and string types', () => {
+    // Asserts that core streak logic cannot accidentally be converted to strings
+    expectTypeOf<StreakStats>().toHaveProperty('currentStreak').toBeNumber();
+    expectTypeOf<StreakStats>().toHaveProperty('longestStreak').toBeNumber();
+    expectTypeOf<StreakStats>().toHaveProperty('totalContributions').toBeNumber();
+    expectTypeOf<StreakStats>().toHaveProperty('todayDate').toBeString();
+  });
+
+  it('Test 2: BadgeTheme should enforce HexColor branding on core properties', () => {
+    // Asserts that standard strings cannot be passed where branded HexColors are required
+    expectTypeOf<BadgeTheme>().toHaveProperty('bg').toEqualTypeOf<HexColor>();
+    expectTypeOf<BadgeTheme>().toHaveProperty('text').toEqualTypeOf<HexColor>();
+    expectTypeOf<BadgeTheme>().toHaveProperty('accent').toEqualTypeOf<HexColor>();
+    // Asserts that the negative state color is optional
+    expectTypeOf<BadgeTheme>().toHaveProperty('negative').toEqualTypeOf<HexColor | undefined>();
+  });
+
+  it('Test 3: ContributionDay should correctly type LoC properties as optional', () => {
+    // Asserts base properties
+    expectTypeOf<ContributionDay>().toHaveProperty('contributionCount').toBeNumber();
+    expectTypeOf<ContributionDay>().toHaveProperty('date').toBeString();
+    // Asserts that Lines of Code (LoC) properties do not break the API if omitted
+    expectTypeOf<ContributionDay>()
+      .toHaveProperty('locAdditions')
+      .toEqualTypeOf<number | undefined>();
+    expectTypeOf<ContributionDay>()
+      .toHaveProperty('locDeletions')
+      .toEqualTypeOf<number | undefined>();
+  });
+
+  it('Test 4: BadgeParams should enforce strict literal unions on configuration flags', () => {
+    expectTypeOf<BadgeParams>().toHaveProperty('user').toBeString();
+    // Asserts that speed requires a specific template literal format (e.g., '4s')
+    expectTypeOf<BadgeParams>().toHaveProperty('speed').toEqualTypeOf<SpeedString>();
+    // Asserts that animations are restricted to exact string literals or undefined
+    expectTypeOf<BadgeParams>()
+      .toHaveProperty('entrance')
+      .toEqualTypeOf<'rise' | 'fade' | 'slide' | 'none' | undefined>();
+  });
+
+  it('Test 5: NotificationPreferences should enforce exact literal types for frequency', () => {
+    expectTypeOf<NotificationPreferences>().toHaveProperty('enabled').toBeBoolean();
+    expectTypeOf<NotificationPreferences>().toHaveProperty('email').toBeString();
+    // Asserts that frequency is tightly bound to the NotificationFrequency type
+    expectTypeOf<NotificationPreferences>()
+      .toHaveProperty('frequency')
+      .toEqualTypeOf<NotificationFrequency>();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2358

Hey @souravjhahind, I've added the 5 type safety assertions for the core interfaces using `expectTypeOf` as requested. The tests pass perfectly on my local machine and the file is pushed. Let me know if you need any adjustments!

## Pillar

- [ ] 🍄 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] ⏱️ Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A - This PR strictly adds TypeScript compiler tests (`.test-d.ts`), so there are no visual UI changes.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (ran `npm run typecheck`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
