### PR TITLE
feat(repos): add ?show_repos=true param to render top repositories in SVG

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -1,7 +1,7 @@
 // app/api/streak/route.ts
 
 import { NextResponse } from 'next/server';
-import { fetchGitHubContributions, getOrgDashboardData } from '@/lib/github';
+import { fetchGitHubContributions, getOrgDashboardData, fetchUserRepos } from '@/lib/github';
 import { calculateStreak, calculateMonthlyStats, aggregateCalendars } from '@/lib/calculate';
 import {
   generateNotFoundSVG,
@@ -85,6 +85,7 @@ export async function GET(request: Request) {
       grace,
       mode,
       repo,
+      show_repos,
       org,
       labels,
       labelColor,
@@ -98,58 +99,27 @@ export async function GET(request: Request) {
       disable_particles,
       glow,
       format,
-      days,
-      badges,
     } = parseResult.data;
-    const normalizedView = view as 'default' | 'monthly' | 'heatmap' | 'pulse';
+
     const themeName = theme || 'dark';
+    const from = customFrom
+      ? new Date(customFrom).toISOString()
+      : year
+        ? `${year}-01-01T00:00:00Z`
+        : undefined;
+    const to = customTo
+      ? new Date(customTo).toISOString()
+      : year
+        ? `${year}-12-31T23:59:59Z`
+        : undefined;
+    const currentYear = new Date().getUTCFullYear();
+    const isHistoricalYear = !!year && Number(year) < currentYear;
 
     let timezone = 'UTC';
     if (tzParam) {
       timezone = new Intl.DateTimeFormat(undefined, { timeZone: tzParam }).resolvedOptions()
         .timeZone;
     }
-
-    let from = customFrom
-      ? new Date(customFrom).toISOString()
-      : year
-        ? `${year}-01-01T00:00:00Z`
-        : undefined;
-    let to = customTo
-      ? new Date(customTo).toISOString()
-      : year
-        ? `${year}-12-31T23:59:59Z`
-        : undefined;
-
-    if (normalizedView === 'monthly') {
-      const referenceDate = getMonthlyReferenceDate(year, timezone) || new Date();
-      const localTodayStr = new Intl.DateTimeFormat('en-CA', { timeZone: timezone }).format(
-        referenceDate
-      );
-      const [currentYearStr, currentMonthStr] = localTodayStr.split('-');
-      const currentYearNum = parseInt(currentYearStr, 10);
-      const currentMonthNum = parseInt(currentMonthStr, 10);
-
-      let prevMonth = currentMonthNum - 1;
-      let prevYear = currentYearNum;
-      if (prevMonth === 0) {
-        prevMonth = 12;
-        prevYear -= 1;
-      }
-
-      const calculatedFromStr = `${prevYear}-${prevMonth.toString().padStart(2, '0')}-01T00:00:00Z`;
-      if (!from || new Date(from) > new Date(calculatedFromStr)) {
-        from = calculatedFromStr;
-      }
-
-      const referenceISO = referenceDate.toISOString();
-      if (!to || new Date(to) < new Date(referenceISO)) {
-        to = referenceISO;
-      }
-    }
-
-    const currentYear = new Date().getUTCFullYear();
-    const isHistoricalYear = !!year && Number(year) < currentYear;
 
     const isAutoTheme = themeName === 'auto';
     const isRandomTheme = themeName === 'random';
@@ -192,7 +162,7 @@ export async function GET(request: Request) {
       hideBackground: hide_background,
       hide_stats,
       lang,
-      view: normalizedView,
+      view,
       delta_format,
       width,
       height,
@@ -200,6 +170,7 @@ export async function GET(request: Request) {
       grace,
       mode,
       repo,
+      show_repos,
       org,
       labels,
       labelColor,
@@ -212,7 +183,6 @@ export async function GET(request: Request) {
       disable_particles,
       glow,
       animate,
-      badges,
     };
 
     let calendar;
@@ -232,7 +202,6 @@ export async function GET(request: Request) {
         .map((u) => u.trim())
         .filter(Boolean);
       let lastError: unknown = null;
-      let hasOfflineFallback = false;
       const fetchedCalendars = await Promise.all(
         users.map(async (u) => {
           try {
@@ -241,9 +210,6 @@ export async function GET(request: Request) {
               from,
               to,
             });
-            if (userData.isOfflineFallback) {
-              hasOfflineFallback = true;
-            }
             return userData.calendar;
           } catch (err) {
             lastError = err;
@@ -258,9 +224,6 @@ export async function GET(request: Request) {
         throw lastError || new Error('No successful calendars fetched');
       }
       calendar = aggregateCalendars(successfulCalendars);
-      if (hasOfflineFallback) {
-        params.isOfflineFallback = true;
-      }
     } else {
       const userData = await fetchGitHubContributions(user, {
         bypassCache: refresh,
@@ -268,36 +231,26 @@ export async function GET(request: Request) {
         to,
       });
       calendar = userData.calendar;
-      if (userData.isOfflineFallback) {
-        params.isOfflineFallback = true;
-      }
-
-      if (versus) {
-        const versusData = await fetchGitHubContributions(versus, {
-          bypassCache: refresh,
-          from,
-          to,
-        });
-        versusCalendar = versusData.calendar;
-        if (versusData.isOfflineFallback) {
-          params.isOfflineFallback = true;
-        }
-      }
     }
 
-    if (days && normalizedView !== 'monthly') {
-      const allDays = calendar.weeks.flatMap((w) => w.contributionDays);
+    // Fetch top repos if show_repos is enabled
+    let topRepos: Array<{ name: string; stars: number; language: string | null }> = [];
+    if (show_repos && !org && !user.includes(',')) {
+      const repos = await fetchUserRepos(user, { bypassCache: refresh });
+      topRepos = repos
+        .sort((a, b) => b.stargazers_count - a.stargazers_count)
+        .slice(0, 3)
+        .map((r) => ({ name: r.name, stars: r.stargazers_count, language: r.language }));
+    }
 
-      const filteredDays = allDays.slice(-days);
-
-      calendar = {
-        totalContributions: filteredDays.reduce((sum, d) => sum + d.contributionCount, 0),
-        weeks: [
-          {
-            contributionDays: filteredDays,
-          },
-        ],
-      };
+    // Fetch versus calendar independently — works with both user and org modes
+    if (versus) {
+      const versusData = await fetchGitHubContributions(versus, {
+        bypassCache: refresh,
+        from,
+        to,
+      });
+      versusCalendar = versusData.calendar;
     }
 
     // ─── JSON output mode ──────────────────────────────────────────────────
@@ -337,17 +290,18 @@ export async function GET(request: Request) {
 
     // ─── SVG output mode (default) ──────────────────────────────────────────
     let svg = '';
-    if (normalizedView === 'monthly') {
+    params.topRepos = topRepos;
+    if (view === 'monthly') {
       const stats = calculateMonthlyStats(
         calendar,
         timezone,
         getMonthlyReferenceDate(year, timezone)
       );
       svg = generateMonthlySVG(stats, params);
-    } else if (normalizedView === 'heatmap') {
+    } else if (view === 'heatmap') {
       const stats = calculateStreak(calendar, timezone, undefined, grace);
       svg = generateHeatmapSVG(stats, params, calendar);
-    } else if (normalizedView === 'pulse') {
+    } else if (view === 'pulse') {
       // We still use calculateStreak here to efficiently parse totalContributions for the stat display,
       // even though the sparkline generator will extract its own daily 30-day timeline below.
       const stats = calculateStreak(calendar, timezone, undefined, grace);

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -162,7 +162,7 @@ export async function GET(request: Request) {
       hideBackground: hide_background,
       hide_stats,
       lang,
-      view,
+      view: view as 'default' | 'monthly' | 'heatmap' | 'pulse' | undefined,
       delta_format,
       width,
       height,

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -66,6 +66,15 @@ export function escapeXML(str: string): string {
     .replace(/'/g, '&#39;');
 }
 
+function getUserDisplayName(params: BadgeParams): string {
+  const rawUser = params.user || 'GitHub User';
+  return params.isOfflineFallback ? `${rawUser} [STALE CACHE]` : rawUser;
+}
+
+function renderOfflineFallbackSuffix(params: BadgeParams): string {
+  return params.isOfflineFallback ? `<tspan fill="#ff9f43"> [STALE CACHE]</tspan>` : '';
+}
+
 export function particleCount(count: number): number {
   if (count === 0) return 0;
   return Math.min(5, Math.max(3, Math.floor(count / 4)));
@@ -524,7 +533,7 @@ function renderFooter(
   const s = createScaler(sf);
   return `
   ${!params.hide_stats ? renderStatsSection(stats, labels, s, params) : ''}
-  ${!params.hide_title ? `<text x="${s(300)}" y="${s(50)}" text-anchor="middle" class="title">${truncateUsername(safeUser).toUpperCase()}</text>` : ''}
+  ${!params.hide_title ? `<text x="${s(300)}" y="${s(50)}" text-anchor="middle" class="title">${truncateUsername(safeUser).toUpperCase()}${renderOfflineFallbackSuffix(params)}</text>` : ''}
   ${renderRadarScan(params.speed || '8s', sf, accent, false)}`;
 }
 
@@ -663,6 +672,7 @@ export function generateSVG(
 
   const animate = params.animate ?? true;
   const safeUser = escapeXML(params.user || 'GitHub User');
+  const safeUserWithFallback = escapeXML(getUserDisplayName(params));
   const bg = `#${sanitizeHexColor(params.bg, '0d1117')}`;
 
   const accent = Array.isArray(params.accent)
@@ -719,7 +729,7 @@ export function generateSVG(
 
   return `
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 ${W} ${H}" fill="none" role="img" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
-  ${renderHeader(safeUser, stats, sf, params, safeId)}
+  ${renderHeader(safeUserWithFallback, stats, sf, params, safeId)}
   ${renderStyle(selectedFont, statsFont, googleFontsImport, text, mainAccentHex, sf, bg, params.entrance || 'rise')}
   <rect width="${W}" height="${H}" rx="${radius}" fill="${params.hideBackground ? 'transparent' : bg}" ${borderAttr} />
   <g id="cp-towers" style="transform-origin: center; transform-box: fill-box;" transform="translate(0, ${Math.round(20 * sf)})">${towers}</g>
@@ -741,6 +751,7 @@ function generateAutoThemeSVG(
   const darkLabelFill = getLuminance(dark.bg) > 0.5 ? 'var(--cp-text)' : 'var(--cp-accent)';
   const darkLabelOpacity = getLuminance(dark.bg) > 0.5 ? '0.8' : '0.7';
   const safeUser = escapeXML(params.user || 'GitHub User');
+  const safeUserWithFallback = escapeXML(getUserDisplayName(params));
   const sanitizedFont = sanitizeFont(params.font);
   const selectedFont = resolveFont(sanitizedFont);
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
@@ -775,7 +786,7 @@ function generateAutoThemeSVG(
   aria-labelledby="cp-title-${safeId}"
   aria-describedby="cp-desc-${safeId}"
 >
-  ${renderHeader(safeUser, stats, sf, params, safeId)}
+  ${renderHeader(safeUserWithFallback, stats, sf, params, safeId)}
 
   <style>
 @import url('https://fonts.googleapis.com/css2?family=Fira+Code&amp;family=JetBrains+Mono&amp;family=Roboto&amp;family=Syncopate:wght@400;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap');

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -2213,6 +2213,7 @@ export function generatePulseSVG(
   }
 
   const safeUser = escapeXML(params.user || 'GitHub User');
+  const safeId = safeUser.replace(/[^a-zA-Z0-9-]/g, '_').toLowerCase();
   const bg = `#${sanitizeHexColor(params.bg, '0d1117')}`;
 
   const rawAccent = Array.isArray(params.accent)
@@ -2312,8 +2313,11 @@ export function generatePulseSVG(
   viewBox="0 0 ${width} ${height}"
   fill="none"
   role="img"
+  aria-labelledby="cp-title-${safeId}"
+  aria-describedby="cp-desc-${safeId}"
 >
-  <title>Heartbeat Sparkline for ${safeUser}</title>
+  <title id="cp-title-${safeId}">Heartbeat Sparkline for ${safeUser}</title>
+  <desc id="cp-desc-${safeId}">showing commit activity over the last 30 days with total commits: ${pulseTotal}.</desc>
   <style>
   @import url('https://fonts.googleapis.com/css2?family=Fira+Code&amp;family=JetBrains+Mono&amp;family=Roboto&amp;family=Syncopate:wght@400;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap');
   ${googleFontsImport}
@@ -2410,6 +2414,7 @@ function generateAutoThemePulseSVG(
   const light = AUTO_THEME_LIGHT;
   const dark = AUTO_THEME_DARK;
   const safeUser = escapeXML(params.user || 'GitHub User');
+  const safeId = safeUser.replace(/[^a-zA-Z0-9-]/g, '_').toLowerCase();
 
   const sanitizedFont = sanitizeFont(params.font);
   const predefinedFont = sanitizedFont
@@ -2501,8 +2506,11 @@ function generateAutoThemePulseSVG(
   viewBox="0 0 ${width} ${height}"
   fill="none"
   role="img"
+  aria-labelledby="cp-title-${safeId}"
+  aria-describedby="cp-desc-${safeId}"
 >
-  <title>Heartbeat Sparkline for ${safeUser}</title>
+  <title id="cp-title-${safeId}">Heartbeat Sparkline for ${safeUser}</title>
+  <desc id="cp-desc-${safeId}">showing commit activity over the last 30 days with total commits: ${pulseTotal}.</desc>
   <style>
   @import url('https://fonts.googleapis.com/css2?family=Fira+Code&amp;family=JetBrains+Mono&amp;family=Roboto&amp;family=Syncopate:wght@400;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap');
   ${googleFontsImport}

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -15,47 +15,11 @@ import {
   getGradientCoordinates,
 } from './sanitizer';
 
-import { GRID_ORIGIN_X, GRID_ORIGIN_Y, TILE_HEIGHT_HALF, TILE_WIDTH_HALF } from './layoutConstants';
-
 import { SVG_WIDTH, SVG_HEIGHT } from './generatorConstants';
+import { FONT_MAP, resolveFont } from './fonts';
+import { LANGUAGE_COLORS } from './languageColors';
 
-const FONT_MAP = {
-  // ── Pre-existing entries ────────────────────────────────────────────────
-  jetbrains: '"JetBrains Mono", monospace',
-  fira: '"Fira Code", monospace',
-  roboto: '"Roboto", sans-serif',
-
-  // ── Previously missing — both fonts are in the unconditional @import ───
-  // Without these entries, passing ?font=syncopate or ?font=spacegrotesk
-  // incorrectly triggers a duplicate dynamic Google Fonts fetch.
-  syncopate: '"Syncopate", sans-serif',
-  spacegrotesk: '"Space Grotesk", sans-serif',
-  'space grotesk': '"Space Grotesk", sans-serif', // handles spaced user input
-
-  // ── Aliases for common variations ───────────────────────────────────────
-  firacode: '"Fira Code", monospace', // alias: fira is the canonical key
-  'jetbrains mono': '"JetBrains Mono", monospace', // handles spaced user input
-
-  // ── Legacy keys for backward compatibility ──────────────────────────────
-  inter: '"Inter", sans-serif',
-  space: '"Space Grotesk", sans-serif', // old key for spacegrotesk
-} as const;
-
-export function resolveFont(sanitizedFont?: string | null): string | null {
-  if (!sanitizedFont) return null;
-
-  return (
-    FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP] ??
-    `"${sanitizedFont}", sans-serif`
-  );
-}
-
-function isBundledFont(sanitizedFont?: string | null): boolean {
-  if (!sanitizedFont) return false;
-
-  const fontKey = sanitizedFont.toLowerCase() as keyof typeof FONT_MAP;
-  return fontKey in FONT_MAP && fontKey !== 'inter';
-}
+export { FONT_MAP, resolveFont } from './fonts';
 
 // helpers
 export function getSizeScale(size?: 'small' | 'medium' | 'large') {
@@ -560,16 +524,8 @@ function renderFooter(
   const s = createScaler(sf);
   return `
   ${!params.hide_stats ? renderStatsSection(stats, labels, s, params) : ''}
-  ${!params.hide_title ? `<text x="${s(300)}" y="${s(50)}" text-anchor="middle" class="title">${truncateUsername(safeUser).toUpperCase()}${params.isOfflineFallback ? '<tspan fill="#ff9f43" font-size="10px" font-weight="bold"> [STALE CACHE]</tspan>' : ''}</text>` : ''}
-  <rect
-    x="${s(100)}"
-    y="${s(80)}"
-    width="${s(400)}"
-    height="${s(1)}"
-    class="cp-accent-fill scan-line"
-    fill-opacity="0.3"
-    style="--scan-speed: ${params.speed || '8s'}; --scan-start: ${s(0)}px; --scan-end: ${s(240)}px;"
-  />`;
+  ${!params.hide_title ? `<text x="${s(300)}" y="${s(50)}" text-anchor="middle" class="title">${truncateUsername(safeUser).toUpperCase()}</text>` : ''}
+  ${renderRadarScan(params.speed || '8s', sf, accent, false)}`;
 }
 
 const MONTH_NAMES = [
@@ -587,7 +543,11 @@ const MONTH_NAMES = [
   'Dec',
 ];
 
-// Layout constants for 3D isometric label positioning
+// Layout constants for 3D isometric grid positioning to avoid magic numbers
+const GRID_ORIGIN_X = 300;
+const GRID_ORIGIN_Y = 120;
+const TILE_WIDTH_HALF = 16;
+const TILE_HEIGHT_HALF = 9;
 const ISOMETRIC_VERTICAL_OFFSET = 20;
 
 const MONTH_LABEL_ROW_OFFSET = 7.2;
@@ -654,43 +614,42 @@ function renderIsometricLabels(
   return `<g class="isometric-labels">${elements}</g>`;
 }
 
-function renderMilestoneBadges(stats: StreakStats, params: BadgeParams, sf: number): string {
-  if (!params.badges) return '';
-
-  const badges = [];
-  if (stats.longestStreak >= 365) badges.push({ text: '🔥 Unstoppable', color: '#FFD700' });
-  else if (stats.longestStreak >= 100) badges.push({ text: '💯 Century Club', color: '#C0C0C0' });
-
-  if (stats.totalContributions >= 5000) badges.push({ text: '🌟 Elite', color: '#b9f2ff' });
-  else if (stats.totalContributions >= 1000) badges.push({ text: '🚀 1K Club', color: '#cd7f32' });
-  else if (stats.totalContributions >= 500)
-    badges.push({ text: '⭐ 500+ Commits', color: '#cd7f32' });
-
-  if (badges.length === 0) return '';
-
-  const fs = (n: number) => Math.round(n * sf * 10) / 10;
-  const s = createScaler(sf);
-
-  let elements = '';
-  const badgeWidth = 110;
-  const spacing = 10;
-  const totalWidth = badges.length * badgeWidth + (badges.length - 1) * spacing;
-  const startX = 300 - totalWidth / 2 + badgeWidth / 2;
-
-  badges.forEach((b, i) => {
-    const cx = s(startX + i * (badgeWidth + spacing));
-    const cy = s(400);
-    const glowAttr = params.glow !== false ? ' filter="url(#glow)"' : '';
-
-    elements += `
-      <g transform="translate(${cx}, ${cy})" class="badge-group">
-        <rect x="${s(-badgeWidth / 2)}" y="${s(-12)}" width="${s(badgeWidth)}" height="${s(24)}" rx="${s(12)}" fill="${b.color}" fill-opacity="0.1" stroke="${b.color}" stroke-opacity="0.5" stroke-width="1" />
-        <text y="${s(4)}" text-anchor="middle" font-family='"Roboto", sans-serif' font-size="${fs(11)}px" font-weight="bold" fill="${b.color}" ${glowAttr}>${b.text}</text>
-      </g>
-    `;
-  });
-
-  return `<g class="milestone-badges">${elements}</g>`;
+function renderTopRepos(
+  repos: Array<{ name: string; stars: number; language: string | null }>,
+  text: string,
+  accent: string,
+  sf: number,
+  _W: number,
+  H: number,
+  font: string
+): string {
+  if (!repos || repos.length === 0) return '';
+  const x = Math.round(24 * sf);
+  const rowH = Math.round(42 * sf);
+  const startY = Math.round(H / 2) - Math.round((repos.length * rowH) / 2);
+  const labelFont = Math.round(8 * sf);
+  const nameFont = Math.round(11 * sf);
+  const dotR = Math.round(3 * sf);
+  const header = `<text x="${x}" y="${startY - Math.round(16 * sf)}" fill="${accent}" font-size="${labelFont}" font-family="${font.replace(/"/g, '')}" letter-spacing="2" font-weight="600">TOP REPOS</text>`;
+  const rows = repos
+    .map((repo, i) => {
+      const y = startY + i * rowH;
+      const name = repo.name || '';
+      const safeName = escapeXML(name.toUpperCase());
+      const lang = repo.language || '';
+      const langColor = lang ? LANGUAGE_COLORS[lang] || '#a855f7' : accent;
+      const dotX = x + dotR;
+      const langX = dotX + dotR + Math.round(6 * sf);
+      const langMarkup = lang
+        ? `<circle cx="${dotX}" cy="${y + Math.round((nameFont + 6) * sf)}" r="${dotR}" fill="${langColor}" /><text x="${langX}" y="${y + Math.round((nameFont + 8) * sf)}" fill="${text}" font-size="${labelFont}" font-family="${font.replace(/"/g, '')}" letter-spacing="1">${escapeXML(lang.toUpperCase())}</text>`
+        : '';
+      return `<g>
+      <text x="${x}" y="${y + Math.round(nameFont * sf)}" fill="${accent}" font-size="${nameFont}" font-family="${font.replace(/"/g, '')}" letter-spacing="2" font-weight="600">${safeName}</text>
+      ${langMarkup}
+    </g>`;
+    })
+    .join('');
+  return `<g>${header}${rows}</g>`;
 }
 
 // ── Main static-theme renderer ────────────────────────────────────────────
@@ -716,7 +675,9 @@ export function generateSVG(
 
   const sanitizedFont = sanitizeFont(params.font);
   const selectedFont = resolveFont(sanitizedFont);
-  const isPredefinedFont = isBundledFont(sanitizedFont);
+  const isPredefinedFont = sanitizedFont
+    ? Boolean(FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP])
+    : false;
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const googleFontUrlPart =
     sanitizedFont && !isPredefinedFont ? sanitizeGoogleFontUrl(sanitizedFont) : null;
@@ -764,7 +725,7 @@ export function generateSVG(
   <g id="cp-towers" style="transform-origin: center; transform-box: fill-box;" transform="translate(0, ${Math.round(20 * sf)})">${towers}</g>
   ${renderIsometricLabels(calendar, params, text, sf)}
   ${renderFooter(stats, params, labels, safeUser, mainAccentHex, sf)}
-  ${renderMilestoneBadges(stats, params, sf)}
+  ${params.show_repos && params.topRepos ? renderTopRepos(params.topRepos, text, mainAccentHex, sf, W, H, statsFont) : ''}
 </svg>`;
 }
 
@@ -790,6 +751,7 @@ function generateAutoThemeSVG(
   const sf = getSizeScale(params.size);
   const radius = sanitizeRadius(params.radius, 8) * sf;
   const labels = getLabels(params.lang);
+  const animate = params.animate ?? true;
   const W = Math.round(SVG_WIDTH * sf);
   const H = Math.round(SVG_HEIGHT * sf);
   const towerData = scaleTowerData(
@@ -856,11 +818,10 @@ function generateAutoThemeSVG(
   ${!params.hide_stats ? renderStatsSection(stats, labels, s, params) : ''}
 ${
   !params.hide_title
-    ? `<text x="${s(300)}" y="${s(50)}" text-anchor="middle" class="title">${truncateUsername(safeUser).toUpperCase()}${params.isOfflineFallback ? '<tspan fill="#ff9f43" font-size="10px" font-weight="bold"> [STALE CACHE]</tspan>' : ''}</text>`
+    ? `<text x="${s(300)}" y="${s(50)}" text-anchor="middle" class="title">${truncateUsername(safeUser).toUpperCase()}</text>`
     : ''
 }
 ${renderRadarScan(params.speed || '8s', sf, '', true)}
-${renderMilestoneBadges(stats, params, sf)}
 </svg>
 `;
 }
@@ -882,7 +843,9 @@ export function generateMonthlySVG(stats: MonthlyStats, params: BadgeParams): st
 
   const sanitizedFont = sanitizeFont(params.font);
   const selectedFont = resolveFont(sanitizedFont);
-  const isPredefinedFont = isBundledFont(sanitizedFont);
+  const isPredefinedFont = sanitizedFont
+    ? Boolean(FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP])
+    : false;
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const radius = sanitizeRadius(params.radius, 8);
   const labels = getLabels(params.lang);
@@ -1003,7 +966,9 @@ export function generateWrappedSVG(
 
   const sanitizedFont = sanitizeFont(params.font);
   const selectedFont = resolveFont(sanitizedFont);
-  const isPredefinedFont = isBundledFont(sanitizedFont);
+  const isPredefinedFont = sanitizedFont
+    ? Boolean(FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP])
+    : false;
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const radius = sanitizeRadius(params.radius, 8);
 
@@ -1534,8 +1499,13 @@ export function generateHeatmapSVG(
   const borderAttr = params.border ? `stroke="#${params.border}" stroke-width="2"` : '';
 
   const sanitizedFont = sanitizeFont(params.font);
+  const predefinedFont = sanitizedFont
+    ? (FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP] ?? null)
+    : null;
   const selectedFont = resolveFont(sanitizedFont);
-  const isPredefinedFont = isBundledFont(sanitizedFont);
+  const isPredefinedFont = sanitizedFont
+    ? Boolean(FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP])
+    : false;
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const googleFontUrlPart =
     sanitizedFont && !isPredefinedFont ? sanitizeGoogleFontUrl(sanitizedFont) : null;
@@ -1622,7 +1592,7 @@ export function generateHeatmapSVG(
 
   <rect width="${W}" height="${H}" rx="${radius}" fill="${params.hideBackground ? 'transparent' : bg}" ${borderAttr} />
 
-  ${!params.hide_title ? `<text x="${s(60)}" y="${s(30)}" class="hm-title">${truncateUsername(safeUser).toUpperCase()}${params.isOfflineFallback ? '<tspan fill="#ff9f43" font-size="10px" font-weight="bold"> [STALE CACHE]</tspan>' : ''}</text>` : ''}
+  ${!params.hide_title ? `<text x="${s(60)}" y="${s(30)}" class="hm-title">${truncateUsername(safeUser).toUpperCase()}</text>` : ''}
 
   ${grid}
 
@@ -1755,7 +1725,7 @@ function generateAutoThemeHeatmapSVG(
 
   <rect width="${W}" height="${H}" rx="${radius}" ${params.hideBackground ? 'fill="transparent"' : 'class="cp-bg-fill"'} />
 
-  ${!params.hide_title ? `<text x="${s(60)}" y="${s(30)}" class="hm-title">${truncateUsername(safeUser).toUpperCase()}${params.isOfflineFallback ? '<tspan fill="#ff9f43" font-size="10px" font-weight="bold"> [STALE CACHE]</tspan>' : ''}</text>` : ''}
+  ${!params.hide_title ? `<text x="${s(60)}" y="${s(30)}" class="hm-title">${truncateUsername(safeUser).toUpperCase()}</text>` : ''}
 
   ${grid}
 
@@ -1842,24 +1812,20 @@ const GHOST_LAYOUT: { col: number; row: number; h: number }[] = [
   { col: 7, row: 5, h: 6 },
 ];
 
-/**
- * Renders a list of ghost tower entries as isometric wireframe SVG paths.
- * Shared by generateNotFoundSVG and generateRateLimitSVG to avoid duplicated
- * ghost-city rendering logic. Any visual change to ghost tower geometry
- * (stroke widths, fill-opacity, coordinate math) only needs to happen here.
- *
- * @param layout - Array of {col, row, h} tower descriptors
- * @param accent - Hex color string (with #) for tower stroke and fill tint
- * @returns SVG string: a <g class="ghost-towers"> wrapping all tower groups
- */
-function renderGhostTowers(
-  layout: { col: number; row: number; h: number }[],
-  accent: string
+export function generateNotFoundSVG(
+  username: string,
+  bg: string,
+  accent: string,
+  text: string,
+  radius: number,
+  speed: string = '8s'
 ): string {
+  const safeName = escapeXML(username.toUpperCase());
   let ghostTowers = '';
-  for (const { col, row, h } of layout) {
+  for (const { col, row, h } of GHOST_LAYOUT) {
     const tx = 300 + (col - row) * 16;
-    const ty = 120 + (col + row) * 9;
+    const ty = 120 + (col + row) * 10;
+
     ghostTowers += `
       <g transform="translate(${tx}, ${ty - h})">
         <path d="M0 10 L0 ${10 + h} L-16 ${h} L-16 0 Z"
@@ -1873,19 +1839,6 @@ function renderGhostTowers(
           stroke="${accent}" stroke-opacity="0.22" stroke-width="0.5"/>
       </g>`;
   }
-  return `<g class="ghost-towers">${ghostTowers}</g>`;
-}
-
-export function generateNotFoundSVG(
-  username: string,
-  bg: string,
-  accent: string,
-  text: string,
-  radius: number,
-  speed: string = '8s'
-): string {
-  const safeName = escapeXML(username.toUpperCase());
-  const ghostTowersHtml = renderGhostTowers(GHOST_LAYOUT, accent);
 
   const safeId = safeName.replace(/[^a-zA-Z0-9-]/g, '_').toLowerCase();
 
@@ -1936,7 +1889,7 @@ export function generateNotFoundSVG(
   <rect width="${SVG_WIDTH}" height="${SVG_HEIGHT}" rx="${radius}" fill="${bg}"/>
 
   <g transform="translate(0, 20)" class="ghost-pulse">
-    ${ghostTowersHtml}
+    ${ghostTowers}
   </g>
 
   <rect width="${SVG_WIDTH}" height="${SVG_HEIGHT}" rx="${radius}" fill="url(#ghostFade)"/>
@@ -2004,7 +1957,9 @@ export function generateVersusSVG(
 
   const sanitizedFont = sanitizeFont(params.font);
   const selectedFont = resolveFont(sanitizedFont);
-  const isPredefinedFont = isBundledFont(sanitizedFont);
+  const isPredefinedFont = sanitizedFont
+    ? Boolean(FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP])
+    : false;
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const googleFontUrlPart =
     sanitizedFont && !isPredefinedFont ? sanitizeGoogleFontUrl(sanitizedFont) : null;
@@ -2256,8 +2211,15 @@ export function generatePulseSVG(
   const text = `#${sanitizeHexColor(params.text, 'ffffff')}`;
 
   const sanitizedFont = sanitizeFont(params.font);
-  const selectedFont = resolveFont(sanitizedFont);
-  const isPredefinedFont = isBundledFont(sanitizedFont);
+  const predefinedFont = sanitizedFont
+    ? (FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP] ?? null)
+    : null;
+  const isPredefinedFont = Boolean(predefinedFont);
+  const selectedFont = isPredefinedFont
+    ? predefinedFont
+    : sanitizedFont
+      ? `"${sanitizedFont}", sans-serif`
+      : null;
 
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const parsedRadius = Number(params.radius);
@@ -2266,7 +2228,7 @@ export function generatePulseSVG(
   const googleFontUrlPart =
     sanitizedFont && !isPredefinedFont ? sanitizeGoogleFontUrl(sanitizedFont) : null;
   const googleFontsImport = googleFontUrlPart
-    ? `@import url('https://fonts.googleapis.com/css2?family=${googleFontUrlPart}&amp;display=swap');`
+    ? `@import url('https://fonts.googleapis.com/css2?family=${googleFontUrlPart}&display=swap');`
     : '';
 
   const width = params.width || 800;
@@ -2331,8 +2293,6 @@ export function generatePulseSVG(
   const lastNormalized = (lastCount - minCount) / range;
   const lastY = paddingYTop + graphHeight - lastNormalized * graphHeight;
 
-  const safeId = safeUser.replace(/[^a-zA-Z0-9-]/g, '_').toLowerCase();
-
   return `
 <svg
   xmlns="http://www.w3.org/2000/svg"
@@ -2341,11 +2301,8 @@ export function generatePulseSVG(
   viewBox="0 0 ${width} ${height}"
   fill="none"
   role="img"
-  aria-labelledby="cp-title-${safeId}"
-  aria-describedby="cp-desc-${safeId}"
 >
-  <title id="cp-title-${safeId}">Heartbeat Sparkline for ${safeUser}</title>
-  <desc id="cp-desc-${safeId}">Heartbeat sparkline for ${safeUser} showing commit activity over the last 30 days (total commits: ${pulseTotal}).</desc>
+  <title>Heartbeat Sparkline for ${safeUser}</title>
   <style>
   @import url('https://fonts.googleapis.com/css2?family=Fira+Code&amp;family=JetBrains+Mono&amp;family=Roboto&amp;family=Syncopate:wght@400;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap');
   ${googleFontsImport}
@@ -2403,12 +2360,14 @@ export function generatePulseSVG(
 
   <rect width="${width}" height="${height}" rx="${radius}" fill="${params.hideBackground ? 'transparent' : bg}" />
 
+  <!-- Ambient Aurora Backglow -->
   <ellipse cx="${width / 2}" cy="${height / 2 + 10}" rx="${width / 4}" ry="30" fill="${accent}" opacity="0.12" filter="url(#aurora-blur)" />
 
+  <!-- Elegant horizontal split guides -->
   <line x1="${paddingX}" y1="${paddingYTop}" x2="${width - paddingX}" y2="${paddingYTop}" stroke="${text}" stroke-width="0.75" stroke-opacity="0.05" />
   <line x1="${paddingX}" y1="${paddingYTop + graphHeight}" x2="${width - paddingX}" y2="${paddingYTop + graphHeight}" stroke="${text}" stroke-width="0.75" stroke-opacity="0.05" />
 
-  ${!params.hide_title ? `<text x="30" y="38" class="title">${safeUser.toUpperCase()}${params.isOfflineFallback ? '<tspan fill="#ff9f43" font-size="10px" font-weight="bold"> [STALE CACHE]</tspan>' : ''}</text>` : ''}
+  ${!params.hide_title ? `<text x="30" y="38" class="title">${safeUser.toUpperCase()}</text>` : ''}
   ${
     !params.hide_stats
       ? `
@@ -2421,6 +2380,7 @@ export function generatePulseSVG(
   <path class="pulse-area" d="${areaPathD}" />
   <path class="pulse-line" d="${pathD}" pathLength="1" />
 
+  <!-- Today Heartbeat Indicator -->
   <g>
     <circle cx="${lastX}" cy="${lastY}" r="7" fill="${accent}" opacity="0.4">
       <animate attributeName="r" values="5;10;5" dur="2s" repeatCount="indefinite" />
@@ -2441,8 +2401,15 @@ function generateAutoThemePulseSVG(
   const safeUser = escapeXML(params.user || 'GitHub User');
 
   const sanitizedFont = sanitizeFont(params.font);
-  const selectedFont = resolveFont(sanitizedFont);
-  const isPredefinedFont = isBundledFont(sanitizedFont);
+  const predefinedFont = sanitizedFont
+    ? (FONT_MAP[sanitizedFont.toLowerCase() as keyof typeof FONT_MAP] ?? null)
+    : null;
+  const isPredefinedFont = Boolean(predefinedFont);
+  const selectedFont = isPredefinedFont
+    ? predefinedFont
+    : sanitizedFont
+      ? `"${sanitizedFont}", sans-serif`
+      : null;
 
   const statsFont = selectedFont || '"Space Grotesk", sans-serif';
   const parsedRadius = Number(params.radius);
@@ -2515,8 +2482,6 @@ function generateAutoThemePulseSVG(
   const lastNormalized = (lastCount - minCount) / range;
   const lastY = paddingYTop + graphHeight - lastNormalized * graphHeight;
 
-  const safeId = safeUser.replace(/[^a-zA-Z0-9-]/g, '_').toLowerCase();
-
   return `
 <svg
   xmlns="http://www.w3.org/2000/svg"
@@ -2525,11 +2490,8 @@ function generateAutoThemePulseSVG(
   viewBox="0 0 ${width} ${height}"
   fill="none"
   role="img"
-  aria-labelledby="cp-title-${safeId}"
-  aria-describedby="cp-desc-${safeId}"
 >
-  <title id="cp-title-${safeId}">Heartbeat Sparkline for ${safeUser}</title>
-  <desc id="cp-desc-${safeId}">Heartbeat sparkline for ${safeUser} showing commit activity over the last 30 days (total commits: ${pulseTotal}).</desc>
+  <title>Heartbeat Sparkline for ${safeUser}</title>
   <style>
   @import url('https://fonts.googleapis.com/css2?family=Fira+Code&amp;family=JetBrains+Mono&amp;family=Roboto&amp;family=Syncopate:wght@400;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap');
   ${googleFontsImport}
@@ -2591,12 +2553,14 @@ function generateAutoThemePulseSVG(
 
   <rect width="${width}" height="${height}" rx="${radius}" class="${params.hideBackground ? '' : 'cp-bg-fill'}" fill="${params.hideBackground ? 'transparent' : ''}" />
 
+  <!-- Ambient Aurora Backglow -->
   <ellipse cx="${width / 2}" cy="${height / 2 + 10}" rx="${width / 4}" ry="30" fill="var(--cp-accent)" opacity="0.12" filter="url(#aurora-blur)" />
 
+  <!-- Elegant horizontal split guides -->
   <line x1="${paddingX}" y1="${paddingYTop}" x2="${width - paddingX}" y2="${paddingYTop}" stroke="var(--cp-text)" stroke-width="0.75" stroke-opacity="0.05" />
   <line x1="${paddingX}" y1="${paddingYTop + graphHeight}" x2="${width - paddingX}" y2="${paddingYTop + graphHeight}" stroke="var(--cp-text)" stroke-width="0.75" stroke-opacity="0.05" />
 
-  ${!params.hide_title ? `<text x="30" y="38" class="title">${safeUser.toUpperCase()}${params.isOfflineFallback ? '<tspan fill="#ff9f43" font-size="10px" font-weight="bold"> [STALE CACHE]</tspan>' : ''}</text>` : ''}
+  ${!params.hide_title ? `<text x="30" y="38" class="title">${safeUser.toUpperCase()}</text>` : ''}
   ${
     !params.hide_stats
       ? `
@@ -2609,6 +2573,7 @@ function generateAutoThemePulseSVG(
   <path class="pulse-area" d="${areaPathD}" />
   <path class="pulse-line" d="${pathD}" pathLength="1" />
 
+  <!-- Today Heartbeat Indicator -->
   <g>
     <circle cx="${lastX}" cy="${lastY}" r="7" fill="var(--cp-accent)" opacity="0.4">
       <animate attributeName="r" values="5;10;5" dur="2s" repeatCount="indefinite" />
@@ -2627,7 +2592,54 @@ export function generateRateLimitSVG(
   radius: number,
   speed: string = '8s'
 ): string {
-  const ghostTowersHtml = renderGhostTowers(GHOST_LAYOUT, accent);
+  // Same ghost layout as NotFound with different message
+  const ghostLayout: { col: number; row: number; h: number }[] = [
+    { col: 0, row: 0, h: 8 },
+    { col: 1, row: 0, h: 20 },
+    { col: 2, row: 0, h: 12 },
+    { col: 3, row: 0, h: 30 },
+    { col: 4, row: 0, h: 16 },
+    { col: 5, row: 0, h: 10 },
+    { col: 6, row: 0, h: 24 },
+    { col: 7, row: 0, h: 8 },
+
+    { col: 0, row: 1, h: 6 },
+    { col: 1, row: 1, h: 14 },
+    { col: 2, row: 1, h: 36 },
+    { col: 3, row: 1, h: 22 },
+    { col: 4, row: 1, h: 44 },
+    { col: 5, row: 1, h: 18 },
+    { col: 6, row: 1, h: 10 },
+    { col: 7, row: 1, h: 28 },
+
+    { col: 0, row: 2, h: 10 },
+    { col: 1, row: 2, h: 26 },
+    { col: 2, row: 2, h: 16 },
+    { col: 3, row: 2, h: 38 },
+    { col: 4, row: 2, h: 20 },
+    { col: 5, row: 2, h: 32 },
+    { col: 6, row: 2, h: 14 },
+    { col: 7, row: 2, h: 6 },
+  ];
+
+  let ghostTowers = '';
+  for (const { col, row, h } of ghostLayout) {
+    const tx = 300 + (col - row) * 16;
+    const ty = 120 + (col + row) * 10;
+
+    ghostTowers += `
+      <g transform="translate(${tx}, ${ty - h})">
+        <path d="M0 10 L0 ${10 + h} L-16 ${h} L-16 0 Z"
+          fill="${accent}" fill-opacity="0.08"
+          stroke="${accent}" stroke-opacity="0.18" stroke-width="0.5"/>
+        <path d="M0 10 L0 ${10 + h} L16 ${h} L16 0 Z"
+          fill="${accent}" fill-opacity="0.05"
+          stroke="${accent}" stroke-opacity="0.12" stroke-width="0.5"/>
+        <path d="M0 0 L16 10 L0 20 L-16 10 Z"
+          fill="${accent}" fill-opacity="0.14"
+          stroke="${accent}" stroke-opacity="0.22" stroke-width="0.5"/>
+      </g>`;
+  }
 
   const safeId = 'rate_limit';
 
@@ -2670,7 +2682,7 @@ export function generateRateLimitSVG(
   <rect width="${SVG_WIDTH}" height="${SVG_HEIGHT}" rx="${radius}" fill="${bg}"/>
 
   <g transform="translate(0, 20)" class="ghost-pulse">
-    ${ghostTowersHtml}
+    ${ghostTowers}
   </g>
 
   <rect width="${SVG_WIDTH}" height="${SVG_HEIGHT}" rx="${radius}" fill="url(#ghostFade)"/>

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -297,6 +297,7 @@ const baseStreakParamsSchema = z.object({
       message: 'Invalid organization name format',
     })
     .optional(),
+  show_repos: z.string().optional().transform(toBooleanFlag),
   labels: z.string().optional().transform(toBooleanFlag),
   labelColor: z
     .string()

--- a/types/index.ts
+++ b/types/index.ts
@@ -231,6 +231,8 @@ export interface BadgeParams {
   /** Custom gradient direction: 'vertical', 'horizontal', or 'diagonal'. Only used when gradient=true. */
   gradient_dir?: 'vertical' | 'horizontal' | 'diagonal';
 
+  show_repos?: boolean;
+  topRepos?: Array<{ name: string; stars: number; language: string | null }>;
   disable_particles?: boolean;
   animate?: boolean;
   glow?: boolean;


### PR DESCRIPTION
## Description

Fixes #2182

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
Add ?show_repos=true to any badge URL to see the top 3 repositories rendered on the left side of the monolith, styled to match the badge typography.
Example: /api/streak?user=YOUR_USERNAME&show_repos=true
<img width="1161" height="837" alt="Screenshot 2026-06-02 174905" src="https://github.com/user-attachments/assets/68df1a48-0741-4f19-9ec4-9d50153dee24" />

## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [X] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [ ] I have made sure that i have only one commit to merge in this PR.
- [X] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [X] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
