### PR TITLE
test(theme-switch): add animation return type validation

### DIFF
--- a/app/components/theme-switch.type-compiler.test.tsx
+++ b/app/components/theme-switch.type-compiler.test.tsx
@@ -7,9 +7,20 @@ describe('ThemeSwitch Type Compiler Validation', () => {
       'circle' | 'rectangle' | 'gif' | 'polygon' | 'circle-blur'
     >();
   });
-
-  it('validates AnimationStart type', () => {
-    expectTypeOf<AnimationStart>().toBeString();
+  it('validates AnimationStart union values', () => {
+    expectTypeOf<AnimationStart>().toEqualTypeOf<
+      | 'top-left'
+      | 'top-right'
+      | 'bottom-left'
+      | 'bottom-right'
+      | 'center'
+      | 'top-center'
+      | 'bottom-center'
+      | 'bottom-up'
+      | 'top-down'
+      | 'left-right'
+      | 'right-left'
+    >();
   });
 
   it('ensures createAnimation returns required structure', () => {
@@ -34,5 +45,13 @@ describe('ThemeSwitch Type Compiler Validation', () => {
 
     expectTypeOf(animation.name).toBeString();
     expectTypeOf(animation.css).toBeString();
+  });
+  it('returns an animation object with name and css strings', () => {
+    const result = createAnimation('circle', 'center');
+
+    expectTypeOf(result).toMatchTypeOf<{
+      name: string;
+      css: string;
+    }>();
   });
 });


### PR DESCRIPTION
## Description

Fixes # 2287

## Pillar

- [ ]  Pillar 1 — New Theme Design
- [ ]  Pillar 2 — Geometric SVG Improvement
- [ ]  Pillar 3 — Timezone Logic Optimization
- [ ] Other (Bug fix, refactoring, docs)

## Visual Preview

## What I solved

Added stronger type compiler validation tests for the Theme Switch component.

### Changes made

* Added a test to verify that `createAnimation()` returns an object with the expected structure.
* Validated that the returned object contains:

  * `name: string`
  * `css: string`
* Added stricter type validation for the `AnimationStart` union type.
* Ensured exported types remain correctly enforced at compile time.

### Testing

* Ran `npx vitest run app/components/theme-switch.type-compiler.test.tsx`
* All 6 tests passed successfully.

