### PR TITLE
fix(resume): validate confirm endpoint payload and persist phone

### DIFF
--- a/app/api/student/resume/confirm/route.ts
+++ b/app/api/student/resume/confirm/route.ts
@@ -2,8 +2,8 @@ import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/mongodb';
 import { StudentProfile } from '@/models/StudentProfile';
 import { RateLimiter } from '@/lib/rate-limit';
-import type { ParsedResume } from '@/types/student';
 import { getClientIp } from '@/utils/getClientIp';
+import { resumeConfirmDataSchema, GITHUB_USERNAME_REGEX } from '@/lib/validations';
 
 const confirmLimiter = new RateLimiter(10, 60000);
 
@@ -33,7 +33,12 @@ export async function POST(req: Request) {
     data?: unknown;
   };
 
-  if (!githubUsername || typeof githubUsername !== 'string') {
+  if (
+    !githubUsername ||
+    typeof githubUsername !== 'string' ||
+    githubUsername.trim().length > 39 ||
+    !GITHUB_USERNAME_REGEX.test(githubUsername.trim())
+  ) {
     return NextResponse.json(
       { success: false, error: 'Invalid or missing githubUsername' },
       { status: 400 }
@@ -47,14 +52,22 @@ export async function POST(req: Request) {
     );
   }
 
-  const profileData = data as ParsedResume;
-
-  if (!profileData.name || !profileData.email) {
+  const { name, email } = data as { name?: unknown; email?: unknown };
+  if (!name || !email) {
     return NextResponse.json(
       { success: false, error: 'Name and email are required' },
       { status: 400 }
     );
   }
+
+  const parsed = resumeConfirmDataSchema.safeParse(data);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: parsed.error.issues[0]?.message ?? 'Invalid profile data' },
+      { status: 400 }
+    );
+  }
+  const profile = parsed.data;
 
   try {
     if (!process.env.MONGODB_URI) {
@@ -68,11 +81,12 @@ export async function POST(req: Request) {
       { githubUsername: githubUsername.trim().toLowerCase() },
       {
         $set: {
-          name: profileData.name,
-          email: profileData.email,
-          skills: profileData.skills || [],
-          education: profileData.education || [],
-          experience: profileData.experience || [],
+          name: profile.name,
+          email: profile.email,
+          phone: profile.phone,
+          skills: profile.skills,
+          education: profile.education,
+          experience: profile.experience,
           updatedAt: new Date(),
         },
       },

--- a/app/api/student/resume/tests/confirm.test.ts
+++ b/app/api/student/resume/tests/confirm.test.ts
@@ -135,4 +135,93 @@ describe('POST /api/student/resume/confirm', () => {
     expect(response.status).toBe(500);
     expect(body.error).toBe('Failed to save profile data');
   });
+
+  it('returns 400 when githubUsername has an invalid format', async () => {
+    const response = await POST(
+      makeRequest({
+        githubUsername: 'bad user!',
+        data: { name: 'John Doe', email: 'john@example.com' },
+      })
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid or missing githubUsername');
+  });
+
+  it('returns 400 when email format is invalid', async () => {
+    const response = await POST(
+      makeRequest({
+        githubUsername: 'testuser',
+        data: { name: 'John Doe', email: 'not-an-email' },
+      })
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid email address');
+  });
+
+  it('returns 400 when name exceeds the length cap', async () => {
+    const response = await POST(
+      makeRequest({
+        githubUsername: 'testuser',
+        data: { name: 'a'.repeat(101), email: 'john@example.com' },
+      })
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Name must be at most 100 characters');
+  });
+
+  it('returns 400 when skills exceed the array cap', async () => {
+    const response = await POST(
+      makeRequest({
+        githubUsername: 'testuser',
+        data: {
+          name: 'John Doe',
+          email: 'john@example.com',
+          skills: Array.from({ length: 101 }, () => 'x'),
+        },
+      })
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Too many skills (max 100)');
+  });
+
+  it('persists the parsed phone number, trims skills, and drops empty rows', async () => {
+    process.env.MONGODB_URI = 'mongodb://localhost:27017/test';
+
+    vi.mocked(StudentProfile.findOneAndUpdate).mockResolvedValueOnce({} as never);
+
+    const response = await POST(
+      makeRequest({
+        githubUsername: 'TestUser',
+        data: {
+          name: 'John Doe',
+          email: 'john@example.com',
+          phone: '+1 555 123 4567',
+          skills: ['  TypeScript  ', ''],
+          education: [{ institution: '', degree: '', field: '', startDate: '', endDate: '' }],
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    const call = vi.mocked(StudentProfile.findOneAndUpdate).mock.calls[0];
+    const setArg = call[1] as { $set: Record<string, unknown> };
+
+    expect(call[0]).toEqual({ githubUsername: 'testuser' });
+    expect(setArg.$set.phone).toBe('+1 555 123 4567');
+    expect(setArg.$set.skills).toEqual(['TypeScript']);
+    expect(setArg.$set.education).toEqual([]);
+  });
 });

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -575,6 +575,58 @@ export const notifyGetSchema = z.object({
     }),
 });
 
+const resumeTextField = (max: number) => z.string().trim().max(max).default('');
+
+export const resumeConfirmDataSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, { message: 'Name and email are required' })
+    .max(100, { message: 'Name must be at most 100 characters' }),
+  email: z
+    .string()
+    .trim()
+    .min(1, { message: 'Name and email are required' })
+    .max(254, { message: 'Email must be at most 254 characters' })
+    .email({ message: 'Invalid email address' }),
+  phone: z.string().trim().max(40, { message: 'Phone must be at most 40 characters' }).default(''),
+  skills: z
+    .array(z.string().trim().max(80, { message: 'Each skill must be at most 80 characters' }))
+    .max(100, { message: 'Too many skills (max 100)' })
+    .default([])
+    .transform((items) => items.filter((s) => s.length > 0)),
+  education: z
+    .array(
+      z.object({
+        institution: resumeTextField(200),
+        degree: resumeTextField(200),
+        field: resumeTextField(200),
+        startDate: resumeTextField(50),
+        endDate: resumeTextField(50),
+      })
+    )
+    .max(50, { message: 'Too many education entries (max 50)' })
+    .default([])
+    .transform((items) =>
+      items.filter((e) => e.institution || e.degree || e.field || e.startDate || e.endDate)
+    ),
+  experience: z
+    .array(
+      z.object({
+        company: resumeTextField(200),
+        role: resumeTextField(200),
+        startDate: resumeTextField(50),
+        endDate: resumeTextField(50),
+        description: resumeTextField(2000),
+      })
+    )
+    .max(50, { message: 'Too many experience entries (max 50)' })
+    .default([])
+    .transform((items) =>
+      items.filter((x) => x.company || x.role || x.startDate || x.endDate || x.description)
+    ),
+});
+
 export type StreakParams = z.infer<typeof streakParamsSchema>;
 export type GithubParams = z.infer<typeof githubParamsSchema>;
 export type CompareParams = z.infer<typeof compareParamsSchema>;
@@ -583,3 +635,4 @@ export type StatsParams = z.infer<typeof statsParamsSchema>;
 export type WrappedParams = z.infer<typeof wrappedParamsSchema>;
 export type NotifyPostParams = z.infer<typeof notifyPostSchema>;
 export type NotifyGetParams = z.infer<typeof notifyGetSchema>;
+export type ResumeConfirmData = z.infer<typeof resumeConfirmDataSchema>;


### PR DESCRIPTION
## Description

Fixes #3483

Hardens the resume profile confirm endpoint (`app/api/student/resume/confirm/route.ts`) so it validates and bounds the payload before writing to MongoDB, instead of storing whatever the client sends after only a truthy name/email check.

Changes:

- Added a `resumeConfirmDataSchema` (zod) in `lib/validations.ts` that validates the email format, caps the lengths of name, email, phone and every education/experience field, caps the sizes of the skills, education and experience arrays, trims values, and drops fully empty skill, education and experience entries.
- Validated `githubUsername` against the existing `GITHUB_USERNAME_REGEX` and the 39 character GitHub limit before it is used as the unique key, matching the other username-bearing endpoints.
- Persisted the parsed `phone` number, which the model already supports but the route previously dropped.

Note on approach: I kept zod as the validation gate rather than enabling Mongoose `runValidators`. The `StudentProfile` education and experience subschemas mark every field `required`, while the parser and the edit form routinely produce partial rows, so enabling `runValidators` would reject legitimate saves. zod now bounds and shapes the data, and empty rows are dropped before the write.

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

Not applicable. This is a backend API change with no visual output.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (added and ran unit tests for the confirm route; the validations suite and `tsc --noEmit` also pass).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable, no SVG output in this change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
