### PR TITLE
test: add empty fallback edge case tests for ContributorsPage

### DIFF
--- a/app/contributors/page.empty-fallback.test.tsx
+++ b/app/contributors/page.empty-fallback.test.tsx
@@ -1,0 +1,127 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ContributorsPage from './page';
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => <img {...props} />,
+}));
+
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('gsap', () => {
+  const tween = { kill: vi.fn() };
+  const mockGsap = {
+    registerPlugin: vi.fn(),
+    to: vi.fn().mockReturnValue(tween),
+    fromTo: vi.fn().mockReturnValue(tween),
+    set: vi.fn(),
+    context: vi.fn((callback: any) => {
+      if (typeof callback === 'function') {
+        callback();
+      }
+      return { revert: vi.fn() };
+    }),
+  };
+  return { default: mockGsap, gsap: mockGsap };
+});
+
+vi.mock('gsap/ScrollTrigger', () => ({
+  ScrollTrigger: {
+    getAll: vi.fn(() => []),
+  },
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: (props: any) => <div {...props}>{props.children}</div>,
+    span: (props: any) => <span {...props}>{props.children}</span>,
+    p: (props: any) => <p {...props}>{props.children}</p>,
+  },
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+  useMotionValue: (initial: any) => ({ current: initial, set: vi.fn() }),
+  useSpring: (value: any) => value,
+  useTransform: (value: any, fn: any) => fn(value.current ?? value),
+}));
+
+describe('ContributorsPage empty fallback', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: async () => [],
+      })
+    ) as any;
+
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+    if (!window.requestAnimationFrame) {
+      window.requestAnimationFrame = (callback: FrameRequestCallback) =>
+        setTimeout(callback, 0) as unknown as number;
+    }
+  });
+
+  it('renders fallback UI when contributors are empty', async () => {
+    const element = await ContributorsPage();
+    render(element);
+
+    expect(screen.getByText(/No architects found/i)).toBeTruthy();
+    expect(screen.getByText(/0 of 0 contributors/i)).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /THE COLLECTIVE/i })).toBeTruthy();
+    expect(screen.getByText(/READY TO BUILD\?/i)).toBeTruthy();
+  });
+
+  it('maintains page layout and empty markers for empty contributor input', async () => {
+    const element = await ContributorsPage();
+    render(element);
+
+    expect(screen.getByRole('heading', { name: /THE VANGUARD/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /THE COLLECTIVE/i })).toBeTruthy();
+    expect(screen.getByText(/Explore The Elite/i)).toBeTruthy();
+    expect(screen.queryByText(/View Profile/i)).toBeNull();
+  });
+
+  it('handles fetch failures gracefully and still renders fallback state', async () => {
+    global.fetch = vi.fn(() => Promise.reject(new Error('Network failure'))) as any;
+    const element = await ContributorsPage();
+    render(element);
+
+    expect(screen.getByText(/No architects found/i)).toBeTruthy();
+    expect(screen.getByText(/0 of 0 contributors/i)).toBeTruthy();
+  });
+
+  it('handles non-ok API responses without breaking the page', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        headers: { get: vi.fn(() => null) },
+        json: async () => [],
+      })
+    ) as any;
+
+    const element = await ContributorsPage();
+    render(element);
+
+    expect(screen.getByText(/No architects found/i)).toBeTruthy();
+    expect(screen.getByText(/0 of 0 contributors/i)).toBeTruthy();
+  });
+
+  it('does not emit console errors when the fallback page renders', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const element = await ContributorsPage();
+    render(element);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/app/contributors/page.empty-fallback.test.tsx
+++ b/app/contributors/page.empty-fallback.test.tsx
@@ -42,9 +42,19 @@ vi.mock('gsap/ScrollTrigger', () => ({
 
 vi.mock('framer-motion', () => ({
   motion: {
-    div: (props: any) => <div {...props}>{props.children}</div>,
-    span: (props: any) => <span {...props}>{props.children}</span>,
-    p: (props: any) => <p {...props}>{props.children}</p>,
+    div: 'div',
+    span: 'span',
+    p: 'p',
+    h1: 'h1',
+    h2: 'h2',
+    h3: 'h3',
+    h4: 'h4',
+    h5: 'h5',
+    h6: 'h6',
+    section: 'section',
+    a: 'a',
+    button: 'button',
+    img: 'img',
   },
   AnimatePresence: ({ children }: any) => <>{children}</>,
   useMotionValue: (initial: any) => ({ current: initial, set: vi.fn() }),


### PR DESCRIPTION
## Description

Fixes #2853

Adds focused test coverage for ContributorsPage empty and fallback states.

### Added Tests

* Verifies fallback UI renders when contributors data is empty
* Verifies page layout remains stable in empty state
* Verifies no contributor cards are rendered when the dataset is empty
* Verifies fetch failures fall back safely
* Verifies fallback rendering does not produce console errors

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [ ] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
