### PR TITLE
feat: Add dynamic glowing milestone badges for streaks and contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ URL Parameter > Theme Default > System Fallback
 | `shading`         | `boolean` | No         | `false`                        | Apply intensity-based opacity shading to tower faces so lower intensity levels appear slightly dimmer                                                                     |
 | `opacity`         | `number`  | No         | `1.0`                          | Global opacity scalar for all tower fill-opacity values (0.1–1.0). `opacity=0.5` = semi-transparent ghost look. `opacity=0.8` = faded, great on light backgrounds.        |
 | `gradient`        | `boolean` | No         | `false`                        | Opt-in to show volumetric gradients on the monolith floor                                                                                                                 |
+| `badges`          | `boolean` | No         | `false`                        | Render dynamic glowing milestone badges (e.g., 365-day streak, 1K+ commits) on the SVG                                                                                    |
 
 ### Grace Period Examples
 

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -99,6 +99,7 @@ export async function GET(request: Request) {
       glow,
       format,
       days,
+      badges,
     } = parseResult.data;
     const normalizedView = view as 'default' | 'monthly' | 'heatmap' | 'pulse';
     const themeName = theme || 'dark';
@@ -182,6 +183,7 @@ export async function GET(request: Request) {
       disable_particles,
       glow,
       animate,
+      badges,
     };
 
     let calendar;

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -654,6 +654,45 @@ function renderIsometricLabels(
   return `<g class="isometric-labels">${elements}</g>`;
 }
 
+function renderMilestoneBadges(stats: StreakStats, params: BadgeParams, sf: number): string {
+  if (!params.badges) return '';
+
+  const badges = [];
+  if (stats.longestStreak >= 365) badges.push({ text: '🔥 Unstoppable', color: '#FFD700' });
+  else if (stats.longestStreak >= 100) badges.push({ text: '💯 Century Club', color: '#C0C0C0' });
+
+  if (stats.totalContributions >= 5000) badges.push({ text: '🌟 Elite', color: '#b9f2ff' });
+  else if (stats.totalContributions >= 1000) badges.push({ text: '🚀 1K Club', color: '#cd7f32' });
+  else if (stats.totalContributions >= 500)
+    badges.push({ text: '⭐ 500+ Commits', color: '#cd7f32' });
+
+  if (badges.length === 0) return '';
+
+  const fs = (n: number) => Math.round(n * sf * 10) / 10;
+  const s = createScaler(sf);
+
+  let elements = '';
+  const badgeWidth = 110;
+  const spacing = 10;
+  const totalWidth = badges.length * badgeWidth + (badges.length - 1) * spacing;
+  const startX = 300 - totalWidth / 2 + badgeWidth / 2;
+
+  badges.forEach((b, i) => {
+    const cx = s(startX + i * (badgeWidth + spacing));
+    const cy = s(400);
+    const glowAttr = params.glow !== false ? ' filter="url(#glow)"' : '';
+
+    elements += `
+      <g transform="translate(${cx}, ${cy})" class="badge-group">
+        <rect x="${s(-badgeWidth / 2)}" y="${s(-12)}" width="${s(badgeWidth)}" height="${s(24)}" rx="${s(12)}" fill="${b.color}" fill-opacity="0.1" stroke="${b.color}" stroke-opacity="0.5" stroke-width="1" />
+        <text y="${s(4)}" text-anchor="middle" font-family='"Roboto", sans-serif' font-size="${fs(11)}px" font-weight="bold" fill="${b.color}" ${glowAttr}>${b.text}</text>
+      </g>
+    `;
+  });
+
+  return `<g class="milestone-badges">${elements}</g>`;
+}
+
 // ── Main static-theme renderer ────────────────────────────────────────────
 
 export function generateSVG(
@@ -725,6 +764,7 @@ export function generateSVG(
   <g id="cp-towers" style="transform-origin: center; transform-box: fill-box;" transform="translate(0, ${Math.round(20 * sf)})">${towers}</g>
   ${renderIsometricLabels(calendar, params, text, sf)}
   ${renderFooter(stats, params, labels, safeUser, mainAccentHex, sf)}
+  ${renderMilestoneBadges(stats, params, sf)}
 </svg>`;
 }
 
@@ -820,6 +860,7 @@ ${
     : ''
 }
 ${renderRadarScan(params.speed || '8s', sf, '', true)}
+${renderMilestoneBadges(stats, params, sf)}
 </svg>
 `;
 }

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -338,6 +338,7 @@ const baseStreakParamsSchema = z.object({
   glow: z.string().optional().transform(toBooleanFlag).default(true),
   opacity: z.string().optional().transform(toOpacityValue),
   entrance: z.enum(['rise', 'fade', 'slide', 'none']).catch('rise').default('rise'),
+  badges: z.string().optional().transform(toBooleanFlag).default(false),
 
   // Output format: 'svg' (default) or 'json' for programmatic access.
   // Invalid values silently fall back to 'svg'.

--- a/types/index.ts
+++ b/types/index.ts
@@ -232,6 +232,7 @@ export interface BadgeParams {
   animate?: boolean;
   glow?: boolean;
   isOfflineFallback?: boolean;
+  badges?: boolean;
 
   /** @internal Temporary property to track custom gradient ID during SVG generation. */
   __customGradientId?: string;


### PR DESCRIPTION
### Fixes / Closes
Closes #3370 
### Description
Introduced a new URL parameter (`&badges=true`) that conditionally renders glowing, isometric-style milestone badges (or medals) directly onto the SVG monolith!
These badges are awarded based on the user's `StreakStats` and displayed beautifully beneath the main monolith:
- 🌟 **Elite** (Diamond Glow): 5,000+ total contributions
- 🚀 **1K Club** (Bronze Glow): 1,000+ total contributions
- ⭐ **500+ Commits** (Bronze Glow): 500+ total contributions
- 🔥 **Unstoppable** (Gold Glow): 365+ days longest streak
- 💯 **Century Club** (Silver Glow): 100+ days longest streak
### Changes
- **`types/index.ts` & `lib/validations.ts`**: Updated the parameter schemas to parse `badges`.
- **`app/api/streak/route.ts`**: Destructured and passed `badges` to the SVG renderer.
- **`lib/svg/generator.ts`**: Injected the new `renderMilestoneBadges` function which handles the logic and SVG generation for the glowing badges.
- **`README.md`**: Documented the parameter.