### PR TITLE
test: add WallOfLove type compiler validation tests

### DIFF
--- a/components/WallOfLove.tsx
+++ b/components/WallOfLove.tsx
@@ -10,7 +10,7 @@ if (typeof window !== 'undefined') {
 }
 
 /* ─── Testimonial Data ─── */
-interface Testimonial {
+export interface Testimonial {
   name: string;
   handle: string;
   avatar: string;

--- a/components/WallOfLove.type-compiler.test.tsx
+++ b/components/WallOfLove.type-compiler.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type { Testimonial } from './WallOfLove';
+
+describe('WallOfLove type compiler validation', () => {
+  it('matches the expected testimonial structure', () => {
+    expectTypeOf<Testimonial>().toMatchObjectType<{
+      name: string;
+      handle: string;
+      avatar: string;
+      message: string;
+      platform: 'twitter' | 'github';
+      accentColor: string;
+    }>();
+  });
+
+  it('enforces string field types', () => {
+    expectTypeOf<Testimonial['name']>().toEqualTypeOf<string>();
+    expectTypeOf<Testimonial['message']>().toEqualTypeOf<string>();
+  });
+
+  it('restricts platform values', () => {
+    expectTypeOf<Testimonial['platform']>().toEqualTypeOf<'twitter' | 'github'>();
+  });
+
+  it('accepts valid testimonial objects', () => {
+    const testimonial: Testimonial = {
+      name: 'Test User',
+      handle: '@test',
+      avatar: 'avatar.png',
+      message: 'Hello',
+      platform: 'twitter',
+      accentColor: '#10b981',
+    };
+
+    expectTypeOf(testimonial).toEqualTypeOf<Testimonial>();
+  });
+
+  it('keeps accentColor typed as string', () => {
+    expectTypeOf<Testimonial['accentColor']>().toEqualTypeOf<string>();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2782 

### Changes Made

* Added `WallOfLove.type-compiler.test.tsx`
* Added TypeScript compiler validation tests using `expectTypeOf`
* Verified `Testimonial` interface structure and field typings
* Verified platform union type constraints (`twitter | github`)
* Exported `Testimonial` interface to enable type-level testing

### Testing

* Ran `npx vitest run components/WallOfLove.type-compiler.test.tsx`
* All type compiler validation tests passed successfully

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable for test-only changes).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
