### PR TITLE
fix(dashboard): correct custom date range shift calculation

### DIFF
--- a/utils/dashboardPeriod.ts
+++ b/utils/dashboardPeriod.ts
@@ -169,7 +169,7 @@ export function shiftDashboardPeriod(
     const to = new Date(period.to);
     const spanDays = Math.max(
       1,
-      Math.round((to.getTime() - from.getTime()) / (24 * 60 * 60 * 1000)) + 1
+      Math.round((to.getTime() - from.getTime()) / (24 * 60 * 60 * 1000))
     );
     const shiftedFrom = addDaysUtc(from, offset * spanDays);
     const shiftedTo = addDaysUtc(to, offset * spanDays);


### PR DESCRIPTION
## Description

Fixes #2458 

This PR fixes an off-by-one error in custom dashboard period shifting within `dashboardPeriod.ts`.

### Problem

The custom date range shift logic calculated the span using:

```ts
const spanDays =
  Math.round((period.to.getTime() - period.from.getTime()) / 86400000) + 1;
```

Custom dashboard periods are already normalized to:

```text
from = 00:00:00.000
to   = 23:59:59.999
```

Because the millisecond difference already represents the correct number of calendar days when divided by `86400000` and rounded, the additional `+1` caused the calculated span to be one day too large.

As a result, shifting a custom period forward or backward would skip an extra calendar day.

### Fix

Removed the redundant `+1` from the span calculation:

```ts
const spanDays = Math.round(
  (period.to.getTime() - period.from.getTime()) / 86400000
);
```

### Result

* Custom date ranges shift by the correct number of days.
* No extra day is skipped during navigation.
* Forward and backward period navigation remain consistent.
* Range length is preserved correctly.

### Additional Notes

Implementation details and reasoning have been documented in:

```text
walkthrough.md
```

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A – Logic-only bug fix. No UI or SVG changes.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no SVG changes in this PR).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
