### PR TITLE
test(LanguageChart): add empty fallback coverage

### DIFF
--- a/components/dashboard/LanguageChart.empty-fallback.test.tsx
+++ b/components/dashboard/LanguageChart.empty-fallback.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import LanguageChart, { buildGradientStops } from './LanguageChart';
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin: string = '';
+  readonly thresholds: ReadonlyArray<number> = [];
+
+  disconnect = vi.fn();
+  observe = vi.fn();
+  takeRecords = vi.fn(() => []);
+  unobserve = vi.fn();
+}
+
+global.IntersectionObserver = MockIntersectionObserver;
+describe('LanguageChart empty fallback', () => {
+  it('renders fallback UI for empty languages array', () => {
+    render(<LanguageChart languages={[]} />);
+
+    expect(screen.getByText('Top Languages')).toBeInTheDocument();
+    expect(screen.getByText('No language data found')).toBeInTheDocument();
+  });
+
+  it('does not render language percentage markers in empty state', () => {
+    render(<LanguageChart languages={[]} />);
+
+    expect(screen.queryByText('%')).not.toBeInTheDocument();
+  });
+
+  it('keeps the fallback layout stable', () => {
+    const { container } = render(<LanguageChart languages={[]} />);
+
+    expect(container.firstChild).toBeInTheDocument();
+    expect(container.textContent).toContain('No language data found');
+  });
+
+  it('does not throw runtime error for empty languages array', () => {
+    expect(() => render(<LanguageChart languages={[]} />)).not.toThrow();
+  });
+
+  it('returns empty gradient stops for empty language data', () => {
+    expect(buildGradientStops([])).toBe('');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2563

Added empty/fallback state test coverage for `LanguageChart`.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`npm run test -- LanguageChart.empty-fallback.test.tsx`).
* [x] I have run `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

## Tests

* Added 5 test cases for `LanguageChart` empty/missing input fallback behavior.
* Verified fallback UI renders without crashing.
* Verified empty layout remains stable.
* Verified no unexpected runtime errors occur.
* Added `IntersectionObserver` mock for test environment stability.
