### PR TITLE
test(theme-switch): add type compiler validation coverage

### DIFF
--- a/app/components/theme-switch.type-compiler.test.tsx
+++ b/app/components/theme-switch.type-compiler.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { createAnimation, type AnimationStart, type AnimationVariant } from './theme-switch';
+
+describe('ThemeSwitch Type Compiler Validation', () => {
+  it('validates AnimationVariant union values', () => {
+    expectTypeOf<AnimationVariant>().toEqualTypeOf<
+      'circle' | 'rectangle' | 'gif' | 'polygon' | 'circle-blur'
+    >();
+  });
+
+  it('validates AnimationStart type', () => {
+    expectTypeOf<AnimationStart>().toBeString();
+  });
+
+  it('ensures createAnimation returns required structure', () => {
+    const animation = createAnimation('circle');
+
+    expectTypeOf(animation.name).toBeString();
+    expectTypeOf(animation.css).toBeString();
+  });
+
+  it('accepts optional parameters without compile errors', () => {
+    const animation = createAnimation('circle');
+
+    expectTypeOf(animation.name).toBeString();
+    expectTypeOf(animation.css).toBeString();
+  });
+
+  it('accepts valid exported types in createAnimation', () => {
+    const variant: AnimationVariant = 'circle';
+    const start: AnimationStart = 'center';
+
+    const animation = createAnimation(variant, start);
+
+    expectTypeOf(animation.name).toBeString();
+    expectTypeOf(animation.css).toBeString();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2842

Added `app/components/theme-switch.type-compiler.test.tsx` to provide TypeScript compiler validation coverage for the Theme Switch component.

### Coverage Added

* AnimationVariant type validation
* AnimationStart type validation
* createAnimation return structure validation
* Optional parameter compatibility checks
* Valid exported type usage validation

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Attached screenshot showing successful execution of all 5 test cases.
<img width="1200" height="287" alt="Screenshot 2026-06-02 161617" src="https://github.com/user-attachments/assets/5f0f2db8-97f4-4b58-bf2b-a2a86e169b38" />


## Checklist

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] My commits follow the Conventional Commits format.
* [x] I have made sure that I have only one commit to merge in this PR.
