### PR TITLE
test(i18n): add Japanese badge label coverage

### DIFF
--- a/lib/i18n/languages/ja.test.ts
+++ b/lib/i18n/languages/ja.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getLabels, labels } from '../badgeLabels';
+
+const requiredKeys = [
+  'CURRENT_STREAK',
+  'ANNUAL_SYNC_TOTAL',
+  'PEAK_STREAK',
+  'COMMITS_THIS_MONTH',
+  'VS_LAST_MONTH',
+] as const;
+
+const expectedJapaneseLabels = {
+  CURRENT_STREAK: '現在のストリーク',
+  ANNUAL_SYNC_TOTAL: '年間合計',
+  PEAK_STREAK: '最高ストリーク',
+  COMMITS_THIS_MONTH: '今月のコミット数',
+  VS_LAST_MONTH: '先月比',
+};
+
+function renderMockBadge(lang: string) {
+  const badgeLabels = getLabels(lang);
+
+  return `
+    <svg role="img" data-lang="${lang}">
+      <text>${badgeLabels.CURRENT_STREAK}</text>
+      <text>${badgeLabels.ANNUAL_SYNC_TOTAL}</text>
+      <text>${badgeLabels.PEAK_STREAK}</text>
+      <text>${badgeLabels.COMMITS_THIS_MONTH}</text>
+      <text>${badgeLabels.VS_LAST_MONTH}</text>
+    </svg>
+  `;
+}
+
+describe('Japanese badge labels', () => {
+  it('includes the ja language key in the labels dictionary', () => {
+    expect(labels.ja).toBeDefined();
+  });
+
+  it('returns the exact Japanese translation mapping through getLabels', () => {
+    expect(getLabels('ja')).toEqual(expectedJapaneseLabels);
+  });
+
+  it('returns the Japanese mapping when lang code casing differs', () => {
+    expect(getLabels('JA')).toEqual(expectedJapaneseLabels);
+  });
+
+  it('sets every required Japanese label to a non-empty string', () => {
+    const japaneseLabels = getLabels('ja');
+
+    for (const key of requiredKeys) {
+      expect(typeof japaneseLabels[key]).toBe('string');
+      expect(japaneseLabels[key].trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('renders a mock SVG with Japanese translated labels', () => {
+    const svg = renderMockBadge('ja');
+
+    expect(svg).toContain('data-lang="ja"');
+
+    for (const value of Object.values(expectedJapaneseLabels)) {
+      expect(svg).toContain(value);
+    }
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2336

Adds focused Vitest coverage for Japanese (`ja`) badge label translations in `lib/i18n/badgeLabels.ts`.

Tests verify:

* The `ja` language key exists in the labels dictionary
* `getLabels('ja')` returns the expected Japanese translations
* Language code casing is handled correctly
* All required translation properties are non-empty strings
* Mock SVG rendering outputs the translated Japanese labels

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
