### PR TITLE
test(compare): add validation test suite for username bounds and self-comparison

### DIFF
--- a/app/api/compare/tests/validation.test.ts
+++ b/app/api/compare/tests/validation.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '../route';
+
+vi.mock('@/lib/github', () => ({
+  getFullDashboardData: vi.fn(),
+}));
+
+import { getFullDashboardData } from '@/lib/github';
+
+const makeRequest = (search: string) => new Request(`http://localhost:3000/api/compare?${search}`);
+
+describe('GET /api/compare - Validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(getFullDashboardData).mockResolvedValue({
+      calendar: {
+        totalContributions: 50,
+        weeks: [],
+      },
+    } as never);
+  });
+
+  it('returns 400 when both usernames are missing', async () => {
+    const res = await GET(makeRequest(''));
+
+    expect(res.status).toBe(400);
+
+    const data = await res.json();
+    expect(data.error).toBeDefined();
+  });
+
+  it('returns 400 when user1 exceeds the maximum length', async () => {
+    const res = await GET(makeRequest(`user1=${'a'.repeat(40)}&user2=octocat`));
+
+    expect(res.status).toBe(400);
+
+    const data = await res.json();
+    expect(data.error).toBeDefined();
+  });
+
+  it('returns 400 for invalid username format', async () => {
+    const res = await GET(makeRequest('user1=-invalid&user2=octocat'));
+
+    expect(res.status).toBe(400);
+
+    const data = await res.json();
+    expect(data.details.fieldErrors.user1).toBeDefined();
+  });
+
+  it('returns 400 when comparing identical usernames', async () => {
+    const res = await GET(makeRequest('user1=octocat&user2=octocat'));
+
+    expect(res.status).toBe(400);
+
+    const data = await res.json();
+
+    expect(data.details.fieldErrors.user2).toContain('Cannot compare a user with themselves.');
+  });
+
+  it('returns 400 for self-comparison regardless of case', async () => {
+    const res = await GET(makeRequest('user1=OctoCat&user2=octocat'));
+
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Description
Adds a dedicated validation test suite for the `/api/compare` route to improve test organization and isolate validation-related behavior.

### Changes

- Created `app/api/compare/tests/validation.test.ts`
- Added focused validation test coverage for:
  - Missing usernames
  - Username length limits
  - Invalid username formats
  - Identical username comparisons
  - Case-insensitive self-comparison checks
- Reused existing request/mocking patterns from compare route tests
- Verified expected status codes and error response structures

### Testing

- [x] Validation tests pass locally
- [x]  Existing compare route tests remain unaffected
- [x]  `vitest run` executed successfully after dependency installation

Fixes #2349

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="1503" height="870" alt="image" src="https://github.com/user-attachments/assets/51367449-cc07-4e00-888b-befeb7173843" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
