### PR TITLE
test(discordbutton-mouse-interactivity): add hover interaction coverage

### DIFF
--- a/components/DiscordButton.test.tsx
+++ b/components/DiscordButton.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import gsap from 'gsap';
 import { DiscordButton } from './DiscordButton';
 // Mock framer-motion
 vi.mock('framer-motion', () => ({
@@ -56,5 +57,55 @@ describe('DiscordButton', () => {
     const link = screen.getByRole('link');
 
     expect(link).toHaveAttribute('target', '_blank');
+  });
+});
+
+describe('DiscordButton mouse interactivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets hover state on mouse enter', () => {
+    render(<DiscordButton />);
+
+    const link = screen.getByRole('link');
+
+    fireEvent.mouseEnter(link);
+
+    expect(link).toBeInTheDocument();
+  });
+
+  it('triggers gsap animation on mouse move while hovered', () => {
+    render(<DiscordButton />);
+
+    const link = screen.getByRole('link');
+
+    fireEvent.mouseEnter(link);
+
+    fireEvent.mouseMove(link, {
+      clientX: 100,
+      clientY: 50,
+    });
+
+    expect(gsap.to).toHaveBeenCalled();
+  });
+
+  it('resets gsap transforms on mouse leave', () => {
+    render(<DiscordButton />);
+
+    const link = screen.getByRole('link');
+
+    fireEvent.mouseEnter(link);
+    fireEvent.mouseLeave(link);
+
+    expect(gsap.to).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        x: 0,
+        y: 0,
+        rotationX: 0,
+        rotationY: 0,
+      })
+    );
   });
 });


### PR DESCRIPTION
## Description

Fixes #2737
## Summary

Added mouse interaction coverage for `DiscordButton` hover behavior and GSAP animation handling.

## Changes Made

* Added hover interaction test cases
* Verified GSAP animation triggers during mouse movement
* Verified transform reset behavior on mouse leave
* Added interaction-focused coverage without duplicating existing render tests

## Validation

```bash
npx vitest components/DiscordButton.test.tsx
npm run lint
npm run format
```

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
