### PR TITLE
test(scroll-restoration): add empty fallback coverage

### DIFF
--- a/app/components/ScrollRestoration.empty-fallback.test.tsx
+++ b/app/components/ScrollRestoration.empty-fallback.test.tsx
@@ -1,0 +1,62 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ScrollRestoration from './ScrollRestoration';
+
+const mockUsePathname = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+describe('ScrollRestoration empty fallback behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mockUsePathname.mockReturnValue('/');
+    window.scrollTo = vi.fn();
+  });
+
+  it('renders null without crashing when no saved scroll position exists', () => {
+    const { container } = render(<ScrollRestoration />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not scroll when sessionStorage has no saved position', () => {
+    render(<ScrollRestoration />);
+
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('restores saved scroll position when value exists', () => {
+    sessionStorage.setItem('scroll-position-/', '250');
+
+    render(<ScrollRestoration />);
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 250);
+  });
+
+  it('stores current scroll position on scroll event', () => {
+    Object.defineProperty(window, 'scrollY', {
+      value: 300,
+      configurable: true,
+    });
+
+    render(<ScrollRestoration />);
+
+    window.dispatchEvent(new Event('scroll'));
+
+    expect(sessionStorage.getItem('scroll-position-/')).toBe('300');
+  });
+
+  it('uses pathname-specific storage keys for empty fallback safety', () => {
+    mockUsePathname.mockReturnValue('/dashboard');
+
+    render(<ScrollRestoration />);
+
+    window.dispatchEvent(new Event('scroll'));
+
+    expect(sessionStorage.getItem('scroll-position-/dashboard')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2823

Added empty fallback test coverage for `app/components/ScrollRestoration.tsx`.

### Tests Added

* Verifies component renders safely when no saved scroll position exists.
* Verifies no scroll restoration occurs when session storage is empty.
* Verifies saved scroll positions are restored correctly.
* Verifies scroll events persist current scroll position.
* Verifies pathname-specific storage keys are used safely.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable)
* [ ] (Recommended) I joined the CommitPulse Discord community.
