### PR TITLE
fix(cache): DistributedCache.update() now writes to Redis on cold L1 …

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -340,11 +340,10 @@ export class DistributedCache<T> {
   }
 
   async update(key: string, value: T): Promise<boolean> {
-    const updated = this.localCache.update(key, value);
-    if (!updated) return false;
+    this.localCache.update(key, value);
 
     if (!this.useRedis) {
-      return true;
+      return this.localCache.has(key);
     }
 
     try {
@@ -354,16 +353,17 @@ export class DistributedCache<T> {
           Authorization: `Bearer ${this.redisToken}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(['SET', key, JSON.stringify(value), 'KEEPTTL']),
+        body: JSON.stringify(['SET', key, JSON.stringify(value), 'KEEPTTL', 'XX']),
       });
 
       if (!res.ok) {
         throw new Error(`Redis HTTP error: ${res.status}`);
       }
-      return true;
+      const data = await res.json();
+      return data.result === 'OK';
     } catch (err) {
       console.error(`[DistributedCache] UPDATE failed for key "${key}":`, err);
-      return true;
+      return false;
     }
   }
 


### PR DESCRIPTION
## Description

Fixes #3025

`DistributedCache.update()` was gating the Redis write behind a local L1 cache check.
On cold serverless instances (common on Vercel), the L1 cache is empty, causing the
method to return `false` and silently skip the Redis update entirely — leaving stale
data cached across all other instances indefinitely.

**Root cause:** `localCache.update()` returns `false` when the key isn't in L1.
The early `if (!updated) return false` guard was preventing the Redis write entirely.

**Fix:**
- Removed the L1 gate — L1 update is now best-effort
- Added `XX` flag to Redis `SET` command to preserve "only update existing keys" semantics
- Fixed return value to reflect actual Redis response instead of hardcoded `true`
- Fixed `catch` block to return `false` instead of silently swallowing errors as `true`

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [X] 🛠️ Other (Bug fix, refactoring, docs)


## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [X] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [X] I have started the repo.
- [X] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [X] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

Suggested labels: `bug`, `GSSoC 2026`, `intermediate`