### PR TITLE
test(discordbutton): add accessibility coverage

### DIFF
--- a/components/DiscordButton.accessibility.test.tsx
+++ b/components/DiscordButton.accessibility.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DiscordButton } from './DiscordButton';
+
+vi.mock(
+  'gsap',
+  () => ({
+    default: {
+      to: vi.fn(),
+    },
+  }),
+  { virtual: true }
+);
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+      <div {...props}>{children}</div>
+    ),
+    a: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+      <a {...props}>{children}</a>
+    ),
+  },
+}));
+
+describe('DiscordButton accessibility behavior', () => {
+  it('renders as an accessible link with visible text', () => {
+    render(<DiscordButton />);
+
+    expect(screen.getByRole('link', { name: /join the core community on discord/i })).toBeDefined();
+  });
+
+  it('uses the correct Discord invite href', () => {
+    render(<DiscordButton />);
+
+    expect(screen.getByRole('link').getAttribute('href')).toBe('https://discord.gg/Cb73bS79j');
+  });
+
+  it('opens external Discord link safely in a new tab', () => {
+    render(<DiscordButton />);
+
+    const link = screen.getByRole('link');
+
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('is keyboard focusable through the anchor element', () => {
+    render(<DiscordButton />);
+
+    const link = screen.getByRole('link');
+    link.focus();
+
+    expect(document.activeElement).toBe(link);
+  });
+
+  it('keeps only one accessible link target for screen readers', () => {
+    render(<DiscordButton />);
+
+    expect(screen.getAllByRole('link')).toHaveLength(1);
+  });
+});

--- a/components/DiscordButton.accessibility.test.tsx
+++ b/components/DiscordButton.accessibility.test.tsx
@@ -3,15 +3,11 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { DiscordButton } from './DiscordButton';
 
-vi.mock(
-  'gsap',
-  () => ({
-    default: {
-      to: vi.fn(),
-    },
-  }),
-  { virtual: true }
-);
+vi.mock('gsap', () => ({
+  default: {
+    to: vi.fn(),
+  },
+}));
 
 vi.mock('framer-motion', () => ({
   motion: {


### PR DESCRIPTION
## Description

Fixes #2736

Added accessibility test coverage for `components/DiscordButton.tsx`.

### Tests Added

* Verifies the Discord button renders as an accessible link with visible text.
* Confirms the Discord invite URL is correctly applied.
* Ensures the external link opens safely in a new tab.
* Verifies the anchor element is keyboard focusable.
* Ensures only one accessible link target is exposed to screen readers.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable)
* [ ] (Recommended) I joined the CommitPulse Discord community.
