### PR TITLE
Fix username placeholder in customization studio

### DIFF
--- a/app/customize/components/ControlsPanel.test.tsx
+++ b/app/customize/components/ControlsPanel.test.tsx
@@ -78,6 +78,13 @@ describe('ControlsPanel Component', () => {
     expect(input).toHaveAttribute('id', 'username-input');
   });
 
+  it('renders a generic username placeholder', () => {
+    render(<ControlsPanel {...defaultProps} />);
+
+    expect(screen.getByPlaceholderText('your-github-username')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('jhasourav07')).not.toBeInTheDocument();
+  });
+
   it('calls onUsernameChange when typing', () => {
     render(<ControlsPanel {...defaultProps} />);
 

--- a/app/customize/components/ControlsPanel.tsx
+++ b/app/customize/components/ControlsPanel.tsx
@@ -145,7 +145,7 @@ export function ControlsPanel({
             type="text"
             value={username}
             onChange={(e) => onUsernameChange(e.target.value)}
-            placeholder="jhasourav07"
+            placeholder="your-github-username"
             className="w-full bg-white/60 backdrop-blur-md border border-black/10 dark:bg-black/40 dark:border-white/10 rounded-xl px-4 py-2.5 text-sm font-mono text-black dark:text-emerald-300 placeholder:text-gray-400 dark:placeholder:text-white/60 outline-none focus:border-emerald-500/50 transition-all duration-300"
           />
         </ControlRow>


### PR DESCRIPTION
## Description

Fixes #2471

Updated the GitHub Username input placeholder in the Customization Studio from the hardcoded creator username `jhasourav07` to the generic hint `your-github-username`.

This makes it clear that the field is empty and waiting for the user to enter their own GitHub username.

## Changes include

- [x] Bug fix

## How Has This Been Tested?

- [x] Ran focused component test:
  `npm.cmd test -- app/customize/components/ControlsPanel.test.tsx`
- [x] Ran TypeScript typecheck:
  `npm.cmd run typecheck`

## Pillar

UI / Enhancement

## Checklist

- [x] My code follows the project style
- [x] I have added/updated tests for this change
- [x] Existing tests pass locally
- [x] This PR fixes issue #2471