### PR TITLE
fix(security): prevent misclassification of unknown traffic as localhost

### DIFF
--- a/utils/getClientIp.ts
+++ b/utils/getClientIp.ts
@@ -121,5 +121,9 @@ export function getClientIp(
   }
 
   // 4. Ultimate Fallback
-  return '127.0.0.1';
+  if (process.env.NODE_ENV === 'development') {
+    return '127.0.0.1';
+  }
+
+  return 'unknown';
 }

--- a/utils/getClientIp.ts
+++ b/utils/getClientIp.ts
@@ -121,7 +121,8 @@ export function getClientIp(
   }
 
   // 4. Ultimate Fallback
-  if (process.env.NODE_ENV === 'development') {
+  // 4. Ultimate Fallback
+  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     return '127.0.0.1';
   }
 


### PR DESCRIPTION
## Description

Fixes #3449 

This PR fixes a security issue in `getClientIp.ts` where missing request
headers caused the function to incorrectly return `127.0.0.1`.

This created a risk where production traffic without forwarded headers
could be misclassified as localhost, affecting rate limiting, logging,
and security checks.

### Fix
- Replaced unsafe fallback `127.0.0.1` with `unknown`
- Added optional environment-based handling for development vs production
- Ensures unknown traffic does not get treated as trusted local requests

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Backend security fix)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally
- [x] I have run `npm run format` and `npm run lint`
- [x] My commits follow Conventional Commits format
- [x] No production traffic is treated as localhost anymore