### PR TITLE
fix(ci): stop echoing raw error message into public issue comment

### DIFF
--- a/.github/scripts/issue-management/main.js
+++ b/.github/scripts/issue-management/main.js
@@ -68,7 +68,7 @@ module.exports = async ({ github, context, core }) => {
         owner,
         repo,
         issue_number: issueNumber,
-        body: `⚠️ An unexpected error occurred while processing your command. Please try again or contact a maintainer.\n\n> \`${error.message}\``,
+        body: `⚠️ An unexpected error occurred while processing your command. Please try again or contact a maintainer.`,
       });
     } catch (_) {}
     core.setFailed(error.message);


### PR DESCRIPTION
## Description

Fixes #3538

The slash-command error handler in `.github/scripts/issue-management/main.js` posted the raw thrown `error.message` into a world-readable issue comment, alongside the maintainer-only `core.error` and `core.setFailed` channels. This removes the leaked detail from the public comment while keeping the full message in the Actions log for maintainers.

Change:

- Drop the `> ${error.message}` suffix from the public comment body (line 71). `core.error` (line 65) and `core.setFailed` (line 74) are unchanged, so maintainers still get the full detail in the Actions log.

Note: the `.github/scripts` directory is excluded from ESLint and has no unit-test harness, so this one-line change is verified by inspection and `prettier`.

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

Not applicable. This is a CI automation change with no visual output.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (verified by inspection and `prettier`; the `.github/scripts` directory is ESLint-excluded and has no unit-test harness).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable, no SVG output in this change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
