### PR TITLE
test(ResumePreviewForm): add unit tests for form rendering, editing, and submission

### DIFF
--- a/components/dashboard/ResumePreviewForm.test.tsx
+++ b/components/dashboard/ResumePreviewForm.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ResumePreviewForm from './ResumePreviewForm';
+import type { ReactNode, HTMLAttributes } from 'react';
+import '@testing-library/jest-dom';
+
+const mocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.error,
+    success: mocks.success,
+  },
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: HTMLAttributes<HTMLDivElement> & { children?: ReactNode }) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+const parsed = {
+  name: 'John Doe',
+  email: 'john@example.com',
+  phone: '1234567890',
+  skills: ['React'],
+  education: [],
+  experience: [],
+};
+
+describe('ResumePreviewForm', () => {
+  const onBack = vi.fn();
+  const onComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders initial parsed values', () => {
+    render(
+      <ResumePreviewForm
+        githubUsername="john"
+        parsed={parsed}
+        fileName="resume.pdf"
+        onBack={onBack}
+        onComplete={onComplete}
+      />
+    );
+
+    expect(screen.getByDisplayValue('John Doe')).toBeTruthy();
+    expect(screen.getByDisplayValue('john@example.com')).toBeTruthy();
+    expect(screen.getByDisplayValue('React')).toBeTruthy();
+  });
+
+  it('updates name, email, and phone fields', () => {
+    render(
+      <ResumePreviewForm
+        githubUsername="john"
+        parsed={parsed}
+        fileName="resume.pdf"
+        onBack={onBack}
+        onComplete={onComplete}
+      />
+    );
+
+    const nameInput = screen.getByDisplayValue('John Doe');
+    const emailInput = screen.getByDisplayValue('john@example.com');
+    fireEvent.change(nameInput, {
+      target: { value: 'Jane Doe' },
+    });
+
+    fireEvent.change(emailInput, {
+      target: { value: 'jane@example.com' },
+    });
+
+    expect((nameInput as HTMLInputElement).value).toBe('Jane Doe');
+    expect((emailInput as HTMLInputElement).value).toBe('jane@example.com');
+  });
+
+  it('adds a new skill', () => {
+    render(
+      <ResumePreviewForm
+        githubUsername="john"
+        parsed={parsed}
+        fileName="resume.pdf"
+        onBack={onBack}
+        onComplete={onComplete}
+      />
+    );
+
+    fireEvent.click(screen.getAllByText('Add')[0]);
+
+    const skillInputs = screen.getAllByRole('textbox');
+    expect(skillInputs.length).toBeGreaterThan(3);
+  });
+
+  it('does not submit when required fields are empty', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <ResumePreviewForm
+        githubUsername="john"
+        parsed={{
+          ...parsed,
+          name: '',
+          email: '',
+        }}
+        fileName="resume.pdf"
+        onBack={onBack}
+        onComplete={onComplete}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Save Profile'));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('submits successfully and calls onComplete', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+      }),
+    }) as unknown as typeof fetch;
+
+    render(
+      <ResumePreviewForm
+        githubUsername="john"
+        parsed={parsed}
+        fileName="resume.pdf"
+        onBack={onBack}
+        onComplete={onComplete}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Save Profile'));
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds comprehensive unit tests for components/dashboard/ResumePreviewForm.tsx to improve confidence in resume data review and submission workflows.

## Changes

- Added tests to verify initial parsed resume data is rendered correctly.
- Added tests to verify name and email fields update when edited.
- Added tests to verify new skills can be added dynamically.
- Added tests to verify submission is blocked when required fields are empty.
- Added tests to verify successful profile save triggers completion flow.
- Mocked external dependencies (sonner, framer-motion, and network requests) to keep tests isolated and deterministic.

Fixes #2274 

## Pillar

- [x] 🎨 Pillar 1 — New Theme Design
- [x] 📐 Pillar 2 — Geometric SVG Improvement
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
