### PR TITLE
test: add githubParamsSchema validation coverage

### DIFF
--- a/lib/validations.githubParamsSchema.test.ts
+++ b/lib/validations.githubParamsSchema.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { githubParamsSchema } from './validations';
+
+const parseValid = (params: Record<string, unknown>) => {
+  const result = githubParamsSchema.safeParse(params);
+
+  expect(result.success).toBe(true);
+
+  if (!result.success) {
+    throw new Error('Expected githubParamsSchema to parse successfully');
+  }
+
+  return result.data;
+};
+
+const parseInvalid = (params: Record<string, unknown>) => {
+  const result = githubParamsSchema.safeParse(params);
+
+  expect(result.success).toBe(false);
+
+  if (result.success) {
+    throw new Error('Expected githubParamsSchema to fail validation');
+  }
+
+  return result.error.flatten().fieldErrors;
+};
+
+describe('githubParamsSchema', () => {
+  it('parses a valid username and defaults refresh to false', () => {
+    const data = parseValid({ username: 'octocat' });
+
+    expect(data.username).toBe('octocat');
+    expect(data.refresh).toBe(false);
+  });
+
+  it('trims username whitespace before validation', () => {
+    const data = parseValid({ username: '  octocat  ' });
+
+    expect(data.username).toBe('octocat');
+  });
+
+  it('transforms refresh to true only when value is exactly "true"', () => {
+    expect(parseValid({ username: 'octocat', refresh: 'true' }).refresh).toBe(true);
+
+    expect(parseValid({ username: 'octocat', refresh: 'false' }).refresh).toBe(false);
+
+    expect(parseValid({ username: 'octocat', refresh: '1' }).refresh).toBe(false);
+
+    expect(parseValid({ username: 'octocat', refresh: 'TRUE' }).refresh).toBe(false);
+  });
+
+  it('rejects missing, empty, and whitespace-only usernames with clear errors', () => {
+    expect(parseInvalid({}).username?.[0]).toBe('Missing "username" parameter');
+
+    expect(parseInvalid({ username: '' }).username?.[0]).toBe('Username is required');
+
+    expect(parseInvalid({ username: '   ' }).username?.[0]).toBe('Username is required');
+  });
+
+  it('enforces GitHub username length boundaries', () => {
+    const maxLengthUsername = 'a'.repeat(39);
+
+    expect(parseValid({ username: maxLengthUsername }).username).toBe(maxLengthUsername);
+
+    expect(parseInvalid({ username: 'a'.repeat(40) }).username?.[0]).toBe(
+      'GitHub username cannot exceed 39 characters'
+    );
+  });
+
+  it('accepts valid GitHub username formats and rejects invalid ones', () => {
+    expect(parseValid({ username: 'valid-user-123' }).username).toBe('valid-user-123');
+
+    expect(parseInvalid({ username: '-octocat' }).username?.[0]).toBe('Invalid GitHub username');
+
+    expect(parseInvalid({ username: 'octocat-' }).username?.[0]).toBe('Invalid GitHub username');
+
+    expect(parseInvalid({ username: 'octo--cat' }).username?.[0]).toBe('Invalid GitHub username');
+
+    expect(parseInvalid({ username: 'octo_cat' }).username?.[0]).toBe('Invalid GitHub username');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2324 

Added focused unit tests for `githubParamsSchema` in a new test file: `lib/validations.githubParamsSchema.test.ts`.

The tests cover:
- Valid username parsing
- Username whitespace trimming
- Default `refresh` value
- `refresh` string-to-boolean transformation
- Missing, empty, and whitespace-only username validation errors
- GitHub username length boundary
- Invalid GitHub username formats

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
Not applicable. This PR only adds unit test coverage for `githubParamsSchema`.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have tested these changes locally (`npm test -- lib/validations.githubParamsSchema.test.ts`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] I have run `npx prettier --write lib/validations.githubParamsSchema.test.ts `locally.
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
