### PR TITLE
test(refresh-policy): add responsive breakpoints test suite (#2939)

### DIFF
--- a/services/github/refresh-policy.responsive-breakpoints.test.ts
+++ b/services/github/refresh-policy.responsive-breakpoints.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { RefreshPolicy } from './refresh-policy';
+
+describe('RefreshPolicy - Responsive Breakpoints Layout Cohesion', () => {
+  beforeEach(() => {
+    window.innerWidth = 375;
+    window.dispatchEvent(new Event('resize'));
+  });
+
+  it('maintains expected cooldown constraints under simulated mobile viewport dimensions', () => {
+    const policy = RefreshPolicy.getInstance();
+    policy.reset();
+
+    expect(window.innerWidth).toBe(375);
+
+    const allowed = policy.isRefreshAllowed('mobile-user');
+    expect(allowed).toBe(true);
+
+    policy.recordRefresh('mobile-user');
+    expect(policy.isRefreshAllowed('mobile-user')).toBe(false);
+  });
+
+  it('verifies that resizing viewport does not disrupt existing active cooldown timers', () => {
+    const policy = RefreshPolicy.getInstance();
+    policy.reset();
+    policy.recordRefresh('resizable-user');
+
+    // Verify it is blocked on mobile
+    expect(policy.isRefreshAllowed('resizable-user')).toBe(false);
+
+    // Resize viewport to desktop breakpoint
+    window.innerWidth = 1440;
+    window.dispatchEvent(new Event('resize'));
+
+    // Cooldown state must be preserved
+    expect(window.innerWidth).toBe(1440);
+    expect(policy.isRefreshAllowed('resizable-user')).toBe(false);
+  });
+
+  it('ensures duration limits are independent of window/responsive viewport heights', () => {
+    const policy = RefreshPolicy.getInstance();
+    policy.reset();
+    policy.setCooldown(5000);
+
+    window.innerHeight = 812;
+    window.dispatchEvent(new Event('resize'));
+
+    expect(policy.getRemainingCooldown('user-a')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

Adds the comprehensive refresh-policy.responsive-breakpoints.test.ts test suite under services to verify window resizing effects on active cooldown states.

Fixes #2939

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Utility/Unit Tests only)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.
