### PR TITLE
test(copyrepobutton): add error resilience coverage

### DIFF
--- a/app/components/CopyRepoButton.error-resilience.test.tsx
+++ b/app/components/CopyRepoButton.error-resilience.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import CopyRepoButton from './CopyRepoButton';
+
+vi.mock('lucide-react', () => ({
+  Copy: () => <svg data-testid="copy-icon" />,
+}));
+
+describe('CopyRepoButton error resilience', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders successfully during initial mount', () => {
+    render(<CopyRepoButton />);
+
+    expect(screen.getByRole('button', { name: /copy url/i })).toBeDefined();
+  });
+
+  it('does not crash when clipboard write rejects', async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error('Clipboard failed')),
+      },
+    });
+
+    render(<CopyRepoButton />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button')).toBeDefined();
+    });
+  });
+
+  it('keeps original label visible after clipboard failure', async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error('Clipboard failed')),
+      },
+    });
+
+    render(<CopyRepoButton />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/copy url/i)).toBeDefined();
+    });
+  });
+
+  it('renders icon even when copy action fails', async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error('Clipboard failed')),
+      },
+    });
+
+    render(<CopyRepoButton />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('copy-icon')).toBeDefined();
+    });
+  });
+
+  it('allows repeated failed copy attempts without crashing', async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error('Clipboard failed')),
+      },
+    });
+
+    render(<CopyRepoButton />);
+
+    const button = screen.getByRole('button');
+
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button')).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2808

Added error resilience test coverage for `app/components/CopyRepoButton.tsx`.

### Tests Added

* Verifies the component renders successfully during initial mount.
* Ensures the component does not crash when clipboard operations fail.
* Confirms the original button label remains visible after clipboard failures.
* Verifies the icon remains rendered during error scenarios.
* Ensures repeated failed copy attempts do not crash the component.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable)
* [ ] (Recommended) I joined the CommitPulse Discord community.
