### PR TITLE
test/commitpulse-logo-type-compiler

### DIFF
--- a/components/commitpulse-logo.type-compiler.test.tsx
+++ b/components/commitpulse-logo.type-compiler.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { CommitPulseLogo } from './commitpulse-logo';
+
+type CommitPulseLogoProps = React.ComponentProps<typeof CommitPulseLogo>;
+
+describe('CommitPulseLogo Type Compiler Validation', () => {
+  it('maintains expected props structure', () => {
+    expectTypeOf<CommitPulseLogoProps>().toEqualTypeOf<{
+      className?: string;
+    }>();
+  });
+  it('accepts optional values without compile errors', () => {
+    const props: CommitPulseLogoProps = {};
+    expectTypeOf(props).toEqualTypeOf<{
+      className?: string;
+    }>();
+  });
+  it('accepts string className values', () => {
+    const props: CommitPulseLogoProps = {
+      className: 'custom-class',
+    };
+
+    expectTypeOf(props.className).toEqualTypeOf<string | undefined>();
+  });
+  it('rejects invalid prop parameter types', () => {
+    const invalid: CommitPulseLogoProps = {
+      // @ts-expect-error className must be string
+      className: 100,
+    };
+
+    void invalid;
+  });
+  it('enforces strict property configuration', () => {
+    expectTypeOf<CommitPulseLogoProps>().toMatchObjectType<{
+      className?: string;
+    }>();
+  });
+});


### PR DESCRIPTION
## Description

Adds TypeScript compiler validation tests for `CommitPulseLogo`.

Fixes #2672

### Changes made

* Added `components/commitpulse-logo.type-compiler.test.tsx`
* Added type assertions using `expectTypeOf`
* Verified optional prop behavior
* Added static invalid-prop checks using `@ts-expect-error`
* Added strict type contract validation to prevent regression

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`) *(not applicable for this change)*
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter *(not applicable)*
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard *(not applicable)*
* [ ] (Recommended) I joined the CommitPulse Discord community

##Screenshot :

<img width="897" height="271" alt="Screenshot 2026-06-03 182106" src="https://github.com/user-attachments/assets/94e65fd8-3382-40c6-837f-d383c0fd2d0f" />
