### PR TITLE
test: add invalid bg hex color validation coverage

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -943,7 +943,11 @@ describe('GET /api/streak', () => {
       expect(body.details).not.toBeNull();
     });
   });
+  it('returns 400 when an invalid hex color is passed as bg', async () => {
+    const response = await GET(makeRequest({ user: 'octocat', bg: '#ZZZZZZ' }));
 
+    expect(response.status).toBe(400);
+  });
   describe('hide parameters', () => {
     it('removes the username title when hide_title=true', async () => {
       const response = await GET(makeRequest({ user: 'octocat', hide_title: 'true' }));


### PR DESCRIPTION
## Description

Adds validation coverage for invalid `bg` hex color input.

## Pillar

- [x] Other (Bug fix, refactoring, docs)

## Changes
- Added a test for invalid `bg` hex values
- Ensures invalid background color input returns HTTP 400
- Verified route tests pass locally


## Testing

- Ran: `npm run test -- app/api/streak/route.test.ts`
- Result: 145/145 tests passed
