### PR TITLE
Add TypeScript compiler validation tests for GrowthTrendChart

### DIFF
--- a/components/dashboard/GrowthTrendChart.type-compiler.test.tsx
+++ b/components/dashboard/GrowthTrendChart.type-compiler.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { z } from 'zod';
+import GrowthTrendChart from './GrowthTrendChart';
+
+type GrowthTrendChartProps = React.ComponentProps<typeof GrowthTrendChart>;
+
+type ActivityItem = GrowthTrendChartProps['activityA'][number];
+
+describe('GrowthTrendChart type & schema compiler checks (Variation 10)', () => {
+  it('Case 1: Validate baseline property types for all props', () => {
+    expectTypeOf<GrowthTrendChartProps['labelA']>().toEqualTypeOf<string>();
+    expectTypeOf<GrowthTrendChartProps['labelB']>().toEqualTypeOf<string>();
+    expectTypeOf<GrowthTrendChartProps['activityA']>().toEqualTypeOf<ActivityItem[]>();
+    expectTypeOf<GrowthTrendChartProps['activityB']>().toEqualTypeOf<ActivityItem[]>();
+    expectTypeOf<ActivityItem['date']>().toEqualTypeOf<string>();
+    expectTypeOf<ActivityItem['count']>().toEqualTypeOf<number>();
+  });
+
+  it('Case 2: Ensure invalid activity item shapes are blocked during static type checks', () => {
+    type InvalidDateType = { date: number; count: string };
+    expectTypeOf<InvalidDateType>().not.toMatchTypeOf<ActivityItem>();
+
+    type ExtraRequiredField = { date: string; count: number; extra: boolean };
+    expectTypeOf<ExtraRequiredField>().toMatchTypeOf<ActivityItem>();
+  });
+
+  it('Case 3: Verify minimal and complete props shapes are structurally compatible', () => {
+    type MinimalProps = {
+      activityA: Array<{ date: string; count: number }>;
+      activityB: Array<{ date: string; count: number }>;
+      labelA: string;
+      labelB: string;
+    };
+    expectTypeOf<MinimalProps>().toMatchTypeOf<GrowthTrendChartProps>();
+
+    type ExtraProps = MinimalProps & { extraField?: string };
+    expectTypeOf<ExtraProps>().toMatchTypeOf<GrowthTrendChartProps>();
+  });
+
+  it('Case 4: Assert schema validation rejects out-of-bounds activity data with flat error reports', () => {
+    const activitySchema = z
+      .object({
+        date: z.string().min(1),
+        count: z.number().int().nonnegative(),
+      })
+      .strict();
+
+    const outOfBoundsRecord = {
+      date: '',
+      count: -5,
+      extraField: 'unexpected',
+    };
+
+    const result = activitySchema.safeParse(outOfBoundsRecord);
+    expect(result.success).toBe(false);
+
+    if (!result.success) {
+      const flatErrors = result.error.flatten();
+      expect(flatErrors.fieldErrors).toHaveProperty('date');
+      expect(flatErrors.fieldErrors).toHaveProperty('count');
+
+      const hasUnrecognizedExtra = result.error.issues.some(
+        (issue) => issue.code === 'unrecognized_keys' && issue.keys.includes('extraField')
+      );
+      expect(hasUnrecognizedExtra).toBe(true);
+    }
+  });
+
+  it('Case 5: Prove compliant activity data clears validation and preserves type integrity', () => {
+    const activitySchema = z
+      .object({
+        date: z.string().min(1),
+        count: z.number().int().nonnegative(),
+      })
+      .strict();
+
+    const validRecord = { date: '2026-06-03', count: 12 };
+    const parsed = activitySchema.parse(validRecord);
+    expect(parsed).toEqual(validRecord);
+
+    type ParsedType = z.infer<typeof activitySchema>;
+    expectTypeOf<ParsedType>().toMatchTypeOf<ActivityItem>();
+  });
+});


### PR DESCRIPTION
## Description

The `GrowthTrendChart` component in `components/dashboard/GrowthTrendChart.tsx` had no type-level test coverage. Its props interface (`GrowthTrendChartProps` with `activityA`, `activityB`, `labelA`, `labelB`) and the nested `ActivityItem` shape were untested against TypeScript compiler validation or runtime schema constraints, making it possible for type regressions to slip through during API or prop changes.

No test file existed for the component at `components/dashboard/GrowthTrendChart.type-compiler.test.tsx`. The component defines a non-exported `GrowthTrendChartProps` interface and relies on structural typing. Without dedicated type-compiler tests, there was no automated guard ensuring the stability of these type constraints.

Fixes #2552

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

## What changed

- Created `components/dashboard/GrowthTrendChart.type-compiler.test.tsx` with 5 test cases:
  - **Case 1**: Baseline type assertion for each prop field (`string`, `number`, array shapes)
  - **Case 2**: Static compile-time blocking of invalid `ActivityItem` shapes (wrong types, extra optional fields)
  - **Case 3**: Structural compatibility check for minimal and extended props objects
  - **Case 4**: Zod schema rejection of out-of-bounds activity data with flattened error reporting
  - **Case 5**: Valid payload parsing with type-level integrity verification

## How to verify

```bash
git fetch origin
git checkout test/growth-trend-chart-type-compiler
npm run test -- components/dashboard/GrowthTrendChart.type-compiler.test.tsx
```

All 5 tests should pass.
