### PR TITLE
fix(validation): clarify hex color error messages to reflect # is accepted

### DIFF
--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -963,7 +963,7 @@ describe('streakParamsSchema — accent parameter HEX color validation', () => {
       // This extra check ensures Variation 5 isn't just a duplicate,
       // but a stricter validation check!
       expect(result.error.issues[0]?.message).toContain(
-        'accent must be a valid 3 or 6 character hex color without #'
+        'accent must be a valid hex color (with or without #)'
       );
     }
   });
@@ -977,7 +977,7 @@ describe('streakParamsSchema — accent parameter HEX color validation', () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.issues[0]?.message).toContain(
-        'accent must be a valid 3 or 6 character hex color without #'
+        'accent must be a valid hex color (with or without #)'
       );
     }
   });

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -156,14 +156,14 @@ const baseStreakParamsSchema = z.object({
     .string()
     .optional()
     .refine((val) => !val || /^[0-9a-fA-F]{3,4}$|^[0-9a-fA-F]{6,8}$/.test(val.replace('#', '')), {
-      message: 'bg must be a valid 3 or 6 character hex color without #',
+      message: 'bg must be a valid hex color (with or without #)',
     })
     .transform((val) => (val ? sanitizeHexColor(val, '0d1117') : undefined)),
   text: z
     .string()
     .optional()
     .refine((val) => !val || /^[0-9a-fA-F]{3,4}$|^[0-9a-fA-F]{6,8}$/.test(val.replace('#', '')), {
-      message: 'text must be a valid 3 or 6 character hex color without #',
+      message: 'text must be a valid hex color (with or without #)',
     })
     .transform((val) => (val ? sanitizeHexColor(val, 'ffffff') : undefined)),
   accent: z
@@ -179,7 +179,7 @@ const baseStreakParamsSchema = z.object({
       },
       {
         message:
-          'accent must be a valid 3 or 6 character hex color without #, or a comma-separated list of them',
+          'accent must be a valid hex color (with or without #), or a comma-separated list of them',
       }
     )
     .transform((val) => {
@@ -474,14 +474,14 @@ export const wrappedParamsSchema = z.object({
     .string()
     .optional()
     .refine((val) => !val || /^[0-9a-fA-F]{3,4}$|^[0-9a-fA-F]{6,8}$/.test(val.replace('#', '')), {
-      message: 'bg must be a valid 3 or 6 character hex color without #',
+      message: 'bg must be a valid hex color (with or without #)',
     })
     .transform((val) => (val ? sanitizeHexColor(val, '0d1117') : undefined)),
   text: z
     .string()
     .optional()
     .refine((val) => !val || /^[0-9a-fA-F]{3,4}$|^[0-9a-fA-F]{6,8}$/.test(val.replace('#', '')), {
-      message: 'text must be a valid 3 or 6 character hex color without #',
+      message: 'text must be a valid hex color (with or without #)',
     })
     .transform((val) => (val ? sanitizeHexColor(val, 'ffffff') : undefined)),
   accent: z
@@ -497,7 +497,7 @@ export const wrappedParamsSchema = z.object({
       },
       {
         message:
-          'accent must be a valid 3 or 6 character hex color without #, or a comma-separated list of them',
+          'accent must be a valid hex color (with or without #), or a comma-separated list of them',
       }
     )
     .transform((val) => {


### PR DESCRIPTION
## Description
Fixes #3233 

Clarified misleading hex color validation error messages in 
`lib/validations.ts`. The old messages said values must be provided 
"without #" but the validator actually strips # automatically before 
checking — meaning # was always supported. The error messages now 
accurately reflect the real behaviour.

**Before:**
`bg must be a valid 3 or 6 character hex color without #`

**After:**
`bg must be a valid hex color (with or without #)`

**Changes made:**

`lib/validations.ts`:
- Updated error messages for `bg`, `text`, `accent` in 
  `baseStreakParamsSchema`
- Updated error messages for `bg`, `text`, `accent` in 
  `wrappedParamsSchema`

`lib/validations.test.ts`:
- Updated test assertions to match the revised error message phrasing
- All tests passing ✅

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual change — error message strings only. Users passing an 
invalid hex color now see accurate guidance instead of misleading 
"without #" instructions.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format (`fix(validation): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not needed)
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [x] (Recommended) I joined the CommitPulse Discord community.