### PR TITLE
fix(api): return error status for notification lookup when database is unavailable

### DIFF
--- a/app/api/notify/route.ts
+++ b/app/api/notify/route.ts
@@ -77,7 +77,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<NotificationR
     if (!process.env.MONGODB_URI) {
       if (process.env.NODE_ENV === 'production') {
         console.error(
-          'CRITICAL: MONGODB_URI is not set in production environment. Notification registration is disabled.'
+          'CRITICAL: MONGODB_URI is not set in production environment. Notification lookup is disabled.'
         );
         return NextResponse.json(
           { success: false, message: 'Database configuration error.' },
@@ -85,13 +85,15 @@ export async function POST(req: NextRequest): Promise<NextResponse<NotificationR
         );
       }
 
-      console.warn(
-        'MONGODB_URI is not set. Bypassing notification registration for local development.'
+      console.warn('MONGODB_URI is not set. Bypassing notification lookup for local development.');
+
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'No notification preferences found (no database configured).',
+        },
+        { status: 503 }
       );
-      return NextResponse.json({
-        success: true,
-        message: 'Notification registration bypassed (no database configured).',
-      });
     }
 
     await dbConnect();
@@ -181,10 +183,14 @@ export async function GET(req: NextRequest): Promise<NextResponse<NotificationRe
       }
 
       console.warn('MONGODB_URI is not set. Bypassing notification lookup for local development.');
-      return NextResponse.json({
-        success: false,
-        message: 'No notification preferences found (no database configured).',
-      });
+
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'No notification preferences found (no database configured).',
+        },
+        { status: 503 } // or 500, depending on project preference
+      );
     }
 
     await dbConnect();

--- a/app/api/notify/route.ts
+++ b/app/api/notify/route.ts
@@ -77,7 +77,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<NotificationR
     if (!process.env.MONGODB_URI) {
       if (process.env.NODE_ENV === 'production') {
         console.error(
-          'CRITICAL: MONGODB_URI is not set in production environment. Notification lookup is disabled.'
+          'CRITICAL: MONGODB_URI is not set in production environment. Notification registration is disabled.'
         );
         return NextResponse.json(
           { success: false, message: 'Database configuration error.' },
@@ -85,15 +85,13 @@ export async function POST(req: NextRequest): Promise<NextResponse<NotificationR
         );
       }
 
-      console.warn('MONGODB_URI is not set. Bypassing notification lookup for local development.');
-
-      return NextResponse.json(
-        {
-          success: false,
-          message: 'No notification preferences found (no database configured).',
-        },
-        { status: 503 }
+      console.warn(
+        'MONGODB_URI is not set. Bypassing notification registration for local development.'
       );
+      return NextResponse.json({
+        success: true,
+        message: 'Notification registration bypassed (no database configured).',
+      });
     }
 
     await dbConnect();
@@ -183,13 +181,12 @@ export async function GET(req: NextRequest): Promise<NextResponse<NotificationRe
       }
 
       console.warn('MONGODB_URI is not set. Bypassing notification lookup for local development.');
-
       return NextResponse.json(
         {
           success: false,
           message: 'No notification preferences found (no database configured).',
         },
-        { status: 503 } // or 500, depending on project preference
+        { status: 503 }
       );
     }
 


### PR DESCRIPTION
## Description

Fixes #3624 

This PR fixes an inconsistency in the `GET /api/notify` endpoint when `MONGODB_URI` is not configured.

Previously, the endpoint returned a failure response (`success: false`) but implicitly responded with HTTP `200 OK` because no status code was specified. This could cause clients and monitoring systems to incorrectly treat the request as successful.

The endpoint now returns an appropriate error status code when notification lookup cannot be performed due to missing database configuration, ensuring consistency between the response payload and HTTP status.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (API-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [x] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
