### PR TITLE
fix(github): preserve GraphQL response body after retry exhaustion

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -524,9 +524,15 @@ async function fetchContributionsUncached(
 
   if (!res.ok) {
     throwIfRateLimited(res);
-    if (res.status === 401) throw new Error('GitHub PAT is invalid or missing');
+
+    const bodyText = await res.text().catch(() => '');
+
+    if (res.status === 401) {
+      throw new Error(`GitHub PAT is invalid or missing. Response: ${bodyText || '<empty>'}`);
+    }
+
     throw new Error(
-      `GitHub GraphQL API returned status ${res.status} after ${MAX_RETRIES} retries`
+      `GitHub GraphQL API returned status ${res.status} after ${MAX_RETRIES} retries. Response: ${bodyText || '<empty>'}`
     );
   }
 


### PR DESCRIPTION
## Description

Fixes #3326 

This PR improves GitHub GraphQL error handling by preserving the original response body when requests continue to fail after all retry attempts have been exhausted.

Previously, the code threw a generic error containing only the HTTP status code, which discarded valuable diagnostic information returned by GitHub. As a result, debugging production failures, rate-limit issues, GraphQL validation errors, and server-side failures was more difficult.

### Changes

* Preserve the original GitHub GraphQL response body before throwing an error.
* Include GitHub-provided error details in the final exception after retry exhaustion.
* Improve observability and debugging for GraphQL failures.
* Retain existing retry behavior without modifying retry logic.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Backend error-handling improvement)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [x] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
