### PR TITLE
test(statscard): add accessibility coverage

### DIFF
--- a/components/dashboard/StatsCard.accessibility.test.tsx
+++ b/components/dashboard/StatsCard.accessibility.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import StatsCard from './StatsCard';
+
+class IntersectionObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('IntersectionObserver', IntersectionObserverMock);
+
+const renderStatsCard = () =>
+  render(
+    <StatsCard
+      title="Total Commits"
+      value="120"
+      description="Commits this month"
+      icon="GitCommit"
+      showUTCDisclaimer
+      utcDate="2026-06-04"
+      chartData={[20, 40, 60, 80]}
+    />
+  );
+
+describe('StatsCard accessibility', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders accessible title, value, and description text', () => {
+    renderStatsCard();
+
+    expect(screen.getByText('Total Commits')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
+    expect(screen.getByText('Commits this month')).toBeInTheDocument();
+  });
+
+  it('renders UTC disclaimer as readable assistive text', () => {
+    renderStatsCard();
+
+    expect(screen.getByText(/Streaks are calculated in UTC/i)).toBeInTheDocument();
+
+    expect(screen.getByText('UTC Date: 2026-06-04')).toBeInTheDocument();
+  });
+
+  it('does not expose decorative chart bars as interactive controls', () => {
+    const { container } = renderStatsCard();
+
+    const chartBars = container.querySelectorAll('.flex-1.bg-black.dark\\:bg-white');
+
+    expect(chartBars.length).toBe(4);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('keeps keyboard tab order clean with no unexpected focusable elements', async () => {
+    const user = userEvent.setup();
+
+    renderStatsCard();
+
+    await user.tab();
+
+    expect(document.body).toHaveFocus();
+  });
+
+  it('uses non-heading text structure without breaking heading hierarchy', () => {
+    renderStatsCard();
+
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+    expect(screen.getByText('Total Commits').tagName.toLowerCase()).toBe('p');
+    expect(screen.getByText('120').tagName.toLowerCase()).toBe('p');
+    expect(screen.getByText('Commits this month').tagName.toLowerCase()).toBe('p');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2626

Added accessibility-focused test coverage for `StatsCard` to verify screen-reader compatibility and accessibility best practices.

### Covered Scenarios

* Accessible rendering of title, value, and description content
* UTC disclaimer accessibility and readable assistive text
* Verification that decorative chart elements are not exposed as interactive controls
* Clean keyboard navigation with no unintended focusable elements
* Validation of logical text structure and heading hierarchy

### Testing

* Added 5 dedicated accessibility test cases
* Mocked `IntersectionObserver` for Framer Motion compatibility
* Verified keyboard navigation and semantic structure
* Confirmed non-interactive decorative elements remain inaccessible to assistive actions

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and resolved formatting issues.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if required.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The changes are focused and do not introduce regressions.
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
