### PR TITLE
test(discordbutton): add error resilience coverage

### DIFF
--- a/components/DiscordButton.error-resilience.test.tsx
+++ b/components/DiscordButton.error-resilience.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DiscordButton } from './DiscordButton';
+
+vi.mock('gsap', () => ({
+  default: {
+    to: vi.fn(),
+  },
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+      <div {...props}>{children}</div>
+    ),
+    a: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+      <a {...props}>{children}</a>
+    ),
+  },
+}));
+
+describe('DiscordButton error resilience', () => {
+  it('renders without crashing', () => {
+    render(<DiscordButton />);
+
+    expect(screen.getByText('Join the core community on Discord')).toBeTruthy();
+  });
+
+  it('renders the discord link even when animations are mocked', () => {
+    render(<DiscordButton />);
+
+    const link = screen.getByRole('link');
+
+    expect(link).toBeTruthy();
+  });
+
+  it('contains a valid discord invite url', () => {
+    render(<DiscordButton />);
+
+    const link = screen.getByRole('link');
+
+    expect(link.getAttribute('href')).toContain('discord.gg');
+  });
+
+  it('opens discord link securely in a new tab', () => {
+    render(<DiscordButton />);
+
+    const link = screen.getByRole('link');
+
+    expect(link.getAttribute('target')).toBe('_blank');
+
+    const rel = link.getAttribute('rel') ?? '';
+
+    expect(rel).toContain('noopener');
+    expect(rel).toContain('noreferrer');
+  });
+
+  it('keeps button content visible after render', () => {
+    render(<DiscordButton />);
+
+    expect(screen.getByText('Join the core community on Discord')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2738

Added error resilience test coverage for the DiscordButton component.

### Changes Made

* Created `components/DiscordButton.error-resilience.test.tsx`
* Added tests to verify safe rendering under mocked animation dependencies
* Verified Discord invite link renders correctly
* Verified external link security attributes (`noopener`, `noreferrer`)
* Added resilience checks to ensure UI remains functional when animation libraries are mocked

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test coverage only)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
