### PR TITLE
fix(frontend): surface compare share failures

### DIFF
--- a/components/dashboard/DashboardClient.test.tsx
+++ b/components/dashboard/DashboardClient.test.tsx
@@ -217,6 +217,30 @@ describe('DashboardClient', () => {
     vi.clearAllMocks();
   });
 
+  const renderInCompareMode = async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockSecondData,
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    render(
+      <DashboardClient initialData={mockInitialData} username="Shivangi1515" period={mockPeriod} />
+    );
+
+    fireEvent.click(screen.getByText('Compare Profile'));
+    fireEvent.change(screen.getByPlaceholderText('Enter GitHub Username'), {
+      target: { value: 'JhaSourav07' },
+    });
+    fireEvent.click(screen.getByText('Compare'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Share Comparison')).toBeDefined();
+    });
+
+    vi.clearAllMocks();
+  };
+
   it('renders standard single profile view by default', () => {
     render(
       <DashboardClient initialData={mockInitialData} username="Shivangi1515" period={mockPeriod} />
@@ -375,6 +399,76 @@ describe('DashboardClient', () => {
       expect(toast.error).toHaveBeenCalledWith('Failed to copy dashboard link');
     });
     expect(toast.success).not.toHaveBeenCalledWith('Link copied to clipboard!');
+  });
+
+  it('copies the comparison link when native sharing is unavailable', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', {
+      value: undefined,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    await renderInCompareMode();
+
+    fireEvent.click(screen.getByText('Share Comparison'));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/dashboard/Shivangi1515?compare=JhaSourav07`
+      );
+      expect(toast.success).toHaveBeenCalledWith('Comparison link copied!');
+    });
+  });
+
+  it('shows an error toast when comparison link copy fails', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('Permission denied'));
+    Object.defineProperty(navigator, 'share', {
+      value: undefined,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    await renderInCompareMode();
+
+    fireEvent.click(screen.getByText('Share Comparison'));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/dashboard/Shivangi1515?compare=JhaSourav07`
+      );
+      expect(toast.error).toHaveBeenCalledWith('Failed to share comparison link');
+    });
+    expect(toast.success).not.toHaveBeenCalledWith('Comparison link copied!');
+  });
+
+  it('does not show an error toast when native comparison sharing is cancelled', async () => {
+    const share = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('AbortError'), { name: 'AbortError' }));
+    Object.defineProperty(navigator, 'share', {
+      value: share,
+      configurable: true,
+    });
+
+    await renderInCompareMode();
+
+    fireEvent.click(screen.getByText('Share Comparison'));
+
+    await waitFor(() => {
+      expect(share).toHaveBeenCalledWith({
+        title: 'Shivangi1515 vs JhaSourav07',
+        text: 'Check out this GitHub profile comparison',
+        url: `${window.location.origin}/dashboard/Shivangi1515?compare=JhaSourav07`,
+      });
+    });
+    expect(toast.error).not.toHaveBeenCalledWith('Failed to share comparison link');
   });
 
   // =========================================================================

--- a/components/dashboard/DashboardClient.tsx
+++ b/components/dashboard/DashboardClient.tsx
@@ -472,8 +472,12 @@ export default function DashboardClient({
         await navigator.clipboard.writeText(compareUrl);
         toast.success('Comparison link copied!');
       }
-    } catch {
-      // user cancelled share dialog
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        return;
+      }
+
+      toast.error('Failed to share comparison link');
     }
   };
 


### PR DESCRIPTION
## Description

Fixes #3057

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## What changed

The compare-mode `Share Comparison` handler was treating every error as a user-cancelled native share dialog. That meant real failures, such as clipboard permission denial in the fallback path, were silently ignored.

This PR keeps `AbortError` quiet for cancelled native share dialogs, but shows an error toast for actual failures:

- clipboard fallback rejects
- native share throws a non-cancel error
- browser sharing fails unexpectedly

I also added focused `DashboardClient` coverage for:

- successful comparison link copy through the clipboard fallback
- rejected comparison link copy showing an error toast
- cancelled native share remaining quiet

Opened as part of GSSoC 2026.

## Visual Preview

N/A — this is an interaction/error-handling fix in the dashboard compare share flow.

## Validation

- [x] `npm run format`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test -- components/dashboard/DashboardClient.test.tsx`
- [x] `npm run test -- app/customize/components/ThemeQuickPresets.test.tsx`

Note: I also ran the full suite with `npm run test`. It completed with one unrelated timeout in `app/customize/components/ThemeQuickPresets.test.tsx`; rerunning that exact file passed with all 16 tests. The touched dashboard test file passed consistently.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse quality standard.
