### PR TITLE
fix(resume): verify uploaded file signature against declared type

### DIFF
--- a/app/api/student/resume/tests/upload.test.ts
+++ b/app/api/student/resume/tests/upload.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { POST } from '../upload/route';
+
+vi.mock('@/lib/rate-limit', () => {
+  class MockRateLimiter {
+    check = vi.fn().mockResolvedValue(true);
+  }
+
+  return {
+    RateLimiter: MockRateLimiter,
+  };
+});
+
+// Build the handler request directly from a real File/FormData so the file bytes are
+// preserved (the multipart transport itself is Next.js's responsibility, not this route's).
+function makeUploadRequest(content: string | number[], type: string, name = 'resume.pdf'): Request {
+  const data = typeof content === 'string' ? content : new Uint8Array(content);
+  const file = new File([data], name, { type });
+  const form = new FormData();
+  form.append('resume', file);
+
+  return {
+    headers: new Headers(),
+    formData: async () => form,
+  } as unknown as Request;
+}
+
+describe('POST /api/student/resume/upload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 400 for a disallowed mime type', async () => {
+    const response = await POST(makeUploadRequest('hello', 'text/html', 'note.html'));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Invalid file type');
+  });
+
+  it('returns 400 when content does not match the declared PDF type', async () => {
+    const response = await POST(
+      makeUploadRequest('<!DOCTYPE html><html></html>', 'application/pdf', 'evil.pdf')
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('does not match');
+  });
+
+  it('accepts a file whose bytes match the declared PDF type', async () => {
+    const response = await POST(
+      makeUploadRequest('%PDF-1.7\nJohn Doe\njohn@example.com', 'application/pdf')
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toBeDefined();
+  });
+});

--- a/app/api/student/resume/upload/route.ts
+++ b/app/api/student/resume/upload/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from 'next/server';
-import { parseResume, ALLOWED_MIME_TYPES, MAX_FILE_SIZE } from '@/lib/resume-parser';
+import {
+  parseResume,
+  ALLOWED_MIME_TYPES,
+  MAX_FILE_SIZE,
+  hasValidFileSignature,
+} from '@/lib/resume-parser';
 import { RateLimiter } from '@/lib/rate-limit';
 import { getClientIp } from '@/utils/getClientIp';
 
@@ -51,6 +56,18 @@ export async function POST(req: Request) {
 
   try {
     const buffer = Buffer.from(await file.arrayBuffer());
+
+    if (!hasValidFileSignature(buffer, file.type)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            'File content does not match its type. Only genuine PDF or DOCX files are accepted.',
+        },
+        { status: 400 }
+      );
+    }
+
     const parsed = await parseResume(buffer, file.type);
 
     return NextResponse.json({

--- a/lib/resume-parser.signature.test.ts
+++ b/lib/resume-parser.signature.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { hasValidFileSignature } from './resume-parser';
+
+const PDF = 'application/pdf';
+const DOCX = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+const DOC = 'application/msword';
+
+describe('hasValidFileSignature', () => {
+  it('accepts a real PDF signature', () => {
+    expect(hasValidFileSignature(Buffer.from('%PDF-1.7\nstream'), PDF)).toBe(true);
+  });
+
+  it('rejects HTML content disguised as a PDF', () => {
+    expect(hasValidFileSignature(Buffer.from('<!DOCTYPE html><html></html>'), PDF)).toBe(false);
+  });
+
+  it('accepts a DOCX (zip) signature', () => {
+    expect(hasValidFileSignature(Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x14]), DOCX)).toBe(true);
+  });
+
+  it('rejects non-zip content disguised as a DOCX', () => {
+    expect(hasValidFileSignature(Buffer.from('plain text, not a zip'), DOCX)).toBe(false);
+  });
+
+  it('accepts a legacy DOC (OLE2) signature', () => {
+    expect(
+      hasValidFileSignature(Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]), DOC)
+    ).toBe(true);
+  });
+
+  it('rejects an unknown mime type even with valid-looking bytes', () => {
+    expect(hasValidFileSignature(Buffer.from('%PDF-1.7'), 'text/html')).toBe(false);
+  });
+
+  it('rejects a buffer shorter than the signature', () => {
+    expect(hasValidFileSignature(Buffer.from([0x25, 0x50]), PDF)).toBe(false);
+  });
+
+  it('rejects an empty buffer', () => {
+    expect(hasValidFileSignature(Buffer.from([]), PDF)).toBe(false);
+  });
+});

--- a/lib/resume-parser.ts
+++ b/lib/resume-parser.ts
@@ -156,3 +156,22 @@ export const ALLOWED_MIME_TYPES = [
 ];
 
 export const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+// Leading-byte signatures used to reject content that does not match its declared MIME type.
+const FILE_SIGNATURES: Record<string, number[][]> = {
+  'application/pdf': [[0x25, 0x50, 0x44, 0x46, 0x2d]],
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': [
+    [0x50, 0x4b, 0x03, 0x04],
+    [0x50, 0x4b, 0x05, 0x06],
+    [0x50, 0x4b, 0x07, 0x08],
+  ],
+  'application/msword': [[0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]],
+};
+
+export function hasValidFileSignature(buffer: Buffer, mimeType: string): boolean {
+  const signatures = FILE_SIGNATURES[mimeType];
+  if (!signatures) return false;
+  return signatures.some(
+    (sig) => buffer.length >= sig.length && sig.every((byte, index) => buffer[index] === byte)
+  );
+}


### PR DESCRIPTION
## Description

Fixes #3513

Adds server-side file-signature (magic-byte) verification to the resume upload endpoint, so a file is only accepted when its actual bytes match its declared MIME type. Previously the client-controlled `file.type` header was the only gate, so any content (for example an HTML or text file) labelled with an allowed type was accepted and parsed.

Changes:

- Added `hasValidFileSignature(buffer, mimeType)` to `lib/resume-parser.ts`, which checks the file's leading bytes against the accepted types: PDF (`%PDF-`), DOCX / OOXML (ZIP `PK` signatures), and legacy DOC (OLE2).
- The upload route now rejects with `400` when the bytes do not match the declared type, before parsing.
- Implemented as a plain byte check with no new dependency, to fit the existing codebase.
- Added unit tests for the signature helper and route-level tests for the reject and accept paths.

Note on scope: for DOCX this confirms a valid ZIP container (the OOXML wrapper); it does not unzip to confirm the inner Word parts, which would require a heavier parser. It still rejects non-document content disguised with a document MIME type, which is the reported gap.

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

Not applicable. This is a backend API change with no visual output.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (added unit tests for the signature helper and the upload route; the resume-parser suite and `tsc --noEmit` also pass).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable, no SVG output in this change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
