### PR TITLE
test: add tooltip utils empty fallback tests

### DIFF
--- a/components/dashboard/tooltipUtils.empty-fallback.test.ts
+++ b/components/dashboard/tooltipUtils.empty-fallback.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatTooltipDate,
+  getActivityInsight,
+  getContributionLabel,
+  getLocalActiveStreak,
+  getStreakLabel,
+} from './tooltipUtils';
+
+describe('tooltipUtils empty fallback behavior', () => {
+  it('returns original value for empty or invalid tooltip dates', () => {
+    expect(formatTooltipDate('')).toBe('');
+    expect(formatTooltipDate('invalid-date')).toBe('invalid-date');
+  });
+
+  it('formats zero contributions with plural fallback label', () => {
+    expect(getContributionLabel(0)).toBe('0 contributions');
+  });
+
+  it('returns no activity insight for zero count without intensity', () => {
+    expect(getActivityInsight(0)).toBe('No activity recorded');
+  });
+
+  it('returns zero local active streak for empty activity data', () => {
+    expect(getLocalActiveStreak([], 0)).toBe(0);
+  });
+
+  it('returns no active streak label for zero or negative streaks', () => {
+    expect(getStreakLabel(0)).toBe('No active streak');
+    expect(getStreakLabel(-1)).toBe('No active streak');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2633

Added isolated Vitest coverage for `components/dashboard/tooltipUtils.ts` empty and fallback edge cases.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.