### PR TITLE
test(contributors): add error resilience coverage

### DIFF
--- a/app/contributors/page.error-resilience.test.tsx
+++ b/app/contributors/page.error-resilience.test.tsx
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+type ContributorsClientProps = {
+  contributors: unknown[];
+  totalContributions: number;
+  topContributors: unknown[];
+};
+
+const mockContributorsClient = vi.fn((_props?: ContributorsClientProps) => (
+  <div data-testid="contributors-client">Contributors Client</div>
+));
+
+vi.mock('./ContributorsClient', () => ({
+  default: (props: ContributorsClientProps) => mockContributorsClient(props),
+}));
+
+describe('ContributorsPage Error Resilience', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders successfully under normal conditions', async () => {
+    const { default: ContributorsPage } = await import('./page');
+
+    const page = await ContributorsPage();
+
+    render(page);
+
+    expect(screen.getByTestId('contributors-client')).toBeInTheDocument();
+  });
+
+  it('handles failed contributor fetches without crashing', async () => {
+    const originalFetch = global.fetch;
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: {
+        get: () => null,
+      },
+    } as unknown as Response);
+
+    const { default: ContributorsPage } = await import('./page');
+
+    const page = await ContributorsPage();
+
+    render(page);
+
+    expect(screen.getByTestId('contributors-client')).toBeInTheDocument();
+
+    global.fetch = originalFetch;
+  });
+
+  it('handles rate limit responses gracefully', async () => {
+    const originalFetch = global.fetch;
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: {
+        get: (name: string) => (name === 'x-ratelimit-remaining' ? '0' : null),
+      },
+    } as unknown as Response);
+
+    const { default: ContributorsPage } = await import('./page');
+
+    const page = await ContributorsPage();
+
+    render(page);
+
+    expect(screen.getByTestId('contributors-client')).toBeInTheDocument();
+
+    global.fetch = originalFetch;
+  });
+
+  it('passes empty contributor collections after fetch failures', async () => {
+    const originalFetch = global.fetch;
+
+    global.fetch = vi.fn().mockRejectedValue(new Error('Database unavailable'));
+
+    const { default: ContributorsPage } = await import('./page');
+
+    const page = await ContributorsPage();
+
+    render(page);
+
+    expect(mockContributorsClient).toHaveBeenCalled();
+
+    const props = mockContributorsClient.mock.calls[0][0] as ContributorsClientProps;
+
+    expect(props.contributors).toEqual([]);
+    expect(props.topContributors).toEqual([]);
+
+    global.fetch = originalFetch;
+  });
+
+  it('continues rendering when unexpected service exceptions occur', async () => {
+    const originalFetch = global.fetch;
+
+    global.fetch = vi.fn().mockRejectedValue(new Error('Unexpected runtime error'));
+
+    const { default: ContributorsPage } = await import('./page');
+
+    const page = await ContributorsPage();
+
+    render(page);
+
+    expect(screen.getByTestId('contributors-client')).toBeInTheDocument();
+
+    global.fetch = originalFetch;
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2858 

Added isolated unit and integration tests for `app/contributors/page.tsx` focusing on hydration stability, exception safety, and error fallback handling.

### Changes
- Added `app/contributors/page.error-resilience.test.tsx`
- Mocked `ContributorsClient` to isolate page-level behavior
- Verified successful rendering under normal conditions
- Tested graceful handling of contributor fetch failures
- Verified GitHub API rate-limit responses do not crash rendering
- Confirmed empty contributor collections are propagated during fallback scenarios
- Ensured unexpected service exceptions are handled without breaking page rendering
- Improved coverage around resilience, recovery paths, and server-side error handling

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no SVG changes made).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.