### PR TITLE
Test/sanitize speed decimals

### DIFF
--- a/components/dashboard/StatsCardSkeleton.test.tsx
+++ b/components/dashboard/StatsCardSkeleton.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+
+import StatsCardSkeleton from './StatsCardSkeleton';
+
+describe('StatsCardSkeleton', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<StatsCardSkeleton />);
+
+    expect(container).toBeDefined();
+  });
+
+  it('renders exactly 12 chart bar elements', () => {
+    const { container } = render(<StatsCardSkeleton />);
+
+    const bars = container.querySelectorAll('.rounded-t-\\[1px\\]');
+
+    expect(bars.length).toBe(12);
+  });
+
+  it('renders shimmer class on all chart bars', () => {
+    const { container } = render(<StatsCardSkeleton />);
+
+    const bars = container.querySelectorAll('.rounded-t-\\[1px\\]');
+
+    bars.forEach((bar) => {
+      expect(bar.className).toContain('shimmer');
+    });
+  });
+
+  it('matches snapshot without random variation', () => {
+    const { container } = render(<StatsCardSkeleton />);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/components/dashboard/StatsCardSkeleton.test.tsx
+++ b/components/dashboard/StatsCardSkeleton.test.tsx
@@ -5,9 +5,7 @@ import StatsCardSkeleton from './StatsCardSkeleton';
 
 describe('StatsCardSkeleton', () => {
   it('renders without crashing', () => {
-    const { container } = render(<StatsCardSkeleton />);
-
-    expect(container).toBeDefined();
+    expect(() => render(<StatsCardSkeleton />)).not.toThrow();
   });
 
   it('renders exactly 12 chart bar elements', () => {

--- a/components/dashboard/__snapshots__/StatsCardSkeleton.test.tsx.snap
+++ b/components/dashboard/__snapshots__/StatsCardSkeleton.test.tsx.snap
@@ -1,0 +1,80 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`StatsCardSkeleton > matches snapshot without random variation 1`] = `
+<div
+  class="p-6 rounded-xl bg-[#0a0a0a] border border-[rgba(255,255,255,0.08)] overflow-hidden"
+>
+  <div
+    class="flex justify-between items-start mb-6"
+  >
+    <div
+      class="space-y-3"
+    >
+      <div
+        class="h-3 w-24 shimmer rounded"
+      />
+      <div
+        class="h-8 w-32 shimmer rounded"
+      />
+      <div
+        class="h-3 w-36 shimmer rounded"
+      />
+    </div>
+    <div
+      class="h-9 w-9 rounded-lg shimmer"
+    />
+  </div>
+  <div
+    class="w-full h-8 flex items-end justify-between gap-px opacity-30"
+  >
+    <div
+      class="flex-1 shimmer rounded-t-[1px]"
+      style="height: 24%;"
+    />
+    <div
+      class="flex-1 shimmer rounded-t-[1px]"
+      style="height: 32%;"
+    />
+    <div
+      class="flex-1 shimmer rounded-t-[1px]"
+      style="height: 18%;"
+    />
+    <div
+      class="flex-1 shimmer rounded-t-[1px]"
+      style="height: 45%;"
+    />
+    <div
+      class="flex-1 shimmer rounded-t-[1px]"
+      style="height: 38%;"
+    />
+    <div
+      class="flex-1 shimmer rounded-t-[1px]"
+      style="height: 52%;"
+    />
+    <div
+      class="flex-1 shimmer rounded-t-[1px]"
+      style="height: 28%;"
+    />
+    <div
+      class="flex-1 shimmer rounded-t-[1px]"
+      style="height: 42%;"
+    />
+    <div
+      class="flex-1 shimmer rounded-t-[1px]"
+      style="height: 35%;"
+    />
+    <div
+      class="flex-1 shimmer rounded-t-[1px]"
+      style="height: 48%;"
+    />
+    <div
+      class="flex-1 shimmer rounded-t-[1px]"
+      style="height: 30%;"
+    />
+    <div
+      class="flex-1 shimmer rounded-t-[1px]"
+      style="height: 22%;"
+    />
+  </div>
+</div>
+`;

--- a/lib/svg/sanitizer.test.ts
+++ b/lib/svg/sanitizer.test.ts
@@ -70,6 +70,22 @@ describe('SVG Sanitizer Utilities', () => {
       expect(sanitizeSpeed('8', '8s')).toBe('8s');
       expect(sanitizeSpeed('s', '8s')).toBe('8s');
     });
+
+    it('accepts valid decimal value 8.0s', () => {
+      expect(sanitizeSpeed('8.0s', '5s')).toBe('8.0s');
+    });
+
+    it('accepts lower boundary decimal value 2.0s', () => {
+      expect(sanitizeSpeed('2.0s', '5s')).toBe('2.0s');
+    });
+
+    it('accepts upper boundary decimal value 20.0s', () => {
+      expect(sanitizeSpeed('20.0s', '5s')).toBe('20.0s');
+    });
+
+    it('accepts decimal value 2.1s within range', () => {
+      expect(sanitizeSpeed('2.1s', '5s')).toBe('2.1s');
+    });
   });
 
   describe('sanitizeRadius', () => {


### PR DESCRIPTION
## Description
Adds edge-case tests for sanitizeSpeed to verify that decimal values matching the regex ^(\d+(\.\d+)?)s$ are accepted when they fall within the valid range.

Fixes #735 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A (test-only change)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

## Tests Added
sanitizeSpeed('8.0s', '5s') → '8.0s'
sanitizeSpeed('2.0s', '5s') → '2.0s'
sanitizeSpeed('20.0s', '5s') → '20.0s'
sanitizeSpeed('2.1s', '5s') → '2.1s'
