### PR TITLE
test(VisualizationTooltip): add empty-fallback edge case coverage

### DIFF
--- a/components/dashboard/VisualizationTooltip.empty-fallback.test.tsx
+++ b/components/dashboard/VisualizationTooltip.empty-fallback.test.tsx
@@ -1,0 +1,102 @@
+// components/dashboard/VisualizationTooltip.empty-fallback.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { HTMLAttributes, ReactNode } from 'react';
+import VisualizationTooltip from './VisualizationTooltip';
+import '@testing-library/jest-dom/vitest';
+
+// framer-motion mock — mirrors the mock used in VisualizationTooltip.test.tsx
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: HTMLAttributes<HTMLDivElement> & { children?: ReactNode }) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+describe('VisualizationTooltip - Edge Cases & Empty/Missing Inputs', () => {
+  it('renders without runtime errors when children is null', () => {
+    expect(() =>
+      render(
+        <VisualizationTooltip title="Empty Children" x={10} y={20}>
+          {null}
+        </VisualizationTooltip>
+      )
+    ).not.toThrow();
+
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+  });
+
+  it('renders without runtime errors when children is undefined', () => {
+    expect(() =>
+      render(
+        <VisualizationTooltip title="Missing Children" x={30} y={40}>
+          {undefined}
+        </VisualizationTooltip>
+      )
+    ).not.toThrow();
+
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+  });
+
+  it('renders without runtime errors when children is an empty fragment', () => {
+    expect(() =>
+      render(
+        <VisualizationTooltip title="Fragment Children" x={50} y={60}>
+          <></>
+        </VisualizationTooltip>
+      )
+    ).not.toThrow();
+
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+  });
+
+  it('preserves the empty title and body containers when both inputs are empty', () => {
+    render(
+      <VisualizationTooltip title="" x={70} y={80}>
+        {null}
+      </VisualizationTooltip>
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    const titleDiv = tooltip.querySelector('div');
+    const bodyDiv = tooltip.querySelectorAll('div')[1];
+
+    expect(tooltip).toBeInTheDocument();
+    expect(titleDiv).not.toBeNull();
+    expect(titleDiv!.textContent).toBe('');
+    expect(bodyDiv).not.toBeNull();
+    expect(bodyDiv!.childElementCount).toBe(0);
+  });
+
+  it('maintains standard layout styles in the default empty fallback state', () => {
+    render(
+      <VisualizationTooltip title="" x={90} y={100}>
+        {null}
+      </VisualizationTooltip>
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    const classNames = tooltip.className.split(' ');
+
+    // Core layout classes that must remain applied even when inputs are empty —
+    // these guarantee the tooltip still floats correctly and keeps its visual identity.
+    const expectedClasses = [
+      'pointer-events-none',
+      'fixed',
+      'z-[9999]',
+      'rounded-xl',
+      'border',
+      'bg-white/95',
+      'shadow-2xl',
+      'backdrop-blur-md',
+      'dark:bg-[#111]/95',
+    ];
+
+    for (const className of expectedClasses) {
+      expect(classNames).toContain(className);
+    }
+
+    expect(tooltip).toHaveStyle({ left: '90px', top: '100px' });
+  });
+});


### PR DESCRIPTION
## Description

Adds isolated edge-case coverage for `components/dashboard/VisualizationTooltip.tsx` focused on **Empty & Missing Inputs** verification. Five new test cases guarantee the tooltip renders safely with `null`, `undefined`, and empty fragment children, while preserving its structural markers and layout styles.

Fixes #2723 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.

### Test cases added

1. Renders without runtime errors when `children` is `null`
2. Renders without runtime errors when `children` is `undefined`
3. Renders without runtime errors when `children` is an empty fragment
4. Preserves empty title and body containers when both inputs are empty
5. Maintains standard layout styles in the default empty fallback state
