### PR TITLE
test(cherry-blossom): add accessibility coverage

### DIFF
--- a/components/CherryBlossom.accessibility.test.tsx
+++ b/components/CherryBlossom.accessibility.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import CherryBlossom from './CherryBlossom';
+import type React from 'react';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>) => (
+      <div data-testid="motion-div" {...props}>
+        {children}
+      </div>
+    ),
+  },
+}));
+
+describe('CherryBlossom accessibility', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders as a decorative non-interactive overlay', async () => {
+    const { container } = render(<CherryBlossom />);
+
+    await waitFor(() => {
+      const overlay = container.querySelector('.pointer-events-none');
+      expect(overlay).toBeInTheDocument();
+    });
+  });
+
+  it('contains no focusable interactive controls', async () => {
+    const { container } = render(<CherryBlossom />);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('button,input,textarea,select,a,[tabindex]')).toHaveLength(
+        0
+      );
+    });
+  });
+
+  it('does not expose interactive motion petals', async () => {
+    render(<CherryBlossom />);
+
+    await waitFor(() => {
+      const petals = screen.getAllByTestId('motion-div');
+
+      petals.forEach((petal) => {
+        expect(petal).not.toHaveAttribute('role', 'button');
+      });
+    });
+  });
+
+  it('maintains normal document accessibility flow', async () => {
+    const { container } = render(<CherryBlossom />);
+
+    await waitFor(() => {
+      const overlay = container.querySelector('.fixed.inset-0');
+      expect(overlay).toBeInTheDocument();
+      expect(overlay).toHaveClass('pointer-events-none');
+    });
+  });
+
+  it('renders decorative SVG content without accessibility violations', async () => {
+    const { container } = render(<CherryBlossom />);
+
+    await waitFor(() => {
+      const svgs = container.querySelectorAll('svg');
+      expect(svgs.length).toBeGreaterThanOrEqual(27);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2656

Adds accessibility-focused test coverage for `CherryBlossom`.

The new test suite verifies:

* Decorative overlay remains non-interactive for users and assistive technologies
* No focusable controls are introduced by the component
* Motion petals do not expose interactive accessibility roles
* Pointer-event isolation preserves normal document accessibility flow
* Decorative SVG content renders safely without affecting accessibility behavior

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
