### PR TITLE
test(theme-dracula): verify color variables and configuration for dra…

### DIFF
--- a/lib/svg/themes/dracula.test.ts
+++ b/lib/svg/themes/dracula.test.ts
@@ -10,12 +10,10 @@ describe('dracula theme', () => {
 
   it('has valid 6-digit hex color strings (without #) for bg, text, and accent', () => {
     const hexRegex = /^[0-9a-fA-F]{6}$/;
-    const dracula = themes.dracula;
-    expect(dracula).toBeDefined();
 
-    expect(dracula.bg).toMatch(hexRegex);
-    expect(dracula.text).toMatch(hexRegex);
-    expect(dracula.accent).toMatch(hexRegex);
+    expect(themes.dracula.bg).toMatch(hexRegex);
+    expect(themes.dracula.text).toMatch(hexRegex);
+    expect(themes.dracula.accent).toMatch(hexRegex);
   });
 
   it('matches the defined dracula color values for the design spec', () => {

--- a/lib/svg/themes/dracula.test.ts
+++ b/lib/svg/themes/dracula.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { themes } from '../themes';
 import { generateSVG } from '../generator';
 import type { BadgeParams, ContributionCalendar, StreakStats } from '../../../types';
+import { contrastRatio } from './test-utils';
 
 describe('dracula theme', () => {
   it('exists as a key in the themes object', () => {
@@ -57,29 +58,7 @@ describe('dracula theme', () => {
   });
 
   it('provides sufficient WCAG AA contrast between background and text', () => {
-    const hexToRgb = (hex: string) => {
-      const r = parseInt(hex.slice(0, 2), 16);
-      const g = parseInt(hex.slice(2, 4), 16);
-      const b = parseInt(hex.slice(4, 6), 16);
-      return { r, g, b };
-    };
-
-    const relativeLuminance = (hex: string) => {
-      const { r, g, b } = hexToRgb(hex);
-      const [rl, gl, bl] = [r, g, b].map((c) => {
-        const s = c / 255;
-        return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
-      });
-      return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
-    };
-
-    const { bg, text } = themes.dracula;
-    const lBg = relativeLuminance(bg);
-    const lText = relativeLuminance(text);
-    const lighter = Math.max(lBg, lText);
-    const darker = Math.min(lBg, lText);
-    const contrast = (lighter + 0.05) / (darker + 0.05);
-
-    expect(contrast).toBeGreaterThanOrEqual(4.5);
+    const ratio = contrastRatio(themes.dracula.bg, themes.dracula.text);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
   });
 });

--- a/lib/svg/themes/dracula.test.ts
+++ b/lib/svg/themes/dracula.test.ts
@@ -8,7 +8,7 @@ describe('dracula theme', () => {
     expect(themes).toHaveProperty('dracula');
   });
 
-  it('has valid hexadecimal color strings for bg, text, and accent', () => {
+  it('has valid 6-digit hex color strings (without #) for bg, text, and accent', () => {
     const hexRegex = /^[0-9a-fA-F]{6}$/;
     const dracula = themes.dracula;
     expect(dracula).toBeDefined();
@@ -31,7 +31,8 @@ describe('dracula theme', () => {
       totalContributions: 100,
       todayDate: '2024-06-12',
     };
-    const mockCalendar = {
+    const mockCalendar: ContributionCalendar = {
+      totalContributions: 10,
       weeks: [
         {
           contributionDays: [
@@ -40,7 +41,7 @@ describe('dracula theme', () => {
           ],
         },
       ],
-    } as ContributionCalendar;
+    };
     const draculaParams: BadgeParams = {
       user: 'testuser',
       bg: themes.dracula.bg,

--- a/lib/svg/themes/dracula.test.ts
+++ b/lib/svg/themes/dracula.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { themes } from '../themes';
+import { generateSVG } from '../generator';
+import type { BadgeParams, ContributionCalendar, StreakStats } from '../../../types';
+
+describe('dracula theme', () => {
+  it('exists as a key in the themes object', () => {
+    expect(themes).toHaveProperty('dracula');
+  });
+
+  it('has valid hexadecimal color strings for bg, text, and accent', () => {
+    const hexRegex = /^[0-9a-fA-F]{6}$/;
+    const dracula = themes.dracula;
+    expect(dracula).toBeDefined();
+
+    expect(dracula.bg).toMatch(hexRegex);
+    expect(dracula.text).toMatch(hexRegex);
+    expect(dracula.accent).toMatch(hexRegex);
+  });
+
+  it('matches the defined dracula color values for the design spec', () => {
+    expect(themes.dracula.bg).toBe('282a36');
+    expect(themes.dracula.text).toBe('f8f8f2');
+    expect(themes.dracula.accent).toBe('bd93f9');
+  });
+
+  it('contains the specific dracula hex colors in generated SVG output', () => {
+    const mockStats: StreakStats = {
+      currentStreak: 5,
+      longestStreak: 10,
+      totalContributions: 100,
+      todayDate: '2024-06-12',
+    };
+    const mockCalendar = {
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 5, date: '2024-06-11' },
+            { contributionCount: 5, date: '2024-06-12' },
+          ],
+        },
+      ],
+    } as ContributionCalendar;
+    const draculaParams: BadgeParams = {
+      user: 'testuser',
+      bg: themes.dracula.bg,
+      text: themes.dracula.text,
+      accent: themes.dracula.accent,
+      speed: '8s',
+      scale: 'linear',
+    };
+
+    const svg = generateSVG(mockStats, draculaParams, mockCalendar);
+
+    expect(svg).toContain(`#${themes.dracula.bg}`);
+    expect(svg).toContain(`#${themes.dracula.text}`);
+    expect(svg).toContain(`#${themes.dracula.accent}`);
+  });
+
+  it('provides sufficient WCAG AA contrast between background and text', () => {
+    const hexToRgb = (hex: string) => {
+      const r = parseInt(hex.slice(0, 2), 16);
+      const g = parseInt(hex.slice(2, 4), 16);
+      const b = parseInt(hex.slice(4, 6), 16);
+      return { r, g, b };
+    };
+
+    const relativeLuminance = (hex: string) => {
+      const { r, g, b } = hexToRgb(hex);
+      const [rl, gl, bl] = [r, g, b].map((c) => {
+        const s = c / 255;
+        return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+      });
+      return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+    };
+
+    const { bg, text } = themes.dracula;
+    const lBg = relativeLuminance(bg);
+    const lText = relativeLuminance(text);
+    const lighter = Math.max(lBg, lText);
+    const darker = Math.min(lBg, lText);
+    const contrast = (lighter + 0.05) / (darker + 0.05);
+
+    expect(contrast).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/lib/svg/themes/test-utils.ts
+++ b/lib/svg/themes/test-utils.ts
@@ -1,0 +1,24 @@
+export function hexToRgb(hex: string) {
+  return {
+    r: parseInt(hex.slice(0, 2), 16),
+    g: parseInt(hex.slice(2, 4), 16),
+    b: parseInt(hex.slice(4, 6), 16),
+  };
+}
+
+export function relativeLuminance(hex: string) {
+  const { r, g, b } = hexToRgb(hex);
+  const [rl, gl, bl] = [r, g, b].map((c) => {
+    const s = c / 255;
+    return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}
+
+export function contrastRatio(bg: string, text: string) {
+  const lBg = relativeLuminance(bg);
+  const lText = relativeLuminance(text);
+  const lighter = Math.max(lBg, lText);
+  const darker = Math.min(lBg, lText);
+  return (lighter + 0.05) / (darker + 0.05);
+}


### PR DESCRIPTION
## Description

Adds dedicated unit tests for the dracula theme in `lib/svg/themes/dracula.test.ts` to verify its color configuration, SVG output, and WCAG contrast compliance.

Fixes #2305

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Testing)

## Summary of Changes

Created `lib/svg/themes/dracula.test.ts` with 5 test cases:

1. **Theme exists** — asserts `themes` has a `dracula` key
2. **Valid hex color strings** — regex-validates `bg`, `text`, `accent` are proper 6-char hex values
3. **Matches design spec** — exact match on `#282a36` (bg), `#f8f8f2` (text), `#bd93f9` (accent)
4. **Hex colors appear in generated SVG** — calls `generateSVG` with dracula theme params and verifies all three hex values are present in the output
5. **WCAG AA contrast compliance** — computes relative luminance per WCAG 2.1 and asserts `bg` vs `text` contrast ratio ≥ 4.5:1

## Visual Preview

Not applicable — this is a testing-only change with no visual output.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (not needed)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (not applicable)
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.