### PR TITLE
feat(themes): add tokyonight and cyberpunk palette

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -173,7 +173,6 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ### Gruvbox
 
-
 ![gruvbox](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=gruvbox)
 
 | Parameter | Value  |

--- a/THEMES.md
+++ b/THEMES.md
@@ -32,6 +32,8 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 | nord_light       | `#eceff4`  | `#2e3440` | `#5e81ac` |
 | obsidian         | `#1a1a2e`  | `#e2e8f0` | `#f59e0b` |
 | cyber-pulse      | `#000000`  | `#ffffff` | `#00ffee` |
+| tokyonight       | `#1a1b26`  | `#c0caf5` | `#f7768e` |
+| cyberpunk        | `#fce22a`  | `#111111` | `#ff003c` |
 
 ---
 
@@ -171,6 +173,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 
 ### Gruvbox
 
+
 ![gruvbox](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=gruvbox)
 
 | Parameter | Value  |
@@ -274,6 +277,30 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 | `bg`      | 1a1a2e |
 | `text`    | e2e8f0 |
 | `accent`  | f59e0b |
+
+---
+
+### Tokyo Night
+
+![tokyonight](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=tokyonight)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 1a1b26 |
+| `text`    | c0caf5 |
+| `accent`  | f7768e |
+
+---
+
+### Cyberpunk
+
+![cyberpunk](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=cyberpunk)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | fce22a |
+| `text`    | 111111 |
+| `accent`  | ff003c |
 
 ---
 

--- a/lib/svg/themes.ts
+++ b/lib/svg/themes.ts
@@ -34,6 +34,8 @@ export const themes: Record<string, BadgeTheme> = {
   'cyber-pulse': makeTheme('000000', 'ffffff', '00ffee', 'ff0055'),
   glacier: makeTheme('e0f2fe', '0369a1', '06b6d4', 'ef4444'),
   lumos: makeTheme('0a0a0a', 'a7f3d0', 'fbbf24', 'ef4444'),
+  tokyonight: makeTheme('1a1b26', 'c0caf5', 'f7768e'),
+  cyberpunk: makeTheme('fce22a', '111111', 'ff003c'),
 };
 
 // Auto-theme pairs: the SVG switches between these two palettes


### PR DESCRIPTION
## Description


Fixes #3074 

Added two new aesthetic themes to the built-in palette to give users more customization options:
- **Tokyo Night** (`tokyonight`): Deep blue/purple background with vibrant neon accents.
- **Cyberpunk** (`cyberpunk`): Yellow/Black/Pink aesthetic.

Updated `lib/svg/themes.ts` to include the configuration and updated `THEMES.md` with visual previews.

## Pillar

- [x] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="602" height="429" alt="2026-06-02_13-50-07" src="https://github.com/user-attachments/assets/0c1ceeb7-e6d9-46ba-a883-ac8ac343cc83" />
<img width="602" height="428" alt="2026-06-02_13-50-16" src="https://github.com/user-attachments/assets/270b7bec-339a-48c1-b0d8-c49a1fa5ba9c" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
