### PR TITLE
fix(compare): classify upstream errors by unwrapping the cause chain

### DIFF
--- a/app/api/compare/route.test.ts
+++ b/app/api/compare/route.test.ts
@@ -124,4 +124,40 @@ describe('GET /api/compare', () => {
     const data = await res.json();
     expect(data.error).toContain('Unable to fetch GitHub data');
   });
+
+  it('returns 404 when the not-found error is wrapped in a cause chain', async () => {
+    vi.mocked(getFullDashboardData).mockRejectedValueOnce(
+      new Error('[GitHub API] Failed to fetch profile for user "ghost123"', {
+        cause: new Error('User not found'),
+      })
+    );
+
+    const res = await GET(makeRequest('user1=ghost123&user2=octocat'));
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when a rate-limit error is wrapped in a cause chain', async () => {
+    vi.mocked(getFullDashboardData).mockRejectedValueOnce(
+      new Error('[GitHub API] Failed to fetch profile for user "octocat"', {
+        cause: new Error('API Rate Limit Exceeded'),
+      })
+    );
+
+    const res = await GET(makeRequest('user1=octocat&user2=torvalds'));
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 500 when a timeout error is wrapped in a cause chain', async () => {
+    vi.mocked(getFullDashboardData).mockRejectedValueOnce(
+      new Error('[GitHub API] Failed to fetch profile for user "octocat"', {
+        cause: new Error('GitHub API request timed out after 8s'),
+      })
+    );
+
+    const res = await GET(makeRequest('user1=octocat&user2=torvalds'));
+
+    expect(res.status).toBe(500);
+  });
 });

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -5,7 +5,12 @@ import { compareParamsSchema } from '@/lib/validations';
 export const revalidate = 3600;
 
 function buildCompareFetchErrorResponse(user: string, reason: unknown): NextResponse {
-  const message = reason instanceof Error ? reason.message : 'Unknown error';
+  // Unwrap wrapped errors so the underlying cause (not found, rate limit, timeout) drives the status.
+  let err: unknown = reason;
+  while (err instanceof Error && err.cause instanceof Error) {
+    err = err.cause;
+  }
+  const message = err instanceof Error ? err.message : 'Unknown error';
   const lowerMessage = message.toLowerCase();
 
   if (lowerMessage.includes('not found') || lowerMessage.includes('could not resolve')) {
@@ -28,7 +33,7 @@ function buildCompareFetchErrorResponse(user: string, reason: unknown): NextResp
     );
   }
 
-  if (lowerMessage.includes('timeout')) {
+  if (lowerMessage.includes('timeout') || lowerMessage.includes('timed out')) {
     return NextResponse.json(
       { error: `Connection timeout. Unable to fetch GitHub data for "${user}".` },
       { status: 500 }


### PR DESCRIPTION
## Description

Fixes #3528

`/api/compare` mapped almost every upstream GitHub failure to a generic `502`. The cause: `getFullDashboardData` throws a wrapped error (`[GitHub API] Failed to fetch profile for user "<user>"`) with the real error on `.cause`, but `buildCompareFetchErrorResponse` only inspected the wrapper's `.message`, so the not-found / rate-limit / timeout branches never matched on the common profile-fetch failure path.

Changes (in `app/api/compare/route.ts`):

- Unwrap the error `cause` chain before classifying, so the underlying cause drives the status: nonexistent user maps to `404`, rate limit to `403`, timeout to `500`, and any other upstream error to `502`.
- Broaden the timeout branch to also match `timed out`, which is the wording the GitHub client actually throws.

Also added route tests that reject with the wrapped error shape the code throws in production (the existing tests only used flat errors, which is why this slipped through).

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

Not applicable. This is a backend API change with no visual output.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (added wrapped-error route tests; the full compare suite and `tsc --noEmit` also pass).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable, no SVG output in this change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
