### PR TITLE
test(contributors): add loading empty fallback coverage

### DIFF
--- a/app/contributors/loading.empty-fallback.test.tsx
+++ b/app/contributors/loading.empty-fallback.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import Loading from './loading';
+
+function hasClasses(element: Element | null, classes: string[]) {
+  expect(element).not.toBeNull();
+
+  for (const className of classes) {
+    expect(element!.classList.contains(className)).toBe(true);
+  }
+}
+
+describe('Contributors loading empty fallback', () => {
+  it('renders safely without props or input data', () => {
+    expect(() => render(<Loading />)).not.toThrow();
+  });
+
+  it('shows a clear fallback loading state', () => {
+    render(<Loading />);
+
+    expect(screen.getByRole('status')).toBeTruthy();
+    expect(screen.getByText('Loading the collective...')).toBeTruthy();
+    expect(screen.getByText('Fetching contributor data from GitHub')).toBeTruthy();
+  });
+
+  it('keeps accessible fallback markers available', () => {
+    render(<Loading />);
+
+    const status = screen.getByRole('status');
+
+    expect(status.getAttribute('aria-live')).toBe('polite');
+    expect(status.children.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('maintains default fallback layout styles', () => {
+    render(<Loading />);
+
+    const status = screen.getByRole('status');
+    const page = status.parentElement;
+
+    hasClasses(page, [
+      'flex',
+      'min-h-screen',
+      'items-center',
+      'justify-center',
+      'bg-[#050505]',
+      'text-white',
+    ]);
+
+    hasClasses(status, ['flex', 'flex-col', 'items-center', 'gap-6']);
+  });
+
+  it('renders fallback spinner structure without hydration-sensitive content', () => {
+    render(<Loading />);
+
+    const status = screen.getByRole('status');
+    const spinnerWrapper = status.firstElementChild;
+    const spinner = spinnerWrapper?.firstElementChild ?? null;
+    const glowOverlay = spinnerWrapper?.children.item(1) ?? null;
+
+    hasClasses(spinnerWrapper, ['relative']);
+
+    hasClasses(spinner, [
+      'h-16',
+      'w-16',
+      'animate-spin',
+      'rounded-full',
+      'border-2',
+      'border-white/10',
+      'border-t-cyan-400',
+    ]);
+
+    hasClasses(glowOverlay, [
+      'absolute',
+      'inset-0',
+      'h-16',
+      'w-16',
+      'rounded-full',
+      'bg-cyan-400/20',
+      'blur-xl',
+      'animate-pulse',
+    ]);
+
+    expect(status.classList.contains('overflow-hidden')).toBe(false);
+    expect(status.classList.contains('text-transparent')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2843

Adds isolated Vitest coverage for edge cases and empty/missing input scenarios in `app/contributors/loading.tsx`.

Tests verify:

* Safe rendering without props or external data
* Presence of fallback loading UI
* Accessibility markers (`role="status"` and `aria-live`)
* Default layout and theme styling in fallback state
* Spinner rendering without hydration-sensitive failures or runtime errors

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
