### PR TITLE
test(types-network): add type safety assertions

### DIFF
--- a/types/network.test.ts
+++ b/types/network.test.ts
@@ -1,0 +1,38 @@
+import { describe, expectTypeOf, test } from 'vitest';
+import type { GetClientIpOptions, TrustedProxyConfig } from './network';
+
+describe('types/network', () => {
+  test('TrustedProxyConfig requires trustedProxies as string array', () => {
+    expectTypeOf<TrustedProxyConfig>().toHaveProperty('trustedProxies').toEqualTypeOf<string[]>();
+  });
+
+  test('TrustedProxyConfig allows optional trustPrivateRanges boolean', () => {
+    expectTypeOf<TrustedProxyConfig>()
+      .toHaveProperty('trustPrivateRanges')
+      .toEqualTypeOf<boolean | undefined>();
+  });
+
+  test('GetClientIpOptions allows optional proxyConfig', () => {
+    expectTypeOf<GetClientIpOptions>()
+      .toHaveProperty('proxyConfig')
+      .toEqualTypeOf<TrustedProxyConfig | undefined>();
+  });
+
+  test('GetClientIpOptions allows optional headersPriority string array', () => {
+    expectTypeOf<GetClientIpOptions>()
+      .toHaveProperty('headersPriority')
+      .toEqualTypeOf<string[] | undefined>();
+  });
+
+  test('standard client IP options config satisfies GetClientIpOptions', () => {
+    const options = {
+      proxyConfig: {
+        trustedProxies: ['127.0.0.1', '10.0.0.0/8'],
+        trustPrivateRanges: true,
+      },
+      headersPriority: ['x-vercel-forwarded-for', 'cf-connecting-ip', 'x-real-ip'],
+    } satisfies GetClientIpOptions;
+
+    expectTypeOf(options).toMatchTypeOf<GetClientIpOptions>();
+  });
+});


### PR DESCRIPTION
## Description

Added type safety assertion tests for `types/network.ts` using Vitest `expectTypeOf`.

These tests verify:
- `TrustedProxyConfig.trustedProxies` is a required `string[]`
- `trustPrivateRanges` is an optional boolean
- `GetClientIpOptions.proxyConfig` uses `TrustedProxyConfig`
- `headersPriority` is an optional `string[]`
- standard client IP config satisfies `GetClientIpOptions`

Fixes #2359

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable. This PR only adds type-level tests and does not change UI/SVG output.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npx vitest run types/network.test.ts`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
