### PR TITLE
test: add empty fallback tests for ComparePage

### DIFF
--- a/app/compare/page.empty-fallback.test.tsx
+++ b/app/compare/page.empty-fallback.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import ComparePage, { metadata } from './page';
+
+vi.mock('./CompareClient', () => ({
+  default: () => <div data-testid="compare-client">Compare Client</div>,
+}));
+
+vi.mock('../components/Footer', () => ({
+  Footer: () => <div data-testid="footer">Footer</div>,
+}));
+
+describe('ComparePage empty fallback behavior', () => {
+  it('renders safely without crashing', () => {
+    expect(() => render(<ComparePage />)).not.toThrow();
+  });
+
+  it('renders CompareClient content', () => {
+    render(<ComparePage />);
+
+    expect(screen.getByTestId('compare-client')).toBeDefined();
+  });
+
+  it('renders Footer component', () => {
+    render(<ComparePage />);
+
+    expect(screen.getByTestId('footer')).toBeDefined();
+  });
+
+  it('exports valid metadata', () => {
+    expect(metadata.title).toBe('Compare | CommitPulse');
+  });
+
+  it('contains openGraph fallback metadata', () => {
+    expect(metadata.openGraph?.title).toBe('Compare Developers | CommitPulse');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2793

Adds empty fallback and edge-case tests for `ComparePage`.

Covered scenarios:

* Safe rendering without crashes
* CompareClient rendering
* Footer rendering
* Metadata validation
* OpenGraph metadata validation

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
