### PR TITLE
test(dashboard): add CommitClock peak detection tests

### DIFF
--- a/components/dashboard/CommitClock.test.tsx
+++ b/components/dashboard/CommitClock.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import type { ReactNode } from 'react';
-import CommitClock from './CommitClock';
-import type { CommitClockData } from '@/types/dashboard';
 import type React from 'react';
 
-// 1. Mock framer-motion to prevent animation errors during DOM testing
+import CommitClock, { findPeakIndex } from './CommitClock';
+import type { CommitClockData } from '@/types/dashboard';
+
+// Mock framer-motion to prevent animation issues during testing
 vi.mock('framer-motion', () => ({
   AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   motion: {
@@ -17,7 +18,7 @@ vi.mock('framer-motion', () => ({
 }));
 
 describe('CommitClock', () => {
-  // Helper to generate properly typed mock data
+  // Helper function for generating mock weekly data
   const generateMockData = (commits: number): CommitClockData[] => [
     { day: 'Sun', commits },
     { day: 'Mon', commits },
@@ -30,17 +31,21 @@ describe('CommitClock', () => {
 
   it("renders 'Commit Clock' heading", () => {
     render(<CommitClock data={generateMockData(5)} />);
+
     expect(screen.getByRole('heading', { name: /commit clock/i })).toBeDefined();
   });
 
   it("renders 'Weekly activity cycle' subtitle", () => {
     render(<CommitClock data={generateMockData(5)} />);
+
     expect(screen.getByText(/weekly activity cycle/i)).toBeDefined();
   });
 
   it('renders all 7 day labels', () => {
     render(<CommitClock data={generateMockData(5)} />);
+
     const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
     days.forEach((day) => {
       expect(screen.getByText(day)).toBeDefined();
     });
@@ -48,10 +53,85 @@ describe('CommitClock', () => {
 
   it('renders an SVG element', () => {
     const { container } = render(<CommitClock data={generateMockData(5)} />);
+
     expect(container.querySelector('svg')).not.toBeNull();
   });
 
   it('renders with all-zero commit data without crashing', () => {
     expect(() => render(<CommitClock data={generateMockData(0)} />)).not.toThrow();
+  });
+});
+
+describe('findPeakIndex', () => {
+  it('returns 0 for a single item', () => {
+    const data: CommitClockData[] = [
+      {
+        day: 'Mon',
+        commits: 5,
+      },
+    ];
+
+    expect(findPeakIndex(data)).toBe(0);
+  });
+
+  it('returns first index when all values are equal', () => {
+    const data: CommitClockData[] = [
+      {
+        day: 'Mon',
+        commits: 3,
+      },
+      {
+        day: 'Tue',
+        commits: 3,
+      },
+      {
+        day: 'Wed',
+        commits: 3,
+      },
+    ];
+
+    expect(findPeakIndex(data)).toBe(0);
+  });
+
+  it('returns index of clear winner', () => {
+    const data: CommitClockData[] = [
+      {
+        day: 'Mon',
+        commits: 1,
+      },
+      {
+        day: 'Tue',
+        commits: 8,
+      },
+      {
+        day: 'Wed',
+        commits: 2,
+      },
+    ];
+
+    expect(findPeakIndex(data)).toBe(1);
+  });
+
+  it('returns first index when all commits are zero', () => {
+    const data: CommitClockData[] = [
+      {
+        day: 'Mon',
+        commits: 0,
+      },
+      {
+        day: 'Tue',
+        commits: 0,
+      },
+      {
+        day: 'Wed',
+        commits: 0,
+      },
+    ];
+
+    expect(findPeakIndex(data)).toBe(0);
+  });
+
+  it('returns 0 for empty array', () => {
+    expect(findPeakIndex([])).toBe(0);
   });
 });

--- a/components/dashboard/CommitClock.tsx
+++ b/components/dashboard/CommitClock.tsx
@@ -6,6 +6,12 @@ import VisualizationTooltip from './VisualizationTooltip';
 import { getContributionLabel } from './tooltipUtils';
 import { CommitClockData } from '@/types/dashboard';
 
+export function findPeakIndex(data: CommitClockData[]): number {
+  if (data.length === 0) return 0;
+
+  return data.reduce((peak, d, i) => (d.commits > data[peak].commits ? i : peak), 0);
+}
+
 export default function CommitClock({ data }: { data: CommitClockData[] }) {
   const maxCommits = Math.max(...data.map((d) => d.commits), 1);
   const radius = 80;
@@ -13,6 +19,7 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
   const cy = 140;
   const r4 = (n: number) => Math.round(n * 1e4) / 1e4;
   const maxSpokeLength = 42;
+
   const [tooltip, setTooltip] = useState<{
     day: string;
     commits: number;
@@ -21,9 +28,10 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
     y: number;
   } | null>(null);
 
-  // Find the peak day index
-  const peakIndex = data.reduce((peak, d, i) => (d.commits > data[peak].commits ? i : peak), 0);
+  const peakIndex = findPeakIndex(data);
+
   const hasData = data.length > 0 && data.some((d) => d.commits > 0);
+
   const showTooltip = (
     e: React.SyntheticEvent<SVGGElement>,
     day: string,
@@ -76,21 +84,20 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
 
               <style>
                 {`
-    :root {
-      --peak-spoke: #111111;
-      --peak-dot: rgba(17,17,17,0.7);
-      --peak-label: #111111;
-    }
+                  :root {
+                    --peak-spoke: #111111;
+                    --peak-dot: rgba(17,17,17,0.7);
+                    --peak-label: #111111;
+                  }
 
-    .dark {
-      --peak-spoke: #ffffff;
-      --peak-dot: rgba(255,255,255,0.8);
-      --peak-label: #ffffff;
-    }
-  `}
+                  .dark {
+                    --peak-spoke: #ffffff;
+                    --peak-dot: rgba(255,255,255,0.8);
+                    --peak-label: #ffffff;
+                  }
+                `}
               </style>
 
-              {/* Base ring */}
               <circle
                 cx={cx}
                 cy={cy}
@@ -100,7 +107,6 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
                 strokeWidth="18"
               />
 
-              {/* Outer boundary ring */}
               <circle
                 cx={cx}
                 cy={cy}
@@ -110,13 +116,11 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
                 strokeWidth="1"
               />
 
-              {/* Subtle background dial (35 ticks = 7 days * 5 sub-intervals) */}
               {Array.from({ length: 35 }).map((_, i) => {
                 const angle = (i * 360) / 35;
                 const rad = (angle * Math.PI) / 180;
                 const isMain = i % 5 === 0;
 
-                // Main spokes get a full-length faint track, interval ticks are short
                 const tickLength = isMain ? maxSpokeLength : 4;
                 const innerOffset = isMain ? 0 : 4;
 
@@ -134,7 +138,6 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
                 );
               })}
 
-              {/* Spokes — one per day of week */}
               {data.map((d, i) => {
                 const angle = (i * 360) / 7;
                 const length = Math.max((d.commits / maxCommits) * maxSpokeLength, 4);
@@ -142,7 +145,6 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
                 const isPeak = i === peakIndex && d.commits > 0;
                 const rad = (angle * Math.PI) / 180;
 
-                // Scale stroke width: 3px base, up to 6px for peak
                 const strokeW = isPeak ? 6 : isHigh ? 5 : 4;
 
                 const x1 = r4(cx + radius * Math.cos(rad));
@@ -169,6 +171,7 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
                   : isHigh
                     ? 'rgba(180,180,180,0.75)'
                     : 'rgba(120,120,120,0.6)';
+
                 return (
                   <motion.g
                     tabIndex={0}
@@ -196,7 +199,6 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
                       filter={isPeak ? 'url(#spoke-glow)' : undefined}
                     />
 
-                    {/* Dot at the end of each spoke */}
                     {d.commits > 0 && (
                       <circle
                         cx={x2}
@@ -207,7 +209,6 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
                       />
                     )}
 
-                    {/* Day and Commit Count Label (stacked vertically via tspan to avoid side overlaps) */}
                     <text
                       x={labelX}
                       y={labelY}
@@ -220,6 +221,7 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
                       <tspan x={labelX} dy="-2">
                         {d.day}
                       </tspan>
+
                       <tspan
                         x={labelX}
                         dy="10"
@@ -240,7 +242,6 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
             </div>
           )}
 
-          {/* Center label */}
           <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
             <span className="text-[8px] text-gray-400 dark:text-white/60 mt-0.5">CYCLE</span>
             <span className="text-lg font-semibold text-gray-700 dark:text-white/65">7d</span>


### PR DESCRIPTION
## Description

Fixes #338

Extracted the `findPeakIndex` helper from `CommitClock` and added unit tests for peak detection logic.

### Added test coverage for:

* single item
* equal commit values (first index wins)
* clear winner
* all zero commits
* empty array

Component rendering and behavior remain unchanged.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (logic extraction + test coverage only)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
