### PR TITLE
test(StatsCard-timezone-boundaries): verify Timezone Normalization & Calendar Data Boundary Alignment (Variation 8)

### DIFF
--- a/components/dashboard/StatsCard.timezone-boundaries.test.tsx
+++ b/components/dashboard/StatsCard.timezone-boundaries.test.tsx
@@ -1,0 +1,106 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StatsCard from './StatsCard';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, className, ...props }: any) => {
+      delete props.initial;
+      delete props.whileInView;
+      delete props.viewport;
+      delete props.whileHover;
+      delete props.transition;
+
+      return (
+        <div className={className} {...props}>
+          {children}
+        </div>
+      );
+    },
+  },
+}));
+
+vi.mock('lucide-react', () => ({
+  Flame: (props: any) => <div data-testid="icon-flame" {...props} />,
+  TrendingUp: (props: any) => <div data-testid="icon-trending-up" {...props} />,
+  GitCommit: (props: any) => <div data-testid="icon-git-commit" {...props} />,
+  LucideIcon: () => null,
+}));
+
+describe('StatsCard Timezone Boundaries', () => {
+  it('renders leap year UTC date correctly', () => {
+    render(
+      <StatsCard
+        title="Current Streak"
+        value="42"
+        description="Consecutive contribution days"
+        icon="Flame"
+        showUTCDisclaimer
+        utcDate="2024-02-29"
+      />
+    );
+
+    expect(screen.getByText(/UTC Date: 2024-02-29/)).toBeDefined();
+  });
+
+  it('renders daylight saving transition date correctly', () => {
+    render(
+      <StatsCard
+        title="Current Streak"
+        value="42"
+        description="Consecutive contribution days"
+        icon="Flame"
+        showUTCDisclaimer
+        utcDate="2024-03-10"
+      />
+    );
+
+    expect(screen.getByText(/UTC Date: 2024-03-10/)).toBeDefined();
+  });
+
+  it('renders end of year boundary date correctly', () => {
+    render(
+      <StatsCard
+        title="Current Streak"
+        value="42"
+        description="Consecutive contribution days"
+        icon="Flame"
+        showUTCDisclaimer
+        utcDate="2024-12-31"
+      />
+    );
+
+    expect(screen.getByText(/UTC Date: 2024-12-31/)).toBeDefined();
+  });
+
+  it('renders new year boundary date correctly', () => {
+    render(
+      <StatsCard
+        title="Current Streak"
+        value="42"
+        description="Consecutive contribution days"
+        icon="Flame"
+        showUTCDisclaimer
+        utcDate="2025-01-01"
+      />
+    );
+
+    expect(screen.getByText(/UTC Date: 2025-01-01/)).toBeDefined();
+  });
+
+  it('preserves UTC date string exactly without modification', () => {
+    render(
+      <StatsCard
+        title="Current Streak"
+        value="42"
+        description="Consecutive contribution days"
+        icon="Flame"
+        showUTCDisclaimer
+        utcDate="2024-06-15"
+      />
+    );
+
+    expect(screen.getByText('UTC Date: 2024-06-15')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2630 

Added test coverage for timezone-related calendar date boundary rendering in `StatsCard`.

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

- N/A (test-only change)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.

## Changes Made

- Created `components/dashboard/StatsCard.timezone-boundaries.test.tsx`
- Added leap year boundary date test coverage
- Added daylight saving transition date rendering coverage
- Added year-end calendar boundary validation
- Added new-year calendar boundary validation
- Verified UTC date strings are rendered without modification

## Result

- Improves coverage around timezone-related date boundary scenarios
- Verifies UTC date rendering remains stable across calendar edge cases
- Helps prevent regressions in date display behavior
- All newly added tests pass successfully
