### PR TITLE
test(svg-constants): add empty fallback coverage

### DIFF
--- a/lib/svg/constants.empty-fallback.test.ts
+++ b/lib/svg/constants.empty-fallback.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CONTRIBUTION_MILESTONES,
+  FONT_MAP,
+  GHOST_HEIGHT_PX,
+  LINEAR_SCALE_MULTIPLIER,
+  LOG_SCALE_MULTIPLIER,
+  MAX_LINEAR_HEIGHT,
+  MAX_LOG_HEIGHT,
+  STREAK_MILESTONES,
+  SVG_HEIGHT,
+  SVG_WIDTH,
+} from './constants';
+
+describe('SVG constants empty fallback behavior', () => {
+  it('provides positive fallback SVG dimensions', () => {
+    expect(SVG_WIDTH).toBeGreaterThan(0);
+    expect(SVG_HEIGHT).toBeGreaterThan(0);
+  });
+
+  it('provides safe fallback scaling constants', () => {
+    expect(GHOST_HEIGHT_PX).toBeGreaterThan(0);
+    expect(LOG_SCALE_MULTIPLIER).toBeGreaterThan(0);
+    expect(LINEAR_SCALE_MULTIPLIER).toBeGreaterThan(0);
+  });
+
+  it('provides maximum height bounds for scaled SVG elements', () => {
+    expect(MAX_LOG_HEIGHT).toBeGreaterThan(0);
+    expect(MAX_LINEAR_HEIGHT).toBeGreaterThan(0);
+  });
+
+  it('provides default font fallbacks when no custom font is selected', () => {
+    expect(Object.keys(FONT_MAP).length).toBeGreaterThan(0);
+    expect(FONT_MAP.jetbrains).toContain('monospace');
+    expect(FONT_MAP.fira).toContain('monospace');
+    expect(FONT_MAP.roboto).toContain('sans-serif');
+  });
+
+  it('provides non-empty milestone fallback arrays', () => {
+    expect(CONTRIBUTION_MILESTONES.length).toBeGreaterThan(0);
+    expect(STREAK_MILESTONES.length).toBeGreaterThan(0);
+    expect(CONTRIBUTION_MILESTONES.every((value) => value > 0)).toBe(true);
+    expect(STREAK_MILESTONES.every((value) => value > 0)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2883

Added empty fallback test coverage for `lib/svg/constants.ts`.

### Tests Added

* Verifies SVG dimensions have positive fallback values.
* Ensures scaling constants remain safe and positive.
* Confirms maximum SVG height bounds are defined.
* Validates default font fallback mappings.
* Ensures contribution and streak milestone arrays are non-empty and contain positive values.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable)
* [ ] (Recommended) I joined the CommitPulse Discord community.
