### PR TITLE
fix: Handle RangeError from Intl.DateTimeFormat for invalid timezones

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -1120,6 +1120,55 @@ describe('GET /api/streak', () => {
       const body = await response.json();
       expect(body.details.fieldErrors.tz[0]).toContain('Invalid timezone');
     });
+
+    it('returns 400 (not 500) when Intl.DateTimeFormat throws RangeError at runtime', async () => {
+      // Test that a RangeError from Intl.DateTimeFormat is caught and returned as 400.
+      // We save/restore the original to avoid cross-test pollution.
+      const OriginalDateTimeFormat = Intl.DateTimeFormat;
+      let callCount = 0;
+
+      // Must use a regular function (not arrow) so it can act as a constructor.
+      function MockDateTimeFormat(
+        this: Intl.DateTimeFormat,
+        ...args: ConstructorParameters<typeof Intl.DateTimeFormat>
+      ): Intl.DateTimeFormat {
+        callCount++;
+        if (callCount === 1) {
+          // First call (Zod validation) — delegate to the real implementation.
+          return Reflect.construct(
+            OriginalDateTimeFormat,
+            args,
+            OriginalDateTimeFormat
+          ) as Intl.DateTimeFormat;
+        }
+        // Subsequent calls (route handler) — simulate an unsupported timezone.
+        throw new RangeError(`Invalid time zone specified: 'edge-case-tz'`);
+      }
+
+      // Copy static members so the shape matches Intl.DateTimeFormat exactly.
+      MockDateTimeFormat.prototype = OriginalDateTimeFormat.prototype;
+      MockDateTimeFormat.supportedLocalesOf = OriginalDateTimeFormat.supportedLocalesOf;
+
+      Object.defineProperty(Intl, 'DateTimeFormat', {
+        value: MockDateTimeFormat as unknown as typeof Intl.DateTimeFormat,
+        configurable: true,
+        writable: true,
+      });
+
+      try {
+        const response = await GET(makeRequest({ user: 'octocat', tz: 'edge-case-tz' }));
+        // Should return 400, not 500
+        expect(response.status).toBe(400);
+        const body = await response.text();
+        expect(body).toContain('Invalid timezone');
+      } finally {
+        Object.defineProperty(Intl, 'DateTimeFormat', {
+          value: OriginalDateTimeFormat,
+          configurable: true,
+          writable: true,
+        });
+      }
+    });
   });
 
   describe('hide_background parameter', () => {

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -106,8 +106,17 @@ export async function GET(request: Request) {
 
     let timezone = 'UTC';
     if (tzParam) {
-      timezone = new Intl.DateTimeFormat(undefined, { timeZone: tzParam }).resolvedOptions()
-        .timeZone;
+      try {
+        timezone = new Intl.DateTimeFormat(undefined, { timeZone: tzParam }).resolvedOptions()
+          .timeZone;
+      } catch (error) {
+        if (error instanceof RangeError) {
+          const validationErr = new Error(`Invalid timezone: ${tzParam}`);
+          validationErr.name = 'ValidationError';
+          throw validationErr;
+        }
+        throw error;
+      }
     }
 
     let from = customFrom


### PR DESCRIPTION
## Summary

Fixes an issue where invalid timezone values could trigger an unhandled `RangeError` and cause a 500 Internal Server Error response.

### Changes Made

* Wrap `Intl.DateTimeFormat` call in a try/catch block to handle `RangeError`
* Convert `RangeError` exceptions into `ValidationError`
* Return a proper 400 Bad Request response instead of a 500 Internal Server Error
* Add a regression test to verify runtime `RangeError` handling
* Prevent invalid timezone parameters from causing unhandled crashes

### Test Results

* All route tests pass successfully
* Added coverage for invalid timezone runtime failures
* Verified proper 400 Bad Request behavior
* Ensures unsupported timezone strings are handled gracefully

Closes #3690

## Description

This PR fixes an edge case where `Intl.DateTimeFormat` could throw a `RangeError` when processing an invalid or unsupported timezone value. Instead of returning a generic 500 error, the API now treats the error as a validation failure and returns a proper 400 Bad Request response.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Backend validation and test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [ ] I have started the repo.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
