### PR TITLE
test(icons): add empty fallback coverage

### DIFF
--- a/app/components/Icons.empty-fallback.test.tsx
+++ b/app/components/Icons.empty-fallback.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { BoxIcon, CheckIcon, CloseIcon, CopyIcon, ZapIcon } from './Icons';
+
+type IconProps = React.SVGProps<SVGSVGElement>;
+
+vi.mock('lucide-react', () => ({
+  Copy: (props: IconProps) => <svg data-testid="copy-icon" {...props} />,
+  Zap: (props: IconProps) => <svg data-testid="zap-icon" {...props} />,
+  Box: (props: IconProps) => <svg data-testid="box-icon" {...props} />,
+  Check: (props: IconProps) => <svg data-testid="check-icon" {...props} />,
+  X: (props: IconProps) => <svg data-testid="close-icon" {...props} />,
+}));
+
+describe('Icons empty fallback behavior', () => {
+  it('renders CopyIcon without crashing', () => {
+    const { getByTestId } = render(<CopyIcon />);
+    expect(getByTestId('copy-icon')).toBeDefined();
+  });
+
+  it('renders ZapIcon without crashing', () => {
+    const { getByTestId } = render(<ZapIcon />);
+    expect(getByTestId('zap-icon')).toBeDefined();
+  });
+
+  it('renders BoxIcon without crashing', () => {
+    const { getByTestId } = render(<BoxIcon />);
+    expect(getByTestId('box-icon')).toBeDefined();
+  });
+
+  it('renders CheckIcon with fallback styling', () => {
+    const { getByTestId } = render(<CheckIcon />);
+    const icon = getByTestId('check-icon');
+
+    expect(icon.getAttribute('stroke')).toBe('#10b981');
+  });
+
+  it('renders CloseIcon without runtime errors', () => {
+    const { getByTestId } = render(<CloseIcon />);
+    expect(getByTestId('close-icon')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2813

Added empty fallback test coverage for `app/components/Icons.tsx`.

### Tests Added

* Verifies CopyIcon renders without crashing.
* Verifies ZapIcon renders without crashing.
* Verifies BoxIcon renders without crashing.
* Verifies CheckIcon renders with expected fallback styling.
* Verifies CloseIcon renders without runtime errors.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable)
* [ ] (Recommended) I joined the CommitPulse Discord community.
