### PR TITLE
test: add timezone boundary tests for ActivityLandscape

### DIFF
--- a/components/dashboard/ActivityLandscape.timezone-boundaries.test.tsx
+++ b/components/dashboard/ActivityLandscape.timezone-boundaries.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { formatTooltipDate, getLocalActiveStreak, getStreakLabel } from './tooltipUtils';
+
+describe('timezone normalization and calendar boundaries', () => {
+  it('formats UTC boundary date consistently', () => {
+    expect(formatTooltipDate('2024-01-01')).toBe('Jan 1, 2024');
+  });
+
+  it('formats leap year date correctly', () => {
+    expect(formatTooltipDate('2024-02-29')).toBe('Feb 29, 2024');
+  });
+
+  it('formats year-end boundary correctly', () => {
+    expect(formatTooltipDate('2024-12-31')).toBe('Dec 31, 2024');
+  });
+
+  it('calculates streak across consecutive calendar days', () => {
+    const data = [
+      { date: '2024-01-01', count: 1, intensity: 1 as const },
+      { date: '2024-01-02', count: 1, intensity: 1 as const },
+      { date: '2024-01-03', count: 1, intensity: 1 as const },
+    ];
+
+    expect(getLocalActiveStreak(data, 1)).toBe(3);
+  });
+
+  it('returns correct streak label', () => {
+    expect(getStreakLabel(3)).toBe('3-day active streak');
+  });
+});


### PR DESCRIPTION
## Description

This PR adds timezone and calendar boundary test coverage for ActivityLandscape-related utilities.

### Tests Added

* UTC boundary date formatting
* Leap year date formatting
* Year-end boundary date formatting
* Active streak calculation across consecutive days
* Streak label generation

Fixes #2490

## Pillar

Tests

## Checklist

* [x] My code follows the project's coding style
* [x] I have tested my changes locally
* [x] I have not introduced unrelated changes
* [x] All new tests pass locally
* [x] This PR addresses issue #2490
