### PR TITLE
test(ThemeSwitch-timezone-boundaries): verify Timezone Normalization & Calendar Data Boundary Alignment

### DIFF
--- a/app/components/theme-switch.timezone-boundaries.test.tsx
+++ b/app/components/theme-switch.timezone-boundaries.test.tsx
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { ThemeToggleButton } from './theme-switch';
+import '@testing-library/jest-dom';
+
+describe('ThemeSwitch - Timezone Boundaries & Calendar Alignment', () => {
+  beforeEach(() => {
+    // 1. Reset document classes
+    document.documentElement.className = '';
+
+    // 2. Clear localStorage
+    window.localStorage.clear();
+
+    // 3. Mock matchMedia to handle prefers-reduced-motion checks safely
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    vi.restoreAllMocks();
+  });
+
+  // --- Test Case 1 ---
+  it('renders theme toggle button successfully in UTC timezone', () => {
+    // Mock UTC offset (0 minutes)
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(0);
+
+    render(<ThemeToggleButton />);
+
+    const button = screen.getByRole('button', { name: /toggle theme/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  // --- Test Case 2 ---
+  it('resolves initial theme state correctly when system timezone is set to EST', () => {
+    // EST is UTC-5, so timezoneOffset is 300 minutes
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(300);
+
+    render(<ThemeToggleButton />);
+
+    // Default initial theme is dark, so 'dark' class should be on document element
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  // --- Test Case 3 ---
+  it('toggles dark and light mode state safely in JST timezone', () => {
+    // JST is UTC+9, so timezoneOffset is -540 minutes
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-540);
+
+    render(<ThemeToggleButton />);
+
+    const button = screen.getByRole('button', { name: /toggle theme/i });
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+    // Trigger theme toggle click inside act() to prevent warning
+    act(() => {
+      button.click();
+    });
+
+    // It should safely toggle to light mode (removing 'dark' class)
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  // --- Test Case 4 ---
+  it('handles hydration and mounting check safely during leap year boundary dates', () => {
+    // Freeze time on Leap Day (Feb 29)
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-02-29T12:00:00Z'));
+
+    render(<ThemeToggleButton />);
+
+    const button = screen.getByRole('button', { name: /toggle theme/i });
+    expect(button).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  // --- Test Case 5 ---
+  it('retains consistent layout styling classes in Indian Standard Time (IST)', () => {
+    // IST is UTC+5:30, so timezoneOffset is -330 minutes
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-330);
+
+    render(<ThemeToggleButton />);
+
+    const button = screen.getByRole('button', { name: /toggle theme/i });
+
+    // Assert structural classes are preserved
+    expect(button).toHaveClass('inline-flex');
+    expect(button).toHaveClass('h-10');
+    expect(button).toHaveClass('w-10');
+    expect(button).toHaveClass('rounded-xl');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2840

## Pillar


- [x] 🛠️ Other (Testing addition)

## Visual Preview
This adds isolated integration tests to verify theme state normalization and calendar boundary offsets across different locales in `ThemeToggleButton`. It ensures that theme state resolution handles timezone shifts (UTC, EST, JST, IST) and leap year dates correctly without throwing exceptions.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npm run test`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have made sure that I have only one commit to merge in this PR.
