### PR TITLE
test: add dashboardPeriod utility tests

### DIFF
--- a/utils/dashboardPeriod.test.ts
+++ b/utils/dashboardPeriod.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { resolveDashboardPeriod } from './dashboardPeriod';
+describe('resolveDashboardPeriod', () => {
+  it('parses valid month period', () => {
+    const result = resolveDashboardPeriod({
+      month: '2024-06',
+    });
+
+    expect(result.kind).toBe('month');
+    expect(result.label).toBe('June 2024');
+  });
+
+  it('parses valid year period', () => {
+    const result = resolveDashboardPeriod({
+      year: '2024',
+    });
+
+    expect(result.kind).toBe('year');
+    expect(result.year).toBe('2024');
+  });
+
+  it('handles leap year month correctly', () => {
+    const result = resolveDashboardPeriod({
+      month: '2024-02',
+    });
+
+    expect(result.kind).toBe('month');
+    expect(result.to).toContain('2024-02-29');
+  });
+
+  it('falls back to rolling period for invalid month', () => {
+    const result = resolveDashboardPeriod({
+      month: '2024-13',
+    });
+
+    expect(result.kind).toBe('rolling');
+    expect(result.label).toBe('Last 12 months');
+  });
+
+  it('creates custom range period', () => {
+    const result = resolveDashboardPeriod({
+      from: '2024-01-01',
+      to: '2024-01-31',
+    });
+
+    expect(result.kind).toBe('range');
+    expect(result.from).toContain('2024-01-01');
+    expect(result.to).toContain('2024-01-31');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2300

Added `utils/dashboardPeriod.test.ts` with comprehensive test coverage for dashboard period resolution logic.

### Changes Made

* Added test for valid month period parsing
* Added test for valid year period parsing
* Added leap year handling test (February 2024)
* Added invalid month fallback test
* Added custom date range period test

All tests pass successfully with Vitest.

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse premium quality aesthetic standard. (Not applicable for tests)
* [ ] (Recommended) I joined the CommitPulse Discord community.
<img width="1500" height="1000" alt="Screenshot 2026-06-02 015112" src="https://github.com/user-attachments/assets/c235dd96-a29a-44e4-9ec2-e4a2c41ccc7b" />
