### PR TITLE
test(student-profile): add empty fallback coverage

### DIFF
--- a/models/StudentProfile.empty-fallback.test.ts
+++ b/models/StudentProfile.empty-fallback.test.ts
@@ -1,0 +1,43 @@
+import mongoose from 'mongoose';
+import { describe, expect, it } from 'vitest';
+import { StudentProfile } from './StudentProfile';
+
+describe('StudentProfile Empty Fallback', () => {
+  it('uses empty string as default phone value', () => {
+    const phonePath = StudentProfile.schema.path('phone') as mongoose.SchemaType & {
+      options: Record<string, unknown>;
+    };
+
+    expect(phonePath.options.default).toBe('');
+  });
+
+  it('uses empty string as default experience description', () => {
+    const experiencePath = StudentProfile.schema.path('experience');
+
+    expect(experiencePath).toBeDefined();
+  });
+
+  it('allows skills to exist as an empty array', () => {
+    const skillsPath = StudentProfile.schema.path('skills') as unknown as {
+      instance: string;
+    };
+
+    expect(skillsPath.instance).toBe('Array');
+  });
+
+  it('allows education to exist as an empty array', () => {
+    const educationPath = StudentProfile.schema.path('education') as unknown as {
+      instance: string;
+    };
+
+    expect(educationPath.instance).toBe('Array');
+  });
+
+  it('allows experience to exist as an empty array', () => {
+    const experiencePath = StudentProfile.schema.path('experience') as unknown as {
+      instance: string;
+    };
+
+    expect(experiencePath.instance).toBe('Array');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2903

Added empty fallback test coverage for `models/StudentProfile.ts`.

### Tests Added

* Verifies optional `phone` field uses an empty string fallback.
* Verifies `skills` is configured as an array field.
* Verifies `education` is configured as an array field.
* Verifies `experience` is configured as an array field.
* Confirms experience schema path exists for empty fallback validation.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable)
* [ ] (Recommended) I joined the CommitPulse Discord community.
