### PR TITLE
test(RadarChart): empty/missing inputs edge cases (#2583)

### DIFF
--- a/components/dashboard/RadarChart.empty-fallback.test.tsx
+++ b/components/dashboard/RadarChart.empty-fallback.test.tsx
@@ -1,0 +1,112 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import RadarChart from './RadarChart';
+import '@testing-library/jest-dom/vitest';
+
+// Mock framer-motion so animated elements render as plain SVG/HTML synchronously in jsdom
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, className, style, ...props }: any) => {
+      delete props.initial;
+      delete props.animate;
+      delete props.whileInView;
+      delete props.viewport;
+      delete props.transition;
+
+      return (
+        <div className={className} style={style} {...props}>
+          {children}
+        </div>
+      );
+    },
+    polygon: ({ children, className, style, ...props }: any) => {
+      delete props.initial;
+      delete props.animate;
+      delete props.transition;
+
+      return (
+        <polygon className={className} style={style} {...props}>
+          {children}
+        </polygon>
+      );
+    },
+  },
+}));
+
+describe('RadarChart - Edge Cases & Empty/Missing Inputs (Variation 1)', () => {
+  it('renders without throwing when both languagesA and languagesB are completely empty', () => {
+    expect(() =>
+      render(<RadarChart languagesA={[]} languagesB={[]} labelA="User A" labelB="User B" />)
+    ).not.toThrow();
+
+    // Title should still be visible — confirms component mounted cleanly
+    expect(screen.getByText('Language Dominance')).toBeInTheDocument();
+    expect(screen.getByText('Radar Comparison')).toBeInTheDocument();
+  });
+
+  it('does NOT render data vertex circles when all language percentages are missing/zero', () => {
+    const { container } = render(
+      <RadarChart languagesA={[]} languagesB={[]} labelA="User A" labelB="User B" />
+    );
+
+    // No <circle> elements should exist because every padded language has 0% (pct > 0 check fails)
+    const circles = container.querySelectorAll('circle');
+    expect(circles.length).toBe(0);
+  });
+
+  it('falls back to padding languages (TypeScript, JavaScript, Python) to guarantee >= 3 axes', () => {
+    const { container } = render(
+      <RadarChart languagesA={[]} languagesB={[]} labelA="Empty A" labelB="Empty B" />
+    );
+
+    // All three pad languages must appear as axis labels in the SVG
+    expect(screen.getAllByText('TypeScript').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('JavaScript').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Python').length).toBeGreaterThan(0);
+
+    // Exactly 3 axis lines (one per padded language) must be rendered
+    const axisLines = container.querySelectorAll('line[stroke-dasharray="2,2"]');
+    expect(axisLines.length).toBe(3);
+  });
+
+  it('keeps standard SVG layout structure intact (grid rings, filters, svg dimensions) with empty inputs', () => {
+    const { container } = render(
+      <RadarChart languagesA={[]} languagesB={[]} labelA="A" labelB="B" />
+    );
+
+    // SVG should be rendered with the fixed dimensions defined in the component
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '320');
+    expect(svg).toHaveAttribute('height', '300');
+
+    // 4 concentric grid polygons (levels: 25, 50, 75, 100) must always exist
+    const gridPolygons = container.querySelectorAll('polygon[fill="none"]');
+    expect(gridPolygons.length).toBe(4);
+
+    // 2 glow filters (cyan + purple) must remain defined even with no data
+    const filters = container.querySelectorAll('filter');
+    expect(filters.length).toBe(2);
+  });
+
+  it('maintains container styling and legend even when both label sets are empty arrays', () => {
+    const { container } = render(
+      <RadarChart languagesA={[]} languagesB={[]} labelA="Solo A" labelB="Solo B" />
+    );
+
+    // Outer container retains its rounded/border/min-height layout classes
+    const wrapper = container.querySelector('div.rounded-xl');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.className).toContain('min-h-[360px]');
+    expect(wrapper?.className).toContain('border');
+
+    // Legend labels still render so the empty state stays informative
+    expect(screen.getByText('Solo A')).toBeInTheDocument();
+    expect(screen.getByText('Solo B')).toBeInTheDocument();
+
+    // Stats table at the bottom exists (grid-cols-2 layout marker)
+    const statsTable = container.querySelector('.grid.grid-cols-2');
+    expect(statsTable).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2583

Added a new isolated test file `components/dashboard/RadarChart.empty-fallback.test.tsx` covering **Edge Cases & Empty/Missing Inputs Verification (Variation 1)** for the `RadarChart` component.

**What's covered (5 test cases):**
- Renders without throwing when both `languagesA` and `languagesB` are completely empty arrays
- Does NOT render data vertex circles when all language percentages are missing/zero
- Falls back to padding languages (TypeScript, JavaScript, Python) to guarantee ≥ 3 axes
- Keeps standard SVG layout structure intact (grid rings, glow filters, fixed dimensions) with empty inputs
- Maintains container styling and legend even when both label sets are empty arrays

**Test results:**
✓ Test Files  1 passed (1)
✓ Tests       5 passed (5)

Run locally with:
`npx vitest run components/dashboard/RadarChart.empty-fallback.test.tsx`

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

_N/A — this PR only adds a unit test file for the `RadarChart` component. No UI changes._

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.