### PR TITLE
test(Icons-accessibility verify Accessibility Standards & Screen Reader Aria Compliance (Variation 4) 

### DIFF
--- a/app/components/Icons.accessibility.test.tsx
+++ b/app/components/Icons.accessibility.test.tsx
@@ -1,0 +1,44 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { BoxIcon, CheckIcon, CloseIcon, CopyIcon, ZapIcon } from './Icons';
+
+describe('Icons accessibility behavior', () => {
+  it('renders CopyIcon as decorative with aria-hidden="true"', () => {
+    const { container } = render(<CopyIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('renders ZapIcon as decorative with aria-hidden="true"', () => {
+    const { container } = render(<ZapIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('renders BoxIcon as decorative with aria-hidden="true"', () => {
+    const { container } = render(<BoxIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('renders CheckIcon as decorative with aria-hidden="true"', () => {
+    const { container } = render(<CheckIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('renders CloseIcon as decorative with aria-hidden="true"', () => {
+    const { container } = render(<CloseIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('includes basic structural roles on SVG elements', () => {
+    const { container } = render(<CopyIcon />);
+    const svg = container.querySelector('svg');
+    // Lucide components use standard svg elements which imply a graphics role,
+    // and setting aria-hidden="true" makes it decorative.
+    expect(svg?.tagName.toLowerCase()).toBe('svg');
+  });
+});


### PR DESCRIPTION
## Description

This PR introduces comprehensive accessibility tests for the `Icons` components. It verifies that all standard `lucide-react` SVG icons are correctly marked as decorative with `aria-hidden="true"` to ensure screen reader compliance and maintain robust accessibility standards.

Fixes #2816

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A (Test addition only, no visual changes).

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.