### PR TITLE
test(statscard): add empty fallback coverage

### DIFF
--- a/components/dashboard/StatsCard.empty-fallback.test.tsx
+++ b/components/dashboard/StatsCard.empty-fallback.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import StatsCard from './StatsCard';
+
+class IntersectionObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('IntersectionObserver', IntersectionObserverMock);
+
+const renderStatsCard = (props = {}) =>
+  render(
+    <StatsCard
+      title="Total Commits"
+      value="120"
+      description="Commits this month"
+      icon="GitCommit"
+      {...props}
+    />
+  );
+
+describe('StatsCard empty fallback', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders safely when chartData is an empty array', () => {
+    const { container } = renderStatsCard({ chartData: [] });
+
+    expect(screen.getByText('Total Commits')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
+
+    const fallbackBars = container.querySelectorAll('.flex-1.bg-black.dark\\:bg-white');
+    expect(fallbackBars.length).toBe(12);
+  });
+
+  it('renders safely when chartData is missing', () => {
+    const { container } = renderStatsCard();
+
+    expect(screen.getByText('Commits this month')).toBeInTheDocument();
+
+    const fallbackBars = container.querySelectorAll('.flex-1.bg-black.dark\\:bg-white');
+    expect(fallbackBars.length).toBe(12);
+  });
+
+  it('uses fallback icon when icon name is unknown', () => {
+    renderStatsCard({ icon: 'UnknownIcon' });
+
+    expect(screen.getByText('Total Commits')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
+  });
+
+  it('does not render UTC fallback section when disclaimer is disabled', () => {
+    renderStatsCard({
+      showUTCDisclaimer: false,
+      utcDate: undefined,
+    });
+
+    expect(screen.queryByText(/Streaks are calculated in UTC/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/UTC Date:/i)).not.toBeInTheDocument();
+  });
+
+  it('preserves default card styles in fallback state', () => {
+    const { container } = renderStatsCard({
+      chartData: [],
+      icon: '',
+    });
+
+    const card = container.firstElementChild as HTMLElement;
+
+    expect(card.className).toContain('rounded-xl');
+    expect(card.className).toContain('bg-white');
+    expect(card.className).toContain('dark:bg-[#0a0a0a]');
+    expect(card.className).toContain('overflow-hidden');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2623

Added empty fallback and edge-case test coverage for `StatsCard` to ensure the component remains stable when receiving missing, empty, or unexpected inputs.

### Covered Scenarios

* Rendering with empty `chartData` arrays
* Rendering when `chartData` is undefined
* Fallback behavior for unknown icon names
* Proper handling when UTC disclaimer is disabled
* Preservation of default card styling during fallback states

### Testing

* Added 5 dedicated Vitest test cases
* Mocked `IntersectionObserver` for Framer Motion compatibility
* Verified fallback chart generation logic
* Confirmed no runtime failures occur with missing optional props
* Validated default layout structure and styling

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)


## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and resolved formatting issues.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if required.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The changes are focused and do not introduce regressions.
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
