### PR TITLE
fix(ui): guard scroll progress calculation against zero-height pages

### DIFF
--- a/components/ReturnToTop.tsx
+++ b/components/ReturnToTop.tsx
@@ -18,7 +18,9 @@ export default function ReturnToTop() {
       setIsVisible(scrollHeight - (scrollTop + clientHeight) < 300);
 
       // Scroll progress calculation
-      const progress = (scrollTop / (scrollHeight - clientHeight)) * 100;
+      const maxScrollableHeight = scrollHeight - clientHeight;
+
+      const progress = maxScrollableHeight > 0 ? (scrollTop / maxScrollableHeight) * 100 : 0;
 
       setScrollProgress(Math.min(Math.max(progress, 0), 100));
     };


### PR DESCRIPTION
## Description

Fixes #3363 

This PR fixes a runtime edge case in `ReturnToTop.tsx` where the scroll progress calculation could produce `NaN` when the page has no scrollable content (i.e., `scrollHeight === clientHeight`).

Previously, the progress formula:

scrollTop / (scrollHeight - clientHeight)

would result in division by zero, causing invalid values that propagate into the SVG stroke calculation (`strokeDashoffset`) and break the progress indicator rendering.

### Fix
- Added a safe guard for `scrollHeight - clientHeight`
- Ensured progress defaults to `0` when no scrollable area exists
- Prevented NaN values from affecting SVG rendering

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (UI behavior fix — no visual changes to layout or design)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`)
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise)
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`)
- [x] I have updated `README.md` if I added a new theme or URL parameter
- [x] I have started the repo
- [x] I have made sure that I have only one commit to merge in this PR
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support