### PR TITLE
test(CopyRepoButton): add mock integration coverage

### DIFF
--- a/app/components/CopyRepoButton.mock-integrations.test.tsx
+++ b/app/components/CopyRepoButton.mock-integrations.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CopyRepoButton from './CopyRepoButton';
+
+vi.mock('lucide-react', () => ({
+  Copy: () => <svg data-testid="copy-icon" />,
+}));
+
+describe('CopyRepoButton mock integrations', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls the clipboard service when the button is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+
+    render(<CopyRepoButton />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('handles delayed async clipboard resolution', async () => {
+    let resolveClipboard!: () => void;
+
+    const writeText = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveClipboard = resolve;
+        })
+    );
+
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+
+    render(<CopyRepoButton />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('button')).toBeDefined();
+
+    resolveClipboard();
+
+    await waitFor(() => {
+      expect(screen.getByText(/copied/i)).toBeDefined();
+    });
+  });
+
+  it('handles permission denied errors gracefully', async () => {
+    const writeText = vi.fn().mockRejectedValue(new DOMException('Permission denied'));
+
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+
+    render(<CopyRepoButton />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/copy failed/i)).toBeDefined();
+    });
+  });
+
+  it('recovers after a failed copy attempt followed by a successful one', async () => {
+    const writeText = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Clipboard failed'))
+      .mockResolvedValueOnce(undefined);
+
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+
+    render(<CopyRepoButton />);
+
+    const button = screen.getByRole('button');
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText(/copy failed/i)).toBeDefined();
+    });
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText(/copied/i)).toBeDefined();
+    });
+
+    expect(writeText).toHaveBeenCalledTimes(2);
+  });
+
+  it('supports multiple rapid copy attempts without crashing', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+
+    render(<CopyRepoButton />);
+
+    const button = screen.getByRole('button');
+
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledTimes(3);
+    });
+
+    expect(screen.getByRole('button')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2811

### What Changed

Added a new test suite:

`app/components/CopyRepoButton.mock-integrations.test.tsx`

to verify asynchronous service mocking and integration behavior for the `CopyRepoButton` component.

### Tests Added

* Verifies the clipboard service is invoked when the button is clicked.
* Verifies the component correctly handles delayed asynchronous clipboard resolution.
* Verifies permission-denied clipboard failures are handled gracefully.
* Verifies the component can recover from a failed copy attempt followed by a successful copy attempt.
* Verifies multiple rapid copy requests are handled without crashes or unexpected behavior.

### Implementation Details

* Mocked the Clipboard API using Vitest stubs.
* Tested asynchronous success and failure flows without relying on real browser clipboard behavior.
* Verified integration behavior between user interactions and clipboard service calls.
* Ensured repeated requests and recovery scenarios behave correctly.
* Added isolated test coverage without modifying production code.

### Result

The CopyRepoButton component now has dedicated integration-focused coverage for asynchronous clipboard interactions, failure recovery scenarios, and repeated user actions, improving confidence in clipboard-related behavior while keeping tests fast and isolated.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)


## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`vitest run CopyRepoButton.mock-integrations.test.tsx`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
