### PR TITLE
test(theme-gruvbox): verify color variables and configuration for gruvbox theme.

### DIFF
--- a/lib/svg/themes/gruvbox.test.ts
+++ b/lib/svg/themes/gruvbox.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { themes } from '../themes';
+
+describe('gruvbox theme', () => {
+  const gruvbox = themes.gruvbox;
+
+  it('exists in the themes collection', () => {
+    expect(gruvbox).toBeDefined();
+    expect(themes).toHaveProperty('gruvbox');
+  });
+
+  it('contains valid hexadecimal color values', () => {
+    const hexRegex = /^[0-9A-Fa-f]{6}$/;
+
+    expect(gruvbox.bg).toMatch(hexRegex);
+    expect(gruvbox.text).toMatch(hexRegex);
+    expect(gruvbox.accent).toMatch(hexRegex);
+
+    if (gruvbox.negative) {
+      expect(gruvbox.negative).toMatch(hexRegex);
+    }
+  });
+
+  it('uses the expected gruvbox theme colors', () => {
+    expect(gruvbox.bg).toBe('282828');
+    expect(gruvbox.text).toBe('ebdbb2');
+    expect(gruvbox.accent).toBe('fe8019');
+    expect(gruvbox.negative).toBe('fb4934');
+  });
+
+  it('contains all required theme properties', () => {
+    expect(gruvbox).toHaveProperty('bg');
+    expect(gruvbox).toHaveProperty('text');
+    expect(gruvbox).toHaveProperty('accent');
+    expect(gruvbox).toHaveProperty('negative');
+  });
+
+  it('provides sufficient contrast between background and text', () => {
+    const luminance = (hex: string) => {
+      const rgb = hex
+        .replace('#', '')
+        .match(/.{2}/g)!
+        .map((v) => parseInt(v, 16) / 255)
+        .map((v) => (v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)));
+
+      return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
+    };
+
+    const bgLum = luminance(gruvbox.bg);
+    const textLum = luminance(gruvbox.text);
+
+    const contrast = (Math.max(bgLum, textLum) + 0.05) / (Math.min(bgLum, textLum) + 0.05);
+
+    expect(contrast).toBeGreaterThan(4.5);
+  });
+});


### PR DESCRIPTION
## Description

Adds a dedicated test suite for the gruvbox theme to ensure its configuration remains consistent and compatible with SVG generation requirements.

## Changes

- Added lib/svg/themes/gruvbox.test.ts
- Verified that the gruvbox theme exists in the exported themes collection
- Validated that bg, text, accent, and negative values are valid hexadecimal color strings
- Asserted the expected theme color values:
- bg: 282828
- text: ebdbb2
- accent: fe8019
- negative: fb4934
- Added accessibility validation by checking WCAG-compliant contrast ratio between background and text colors
- Included SVG/theme configuration validation to ensure theme values are available for rendering

Fixes #2312 

## Pillar

- [x] 📐 Pillar 2 — Geometric SVG Improvement


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
