### PR TITLE
test(components): add vitest suite for commitpulse-logo

### DIFF
--- a/components/commitpulse-logo.test.tsx
+++ b/components/commitpulse-logo.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { CommitPulseLogo } from './commitpulse-logo';
+
+describe('CommitPulseLogo Component', () => {
+  it('renders an <svg> element with proper viewport dimensions', () => {
+    const { container } = render(<CommitPulseLogo />);
+    const svg = container.querySelector('svg');
+
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 24 24');
+  });
+
+  it('asserts that path elements are drawn representing the pulse shape', () => {
+    const { container } = render(<CommitPulseLogo />);
+    const paths = container.querySelectorAll('path');
+
+    // The component specifically draws 4 geometric paths
+    expect(paths.length).toBe(4);
+  });
+
+  it('verifies support for custom className properties', () => {
+    const testClass = 'custom-pulse-class';
+    const { container } = render(<CommitPulseLogo className={testClass} />);
+    const svg = container.querySelector('svg');
+
+    expect(svg?.classList.contains(testClass)).toBe(true);
+  });
+
+  it('verifies support for custom width and height properties via Tailwind classes', () => {
+    const { container } = render(<CommitPulseLogo className="w-12 h-12" />);
+    const svg = container.querySelector('svg');
+
+    // The default h-5 w-5 should be replaced or overridden by the provided class
+    expect(svg?.classList.contains('w-12')).toBe(true);
+    expect(svg?.classList.contains('h-12')).toBe(true);
+  });
+
+  it('verifies theme colors map correctly to the SVG via currentColor', () => {
+    const { container } = render(<CommitPulseLogo />);
+    const svg = container.querySelector('svg');
+
+    // For Tailwind text-* classes to color the SVG, stroke must be currentColor and fill must be none
+    expect(svg?.getAttribute('stroke')).toBe('currentColor');
+    expect(svg?.getAttribute('fill')).toBe('none');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2271 

**What Changed:**
* **Logo Component Tests (`components/commitpulse-logo.test.tsx`):** Added a dedicated Vitest test suite with 5 test cases to verify SVG viewport dimensions, path geometry, custom Tailwind class support (for width/height adjustments), and theme color properties (`currentColor`). Implemented using native DOM queries (`getAttribute`, `classList`) to ensure bulletproof CI pipeline compatibility.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

*N/A — Frontend component test coverage only.*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
