### PR TITLE
Add mock integration tests for TrackUserProtection async layer and cache stubs

### DIFF
--- a/services/security/track-user-protection.mock-integrations.test.ts
+++ b/services/security/track-user-protection.mock-integrations.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { trackUserProtection } from './track-user-protection';
+import { gitHubUserValidator } from '../github/validate-user';
+
+vi.mock('../github/validate-user', () => ({
+  gitHubUserValidator: {
+    validateUser: vi.fn(),
+  },
+}));
+
+describe('TrackUserProtection Async Service Mocking & Local Cache Stubs', () => {
+  beforeEach(() => {
+    trackUserProtection.reset();
+    vi.clearAllMocks();
+  });
+
+  it('mocks async service layer and resolves user verification correctly', async () => {
+    vi.mocked(gitHubUserValidator.validateUser).mockResolvedValue(true);
+
+    const result = await trackUserProtection.verifyAndDeduplicate('octocat');
+
+    expect(gitHubUserValidator.validateUser).toHaveBeenCalledTimes(1);
+    expect(gitHubUserValidator.validateUser).toHaveBeenCalledWith('octocat');
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it('queries local cache stub before triggering async database retrieval', async () => {
+    trackUserProtection.recordWrite('testuser');
+
+    const result = await trackUserProtection.verifyAndDeduplicate('testuser');
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('COOLDOWN_ACTIVE');
+    expect(gitHubUserValidator.validateUser).not.toHaveBeenCalled();
+  });
+
+  it('propagates async service rejection as fallback on endpoint timeout', async () => {
+    const networkError = new Error('GitHub API timeout');
+    vi.mocked(gitHubUserValidator.validateUser).mockRejectedValue(networkError);
+
+    await expect(trackUserProtection.verifyAndDeduplicate('octocat')).rejects.toThrow(
+      'GitHub API timeout'
+    );
+  });
+
+  it('writes cache sync state on successful record callback', async () => {
+    expect(trackUserProtection.isWriteAllowed('testuser')).toBe(true);
+
+    trackUserProtection.recordWrite('testuser');
+
+    expect(trackUserProtection.isWriteAllowed('testuser')).toBe(false);
+  });
+
+  it('isolates cache entries per user without cross-contamination', async () => {
+    trackUserProtection.recordWrite('userA');
+
+    expect(trackUserProtection.isWriteAllowed('userA')).toBe(false);
+    expect(trackUserProtection.isWriteAllowed('userB')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2971

The `TrackUserProtection` class in `services/security/track-user-protection.ts` depends on the async `gitHubUserValidator.validateUser` service and an internal `lastWriteTimes` cooldown cache, but the async service layer was never tested with isolated mocks and the cache stubs had no coverage verifying they are queried before the database retrieval. Without these tests, a change to the validator contract or a cache logic regression could silently break deduplication guarantees.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — this is a test-only change.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] I have run `npm run test` and all tests pass locally.
- [x] I have run `npm run test:coverage` and branch coverage is at or above 70%.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.