### PR TITLE
test(resumeprofilesection): add type compiler validation coverage

### DIFF
--- a/components/dashboard/ResumeProfileSection.type-compiler.test.tsx
+++ b/components/dashboard/ResumeProfileSection.type-compiler.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import ResumeProfileSection from './ResumeProfileSection';
+
+describe('ResumeProfileSection TypeScript compiler validation', () => {
+  it('accepts valid githubUsername prop type', () => {
+    type Props = React.ComponentProps<typeof ResumeProfileSection>;
+
+    expectTypeOf<Props>().toMatchTypeOf<{
+      githubUsername: string;
+    }>();
+  });
+
+  it('enforces githubUsername as required string', () => {
+    type Props = React.ComponentProps<typeof ResumeProfileSection>;
+
+    expectTypeOf<Props['githubUsername']>().toEqualTypeOf<string>();
+  });
+
+  it('does not allow githubUsername to be undefined', () => {
+    type Props = React.ComponentProps<typeof ResumeProfileSection>;
+
+    expectTypeOf<Props['githubUsername']>().not.toEqualTypeOf<string | undefined>();
+  });
+
+  it('validates component props structure', () => {
+    type Props = React.ComponentProps<typeof ResumeProfileSection>;
+
+    const validProps: Props = {
+      githubUsername: 'aanyacloud',
+    };
+
+    expectTypeOf(validProps.githubUsername).toBeString();
+  });
+
+  it('supports strict prop type checking', () => {
+    type Props = React.ComponentProps<typeof ResumeProfileSection>;
+
+    expectTypeOf<Props>().toExtend<{
+      githubUsername: string;
+    }>();
+  });
+
+  it('supports valid string values for githubUsername', () => {
+    type Props = React.ComponentProps<typeof ResumeProfileSection>;
+
+    const props: Props = {
+      githubUsername: '',
+    };
+
+    expectTypeOf(props.githubUsername).toBeString();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2712

This PR adds the new test file:

`components/dashboard/ResumeProfileSection.type-compiler.test.tsx`

The new test suite validates TypeScript compiler behavior and prop type safety for `ResumeProfileSection.tsx`.

It includes type assertions for:

* required prop enforcement
* strict prop validation
* undefined rejection
* compile-safe prop structure validation
* valid string prop acceptance

using `expectTypeOf`.

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (type compiler test coverage update)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
