### PR TITLE
fix: replace deprecated execCommand copy in ShareSheet (#3694)

### DIFF
--- a/components/dashboard/ShareSheet.tsx
+++ b/components/dashboard/ShareSheet.tsx
@@ -233,16 +233,22 @@ export default function ShareSheet({ username, isOpen, onClose, exportData }: Sh
     setTimeout(() => setToast((t) => (t?.id === id ? null : t)), 2400);
   }, []);
 
-  const handleLocalCopyLink = (e: React.MouseEvent) => {
+  const handleLocalCopyLink = async (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (inputRef.current) {
-      inputRef.current.select();
-      document.execCommand('copy');
-      setLinkCopied(true);
-      showToast('✓ Link copied');
-      setTimeout(() => setLinkCopied(false), 2200);
+
+    try {
+      await navigator.clipboard.writeText(profileUrl);
+    } catch {
+      if (inputRef.current) {
+        inputRef.current.select();
+        document.execCommand('copy');
+      }
     }
+
+    setLinkCopied(true);
+    showToast('✓ Link copied');
+    setTimeout(() => setLinkCopied(false), 2200);
   };
 
   const handleCopyQRAsImage = async (e: React.MouseEvent) => {


### PR DESCRIPTION
## Description

This PR replaces the deprecated `document.execCommand('copy')` API in the ShareSheet component with the modern `navigator.clipboard.writeText()` API.

To maintain compatibility with older browsers and environments where the Clipboard API may not be available, a fallback to `document.execCommand('copy')` has been retained.

Fixes #3694

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A – This change only updates clipboard handling logic and does not affect the visual UI.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
