### PR TITLE
test: add RefreshButton accessibility test suite

### DIFF
--- a/components/dashboard/RefreshButton.accessibility.test.tsx
+++ b/components/dashboard/RefreshButton.accessibility.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import RefreshButton from './RefreshButton';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useTransition } from 'react';
+
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react');
+  return {
+    ...actual,
+    useTransition: vi.fn(),
+  };
+});
+
+const mockPush = vi.fn();
+const mockReplace = vi.fn();
+const mockRefresh = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  (useRouter as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    push: mockPush,
+    replace: mockReplace,
+    refresh: mockRefresh,
+  });
+
+  (useSearchParams as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    get: () => null,
+    toString: () => '',
+  });
+
+  (useTransition as unknown as ReturnType<typeof vi.fn>).mockReturnValue([
+    false,
+    (cb: () => void) => cb(),
+  ]);
+});
+
+describe('RefreshButton Accessibility', () => {
+  it('has correct aria-label for screen readers', () => {
+    render(<RefreshButton username="testuser" />);
+
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Refresh dashboard contribution data'
+    );
+  });
+
+  it('has correct title attribute for tooltip accessibility', () => {
+    render(<RefreshButton username="testuser" />);
+
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'title',
+      'Refresh dashboard contribution data'
+    );
+  });
+
+  it('is reachable via keyboard focus', () => {
+    render(<RefreshButton username="testuser" />);
+
+    const btn = screen.getByRole('button');
+    btn.focus();
+
+    expect(btn).toHaveFocus();
+  });
+
+  it('is accessible via role', () => {
+    render(<RefreshButton username="testuser" />);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('supports disabled state when pending', () => {
+    (useTransition as unknown as ReturnType<typeof vi.fn>).mockReturnValueOnce([
+      true,
+      (cb: () => void) => cb(),
+    ]);
+
+    render(<RefreshButton username="testuser" />);
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});

--- a/components/dashboard/RefreshButton.test.tsx
+++ b/components/dashboard/RefreshButton.test.tsx
@@ -55,6 +55,22 @@ afterEach(() => {
 });
 
 describe('RefreshButton', () => {
+  it('has correct aria-label for accessibility', () => {
+    render(<RefreshButton username="testuser" />);
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Refresh dashboard contribution data'
+    );
+  });
+
+  it('has correct title attribute for tooltip accessibility', () => {
+    render(<RefreshButton username="testuser" />);
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'title',
+      'Refresh dashboard contribution data'
+    );
+  });
+
   it("renders 'Refresh Data' button text", () => {
     render(<RefreshButton username="testuser" />);
     expect(screen.getByText('Refresh Data')).toBeDefined();


### PR DESCRIPTION
## Description
Adds accessibility test coverage for the RefreshButton component.

Fixes # 2596

## Pillar
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## What changed
- Added aria-label test for screen readers
- Added title attribute test for tooltip accessibility
- Added keyboard focus test
- Added disabled state test when pending

## Visual Preview
N/A

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally
- [x] I have run `npm run format` and `npm run lint` locally
- [x] My commits follow Conventional Commits format
- [x] I have made sure that I have only one commit to merge in this PR
