### PR TITLE
test(leaderboard): add type compiler coverage

### DIFF
--- a/components/Leaderboard.type-compiler.test.tsx
+++ b/components/Leaderboard.type-compiler.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import Leaderboard, { type Contributor } from './Leaderboard';
+
+type LeaderboardProps = Parameters<typeof Leaderboard>[0];
+
+const requiredContributorKeys = ['id', 'login', 'avatar_url', 'contributions', 'html_url'] as const;
+
+function validateContributor(value: Contributor) {
+  return {
+    valid:
+      Number.isInteger(value.id) &&
+      typeof value.login === 'string' &&
+      typeof value.avatar_url === 'string' &&
+      typeof value.contributions === 'number' &&
+      typeof value.html_url === 'string',
+    keys: Object.keys(value),
+  };
+}
+
+describe('Leaderboard type compiler validation', () => {
+  it('exports a component that requires contributors props', () => {
+    expectTypeOf<LeaderboardProps>().toEqualTypeOf<{
+      contributors: Contributor[];
+    }>();
+  });
+
+  it('enforces the Contributor field contract', () => {
+    expectTypeOf<Contributor>().toEqualTypeOf<{
+      id: number;
+      login: string;
+      avatar_url: string;
+      contributions: number;
+      html_url: string;
+    }>();
+  });
+
+  it('blocks invalid contributor field types at compile time', () => {
+    expectTypeOf<Contributor>().not.toEqualTypeOf<{
+      id: string;
+      login: string;
+      avatar_url: string;
+      contributions: string;
+      html_url: string;
+    }>();
+  });
+
+  it('accepts optional contributor-like values before validation', () => {
+    type OptionalContributor = Partial<Contributor>;
+
+    const draftContributor: OptionalContributor = {
+      login: 'alice',
+      contributions: 10,
+    };
+
+    expectTypeOf<OptionalContributor>().toEqualTypeOf<Partial<Contributor>>();
+    expect(draftContributor.login).toBe('alice');
+  });
+
+  it('returns strict validation reports for contributor schema constraints', () => {
+    const contributor: Contributor = {
+      id: 1,
+      login: 'alice',
+      avatar_url: '/alice.png',
+      contributions: 42,
+      html_url: 'https://github.com/alice',
+    };
+
+    const report = validateContributor(contributor);
+
+    expect(report.valid).toBe(true);
+
+    for (const key of requiredContributorKeys) {
+      expect(report.keys).toContain(key);
+    }
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2762

Adds focused TypeScript compiler validation coverage for `components/Leaderboard.tsx`.

Tests verify:

* Leaderboard props enforce the expected contributor array contract
* Contributor type definitions maintain required field structure
* Invalid contributor field types are rejected by compile-time assertions
* Optional contributor-like values are accepted through partial typing
* Contributor schema constraints produce strict validation reports

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
