### PR TITLE
fix(github-api): propagate GraphQL not-found errors and skip badge on…

### DIFF
--- a/app/api/user-details/route.ts
+++ b/app/api/user-details/route.ts
@@ -18,7 +18,13 @@ export async function GET(request: Request) {
   try {
     const [profile, contributions] = await Promise.all([
       fetchUserProfile(username),
-      fetchGitHubContributions(username).catch(() => null),
+      fetchGitHubContributions(username).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : '';
+        // Propagate "not found" so both endpoints agree on user existence.
+        // Swallow transient failures (rate limits, timeouts) and return partial data.
+        if (msg.toLowerCase().includes('not found')) throw err;
+        return null;
+      }),
     ]);
 
     let stats = { currentStreak: 0, longestStreak: 0, totalContributions: 0 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -740,12 +740,7 @@ export default function LandingPage() {
             <div className="relative flex flex-col min-h-[480px] md:min-h-[520px] items-center justify-center overflow-hidden rounded-3xl border border-black/5 bg-white/50 p-8 backdrop-blur-xl shadow-2xl dark:border-white/10 dark:bg-[#0a0a0a]/80">
               {hasUsername ? (
                 <div className="w-full flex flex-col items-center justify-center gap-4">
-                  {!badgeLoaded && !badgeError && (
-                    <div className="h-[240px] w-full max-w-[700px] rounded-2xl bg-black/5 dark:bg-white/5 animate-pulse flex items-center justify-center">
-                      <Loader2 className="animate-spin text-zinc-500" size={32} />
-                    </div>
-                  )}
-                  {badgeError && (
+                  {userDetailsError === 'User not found' ? (
                     <div className="flex flex-col items-center justify-center gap-4 py-12 text-center">
                       <div className="flex h-16 w-16 items-center justify-center rounded-3xl border border-red-500/20 bg-red-500/10 shadow-inner">
                         <X size={32} className="text-red-500" />
@@ -759,27 +754,53 @@ export default function LandingPage() {
                         </p>
                       </div>
                     </div>
-                  )}
-                  <motion.img
-                    key={badgeUrl}
-                    data-testid="badge-img"
-                    src={badgeUrl}
-                    alt={`CommitPulse badge for ${previewUsername}`}
-                    initial={{ opacity: 0, scale: 0.95 }}
-                    animate={{ opacity: badgeLoaded ? 1 : 0, scale: badgeLoaded ? 1 : 0.95 }}
-                    transition={{ duration: 0.5, ease: 'easeOut' }}
-                    className="w-full max-w-[700px] h-auto drop-shadow-[0_30px_60px_rgba(0,0,0,0.15)] dark:drop-shadow-[0_30px_60px_rgba(0,0,0,0.5)]"
-                    onLoad={() => setBadgeResult({ username: previewUsername, status: 'loaded' })}
-                    onError={() => setBadgeResult({ username: previewUsername, status: 'error' })}
-                  />
-
-                  {badgeLoaded && (
-                    <button
-                      onClick={DownloadSVG}
-                      className="mt-6 px-4 py-2 rounded-lg bg-sky-600 text-sm font-medium text-white hover:bg-sky-800 transition-colors"
-                    >
-                      Download SVG
-                    </button>
+                  ) : (
+                    <>
+                      {!badgeLoaded && !badgeError && (
+                        <div className="h-[240px] w-full max-w-[700px] rounded-2xl bg-black/5 dark:bg-white/5 animate-pulse flex items-center justify-center">
+                          <Loader2 className="animate-spin text-zinc-500" size={32} />
+                        </div>
+                      )}
+                      {badgeError && (
+                        <div className="flex flex-col items-center justify-center gap-4 py-12 text-center">
+                          <div className="flex h-16 w-16 items-center justify-center rounded-3xl border border-red-500/20 bg-red-500/10 shadow-inner">
+                            <X size={32} className="text-red-500" />
+                          </div>
+                          <div>
+                            <p className="text-lg font-bold text-gray-900 dark:text-white tracking-tight">
+                              GitHub user not found
+                            </p>
+                            <p className="text-sm text-gray-500 dark:text-white/65 mt-1">
+                              Please check the username and try again.
+                            </p>
+                          </div>
+                        </div>
+                      )}
+                      <motion.img
+                        key={badgeUrl}
+                        data-testid="badge-img"
+                        src={badgeUrl}
+                        alt={`CommitPulse badge for ${previewUsername}`}
+                        initial={{ opacity: 0, scale: 0.95 }}
+                        animate={{ opacity: badgeLoaded ? 1 : 0, scale: badgeLoaded ? 1 : 0.95 }}
+                        transition={{ duration: 0.5, ease: 'easeOut' }}
+                        className="w-full max-w-[700px] h-auto drop-shadow-[0_30px_60px_rgba(0,0,0,0.15)] dark:drop-shadow-[0_30px_60px_rgba(0,0,0,0.5)]"
+                        onLoad={() =>
+                          setBadgeResult({ username: previewUsername, status: 'loaded' })
+                        }
+                        onError={() =>
+                          setBadgeResult({ username: previewUsername, status: 'error' })
+                        }
+                      />
+                      {badgeLoaded && (
+                        <button
+                          onClick={DownloadSVG}
+                          className="mt-6 px-4 py-2 rounded-lg bg-sky-600 text-sm font-medium text-white hover:bg-sky-800 transition-colors"
+                        >
+                          Download SVG
+                        </button>
+                      )}
+                    </>
                   )}
                 </div>
               ) : (


### PR DESCRIPTION
## Description

Fixes #3614 

The landing page was showing a **"Verified Profile"** badge and a **"NOT FOUND"** badge preview simultaneously for the same username. This happened because `/api/user-details` and `/api/streak` used the same GitHub GraphQL API but handled its errors differently — user-details swallowed all GraphQL errors and returned `exists: true` on REST success alone, while the streak endpoint surfaced GraphQL "not found" as a 404, producing contradictory UI states.

**Fix — two changes:**

1. **`app/api/user-details/route.ts`** — The `.catch()` now re-throws errors whose message includes `"not found"`, making the endpoint return 404 in the same cases the streak API does. Transient failures (rate limits, timeouts) are still swallowed so partial data can still be shown when the user genuinely exists.

2. **`app/page.tsx`** — The badge preview area now short-circuits to the not-found UI when `userDetailsError === 'User not found'`, instead of attempting to load the badge image (which would also fail, but only after an extra network round-trip). This eliminates the brief window where the "Verified Profile" pill and the NOT FOUND SVG were visible at the same time.


## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
