### PR TITLE
fix: add pointer cursor to activity landscape timeframe filters

### DIFF
--- a/components/dashboard/ActivityLandscape.test.tsx
+++ b/components/dashboard/ActivityLandscape.test.tsx
@@ -33,6 +33,14 @@ it('renders all tab buttons', () => {
   expect(screen.getByText('3M')).toBeTruthy();
   expect(screen.getByText('1Y')).toBeTruthy();
 });
+it('shows pointer cursor styling on timeframe tabs', () => {
+  render(<ActivityLandscape data={mockData} />);
+
+  expect(screen.getByText('1W').className).toContain('cursor-pointer');
+  expect(screen.getByText('1M').className).toContain('cursor-pointer');
+  expect(screen.getByText('3M').className).toContain('cursor-pointer');
+  expect(screen.getByText('1Y').className).toContain('cursor-pointer');
+});
 it('has 3M active by default', () => {
   render(<ActivityLandscape data={mockData} />);
 

--- a/components/dashboard/ActivityLandscape.test.tsx
+++ b/components/dashboard/ActivityLandscape.test.tsx
@@ -36,17 +36,20 @@ it('renders all tab buttons', () => {
 it('shows pointer cursor styling on timeframe tabs', () => {
   render(<ActivityLandscape data={mockData} />);
 
-  expect(screen.getByText('1W').className).toContain('cursor-pointer');
-  expect(screen.getByText('1M').className).toContain('cursor-pointer');
-  expect(screen.getByText('3M').className).toContain('cursor-pointer');
-  expect(screen.getByText('1Y').className).toContain('cursor-pointer');
+  const tabLabels = ['1W', '1M', '3M', '1Y'];
+
+  tabLabels.forEach((label) => {
+    const tabButton = screen.getByText(label);
+
+    expect(tabButton.classList.contains('cursor-pointer')).toBe(true);
+  });
 });
 it('has 3M active by default', () => {
   render(<ActivityLandscape data={mockData} />);
 
   const tab = screen.getByText('3M');
 
-  expect(tab.className).toContain('bg-black');
+  expect(tab.classList.contains('bg-black')).toBe(true);
 });
 it('activates 1W tab when clicked', () => {
   render(<ActivityLandscape data={mockData} />);
@@ -55,7 +58,7 @@ it('activates 1W tab when clicked', () => {
 
   fireEvent.click(tab);
 
-  expect(tab.className).toContain('bg-black');
+  expect(tab.classList.contains('bg-black')).toBe(true);
 });
 it('renders activity chart', () => {
   render(<ActivityLandscape data={mockData} />);

--- a/components/dashboard/ActivityLandscape.tsx
+++ b/components/dashboard/ActivityLandscape.tsx
@@ -89,7 +89,7 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
             <div className="flex items-center rounded-lg border border-black/5 bg-gray-100 p-0.5 dark:border-[rgba(255,255,255,0.08)] dark:bg-[#111]">
               <button
                 onClick={() => setMode('commits')}
-                className={`rounded-md px-3 py-1.5 text-xs font-semibold transition-all ${
+                className={`cursor-pointer rounded-md px-3 py-1.5 text-xs font-semibold transition-all ${
                   mode === 'commits'
                     ? 'border border-black/5 bg-white text-black shadow-sm dark:border-white/5 dark:bg-[#222] dark:text-white'
                     : 'text-gray-500 hover:text-black dark:hover:text-white'
@@ -99,7 +99,7 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
               </button>
               <button
                 onClick={() => setMode('loc')}
-                className={`rounded-md px-3 py-1.5 text-xs font-semibold transition-all ${
+                className={`cursor-pointer rounded-md px-3 py-1.5 text-xs font-semibold transition-all ${
                   mode === 'loc'
                     ? 'border border-black/5 bg-white text-black shadow-sm dark:border-white/5 dark:bg-[#222] dark:text-white'
                     : 'text-gray-500 hover:text-black dark:hover:text-white'
@@ -115,7 +115,7 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
                 <button
                   key={tab}
                   onClick={() => setActiveTab(tab)}
-                  className={`border-r border-black/10 px-3.5 py-1.5 text-xs font-medium transition-all duration-200 last:border-r-0 dark:border-[rgba(255,255,255,0.08)] ${
+                  className={`cursor-pointer border-r border-black/10 px-3.5 py-1.5 text-xs font-medium transition-all duration-200 last:border-r-0 dark:border-[rgba(255,255,255,0.08)] ${
                     activeTab === tab
                       ? 'bg-black text-white dark:bg-white dark:text-black'
                       : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-black dark:bg-transparent dark:text-white/65 dark:hover:bg-[rgba(255,255,255,0.05)] dark:hover:text-white'
@@ -130,7 +130,7 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
 
         {/* Graph */}
         <div
-          className="relative flex h-[200px] w-full items-end justify-between gap-[2px]"
+          className="relative flex h-50 w-full items-end justify-between gap-0.5"
           role="img"
           aria-label="Activity chart showing contribution frequency over time"
         >
@@ -164,7 +164,7 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
                     delay: i * 0.008,
                     ease: [0.16, 1, 0.3, 1],
                   }}
-                  className={`w-full rounded-t-[2px] transition-all duration-200 ${
+                  className={`w-full rounded-t-xs transition-all duration-200 ${
                     isHigh
                       ? mode === 'loc'
                         ? 'bg-indigo-500 dark:bg-indigo-400'

--- a/components/dashboard/ActivityLandscape.tsx
+++ b/components/dashboard/ActivityLandscape.tsx
@@ -130,7 +130,7 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
 
         {/* Graph */}
         <div
-          className="relative flex h-50 w-full items-end justify-between gap-0.5"
+          className="relative flex h-[200px] w-full items-end justify-between gap-0.5"
           role="img"
           aria-label="Activity chart showing contribution frequency over time"
         >
@@ -164,7 +164,7 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
                     delay: i * 0.008,
                     ease: [0.16, 1, 0.3, 1],
                   }}
-                  className={`w-full rounded-t-xs transition-all duration-200 ${
+                  className={`w-full rounded-t-[2px] transition-all duration-200 ${
                     isHigh
                       ? mode === 'loc'
                         ? 'bg-indigo-500 dark:bg-indigo-400'


### PR DESCRIPTION
## Description

### What does this PR do? Which issue does it fix?

This PR adds `cursor-pointer` styling to the Activity Landscape timeframe filter buttons (`1W`, `1M`, `3M`, `1Y`) to provide consistent visual feedback for interactive controls across the dashboard.

### Changes Made

* Added `cursor-pointer` styling to Activity Landscape timeframe filter buttons.
* Improved UI consistency with other interactive dashboard elements.
* Enhanced user experience by clearly indicating clickable controls.
* No functional changes were made to the filtering behavior.

### Issue Fixed

Fixes #3267

### Pillar

Frontend / UI Enhancement

### Checklist

* [x] Code follows the project's style guidelines.
* [x] Changes have been tested locally.
* [x] No existing functionality has been affected.
* [x] No new warnings or errors introduced.
* [x] Documentation updated where applicable.
