### PR TITLE
test(generator-themeLookup): create isolated helper tests

### DIFF
--- a/lib/svg/generator.themeLookup.test.ts
+++ b/lib/svg/generator.themeLookup.test.ts
@@ -1,0 +1,34 @@
+// lib/svg/generator.themeLookup.test.ts
+
+import { describe, it, expect, vi } from 'vitest';
+import { resolveFont } from './generator';
+
+describe('themeLookup / font resolving behavior', () => {
+  it('should return null if no font parameter is provided', () => {
+    expect(resolveFont()).toBeNull();
+    expect(resolveFont(null)).toBeNull();
+    expect(resolveFont('')).toBeNull();
+  });
+
+  it('should resolve bundled fonts standard parameters correctly', () => {
+    expect(resolveFont('jetbrains')).toBe('"JetBrains Mono", monospace');
+    expect(resolveFont('fira')).toBe('"Fira Code", monospace');
+    expect(resolveFont('roboto')).toBe('"Roboto", sans-serif');
+  });
+
+  it('should resolve previously missing bundled fonts without dynamic dynamic google font trigger', () => {
+    expect(resolveFont('syncopate')).toBe('"Syncopate", sans-serif');
+    expect(resolveFont('spacegrotesk')).toBe('"Space Grotesk", sans-serif');
+  });
+
+  it('should remain robust and case-insensitive under out-of-bounds or spaced inputs', () => {
+    expect(resolveFont('JETBRAINS')).toBe('"JetBrains Mono", monospace');
+    expect(resolveFont('space grotesk')).toBe('"Space Grotesk", sans-serif');
+    expect(resolveFont('JetBrains Mono')).toBe('"JetBrains Mono", monospace');
+  });
+
+  it('should fall back gracefully to a standard sans-serif font stack for unrecognized dynamic fonts', () => {
+    expect(resolveFont('Comic Sans')).toBe('"Comic Sans", sans-serif');
+    expect(resolveFont('custom-font')).toBe('"custom-font", sans-serif');
+  });
+});


### PR DESCRIPTION
## Description
Adds a dedicated test file for the themeLookup helper function in `lib/svg/generator.ts` to improve test isolation and maintainability.

### Changes Made

- Created `lib/svg/generator.themeLookup.test.ts`
- Added coverage for standard valid inputs
- Added edge case tests for:
- `null` values
- `undefined` values
- empty inputs
- out-of-bounds parameters
- Verified outputs match expected behavior and technical specifications
- Ensured test execution completes within normal test runtime expectations

### Test Cases Added

1. Returns expected result for valid standard parameters
2. Handles `null` input safely
3. Handles `undefined` input safely
4. Handles empty input values correctly
5. Handles out-of-bounds parameters correctly

### Verification

- [x] All new tests pass
- [x]  Existing test suite remains green
- [x]  No production code changes

Fixes #2369

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="1542" height="932" alt="image" src="https://github.com/user-attachments/assets/1ccfe9ce-2adb-48b1-8522-eb6f2c2433fd" />

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
