### PR TITLE
test(theme-neon): verify color variables and configuration for neon t…

### DIFF
--- a/lib/svg/themes/neon.test.ts
+++ b/lib/svg/themes/neon.test.ts
@@ -10,12 +10,10 @@ describe('neon theme', () => {
 
   it('has valid 6-digit hex color strings (without #) for bg, text, and accent', () => {
     const hexRegex = /^[0-9a-fA-F]{6}$/;
-    const neon = themes.neon;
-    expect(neon).toBeDefined();
 
-    expect(neon.bg).toMatch(hexRegex);
-    expect(neon.text).toMatch(hexRegex);
-    expect(neon.accent).toMatch(hexRegex);
+    expect(themes.neon.bg).toMatch(hexRegex);
+    expect(themes.neon.text).toMatch(hexRegex);
+    expect(themes.neon.accent).toMatch(hexRegex);
   });
 
   it('contains the specific neon hex colors in generated SVG output', () => {

--- a/lib/svg/themes/neon.test.ts
+++ b/lib/svg/themes/neon.test.ts
@@ -10,11 +10,12 @@ describe('neon theme', () => {
 
   it('has valid hexadecimal color strings for bg, text, and accent', () => {
     const hexRegex = /^[0-9a-fA-F]{6}$/;
-    const { bg, text, accent } = themes.neon;
+    const neon = themes.neon;
+    expect(neon).toBeDefined();
 
-    expect(bg).toMatch(hexRegex);
-    expect(text).toMatch(hexRegex);
-    expect(accent).toMatch(hexRegex);
+    expect(neon.bg).toMatch(hexRegex);
+    expect(neon.text).toMatch(hexRegex);
+    expect(neon.accent).toMatch(hexRegex);
   });
 
   it('contains the specific neon hex colors in generated SVG output', () => {
@@ -45,9 +46,9 @@ describe('neon theme', () => {
 
     const svg = generateSVG(mockStats, neonParams, mockCalendar);
 
-    expect(svg).toContain(themes.neon.bg);
-    expect(svg).toContain(themes.neon.text);
-    expect(svg).toContain(themes.neon.accent);
+    expect(svg).toContain(`#${themes.neon.bg}`);
+    expect(svg).toContain(`#${themes.neon.text}`);
+    expect(svg).toContain(`#${themes.neon.accent}`);
   });
 
   it('matches the defined neon color values for the design spec', () => {

--- a/lib/svg/themes/neon.test.ts
+++ b/lib/svg/themes/neon.test.ts
@@ -8,7 +8,7 @@ describe('neon theme', () => {
     expect(themes).toHaveProperty('neon');
   });
 
-  it('has valid hexadecimal color strings for bg, text, and accent', () => {
+  it('has valid 6-digit hex color strings (without #) for bg, text, and accent', () => {
     const hexRegex = /^[0-9a-fA-F]{6}$/;
     const neon = themes.neon;
     expect(neon).toBeDefined();
@@ -25,7 +25,8 @@ describe('neon theme', () => {
       totalContributions: 100,
       todayDate: '2024-06-12',
     };
-    const mockCalendar = {
+    const mockCalendar: ContributionCalendar = {
+      totalContributions: 10,
       weeks: [
         {
           contributionDays: [
@@ -34,7 +35,7 @@ describe('neon theme', () => {
           ],
         },
       ],
-    } as ContributionCalendar;
+    };
     const neonParams: BadgeParams = {
       user: 'testuser',
       bg: themes.neon.bg,

--- a/lib/svg/themes/neon.test.ts
+++ b/lib/svg/themes/neon.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { themes } from '../themes';
+import { generateSVG } from '../generator';
+import type { BadgeParams, ContributionCalendar, StreakStats } from '../../../types';
+
+describe('neon theme', () => {
+  it('exists as a key in the themes object', () => {
+    expect(themes).toHaveProperty('neon');
+  });
+
+  it('has valid hexadecimal color strings for bg, text, and accent', () => {
+    const hexRegex = /^[0-9a-fA-F]{6}$/;
+    const { bg, text, accent } = themes.neon;
+
+    expect(bg).toMatch(hexRegex);
+    expect(text).toMatch(hexRegex);
+    expect(accent).toMatch(hexRegex);
+  });
+
+  it('contains the specific neon hex colors in generated SVG output', () => {
+    const mockStats: StreakStats = {
+      currentStreak: 5,
+      longestStreak: 10,
+      totalContributions: 100,
+      todayDate: '2024-06-12',
+    };
+    const mockCalendar = {
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 5, date: '2024-06-11' },
+            { contributionCount: 5, date: '2024-06-12' },
+          ],
+        },
+      ],
+    } as ContributionCalendar;
+    const neonParams: BadgeParams = {
+      user: 'testuser',
+      bg: themes.neon.bg,
+      text: themes.neon.text,
+      accent: themes.neon.accent,
+      speed: '8s',
+      scale: 'linear',
+    };
+
+    const svg = generateSVG(mockStats, neonParams, mockCalendar);
+
+    expect(svg).toContain(themes.neon.bg);
+    expect(svg).toContain(themes.neon.text);
+    expect(svg).toContain(themes.neon.accent);
+  });
+
+  it('matches the defined neon color values for the design spec', () => {
+    expect(themes.neon.bg).toBe('000000');
+    expect(themes.neon.text).toBe('00ffcc');
+    expect(themes.neon.accent).toBe('ff00ff');
+  });
+
+  it('provides sufficient WCAG AA contrast between background and text', () => {
+    const hexToRgb = (hex: string) => {
+      const r = parseInt(hex.slice(0, 2), 16);
+      const g = parseInt(hex.slice(2, 4), 16);
+      const b = parseInt(hex.slice(4, 6), 16);
+      return { r, g, b };
+    };
+
+    const relativeLuminance = (hex: string) => {
+      const { r, g, b } = hexToRgb(hex);
+      const [rl, gl, bl] = [r, g, b].map((c) => {
+        const s = c / 255;
+        return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+      });
+      return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+    };
+
+    const { bg, text } = themes.neon;
+    const lBg = relativeLuminance(bg);
+    const lText = relativeLuminance(text);
+    const lighter = Math.max(lBg, lText);
+    const darker = Math.min(lBg, lText);
+    const contrast = (lighter + 0.05) / (darker + 0.05);
+
+    expect(contrast).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/lib/svg/themes/neon.test.ts
+++ b/lib/svg/themes/neon.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { themes } from '../themes';
 import { generateSVG } from '../generator';
 import type { BadgeParams, ContributionCalendar, StreakStats } from '../../../types';
+import { contrastRatio } from './test-utils';
 
 describe('neon theme', () => {
   it('exists as a key in the themes object', () => {
@@ -57,29 +58,7 @@ describe('neon theme', () => {
   });
 
   it('provides sufficient WCAG AA contrast between background and text', () => {
-    const hexToRgb = (hex: string) => {
-      const r = parseInt(hex.slice(0, 2), 16);
-      const g = parseInt(hex.slice(2, 4), 16);
-      const b = parseInt(hex.slice(4, 6), 16);
-      return { r, g, b };
-    };
-
-    const relativeLuminance = (hex: string) => {
-      const { r, g, b } = hexToRgb(hex);
-      const [rl, gl, bl] = [r, g, b].map((c) => {
-        const s = c / 255;
-        return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
-      });
-      return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
-    };
-
-    const { bg, text } = themes.neon;
-    const lBg = relativeLuminance(bg);
-    const lText = relativeLuminance(text);
-    const lighter = Math.max(lBg, lText);
-    const darker = Math.min(lBg, lText);
-    const contrast = (lighter + 0.05) / (darker + 0.05);
-
-    expect(contrast).toBeGreaterThanOrEqual(4.5);
+    const ratio = contrastRatio(themes.neon.bg, themes.neon.text);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
   });
 });

--- a/lib/svg/themes/test-utils.ts
+++ b/lib/svg/themes/test-utils.ts
@@ -1,0 +1,24 @@
+export function hexToRgb(hex: string) {
+  return {
+    r: parseInt(hex.slice(0, 2), 16),
+    g: parseInt(hex.slice(2, 4), 16),
+    b: parseInt(hex.slice(4, 6), 16),
+  };
+}
+
+export function relativeLuminance(hex: string) {
+  const { r, g, b } = hexToRgb(hex);
+  const [rl, gl, bl] = [r, g, b].map((c) => {
+    const s = c / 255;
+    return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}
+
+export function contrastRatio(bg: string, text: string) {
+  const lBg = relativeLuminance(bg);
+  const lText = relativeLuminance(text);
+  const lighter = Math.max(lBg, lText);
+  const darker = Math.min(lBg, lText);
+  return (lighter + 0.05) / (darker + 0.05);
+}


### PR DESCRIPTION
## Description

Adds dedicated unit tests for the neon theme in `lib/svg/themes/neon.test.ts` to verify its color configuration, SVG output, and WCAG contrast compliance.

Fixes #2304

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Testing)

## Summary of Changes

Created `lib/svg/themes/neon.test.ts` with 5 test cases:

1. **Theme exists** — asserts `themes` has a `neon` key
2. **Valid hex color strings** — regex-validates `bg`, `text`, `accent` are proper 6-char hex values
3. **Matches design spec** — exact match on `#000000` (bg), `#00ffcc` (text), `#ff00ff` (accent)
4. **Hex colors appear in generated SVG** — calls `generateSVG` with neon theme params and verifies all three hex values are present in the output
5. **WCAG AA contrast compliance** — computes relative luminance per WCAG 2.1 and asserts `bg` vs `text` contrast ratio ≥ 4.5:1

## Visual Preview

Not applicable — this is a testing-only change with no visual output.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (not needed)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (not applicable)
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.