### PR TITLE
test(commitpulse-logo): add responsive breakpoint coverage

### DIFF
--- a/components/commitpulse-logo.responsive-breakpoints.test.tsx
+++ b/components/commitpulse-logo.responsive-breakpoints.test.tsx
@@ -1,0 +1,61 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it } from 'vitest';
+import { CommitPulseLogo } from './commitpulse-logo';
+
+describe('CommitPulseLogo responsive breakpoints', () => {
+  it('renders the default compact mobile-safe logo size', () => {
+    const { container } = render(<CommitPulseLogo />);
+    const logo = container.querySelector('svg');
+
+    expect(logo).toBeInTheDocument();
+    expect(logo).toHaveClass('h-5');
+    expect(logo).toHaveClass('w-5');
+  });
+
+  it('accepts responsive width and height classes for mobile-to-desktop scaling', () => {
+    const { container } = render(
+      <CommitPulseLogo className="h-6 w-6 sm:h-7 sm:w-7 md:h-8 md:w-8" />
+    );
+    const logo = container.querySelector('svg');
+
+    expect(logo).toBeInTheDocument();
+    expect(logo).toHaveClass('h-6');
+    expect(logo).toHaveClass('w-6');
+    expect(logo).toHaveClass('sm:h-7');
+    expect(logo).toHaveClass('sm:w-7');
+    expect(logo).toHaveClass('md:h-8');
+    expect(logo).toHaveClass('md:w-8');
+  });
+
+  it('keeps scalable svg viewport dimensions for responsive rendering', () => {
+    const { container } = render(<CommitPulseLogo />);
+    const logo = container.querySelector('svg');
+
+    expect(logo).toBeInTheDocument();
+    expect(logo).toHaveAttribute('viewBox', '0 0 24 24');
+    expect(logo).not.toHaveAttribute('width');
+    expect(logo).not.toHaveAttribute('height');
+  });
+
+  it('avoids absolute layout classes that can cause mobile overflow', () => {
+    const { container } = render(<CommitPulseLogo className="h-5 w-5 shrink-0" />);
+    const logo = container.querySelector('svg');
+
+    expect(logo).toBeInTheDocument();
+    expect(logo).toHaveClass('shrink-0');
+    expect(logo).not.toHaveClass('min-w-screen');
+    expect(logo).not.toHaveClass('w-screen');
+    expect(logo).not.toHaveClass('fixed');
+  });
+
+  it('preserves decorative accessibility while scaling across viewports', () => {
+    const { container } = render(<CommitPulseLogo className="h-5 w-5 sm:h-6 sm:w-6" />);
+    const logo = container.querySelector('svg');
+
+    expect(logo).toBeInTheDocument();
+    expect(logo).toHaveAttribute('aria-hidden', 'true');
+    expect(logo).toHaveClass('sm:h-6');
+    expect(logo).toHaveClass('sm:w-6');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2669

Adds responsive breakpoint test coverage for `CommitPulseLogo`.

The new test suite verifies:

- Default logo dimensions render correctly for compact layouts
- Responsive Tailwind size classes are applied across breakpoints
- SVG viewport remains scalable across device sizes
- Layout avoids absolute sizing patterns that can cause overflow on small screens
- Decorative accessibility attributes remain intact while scaling responsively

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.