### PR TITLE
feat(themes): add tokyonight and cyberpunk palettes

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -103,3 +103,19 @@ Usage: `/api/streak?user=yourusername&theme=synthwave`
 Near-black background with vivid red-orange accent and medium-grey text — maximum legibility on both solid and transparent backgrounds for low-vision accessibility.
 
 Usage: `/api/streak?user=yourusername&theme=highcontrast`
+
+---
+
+## 🏙️ Tokyo Night
+
+![Tokyo Night](assets/themes/tokyonight.png)
+
+Usage: `/api/streak?user=yourusername&theme=tokyonight`
+
+---
+
+## 🤖 Cyberpunk
+
+![Cyberpunk](assets/themes/cyberpunk.png)
+
+Usage: `/api/streak?user=yourusername&theme=cyberpunk`

--- a/lib/svg/themes.ts
+++ b/lib/svg/themes.ts
@@ -67,6 +67,16 @@ export const themes: Record<string, BadgeTheme> = {
     text: '888888',
     accent: 'ff4500',
   },
+  tokyonight: {
+    bg: '1a1b26',
+    text: 'c0caf5',
+    accent: 'f7768e',
+  },
+  cyberpunk: {
+    bg: 'fce22a',
+    text: '111111',
+    accent: 'ff003c',
+  },
 };
 
 // Auto-theme pairs: the SVG switches between these two palettes


### PR DESCRIPTION
## Description

Fixes #3074 
 

Added two new aesthetic themes to the built-in palette to give users more customization options:
- **Tokyo Night** (`tokyonight`): Deep blue/purple background with vibrant neon accents.
- **Cyberpunk** (`cyberpunk`): Yellow/Black/Pink aesthetic.

Updated `lib/svg/themes.ts` to include the configuration and updated `THEMES.md` with visual previews.

## Pillar

- [x] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="602" height="429" alt="2026-06-02_13-50-07" src="https://github.com/user-attachments/assets/8f8e1dd9-c652-467f-ac99-4ab44dc3cfe0" />
<img width="602" height="428" alt="2026-06-02_13-50-16" src="https://github.com/user-attachments/assets/b1c977b7-f3e6-45f6-9a44-6937a6732fff" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
