### PR TITLE
fix(api): return proper 404/429 status codes from /api/stats instead of generic 500

### DIFF
--- a/app/api/stats/route.test.ts
+++ b/app/api/stats/route.test.ts
@@ -170,14 +170,14 @@ describe('GET /api/stats', () => {
     expect(body.error).toBe('User not found');
   });
 
-  it('returns 403 when GitHub rate limiting bubbles up from the client', async () => {
+  it('returns 429 when GitHub rate limiting bubbles up from the client', async () => {
     vi.mocked(fetchGitHubContributions).mockRejectedValue(new Error('API Rate Limit Exceeded'));
 
     const response = await GET(makeRequest({ user: 'testuser' }));
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(429);
     const body = await response.json();
-    expect(body.error).toBe('GitHub API rate limit reached. Please configure GITHUB_TOKEN.');
+    expect(body.error).toBe('GitHub API rate limit reached. Please try again later.');
   });
 
   it('returns 500 with a generic message for non-Error throws', async () => {

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -97,8 +97,8 @@ export async function GET(request: Request) {
       message.includes('status 403')
     ) {
       return NextResponse.json(
-        { error: 'GitHub API rate limit reached. Please configure GITHUB_TOKEN.' },
-        { status: 403 }
+        { error: 'GitHub API rate limit reached. Please try again later.' },
+        { status: 429 }
       );
     }
 


### PR DESCRIPTION
## Description

Fixes #2430

The `/api/stats` endpoint was returning `403 Forbidden` for GitHub API rate limit errors. The semantically correct HTTP status code for rate limiting is `429 Too Many Requests`. This PR updates the status code and error message to be more accurate and user-friendly.

**Changes:**
- Changed rate limit error response from `403` to `429 Too Many Requests`
- Updated error message from "Please configure GITHUB_TOKEN" to "Please try again later" (more appropriate for end-user-facing API)
- Updated the corresponding test to expect `429` instead of `403`

The `404 Not Found` handling for non-existent users was already in place from a previous upstream commit.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — this is a backend API status code fix.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.