### PR TITLE
fix(png): log error server-side and stop leaking raw error text

### DIFF
--- a/app/api/streak/png/route.test.ts
+++ b/app/api/streak/png/route.test.ts
@@ -69,7 +69,8 @@ describe('PNG Route', () => {
     expect(data.error).toBe('Invalid parameters');
   });
 
-  it('handles SVG conversion errors', async () => {
+  it('handles SVG conversion errors without leaking internal error details', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const mockRequest = new Request('http://localhost:3000/api/streak/png?user=testuser');
 
     const mockSvgResponse = new NextResponse('<svg>invalid</svg>', {
@@ -90,5 +91,10 @@ describe('PNG Route', () => {
     expect(response.status).toBe(500);
     const data = await response.json();
     expect(data.error).toBe('Failed to convert SVG to PNG');
+    expect(data.details).toBeUndefined();
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
   });
 });

--- a/app/api/streak/png/route.ts
+++ b/app/api/streak/png/route.ts
@@ -40,9 +40,10 @@ export async function GET(request: Request) {
       headers,
     });
   } catch (err) {
+    console.error('[streak/png] Failed to convert SVG to PNG:', err);
     return NextResponse.json(
-      { error: 'Failed to convert SVG to PNG', details: String(err) },
-      { status: 500 }
+      { error: 'Failed to convert SVG to PNG' },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } }
     );
   }
 }


### PR DESCRIPTION
## Description

Fixes #3531

The PNG route returned `details: String(err)` on failure, leaking raw `@resvg/resvg-js` error text to anonymous callers, and it never logged the error server-side. This aligns it with the SVG route's convention: log the detailed error server-side and return only a generic message.

Changes (in `app/api/streak/png/route.ts`):

- Log the failure with `console.error` so maintainers can diagnose it.
- Return a generic `{ error: 'Failed to convert SVG to PNG' }` with no internal `details`.
- Add `Cache-Control: no-store` to the error response so transient failures are not cached.

Hardened the existing route test to assert no `details` field is returned, that the error is logged, and that the error response is not cached.

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

Not applicable. This is a backend API change with no visual output.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (hardened the PNG route test; it and `tsc --noEmit` pass).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable, no SVG output in this change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
