### PR TITLE
test(theme-synthwave): verify color variables and configuration for synthwave theme

### DIFF
--- a/lib/svg/themes/synthwave.test.ts
+++ b/lib/svg/themes/synthwave.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { themes } from '../themes';
+
+describe('synthwave theme', () => {
+  const synthwave = themes.synthwave;
+
+  it('exists in the themes collection', () => {
+    expect(synthwave).toBeDefined();
+    expect(themes).toHaveProperty('synthwave');
+  });
+
+  it('contains valid hexadecimal color values', () => {
+    const hexRegex = /^[0-9A-Fa-f]{6}$/;
+
+    expect(synthwave.bg).toMatch(hexRegex);
+    expect(synthwave.text).toMatch(hexRegex);
+    expect(synthwave.accent).toMatch(hexRegex);
+
+    if (synthwave.negative) {
+      expect(synthwave.negative).toMatch(hexRegex);
+    }
+  });
+
+  it('uses the expected synthwave theme colors', () => {
+    expect(synthwave.bg).toBe('0d0221');
+    expect(synthwave.text).toBe('f8f8f2');
+    expect(synthwave.accent).toBe('ff2d78');
+    expect(synthwave.negative).toBe('ff3864');
+  });
+
+  it('contains all required theme properties', () => {
+    expect(synthwave).toHaveProperty('bg');
+    expect(synthwave).toHaveProperty('text');
+    expect(synthwave).toHaveProperty('accent');
+    expect(synthwave).toHaveProperty('negative');
+  });
+
+  it('provides sufficient contrast between background and text', () => {
+    const luminance = (hex: string) => {
+      const rgb = hex
+        .match(/.{2}/g)!
+        .map((v) => parseInt(v, 16) / 255)
+        .map((v) => (v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)));
+
+      return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
+    };
+
+    const bgLum = luminance(synthwave.bg);
+    const textLum = luminance(synthwave.text);
+
+    const contrast = (Math.max(bgLum, textLum) + 0.05) / (Math.min(bgLum, textLum) + 0.05);
+
+    expect(contrast).toBeGreaterThan(4.5);
+  });
+});


### PR DESCRIPTION
## Description

Adds a dedicated test suite for the synthwave theme to validate theme configuration, color definitions, and accessibility requirements.

## Changes

- Added lib/svg/themes/synthwave.test.ts
- Verified that the synthwave theme exists in the exported themes collection
- Validated that all theme colors are properly formatted hexadecimal values
- Confirmed the expected synthwave color palette is configured correctly
- Verified required theme properties are present
- Added contrast ratio validation between background and text colors

Fixes #2311 

## Pillar

- [x] 📐 Pillar 2 — Geometric SVG Improvement
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
