### PR TITLE
test(resume-preview-form): add empty fallback coverage

### DIFF
--- a/components/dashboard/ResumePreviewForm.empty-fallback.test.tsx
+++ b/components/dashboard/ResumePreviewForm.empty-fallback.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode, HTMLAttributes } from 'react';
+import '@testing-library/jest-dom';
+
+import ResumePreviewForm from './ResumePreviewForm';
+
+const mocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.error,
+    success: mocks.success,
+  },
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: HTMLAttributes<HTMLDivElement> & { children?: ReactNode }) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+const emptyParsed = {
+  name: '',
+  email: '',
+  phone: '',
+  skills: [],
+  education: [],
+  experience: [],
+};
+
+describe('ResumePreviewForm empty fallback behavior', () => {
+  const onBack = vi.fn();
+  const onComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders safely with empty parsed resume values', () => {
+    render(
+      <ResumePreviewForm
+        githubUsername="john"
+        parsed={emptyParsed}
+        fileName="empty.pdf"
+        onBack={onBack}
+        onComplete={onComplete}
+      />
+    );
+
+    expect(screen.getByText('Review Parsed Data')).toBeInTheDocument();
+  });
+
+  it('shows empty fallback input fields for missing profile values', () => {
+    render(
+      <ResumePreviewForm
+        githubUsername="john"
+        parsed={emptyParsed}
+        fileName="empty.pdf"
+        onBack={onBack}
+        onComplete={onComplete}
+      />
+    );
+
+    const inputs = screen.getAllByRole('textbox');
+
+    expect(inputs[0]).toHaveValue('');
+    expect(inputs[1]).toHaveValue('');
+  });
+
+  it('does not crash when skills array is empty', () => {
+    render(
+      <ResumePreviewForm
+        githubUsername="john"
+        parsed={emptyParsed}
+        fileName="empty.pdf"
+        onBack={onBack}
+        onComplete={onComplete}
+      />
+    );
+
+    expect(screen.getByText(/skills/i)).toBeInTheDocument();
+  });
+
+  it('prevents submission when required fallback fields are empty', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <ResumePreviewForm
+        githubUsername="john"
+        parsed={emptyParsed}
+        fileName="empty.pdf"
+        onBack={onBack}
+        onComplete={onComplete}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Save Profile'));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('allows user to add a skill from an empty fallback state', () => {
+    render(
+      <ResumePreviewForm
+        githubUsername="john"
+        parsed={emptyParsed}
+        fileName="empty.pdf"
+        onBack={onBack}
+        onComplete={onComplete}
+      />
+    );
+
+    fireEvent.click(screen.getAllByText('Add')[0]);
+
+    expect(screen.getByText('Skills')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2693

Added empty fallback test coverage for `components/dashboard/ResumePreviewForm.tsx`.

### Tests Added

* Verifies the component renders safely with empty parsed resume data.
* Confirms empty input fields render correctly when profile values are missing.
* Ensures the component does not crash when the skills array is empty.
* Verifies submission is blocked when required fields are empty.
* Confirms fallback UI remains functional in an empty-data state.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable)
* [ ] (Recommended) I joined the CommitPulse Discord community.
