### PR TITLE
fix: preserve authoritative total contributions during delta sync

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -328,7 +328,8 @@ export function displayName(profile: GitHubUserProfile): string {
 
 function mergeCalendars(
   oldCal: ContributionCalendar,
-  newCal: ContributionCalendar
+  newCal: ContributionCalendar,
+  authoritativeTotal?: number
 ): ContributionCalendar {
   const dayMap = new Map<string, ContributionDay>();
 
@@ -361,10 +362,10 @@ function mergeCalendars(
     mergedWeeks.push(currentWeek);
   }
 
-  const total = sortedDays.reduce((sum, d) => sum + d.contributionCount, 0);
+  const calculatedTotal = sortedDays.reduce((sum, d) => sum + d.contributionCount, 0);
 
   return {
-    totalContributions: total,
+    totalContributions: authoritativeTotal ?? calculatedTotal,
     weeks: mergedWeeks,
   };
 }
@@ -486,9 +487,12 @@ async function fetchContributionsUncached(
   }
 
   if (isDeltaSync && cached) {
-    calendar = mergeCalendars(cached.calendar, calendar);
+    calendar = mergeCalendars(
+      cached.calendar,
+      calendar,
+      data.data.user.contributionsCollection.contributionCalendar.totalContributions
+    );
   }
-
   // Inject deterministic Lines of Code (LoC) approximation
   // Since GitHub's contributionCalendar doesn't provide native LoC metrics,
   // we generate a consistent estimation based on the day's commit volume.


### PR DESCRIPTION
## Description

Fixes #2439 

Preserves GitHub's authoritative `totalContributions` value during delta synchronization.

Currently, `mergeCalendars()` recomputes `totalContributions` from merged day-level contribution data after combining cached and freshly fetched calendars. During delta sync, GitHub already provides an authoritative `contributionCalendar.totalContributions` value, but this value is discarded and replaced with a client-side calculation.

This change updates the merge logic to preserve GitHub's source-of-truth contribution total while continuing to merge day-level calendar data as before.

### Changes Made

* Added an optional `authoritativeTotal` parameter to `mergeCalendars()`
* Preserved GitHub's `totalContributions` value during delta synchronization
* Kept the existing calculated total as a fallback for non-delta use cases
* Left week/day merge behavior unchanged

### Validation

* Successfully ran `npm run lint`
* Successfully ran `npm run build`
* Verified no TypeScript errors were introduced

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — Internal data integrity and synchronization logic change. No UI modifications.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (existing unrelated warning in `WallOfLove.tsx` remains unchanged).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no SVG/UI output affected).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
