### PR TITLE
test: add StatsCard theme contrast coverage

### DIFF
--- a/components/dashboard/StatsCard.theme-contrast.test.tsx
+++ b/components/dashboard/StatsCard.theme-contrast.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import StatsCard from './StatsCard';
+
+class IntersectionObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('IntersectionObserver', IntersectionObserverMock);
+
+const renderStatsCard = () =>
+  render(
+    <StatsCard
+      title="Total Commits"
+      value="120"
+      description="Commits this month"
+      icon="GitCommit"
+      showUTCDisclaimer
+      utcDate="2026-06-04"
+      chartData={[20, 40, 60, 80]}
+    />
+  );
+
+const setTheme = (theme: 'dark' | 'light') => {
+  document.documentElement.className = theme === 'dark' ? 'dark' : '';
+};
+
+describe('StatsCard theme contrast', () => {
+  afterEach(() => {
+    document.documentElement.className = '';
+    vi.clearAllMocks();
+  });
+
+  it('renders readable text in light theme', () => {
+    setTheme('light');
+    renderStatsCard();
+
+    expect(screen.getByText('Total Commits')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
+    expect(screen.getByText('Commits this month')).toBeInTheDocument();
+  });
+
+  it('renders readable text in dark theme', () => {
+    setTheme('dark');
+    renderStatsCard();
+
+    expect(screen.getByText('Total Commits')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
+    expect(screen.getByText('Commits this month')).toBeInTheDocument();
+  });
+
+  it('contains light and dark theme contrast classes', () => {
+    const { container } = renderStatsCard();
+
+    const card = container.firstElementChild as HTMLElement;
+
+    expect(card.className).toContain('bg-white');
+    expect(card.className).toContain('dark:bg-[#0a0a0a]');
+    expect(card.className).toContain('border-black/10');
+    expect(card.className).toContain('dark:border-[rgba(255,255,255,0.08)]');
+  });
+
+  it('applies proper text contrast classes', () => {
+    renderStatsCard();
+
+    expect(screen.getByText('120').className).toContain('text-gray-900');
+    expect(screen.getByText('120').className).toContain('dark:text-white');
+    expect(screen.getByText('Total Commits').className).toContain('text-[#A1A1AA]');
+    expect(screen.getByText('Commits this month').className).toContain('text-[#A1A1AA]');
+  });
+
+  it('keeps foreground content inside overflow-hidden card', () => {
+    const { container } = renderStatsCard();
+
+    const card = container.firstElementChild as HTMLElement;
+
+    expect(card.className).toContain('overflow-hidden');
+    expect(screen.getByText('Total Commits')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
+    expect(screen.getByText('UTC Date: 2026-06-04')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2625

Added comprehensive theme contrast tests for `StatsCard` to verify visual cohesion across light and dark color schemes.

### Covered Scenarios

* Light theme text rendering
* Dark theme text rendering
* Theme-specific background and border classes
* Text contrast styling verification
* Foreground content preservation within overflow-hidden containers

### Testing

* Added 5 dedicated Vitest test cases
* Mocked `IntersectionObserver` for Framer Motion compatibility
* Verified theme-related Tailwind classes and content rendering

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test-only contribution)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and resolved formatting issues.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if required.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The changes are focused and do not introduce regressions.
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
