### PR TITLE
test(brand-particles): add accessibility coverage

### DIFF
--- a/components/BrandParticles.accessibility.test.tsx
+++ b/components/BrandParticles.accessibility.test.tsx
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const mockUseReducedMotion = vi.fn();
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: (props: React.HTMLAttributes<HTMLDivElement>) => <div data-testid="particle" {...props} />,
+  },
+  useReducedMotion: () => mockUseReducedMotion(),
+}));
+
+import BrandParticles from './BrandParticles';
+
+describe('BrandParticles Accessibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders decorative particle elements successfully', async () => {
+    mockUseReducedMotion.mockReturnValue(false);
+
+    render(<BrandParticles />);
+
+    const particles = await screen.findAllByTestId('particle');
+
+    expect(particles.length).toBeGreaterThan(0);
+  });
+
+  it('maintains non-interactive accessibility behavior', async () => {
+    mockUseReducedMotion.mockReturnValue(false);
+
+    const { container } = render(<BrandParticles />);
+
+    await screen.findAllByTestId('particle');
+
+    expect(container.querySelector('.pointer-events-none')).toBeTruthy();
+  });
+
+  it('does not expose focusable button elements', async () => {
+    mockUseReducedMotion.mockReturnValue(false);
+
+    render(<BrandParticles />);
+
+    await screen.findAllByTestId('particle');
+
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('renders successfully when reduced motion is enabled', async () => {
+    mockUseReducedMotion.mockReturnValue(true);
+
+    render(<BrandParticles />);
+
+    const particles = await screen.findAllByTestId('particle');
+
+    expect(particles.length).toBeGreaterThan(0);
+  });
+
+  it('does not throw during accessibility-oriented rendering', () => {
+    mockUseReducedMotion.mockReturnValue(false);
+
+    expect(() => render(<BrandParticles />)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2646 

Added isolated unit tests for `components/BrandParticles.tsx` focusing on accessibility-oriented rendering behavior and decorative particle layer validation.

### Changes
- Added `components/BrandParticles.accessibility.test.tsx`
- Mocked `framer-motion` dependencies to isolate component rendering
- Verified decorative particle elements render successfully
- Confirmed the particle layer maintains non-interactive behavior through the `pointer-events-none` container
- Verified no unintended focusable button elements are introduced by the background particle system
- Tested rendering behavior when reduced-motion preferences are enabled
- Ensured component lifecycle execution does not throw runtime exceptions
- Improved coverage around accessibility-related rendering stability and decorative background behavior

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no visual changes made).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.