### PR TITLE
test: add CopyRepoButton type compiler tests

### DIFF
--- a/app/components/CopyRepoButton.type-compiler.test.tsx
+++ b/app/components/CopyRepoButton.type-compiler.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import CopyRepoButton from './CopyRepoButton';
+
+describe('CopyRepoButton Type Compiler Validation', () => {
+  it('exports CopyRepoButton as a function component', () => {
+    expectTypeOf(CopyRepoButton).toBeFunction();
+  });
+
+  it('accepts no parameters', () => {
+    expectTypeOf(CopyRepoButton).parameters.toEqualTypeOf<[]>();
+  });
+
+  it('returns a valid component type', () => {
+    expectTypeOf<ReturnType<typeof CopyRepoButton>>().toBeObject();
+  });
+
+  it('maintains a stable callable signature', () => {
+    expectTypeOf(CopyRepoButton).toEqualTypeOf<typeof CopyRepoButton>();
+  });
+
+  it('preserves return type consistency', () => {
+    expectTypeOf<ReturnType<typeof CopyRepoButton>>().toEqualTypeOf<
+      ReturnType<typeof CopyRepoButton>
+    >();
+  });
+});


### PR DESCRIPTION
Description

Fixes #2812

Added "CopyRepoButton.type-compiler.test.tsx" to validate the TypeScript signature of the "CopyRepoButton" component using "expectTypeOf()".

The test suite verifies:

- Component export type
- Callable function signature
- Parameter types
- Return type consistency
- Type stability across usage

All tests pass successfully with Vitest.

Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

Visual Preview

N/A (test-only change, no UI modifications)

Checklist before requesting a review:

- [x] I have read the "CONTRIBUTING.md" file.
- [ ] I have tested these changes locally ("localhost:3000/api/streak?user=YOUR_USERNAME").
- [ ] I have run "npm run format" and "npm run lint" locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated "README.md" if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.