### PR TITLE
test(refresh-policy): add coverage for cooldown timing and quota restrictions

### DIFF
--- a/services/github/refresh-policy.test.ts
+++ b/services/github/refresh-policy.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { refreshPolicy } from './refresh-policy';
+import { quotaMonitor } from './quota-monitor';
+
+describe('RefreshPolicy', () => {
+  beforeEach(() => {
+    refreshPolicy.reset();
+    quotaMonitor.reset();
+
+    vi.restoreAllMocks();
+  });
+
+  it('allows refresh for a user with no previous refresh history', () => {
+    expect(refreshPolicy.isRefreshAllowed('kanishka')).toBe(true);
+  });
+
+  it('blocks refresh during cooldown period', () => {
+    refreshPolicy.setCooldown(60_000);
+
+    refreshPolicy.recordRefresh('kanishka');
+
+    expect(refreshPolicy.isRefreshAllowed('kanishka')).toBe(false);
+  });
+
+  it('allows refresh again after cooldown expires', () => {
+    vi.useFakeTimers();
+
+    refreshPolicy.setCooldown(60_000);
+
+    refreshPolicy.recordRefresh('kanishka');
+
+    vi.advanceTimersByTime(60_001);
+
+    expect(refreshPolicy.isRefreshAllowed('kanishka')).toBe(true);
+
+    vi.useRealTimers();
+  });
+
+  it('returns remaining cooldown time correctly', () => {
+    vi.useFakeTimers();
+
+    refreshPolicy.setCooldown(60_000);
+
+    refreshPolicy.recordRefresh('kanishka');
+
+    vi.advanceTimersByTime(20_000);
+
+    expect(refreshPolicy.getRemainingCooldown('kanishka')).toBe(40_000);
+
+    vi.useRealTimers();
+  });
+
+  it('blocks refresh when GitHub quota is low', () => {
+    quotaMonitor.setQuota(
+      5000,
+      100, // < 10%
+      Date.now() + 60_000
+    );
+
+    expect(refreshPolicy.isRefreshAllowed('kanishka')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Adds a comprehensive test suite for services/github/refresh-policy.ts to validate refresh cooldown behavior, quota enforcement, and timing calculations.

## Changes

Created:

services/github/refresh-policy.test.ts

Implemented 5 test cases covering:

Allows refresh when a user has never been refreshed before.
Blocks refresh requests during the active cooldown window.
Allows refresh again once the cooldown period has elapsed.
Correctly calculates remaining cooldown time.
Prevents refreshes when GitHub API quota is critically low.

Fixes #2296 

## Pillar

- [x] 📐 Pillar 2 — Geometric SVG Improvement
- [x] 🛠️ Other (Bug fix, refactoring, docs)


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
