### PR TITLE
test(track-user-protection): validate service logic

### DIFF
--- a/services/security/track-user-protection.responsive-breakpoints.test.ts
+++ b/services/security/track-user-protection.responsive-breakpoints.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { trackUserProtection } from './track-user-protection';
+import { gitHubUserValidator } from '../github/validate-user';
+
+vi.mock('../github/validate-user', () => ({
+  gitHubUserValidator: {
+    validateUser: vi.fn(),
+  },
+}));
+
+describe('TrackUserProtection Service Logic', () => {
+  beforeEach(() => {
+    trackUserProtection.reset();
+    vi.clearAllMocks();
+  });
+
+  it('accepts valid GitHub usernames', () => {
+    expect(trackUserProtection.validateFormat('octocat')).toBe(true);
+    expect(trackUserProtection.validateFormat('test-user')).toBe(true);
+  });
+
+  it('rejects invalid GitHub usernames', () => {
+    expect(trackUserProtection.validateFormat('-octocat')).toBe(false);
+    expect(trackUserProtection.validateFormat('octocat-')).toBe(false);
+  });
+
+  it('blocks writes during cooldown period', () => {
+    trackUserProtection.recordWrite('octocat');
+    expect(trackUserProtection.isWriteAllowed('octocat')).toBe(false);
+  });
+
+  it('reset clears cooldown state', () => {
+    trackUserProtection.recordWrite('octocat');
+    trackUserProtection.reset();
+
+    expect(trackUserProtection.isWriteAllowed('octocat')).toBe(true);
+  });
+
+  it('returns allowed true for valid existing user', async () => {
+    vi.mocked(gitHubUserValidator.validateUser).mockResolvedValue(true);
+
+    const result = await trackUserProtection.verifyAndDeduplicate('octocat');
+
+    expect(result).toEqual({ allowed: true });
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2969

Added a dedicated test suite for `TrackUserProtection` that validates the actual service behavior instead of UI-related assertions.

Covered scenarios:

* GitHub username format validation
* Invalid username rejection
* Write cooldown enforcement
* Reset behavior clearing cooldown state
* Successful verification flow for valid users

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.