### PR TITLE
Improve back to top button UX

### DIFF
--- a/components/ReturnToTop.tsx
+++ b/components/ReturnToTop.tsx
@@ -1,101 +1,134 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { useEffect, useState } from 'react';
+import {
+  AnimatePresence,
+  motion,
+  useReducedMotion,
+  useScroll,
+  useSpring,
+  useTransform,
+} from 'framer-motion';
 import { ChevronUp } from 'lucide-react';
 
 export default function ReturnToTop() {
   const [isVisible, setIsVisible] = useState(false);
-  const [scrollProgress, setScrollProgress] = useState(0);
+  const shouldReduceMotion = useReducedMotion();
+
+  const { scrollYProgress } = useScroll();
+
+  const smoothScrollProgress = useSpring(scrollYProgress, {
+    stiffness: 120,
+    damping: 24,
+    mass: 0.2,
+  });
+
+  const radius = 22;
+  const circumference = 2 * Math.PI * radius;
+
+  const strokeDashoffset = useTransform(smoothScrollProgress, [0, 1], [circumference, 0]);
 
   useEffect(() => {
-    const toggleVisibility = () => {
-      const scrollHeight = document.documentElement.scrollHeight;
-      const scrollTop = window.scrollY;
-      const clientHeight = window.innerHeight;
-
-      // Existing visibility logic
-      setIsVisible(scrollHeight - (scrollTop + clientHeight) < 300);
-
-      // Scroll progress calculation
-      const progress = (scrollTop / (scrollHeight - clientHeight)) * 100;
-
-      setScrollProgress(Math.min(Math.max(progress, 0), 100));
+    const updateVisibility = () => {
+      setIsVisible(window.scrollY > 300);
     };
 
-    toggleVisibility();
-    window.addEventListener('scroll', toggleVisibility, { passive: true });
+    updateVisibility();
 
-    return () => window.removeEventListener('scroll', toggleVisibility);
+    window.addEventListener('scroll', updateVisibility, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', updateVisibility);
+    };
   }, []);
 
   const scrollToTop = () => {
     window.scrollTo({
       top: 0,
-      behavior: 'smooth',
+      behavior: shouldReduceMotion ? 'auto' : 'smooth',
     });
   };
-
-  // SVG ring values
-  const radius = 24;
-  const circumference = 2 * Math.PI * radius;
-
-  const strokeDashoffset = circumference - (scrollProgress / 100) * circumference;
 
   return (
     <AnimatePresence>
       {isVisible && (
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: 20 }}
-          transition={{ duration: 0.3 }}
-          className="fixed bottom-8 right-8 z-50"
+          initial={{ opacity: 0, y: 18, scale: 0.96 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: 18, scale: 0.96 }}
+          transition={{ duration: 0.22, ease: 'easeOut' }}
+          className="fixed bottom-6 right-6 z-50 sm:bottom-8 sm:right-8"
         >
-          <div className="relative flex items-center justify-center">
-            {/* Progress Ring */}
-            <svg className="absolute -rotate-90" width="64" height="64" aria-hidden="true">
-              {/* Track */}
+          <motion.button
+            type="button"
+            onClick={scrollToTop}
+            whileHover={shouldReduceMotion ? undefined : { y: -2 }}
+            whileTap={shouldReduceMotion ? undefined : { scale: 0.96 }}
+            aria-label="Back to top"
+            className="
+              group relative flex h-14 w-14 items-center justify-center rounded-full
+              border border-violet-400/45 bg-zinc-950/80 text-violet-300
+              shadow-[0_0_24px_rgba(167,139,250,0.16)]
+              backdrop-blur-md transition-all duration-200
+              hover:border-violet-300 hover:bg-violet-950/35 hover:text-violet-200
+              hover:shadow-[0_0_28px_rgba(167,139,250,0.28)]
+              active:translate-y-0
+              focus-visible:outline focus-visible:outline-2
+              focus-visible:outline-offset-4 focus-visible:outline-violet-400
+            "
+          >
+            {!shouldReduceMotion && (
+              <span className="absolute inset-0 rounded-full border border-violet-400/35 opacity-70 animate-ping" />
+            )}
+
+            <svg
+              aria-hidden="true"
+              width="58"
+              height="58"
+              viewBox="0 0 58 58"
+              className="absolute -rotate-90"
+            >
               <circle
-                cx="32"
-                cy="32"
+                cx="29"
+                cy="29"
                 r={radius}
                 fill="none"
                 stroke="currentColor"
-                strokeWidth="3"
-                className="text-emerald-500/15 dark:text-emerald-400/15"
+                strokeWidth="2"
+                className="text-violet-400/15"
               />
 
-              {/* Progress */}
-              <circle
-                cx="32"
-                cy="32"
+              <motion.circle
+                cx="29"
+                cy="29"
                 r={radius}
                 fill="none"
                 stroke="currentColor"
-                strokeWidth="3"
+                strokeWidth="2"
                 strokeLinecap="round"
-                className="text-emerald-500 dark:text-emerald-400 transition-all duration-100"
                 strokeDasharray={circumference}
-                strokeDashoffset={strokeDashoffset}
+                style={{ strokeDashoffset }}
+                className="text-violet-300"
               />
             </svg>
 
-            {/* Existing Button */}
-            <button
-              onClick={scrollToTop}
-              className={
-                'relative p-3 rounded-full border border-emerald-500/20 bg-white ' +
-                'text-emerald-600 hover:bg-emerald-500 hover:text-white ' +
-                'hover:border-emerald-500 dark:border-emerald-400/20 ' +
-                'dark:bg-slate-900 dark:text-emerald-400 dark:hover:bg-emerald-600 ' +
-                'dark:hover:text-white transition-colors duration-200'
-              }
-              aria-label="Return to top"
+            <motion.span
+              aria-hidden="true"
+              animate={shouldReduceMotion ? undefined : { y: [0, -3, 0] }}
+              transition={{
+                duration: 1.6,
+                repeat: Infinity,
+                ease: 'easeInOut',
+              }}
+              className="relative z-10"
             >
-              <ChevronUp size={24} />
-            </button>
-          </div>
+              <ChevronUp
+                size={23}
+                strokeWidth={2.4}
+                className="transition-transform duration-200 group-hover:-translate-y-0.5"
+              />
+            </motion.span>
+          </motion.button>
         </motion.div>
       )}
     </AnimatePresence>


### PR DESCRIPTION
## Description

This PR improves the Back to Top button UX on the landing page.

Fixes #2469

Changes include:
- Button now appears only after the user scrolls past 300px
- Added smooth entrance and exit animation
- Updated styling to match the CommitPulse dark/violet theme
- Added violet accent border and glow states
- Added animated upward arrow and pulse effect
- Added smooth scroll-to-top behavior
- Improved accessibility with `aria-label`, keyboard focus styles, and reduced motion support
- Added a smooth scroll progress ring using Framer Motion scroll values

## Pillar

UI / Enhancement

## Checklist

- [x] I have read the contribution guidelines
- [x] My code follows the project style
- [x] I have tested the changes locally
- [x] This PR fixes a linked issue
- [x] I have kept the changes focused and minimal

## Screenshot 
<img width="1920" height="888" alt="Screenshot (631)" src="https://github.com/user-attachments/assets/a0777552-9f3b-4d82-8be0-42e3d5a501ca" />
<img width="1920" height="891" alt="Screenshot (632)" src="https://github.com/user-attachments/assets/52e8283d-0a1f-4353-84a6-0231687f1e56" />
