### PR TITLE
test(copyrepobutton): add accessibility coverage

### DIFF
--- a/app/components/CopyRepoButton.accessibility.test.tsx
+++ b/app/components/CopyRepoButton.accessibility.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import CopyRepoButton from './CopyRepoButton';
+
+vi.mock('lucide-react', () => ({
+  Copy: () => <svg aria-hidden="true" data-testid="copy-icon" />,
+}));
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: vi.fn().mockResolvedValue(undefined),
+  },
+});
+
+describe('CopyRepoButton accessibility behavior', () => {
+  it('renders as an accessible button with visible label', () => {
+    render(<CopyRepoButton />);
+
+    expect(screen.getByRole('button', { name: /copy url/i })).toBeDefined();
+  });
+
+  it('keeps decorative copy icon hidden from assistive technology', () => {
+    render(<CopyRepoButton />);
+
+    expect(screen.getByTestId('copy-icon').getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('is keyboard focusable through the native button element', () => {
+    render(<CopyRepoButton />);
+
+    const button = screen.getByRole('button', { name: /copy url/i });
+    button.focus();
+
+    expect(document.activeElement).toBe(button);
+  });
+
+  it('updates accessible button name after successful copy action', async () => {
+    render(<CopyRepoButton />);
+
+    const button = screen.getByRole('button', { name: /copy url/i });
+    fireEvent.click(button);
+
+    expect(await screen.findByRole('button', { name: /copied/i })).toBeDefined();
+  });
+
+  it('preserves semantic button role after interaction', async () => {
+    render(<CopyRepoButton />);
+
+    fireEvent.click(screen.getByRole('button', { name: /copy url/i }));
+
+    expect(await screen.findByRole('button', { name: /copied/i })).toBeDefined();
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2806

Added accessibility test coverage for `app/components/CopyRepoButton.tsx`.

### Tests Added

* Verifies the component renders as an accessible button with visible label.
* Confirms the decorative copy icon is hidden from assistive technologies.
* Ensures the button is keyboard focusable.
* Verifies the accessible button name updates after a successful copy action.
* Confirms the semantic button role is preserved after interaction.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable)
* [ ] (Recommended) I joined the CommitPulse Discord community.
