### PR TITLE
test(RepositoryGraph): empty/missing inputs edge cases (#2603)

### DIFF
--- a/components/dashboard/RepositoryGraph.empty-fallback.test.tsx
+++ b/components/dashboard/RepositoryGraph.empty-fallback.test.tsx
@@ -1,0 +1,118 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import RepositoryGraph from './RepositoryGraph';
+import type { GraphNode, GraphLink } from '@/types';
+
+// Mock next/dynamic so ForceGraph2D renders synchronously and never touches the real canvas library
+vi.mock('next/dynamic', () => {
+  const DynamicForceGraphMock = React.forwardRef((props: any, ref: any) => {
+    React.useImperativeHandle(ref, () => ({
+      centerAt: vi.fn(),
+      zoom: vi.fn(),
+    }));
+
+    return (
+      <div data-testid="force-graph-2d">
+        {props.graphData?.nodes?.map((node: any) => (
+          <span key={node.id} data-testid={`graph-node-${node.id}`}>
+            {node.name}
+          </span>
+        ))}
+      </div>
+    );
+  });
+  DynamicForceGraphMock.displayName = 'ForceGraph2D';
+  return {
+    default: () => DynamicForceGraphMock,
+  };
+});
+
+// Make container dimensions deterministic in jsdom
+Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+  configurable: true,
+  value: 800,
+});
+
+describe('RepositoryGraph - Edge Cases & Empty/Missing Inputs (Variation 1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the fallback UI when nodes array is completely empty', () => {
+    const emptyData = { nodes: [] as GraphNode[], links: [] as GraphLink[] };
+    render(<RepositoryGraph data={emptyData} />);
+
+    // Fallback message must be visible
+    expect(screen.getByText('No repository relationship data available yet.')).toBeDefined();
+
+    // The actual force graph must NOT render
+    expect(screen.queryByTestId('force-graph-2d')).toBeNull();
+  });
+
+  it('renders the fallback UI when only a single User node is provided (nodes.length <= 1)', () => {
+    const singleNodeData = {
+      nodes: [
+        { id: 'user1', name: 'Solo User', type: 'User', val: 30, color: '#FFF' },
+      ] as GraphNode[],
+      links: [] as GraphLink[],
+    };
+    render(<RepositoryGraph data={singleNodeData} />);
+
+    expect(screen.getByText('No repository relationship data available yet.')).toBeDefined();
+    // Header of the full graph view should NOT appear in fallback state
+    expect(screen.queryByText('🌐 Repository Dependency Graph')).toBeNull();
+  });
+
+  it('renders the fallback container with the correct DOM structure and styling markers', () => {
+    const emptyData = { nodes: [] as GraphNode[], links: [] as GraphLink[] };
+    const { container } = render(<RepositoryGraph data={emptyData} />);
+
+    const fallback = container.querySelector('div.border-dashed');
+    // Key DOM markers exist for the empty/fallback state
+    expect(fallback).not.toBeNull();
+    expect(fallback?.className).toContain('rounded-xl');
+    expect(fallback?.className).toContain('flex');
+
+    // The Box icon (lucide-react) should be rendered inside fallback as an svg
+    const icon = fallback?.querySelector('svg');
+    expect(icon).not.toBeNull();
+  });
+
+  it('does not throw runtime errors or hydration failures with missing/empty links', () => {
+    const dataWithMissingLinks = {
+      nodes: [] as GraphNode[],
+      links: [] as GraphLink[],
+    };
+
+    // The render itself must complete without throwing
+    expect(() => render(<RepositoryGraph data={dataWithMissingLinks} />)).not.toThrow();
+    expect(screen.getByText('No repository relationship data available yet.')).toBeDefined();
+  });
+
+  it('keeps fallback UI stable even when nodes contain a single non-User node (still <= 1)', () => {
+    const singleRepoData = {
+      nodes: [
+        {
+          id: 'repo-only',
+          name: 'Lonely Repo',
+          type: 'Repo',
+          val: 10,
+          color: '#FFF',
+          stats: { stars: 0, forks: 0 },
+        },
+      ] as GraphNode[],
+      links: [] as GraphLink[],
+    };
+
+    render(<RepositoryGraph data={singleRepoData} />);
+
+    // Fallback should still show since nodes.length <= 1
+    expect(screen.getByText('No repository relationship data available yet.')).toBeDefined();
+    // No interactive filter buttons should be rendered in fallback state
+    expect(screen.queryByText('Personal')).toBeNull();
+    expect(screen.queryByText('Contributions')).toBeNull();
+    expect(screen.queryByText('Forks')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2603

Added a new isolated test file `components/dashboard/RepositoryGraph.empty-fallback.test.tsx` covering **Edge Cases & Empty/Missing Inputs Verification (Variation 1)** for the `RepositoryGraph` component.

**What's covered (5 test cases):**
- Renders fallback UI when `nodes` array is completely empty
- Renders fallback UI when only a single User node is provided (`nodes.length <= 1`)
- Verifies fallback container has correct DOM structure and styling markers (`border-dashed`, `rounded-xl`, Box icon)
- Ensures no runtime errors or hydration failures with missing/empty links
- Confirms fallback UI stays stable even with a single non-User node

**Test results:**
✓ Test Files  1 passed (1)
✓ Tests       5 passed (5)

Run locally with:
`npx vitest run components/dashboard/RepositoryGraph.empty-fallback.test.tsx`

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

_N/A — this PR only adds a unit test file for the `RepositoryGraph` component. No UI changes._

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.