### PR TITLE
feat: add ETag and If-None-Match support for badge caching

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -1,5 +1,6 @@
 // app/api/streak/route.ts
 
+import crypto from 'crypto';
 import { NextResponse } from 'next/server';
 import { fetchGitHubContributions, getOrgDashboardData } from '@/lib/github';
 import { calculateStreak, calculateMonthlyStats, aggregateCalendars } from '@/lib/calculate';
@@ -326,23 +327,38 @@ export async function GET(request: Request) {
         ? 'no-cache, no-store, must-revalidate'
         : `public, s-maxage=${secondsToMidnight}, stale-while-revalidate=86400`;
 
-      return NextResponse.json(
-        {
-          user: targetEntity,
-          stats,
-          monthlyStats,
-          calendar: {
-            totalContributions: calendar.totalContributions,
-            weeks: calendar.weeks,
-          },
+      const jsonPayload = JSON.stringify({
+        user: targetEntity,
+        stats,
+        monthlyStats,
+        calendar: {
+          totalContributions: calendar.totalContributions,
+          weeks: calendar.weeks,
         },
-        {
+      });
+
+      const etag = crypto.createHash('sha1').update(jsonPayload).digest('hex');
+      const weakEtag = `W/"${etag}"`;
+      const ifNoneMatch = request.headers.get('if-none-match');
+
+      if (ifNoneMatch === weakEtag || ifNoneMatch === `"${etag}"`) {
+        return new NextResponse(null, {
+          status: 304,
           headers: {
             'Cache-Control': cacheControl,
-            'X-Cache-Status': refresh ? `BYPASS, fetched=${new Date().toISOString()}` : 'HIT',
+            ETag: weakEtag,
           },
-        }
-      );
+        });
+      }
+
+      return new NextResponse(jsonPayload, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': cacheControl,
+          ETag: weakEtag,
+          'X-Cache-Status': refresh ? `BYPASS, fetched=${new Date().toISOString()}` : 'HIT',
+        },
+      });
     }
 
     // ─── SVG output mode (default) ──────────────────────────────────────────
@@ -380,11 +396,26 @@ export async function GET(request: Request) {
         ? 'public, s-maxage=31536000, immutable'
         : `public, s-maxage=${secondsToMidnight}, stale-while-revalidate=86400`;
 
+    const etag = crypto.createHash('sha1').update(svg).digest('hex');
+    const weakEtag = `W/"${etag}"`;
+    const ifNoneMatch = request.headers.get('if-none-match');
+
+    if (ifNoneMatch === weakEtag || ifNoneMatch === `"${etag}"`) {
+      return new NextResponse(null, {
+        status: 304,
+        headers: {
+          'Cache-Control': cacheControl,
+          ETag: weakEtag,
+        },
+      });
+    }
+
     return new NextResponse(svg, {
       headers: {
         'Content-Type': 'image/svg+xml',
         'Cache-Control': cacheControl,
         'Content-Security-Policy': SVG_CSP_HEADER,
+        ETag: weakEtag,
         'X-Cache-Status': refresh ? `BYPASS, fetched=${new Date().toISOString()}` : 'HIT',
       },
     });


### PR DESCRIPTION
## Description

Fixes #3728 

Implemented support for `ETag` and `If-None-Match` headers for the streak API responses.

### What changed

* Added ETag generation for both SVG and JSON responses using a SHA-1 hash of the rendered output.
* Added support for conditional requests via the `If-None-Match` header.
* Returns `304 Not Modified` when the client's ETag matches the current response content.
* Preserved the existing `Cache-Control: s-maxage` behavior and UTC-midnight cache invalidation strategy.
* Reduced unnecessary bandwidth usage and improved cache efficiency for profile badge requests.

### Technical Details

* Imported Node.js `crypto` to generate stable ETags.
* Generated weak ETags (`W/"hash"`) from the final response payload.
* Added ETag validation before sending the response body.
* Supports both:
  * `format=json`
  * Default SVG output

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
