### PR TITLE
refactor: standardize theme unit test file locations

### DIFF
--- a/lib/svg/themes/lumos.test.ts
+++ b/lib/svg/themes/lumos.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { themes } from './themes';
-import { generateSVG } from './generator';
-import { getLuminance, hexColor } from './sanitizer';
-import type { StreakStats, ContributionCalendar, BadgeParams } from '../../types';
+import { themes } from '../themes';
+import { generateSVG } from '../generator';
+import { getLuminance, hexColor } from '../sanitizer';
+import type { StreakStats, ContributionCalendar, BadgeParams } from '../../../types';
 
 describe('lumos theme', () => {
   // Test 1: Verify lumos theme exists with all required color properties

--- a/lib/svg/themes/nord.test.ts
+++ b/lib/svg/themes/nord.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { themes } from './themes';
-import { generateSVG } from './generator';
-import { getLuminance } from './sanitizer';
-import type { BadgeParams, ContributionCalendar, StreakStats } from '../../types';
+import { themes } from '../themes';
+import { generateSVG } from '../generator';
+import { getLuminance } from '../sanitizer';
+import type { BadgeParams, ContributionCalendar, StreakStats } from '../../../types';
 
 describe('Nord Theme', () => {
   const mockStats: StreakStats = {


### PR DESCRIPTION
## Description

Moves `lumos.test.ts` and `nord.test.ts` from `lib/svg/` into the `lib/svg/themes/` subdirectory, aligning them with all other per-theme test files (dracula, forest, gruvbox, light, neon, ocean, rose, sunset, synthwave, dark) which already live under `lib/svg/themes/`.

### Problem
`lib/svg/lumos.test.ts` and `lib/svg/nord.test.ts` were sitting at the wrong level — directly in `lib/svg/` — while every other theme test file was co-located under `lib/svg/themes/`. This made the directory structure inconsistent and harder to navigate.

### Changes
- **Moved** `lib/svg/lumos.test.ts` → `lib/svg/themes/lumos.test.ts`
- **Moved** `lib/svg/nord.test.ts` → `lib/svg/themes/nord.test.ts`
- **Updated import paths** in both files to reflect the new location:
  - `./themes` → `../themes`
  - `./generator` → `../generator`
  - `./sanitizer` → `../sanitizer`
  - `../../types` → `../../../types`

Fixes #3236 

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.