### PR TITLE
fix(ux): show refresh toast only after data transition completes

### DIFF
--- a/components/dashboard/RefreshButton.test.tsx
+++ b/components/dashboard/RefreshButton.test.tsx
@@ -65,7 +65,23 @@ describe('RefreshButton', () => {
     expect(mockPush).toHaveBeenCalledWith('/dashboard/testuser?refresh=true');
   });
 
-  it("calls toast.success when refresh searchParam is 'true'", () => {
+  it('shows toast.success when transition completes (isPending: true → false)', () => {
+    // First render: isPending = true (transition in progress)
+    vi.mocked(useTransition).mockReturnValue([true, (cb) => cb()]);
+
+    const { rerender } = render(<RefreshButton username="testuser" />);
+
+    // Toast should NOT fire while still pending
+    expect(toast.success).not.toHaveBeenCalled();
+
+    // Second render: isPending = false (transition completed)
+    vi.mocked(useTransition).mockReturnValue([false, (cb) => cb()]);
+    rerender(<RefreshButton username="testuser" />);
+
+    expect(toast.success).toHaveBeenCalledWith('Dashboard refreshed successfully');
+  });
+
+  it('cleans up ?refresh=true from URL without showing toast', () => {
     // Simulate the URL being: /dashboard/testuser?refresh=true
     vi.mocked(useSearchParams).mockReturnValue({
       get: (key: string) => (key === 'refresh' ? 'true' : null),
@@ -73,7 +89,10 @@ describe('RefreshButton', () => {
 
     render(<RefreshButton username="testuser" />);
 
-    expect(toast.success).toHaveBeenCalledWith('Dashboard refreshed successfully');
+    // Should clean up the URL
+    expect(mockReplace).toHaveBeenCalledWith('/dashboard/testuser');
+    // Should NOT show toast just because the param is present
+    expect(toast.success).not.toHaveBeenCalled();
   });
 
   it('button is disabled when isPending is true', () => {

--- a/components/dashboard/RefreshButton.tsx
+++ b/components/dashboard/RefreshButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useTransition } from 'react';
+import { useEffect, useRef, useTransition } from 'react';
 import { RefreshCw } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
@@ -16,10 +16,20 @@ export default function RefreshButton({ username }: RefreshButtonProps) {
 
   const [isPending, startTransition] = useTransition();
 
-  useEffect(() => {
-    if (searchParams.get('refresh') === 'true') {
-      toast.success('Dashboard refreshed successfully');
+  // Track previous pending state to detect transition completion
+  const wasPendingRef = useRef(false);
 
+  useEffect(() => {
+    // Show success toast only when the transition finishes (isPending: true → false)
+    if (wasPendingRef.current && !isPending) {
+      toast.success('Dashboard refreshed successfully');
+    }
+    wasPendingRef.current = isPending;
+  }, [isPending]);
+
+  useEffect(() => {
+    // Clean up the ?refresh=true param from the URL without triggering a toast
+    if (searchParams.get('refresh') === 'true') {
       router.replace(`/dashboard/${username}`);
     }
   }, [searchParams, router, username]);


### PR DESCRIPTION
## Description

Fixes #2432

The RefreshButton was showing "Dashboard refreshed successfully" toast immediately when the `?refresh=true` URL parameter appeared — before the server had actually returned fresh data. This created a misleading UX where users saw a success message while stale data was still displayed.

**Changes:**
- Replaced the URL-param-based toast trigger with a `useRef`-based transition completion detector
- Toast now fires only when `isPending` transitions from `true` to `false` (i.e., when React's transition actually finishes and new data is rendered)
- The `?refresh=true` URL cleanup still happens via `router.replace()` but no longer triggers a toast
- Updated tests to verify the new behavior: toast fires on transition completion, not on URL param presence
- Added a new test verifying URL cleanup does NOT trigger a premature toast

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — this is a UX timing fix. The toast still appears, just at the correct moment.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.