### PR TITLE
test: add empty input and fallback coverage for track user protection

### DIFF
--- a/services/security/track-user-protection.empty-fallback.test.ts
+++ b/services/security/track-user-protection.empty-fallback.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { trackUserProtection } from './track-user-protection';
+import { gitHubUserValidator } from '../github/validate-user';
+
+vi.mock('../github/validate-user', () => ({
+  gitHubUserValidator: {
+    validateUser: vi.fn(),
+  },
+}));
+
+describe('trackUserProtection empty/fallback cases', () => {
+  beforeEach(() => {
+    trackUserProtection.reset();
+    vi.clearAllMocks();
+  });
+
+  it('returns INVALID_FORMAT for empty string', async () => {
+    const result = await trackUserProtection.verifyAndDeduplicate('');
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'INVALID_FORMAT',
+    });
+  });
+
+  it('returns INVALID_FORMAT for whitespace only input', async () => {
+    const result = await trackUserProtection.verifyAndDeduplicate('   ');
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'INVALID_FORMAT',
+    });
+  });
+
+  it('returns INVALID_FORMAT for username longer than 39 characters', async () => {
+    const result = await trackUserProtection.verifyAndDeduplicate('a'.repeat(40));
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'INVALID_FORMAT',
+    });
+  });
+
+  it('returns USER_NOT_FOUND when validator reports missing user', async () => {
+    vi.mocked(gitHubUserValidator.validateUser).mockResolvedValue(false);
+
+    const result = await trackUserProtection.verifyAndDeduplicate('octocat');
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'USER_NOT_FOUND',
+    });
+  });
+
+  it('handles cooldown after write record', async () => {
+    vi.mocked(gitHubUserValidator.validateUser).mockResolvedValue(true);
+
+    trackUserProtection.recordWrite('octocat');
+
+    const result = await trackUserProtection.verifyAndDeduplicate('octocat');
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('COOLDOWN_ACTIVE');
+    expect(result.remainingMs).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2963 

Adds edge-case and fallback coverage for `TrackUserProtection`.

### Added tests

- Empty string returns `INVALID_FORMAT`
- Whitespace-only input returns `INVALID_FORMAT`
- Username longer than GitHub's 39-character limit returns `INVALID_FORMAT`
- Missing GitHub user returns `USER_NOT_FOUND`
- Cooldown protection returns `COOLDOWN_ACTIVE`

Created:

`services/security/track-user-protection.empty-fallback.test.ts`

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

<img width="842" height="281" alt="image" src="https://github.com/user-attachments/assets/4574ceda-d980-4150-9964-fe083f129959" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The change is limited to test coverage and does not affect SVG output.
- [x] (Recommended) I joined the CommitPulse Discord community.