### PR TITLE
test(brand-particles): add theme contrast coverage

### DIFF
--- a/components/BrandParticles.theme-contrast.test.tsx
+++ b/components/BrandParticles.theme-contrast.test.tsx
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const mockUseReducedMotion = vi.fn();
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: (props: React.HTMLAttributes<HTMLDivElement>) => <div data-testid="particle" {...props} />,
+  },
+  useReducedMotion: () => mockUseReducedMotion(),
+}));
+
+import BrandParticles from './BrandParticles';
+
+describe('BrandParticles Theme Contrast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.documentElement.className = '';
+  });
+
+  it('renders successfully in light mode', async () => {
+    mockUseReducedMotion.mockReturnValue(false);
+
+    render(<BrandParticles />);
+
+    const particles = await screen.findAllByTestId('particle');
+
+    expect(particles.length).toBeGreaterThan(0);
+  });
+
+  it('renders successfully in dark mode', async () => {
+    document.documentElement.classList.add('dark');
+
+    mockUseReducedMotion.mockReturnValue(false);
+
+    render(<BrandParticles />);
+
+    const particles = await screen.findAllByTestId('particle');
+
+    expect(particles.length).toBeGreaterThan(0);
+  });
+
+  it('contains dark mode styling class on overlay container', async () => {
+    mockUseReducedMotion.mockReturnValue(false);
+
+    const { container } = render(<BrandParticles />);
+
+    await screen.findAllByTestId('particle');
+
+    const overlay = container.querySelector('.dark\\:opacity-40');
+
+    expect(overlay).toBeTruthy();
+  });
+
+  it('preserves particle rendering across theme changes', async () => {
+    mockUseReducedMotion.mockReturnValue(false);
+
+    const { rerender } = render(<BrandParticles />);
+
+    document.documentElement.classList.add('dark');
+
+    rerender(<BrandParticles />);
+
+    const particles = await screen.findAllByTestId('particle');
+
+    expect(particles.length).toBeGreaterThan(0);
+  });
+
+  it('renders overlay container without clipping content structure', async () => {
+    mockUseReducedMotion.mockReturnValue(true);
+
+    const { container } = render(<BrandParticles />);
+
+    await screen.findAllByTestId('particle');
+
+    expect(container.firstChild).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2645 

Added isolated unit tests for `components/BrandParticles.tsx` focusing on dark/light theme rendering behavior and visual consistency across color-scheme preferences.

### Changes
- Added `components/BrandParticles.theme-contrast.test.tsx`
- Mocked `framer-motion` dependencies to isolate component behavior
- Verified component renders successfully in simulated light mode
- Verified component renders successfully in simulated dark mode
- Confirmed dark-mode opacity styling classes are present on the overlay container
- Tested particle rendering stability across theme transitions
- Verified overlay container structure remains intact during rendering
- Improved coverage around theme-aware rendering behavior and visual cohesion

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no visual changes made).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.