### PR TITLE
test(calculate): add variation 2 multi-week gap timeline coverage

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -79,6 +79,50 @@ describe('calculateStreak', () => {
     expect(result.longestStreak).toBe(7);
     expect(result.totalContributions).toBe(14);
   });
+  it('verify streak formulas for multiple weeks gaps timeline (Variation 2)', () => {
+    // Streak 1: 5 days
+    // Gap: 14 days (2 full weeks)
+    // Streak 2: 9 days (current + longest)
+
+    const calendar = buildCalendar([
+      1,
+      1,
+      1,
+      1,
+      1, // Streak 1
+
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0, // Gap week 1
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0, // Gap week 2
+
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1, // Streak 2
+    ]);
+
+    const result = calculateStreak(calendar);
+
+    expect(result.currentStreak).toBe(9);
+    expect(result.longestStreak).toBe(9);
+    expect(result.totalContributions).toBe(14);
+  });
 
   it('counts an active streak when the last day has contributions', () => {
     // The last element represents "today" — committing today keeps the streak alive.


### PR DESCRIPTION
## Description

Fixes #1479

Added an additional test case for a multiple-week contribution gap timeline in `lib/calculate.test.ts`.

The new test verifies:
- Current streak calculation after a multi-week gap
- Longest streak calculation
- Total contribution count consistency

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
Visual Preview: N/A (test-only change)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x ] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
