### PR TITLE
test(time): verify behavior for invalid timezone identifiers

### DIFF
--- a/utils/time.test.ts
+++ b/utils/time.test.ts
@@ -282,4 +282,10 @@ describe('getSecondsUntilMidnightInTimezone — extreme timezone offset boundary
 
     expect(getSecondsUntilMidnightInTimezone('Pacific/Midway')).toBe(86400);
   });
+
+  it('throws a RangeError for invalid timezone identifiers', () => {
+    vi.setSystemTime(new Date('2024-06-15T12:00:00.000Z'));
+
+    expect(() => getSecondsUntilMidnightInTimezone('Invalid/Timezone')).toThrow(RangeError);
+  });
 });


### PR DESCRIPTION
## Description

Fixes #2143 

Added test coverage for invalid timezone identifiers in `getSecondsUntilMidnightInTimezone`.

## Pillar

- [x] Pillar 3 — Timezone Logic Optimization

## Checklist

- [x] I have read the CONTRIBUTING.md file.
- [x] I have run npm run format.
- [x] I have run npm run lint.
- [x] I have run npm run typecheck.
- [x] I have run npm run test.
- [x] I have only one commit in this PR.

## Visual Preview

N/A (test-only change)

## Changes Made

- Added test for invalid timezone identifiers
- Verified RangeError is thrown for unsupported timezone values
- Documented current formatter behavior without modifying implementation

## Result

- Improves test coverage for timezone validation edge cases
- Prevents regressions in timezone handling behavior
- Existing tests continue to pass