### PR TITLE
test: prevent next/image fill prop warnings in mocks

### DIFF
--- a/app/contributors/page.empty-fallback.test.tsx
+++ b/app/contributors/page.empty-fallback.test.tsx
@@ -1,11 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @next/next/no-img-element, jsx-a11y/alt-text */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import ContributorsPage from './page';
 
 vi.mock('next/image', () => ({
   __esModule: true,
-  default: (props: any) => <img {...props} />,
+  default: (props: any) => {
+    const { fill, ...rest } = props || {};
+    return <img {...rest} />;
+  },
 }));
 
 vi.mock('next/link', () => ({

--- a/app/contributors/page.responsive-breakpoints.test.tsx
+++ b/app/contributors/page.responsive-breakpoints.test.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @next/next/no-img-element */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import ContributorsPage from './page';
@@ -6,9 +9,10 @@ import '@testing-library/jest-dom';
 
 vi.mock('next/image', () => ({
   __esModule: true,
-  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-    <img {...props} alt={props.alt || ''} />
-  ),
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    const { fill, ...rest } = props as any;
+    return <img {...rest} alt={props.alt || ''} />;
+  },
 }));
 
 vi.mock('next/link', () => ({

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -26,7 +26,10 @@ vi.mock('@/components/DiscordButton', () => ({
 // rendered inline. The mock below keeps the import from erroring if any
 // other test file still imports it.
 vi.mock('next/image', () => ({
-  default: (props: any) => <img {...props} />,
+  default: (props: any) => {
+    const { fill, ...rest } = props || {};
+    return <img {...rest} />;
+  },
 }));
 
 vi.mock('next/link', () => ({


### PR DESCRIPTION
## Description

Fixes #3197

This PR removes React warnings generated during test execution by updating the mocked `next/image` implementation used throughout the test suite.

### Problem

Several test files mocked `next/image` by forwarding all received props directly to a native `<img>` element:

```tsx
<img {...props} />
```

When components rendered images using Next.js's `fill` prop:

```tsx
<Image fill />
```

the mock produced:

```tsx
<img fill={true} />
```

which caused React warnings during test execution:

```text
Warning: Received `true` for a non-boolean attribute `fill`.
```

While tests continued to pass, the warnings cluttered CI logs and made it harder to identify legitimate issues.

### Fix

Updated the test mocks to remove the `fill` prop before forwarding remaining props to the native `<img>` element:

```tsx
const { fill, ...rest } = props;
return <img {...rest} />;
```

### Files Updated

```text
page.test.tsx
page.responsive-breakpoints.test.tsx
page.empty-fallback.test.tsx
```

### Result

* Eliminates React DOM warnings during tests.
* Keeps CI output clean and easier to review.
* Better mirrors actual Next.js image behavior.
* Prevents invalid attributes from being rendered in mocked components.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A – Test-only change. No UI, SVG, or visual output modifications.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (No SVG changes in this PR).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
