### PR TITLE
test(DiscordButton): add comprehensive unit tests for link rendering and accessibility

### DIFF
--- a/components/DiscordButton.test.tsx
+++ b/components/DiscordButton.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { DiscordButton } from './DiscordButton';
+// Mock framer-motion
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: (props: React.ComponentProps<'div'>) => <div {...props} />,
+    a: (props: React.ComponentProps<'a'>) => <a {...props} />,
+  },
+}));
+
+// Mock gsap
+
+vi.mock('gsap', () => ({
+  default: {
+    to: vi.fn(),
+  },
+}));
+
+describe('DiscordButton', () => {
+  it('renders discord invite link with correct href', () => {
+    render(<DiscordButton />);
+
+    const link = screen.getByRole('link');
+
+    expect(link).toHaveAttribute('href', 'https://discord.gg/Cb73bS79j');
+  });
+
+  it('sets target and rel attributes for security', () => {
+    render(<DiscordButton />);
+
+    const link = screen.getByRole('link');
+
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders discord call-to-action text', () => {
+    render(<DiscordButton />);
+
+    expect(screen.getByText('Join the core community on Discord')).toBeInTheDocument();
+  });
+
+  it('renders svg icons', () => {
+    const { container } = render(<DiscordButton />);
+
+    const svgs = container.querySelectorAll('svg');
+
+    expect(svgs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders external link target', () => {
+    render(<DiscordButton />);
+
+    const link = screen.getByRole('link');
+
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+});


### PR DESCRIPTION
## Description

Adds a dedicated test suite for the `DiscordButton` component to verify link configuration, accessibility attributes, and rendered content.

## Changes

- Added `components/DiscordButton.test.tsx`
- Verified Discord invite link renders with the correct URL
- Verified `target="_blank"` is set for external navigation
- Verified `rel="noopener noreferrer"` is present for security
- Verified CTA text is rendered correctly
- Verified Discord-related SVG icons are rendered

Fixes #2278 

## Pillar

- [x] 📐 Pillar 2 — Geometric SVG Improvement
- [x] 🛠️ Other (Bug fix, refactoring, docs)


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
