### PR TITLE
fix(calculate): return 'N/A' instead of empty string for mostActiveDate on empty calendar

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -1889,20 +1889,69 @@ describe('calculateWrappedStats', () => {
 
   // ISSUE OBJECTIVE #1056: Verify empty calendar returns safe zero values
   it('verify empty calendar returns safe zero values', () => {
-    // 1. Call calculateWrappedStats with empty data
     expect(() => calculateWrappedStats({ totalContributions: 0, weeks: [] })).not.toThrow();
-
-    // 2. Actually get the result to test its properties
     const result = calculateWrappedStats({ totalContributions: 0, weeks: [] });
 
-    // 3. Assert weekendRatio === 0 (and specifically not NaN)
+    // weekendRatio must be 0 and not NaN
     expect(result.weekendRatio).toBe(0);
 
-    // 4. Assert highestDailyCount === 0
+    // highestDailyCount must be 0
     expect(result.highestDailyCount).toBe(0);
 
+    // busiestMonth must be 'N/A' — not '' (fixed in PR #2264)
     expect(result.busiestMonth).toBe('N/A');
     expect(result.busiestMonth).not.toBe('');
+
+    // mostActiveDate must be 'N/A' — not '' (this fix)
+    // Regression guard: initialising to { date: '' } silently returns ''
+    // for empty calendars. 'N/A' is the correct explicit fallback.
+    expect(result.mostActiveDate).toBe('N/A');
+    expect(result.mostActiveDate).not.toBe('');
+  });
+
+  it('mostActiveDate is never an empty string regardless of calendar input', () => {
+    // Empty calendar
+    const emptyResult = calculateWrappedStats({ totalContributions: 0, weeks: [] });
+    expect(emptyResult.mostActiveDate).not.toBe('');
+
+    // Active calendar — mostActiveDate should be a real YYYY-MM-DD date
+    const activeResult = calculateWrappedStats({
+      totalContributions: 15,
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 5, date: '2024-06-10' },
+            { contributionCount: 15, date: '2024-06-11' },
+            { contributionCount: 3, date: '2024-06-12' },
+          ],
+        },
+      ],
+    });
+    expect(activeResult.mostActiveDate).toBe('2024-06-11');
+    expect(activeResult.mostActiveDate).not.toBe('');
+    expect(activeResult.mostActiveDate).not.toBe('N/A');
+  });
+
+  it('mostActiveDate returns N/A for empty weeks but real date for active calendar', () => {
+    const emptyResult = calculateWrappedStats({ totalContributions: 0, weeks: [] });
+    expect(emptyResult.mostActiveDate).toBe('N/A');
+
+    // A calendar with all-zero contribution days — loop runs but never
+    // overwrites the initial value since 0 > 0 is false.
+    // mostActiveDate should still be 'N/A' (the initial fallback)
+    const allZeroResult = calculateWrappedStats({
+      totalContributions: 0,
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 0, date: '2024-06-10' },
+            { contributionCount: 0, date: '2024-06-11' },
+          ],
+        },
+      ],
+    });
+    expect(allZeroResult.mostActiveDate).toBe('N/A');
+    expect(allZeroResult.mostActiveDate).not.toBe('');
   });
 
   it('returns busiestMonth as "N/A" for a calendar with all-zero contribution days', () => {

--- a/lib/calculate.ts
+++ b/lib/calculate.ts
@@ -288,7 +288,7 @@ export function calculateWrappedStats(calendar: ContributionCalendar) {
   const weeks = calendar?.weeks || [];
   const days = weeks.flatMap((w) => w?.contributionDays || []);
 
-  let mostActiveDay = { date: '', count: 0 };
+  let mostActiveDay = { date: 'N/A', count: 0 };
   const monthCounts: Record<string, number> = {};
   let weekendCommits = 0;
   let weekdayCommits = 0;


### PR DESCRIPTION
## Description

Fixes #3642 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No SVG visual change. This is a pure data correctness fix in lib/calculate.ts.
GithubWrapped.tsx will now render "N/A" instead of a blank field for users
with zero contributions.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.
