### PR TITLE
test(commitclock-empty-fallback): verify edge cases and empty input handling

### DIFF
--- a/components/dashboard/CommitClock.empty-fallback.test.tsx
+++ b/components/dashboard/CommitClock.empty-fallback.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CommitClock from './CommitClock';
+import { vi } from 'vitest';
+import type { ReactNode, SVGProps, HTMLAttributes } from 'react';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: HTMLAttributes<HTMLDivElement> & { children?: ReactNode }) => (
+      <div {...props}>{children}</div>
+    ),
+
+    g: ({ children, ...props }: SVGProps<SVGGElement> & { children?: ReactNode }) => (
+      <g {...props}>{children}</g>
+    ),
+  },
+
+  AnimatePresence: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+describe('CommitClock - Empty Fallback', () => {
+  it('renders fallback UI when data array is empty', () => {
+    render(<CommitClock data={[]} />);
+
+    expect(screen.getByText(/No recent activity to display/i)).toBeInTheDocument();
+  });
+
+  it('renders title and subtitle with empty data', () => {
+    render(<CommitClock data={[]} />);
+
+    expect(screen.getByText('Commit Clock')).toBeInTheDocument();
+    expect(screen.getByText('Weekly activity cycle')).toBeInTheDocument();
+  });
+
+  it('does not render svg when no activity data exists', () => {
+    const { container } = render(<CommitClock data={[]} />);
+
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  it('renders cycle indicator even in fallback state', () => {
+    render(<CommitClock data={[]} />);
+
+    expect(screen.getByText('CYCLE')).toBeInTheDocument();
+    expect(screen.getByText('7d')).toBeInTheDocument();
+  });
+
+  it('shows fallback UI when all commit counts are zero', () => {
+    render(
+      <CommitClock
+        data={[
+          { day: 'Mon', commits: 0 },
+          { day: 'Tue', commits: 0 },
+          { day: 'Wed', commits: 0 },
+          { day: 'Thu', commits: 0 },
+          { day: 'Fri', commits: 0 },
+          { day: 'Sat', commits: 0 },
+          { day: 'Sun', commits: 0 },
+        ]}
+      />
+    );
+
+    expect(screen.getByText(/No recent activity to display/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Adds isolated tests for CommitClock empty and missing activity scenarios.

## Changes

- Added `CommitClock.empty-fallback.test.tsx`
- Verified fallback UI renders when data is empty
- Verified component header remains visible
- Verified SVG is not rendered without activity
- Verified cycle indicator remains present
- Verified all-zero commit datasets trigger fallback state

Fixes #2503 

## Pillar

- [x] 📐 Pillar 2 — Geometric SVG Improvement
- [x] 🛠️ Other (Bug fix, refactoring, docs)


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
