### PR TITLE
fix(svg): escape data-derived strings in wrapped badge

### DIFF
--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -1148,7 +1148,7 @@ export function generateWrappedSVG(
   aria-describedby="cp-desc-${safeId}"
 >
   <title id="cp-title-${safeId}">${safeUser}'s GitHub Wrapped ${year}</title>
-  <desc id="cp-desc-${safeId}">GitHub Wrapped stats for ${safeUser} in ${year}: ${stats.totalContributions} total contributions, top language is ${stats.topLanguage || 'Unknown'}, busiest month is ${stats.busiestMonth || 'Unknown'}.</desc>
+  <desc id="cp-desc-${safeId}">GitHub Wrapped stats for ${safeUser} in ${year}: ${stats.totalContributions} total contributions, top language is ${escapeXML(stats.topLanguage || 'Unknown')}, busiest month is ${escapeXML(stats.busiestMonth || 'Unknown')}.</desc>
   <defs>
     ${filterGlow}
   </defs>
@@ -1214,7 +1214,7 @@ export function generateWrappedSVG(
   <g transform="translate(210, 80)">
     <g transform="translate(0, 20)">
       <text x="0" y="0" class="grid-label" ${textClass}>TOP LANGUAGE</text>
-      <text x="0" y="20" class="grid-val" ${accentClass}>${stats.topLanguage || 'Unknown'}</text>
+      <text x="0" y="20" class="grid-val" ${accentClass}>${escapeXML(stats.topLanguage || 'Unknown')}</text>
     </g>
 
     <g transform="translate(130, 20)">
@@ -1233,14 +1233,14 @@ export function generateWrappedSVG(
     <text x="0" y="0" class="grid-label" ${textClass}>PEAK DAY</text>
     <text x="0" y="20" class="grid-val" ${textClass}>
       ${stats.highestDailyCount} COMMITS
-      <tspan font-size="10.5" font-weight="500" ${accentClass} opacity="0.8">ON ${formattedPeakDate.toUpperCase()}</tspan>
+      <tspan font-size="10.5" font-weight="500" ${accentClass} opacity="0.8">ON ${escapeXML(formattedPeakDate.toUpperCase())}</tspan>
     </text>
   </g>
 
   <g transform="translate(210, 205)">
     <text x="0" y="0" class="grid-label" ${textClass}>BUSIEST MONTH</text>
     <text x="0" y="20" class="grid-val" ${textClass}>
-      ${monthName}
+      ${escapeXML(monthName)}
       <tspan font-size="11" font-weight="500" ${accentClass}>🔥</tspan>
     </text>
   </g>

--- a/lib/svg/generator.wrappedEscape.test.ts
+++ b/lib/svg/generator.wrappedEscape.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { generateWrappedSVG } from './generator';
+import type { BadgeParams } from '@/types';
+import type { WrappedStats } from '@/types/dashboard';
+
+const params = {
+  user: 'tester',
+  bg: '0d1117',
+  text: 'ffffff',
+  accent: '00ffaa',
+  speed: '8s',
+  scale: 'linear',
+} as unknown as BadgeParams;
+
+const emptyCalendar = { totalContributions: 0, weeks: [] };
+
+function makeStats(overrides: Partial<WrappedStats>): WrappedStats {
+  return {
+    totalContributions: 100,
+    mostActiveDate: '2025-03-15',
+    highestDailyCount: 12,
+    busiestMonth: '2025-03',
+    weekendRatio: 30,
+    topLanguage: 'TypeScript',
+    calendar: emptyCalendar,
+    ...overrides,
+  } as WrappedStats;
+}
+
+describe('generateWrappedSVG escaping', () => {
+  it('escapes XML metacharacters in topLanguage', () => {
+    const stats = makeStats({ topLanguage: 'C++<img src=x onerror=alert(1)>' });
+    const svg = generateWrappedSVG(stats, params, '2025', stats.calendar);
+
+    expect(svg).not.toContain('<img src=x');
+    expect(svg).toContain('C++&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  it('escapes XML metacharacters in busiestMonth and the derived month name', () => {
+    const stats = makeStats({ busiestMonth: '2025-<script>' });
+    const svg = generateWrappedSVG(stats, params, '2025', stats.calendar);
+
+    expect(svg).not.toContain('<script>');
+    expect(svg).toContain('&lt;script&gt;');
+  });
+
+  it('escapes ampersands in the peak date value', () => {
+    const stats = makeStats({ mostActiveDate: 'A&B' });
+    const svg = generateWrappedSVG(stats, params, '2025', stats.calendar);
+
+    expect(svg).toContain('A&amp;B');
+  });
+
+  it('renders ordinary values normally', () => {
+    const stats = makeStats({ topLanguage: 'TypeScript' });
+    const svg = generateWrappedSVG(stats, params, '2025', stats.calendar);
+
+    expect(svg).toContain('TypeScript');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #3522

Makes XML escaping consistent in the GitHub Wrapped SVG. `generateWrappedSVG` already escapes the username, but interpolated several other data-derived strings raw. This wraps them all in the existing `escapeXML` helper so the SVG is always well-formed regardless of input.

Changes (all in `lib/svg/generator.ts`, `generateWrappedSVG`):

- Escape `stats.topLanguage` and `stats.busiestMonth` in the `<desc>` accessibility text.
- Escape `stats.topLanguage` in the TOP LANGUAGE value.
- Escape the derived `monthName` in the BUSIEST MONTH value.
- Escape the formatted peak date (derived from `stats.mostActiveDate`) in the PEAK DAY value.

These values currently come from the GitHub API and do not contain XML metacharacters, so this is a defense-in-depth and consistency fix rather than a fix for a live exploit. Added a unit test covering each escaped field.

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

No visual change for normal inputs. The badge renders identically; only inputs containing XML metacharacters now produce well-formed output instead of raw characters.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (added a unit test for the escaped fields; the full generator suite and `tsc --noEmit` also pass).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no visual change for normal inputs).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
