### PR TITLE
fix(github): propagate contributed-repos fetch errors instead of caching empty

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -800,8 +800,14 @@ describe('fetchUserRepos', () => {
 });
 
 describe('fetchContributedRepos', () => {
-  beforeEach(() => vi.spyOn(global, 'fetch'));
-  afterEach(() => vi.restoreAllMocks());
+  beforeEach(() => {
+    vi.spyOn(global, 'fetch');
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
 
   it('returns contributed repos on success', async () => {
     const mockNodes = [
@@ -831,16 +837,47 @@ describe('fetchContributedRepos', () => {
     expect(result).toEqual(mockNodes);
   });
 
-  it('returns empty array when fetch fails', async () => {
-    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 500 }));
-    const result = await fetchContributedRepos('octocat');
-    expect(result).toEqual([]);
-  });
-
   it('returns empty array if data structure is missing', async () => {
     vi.mocked(fetch).mockResolvedValue(mockResponse({ data: null }));
     const result = await fetchContributedRepos('octocat');
     expect(result).toEqual([]);
+  });
+
+  it('throws (rather than returning []) when the request fails so the empty result is not cached', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 500 }));
+
+    const promise = fetchContributedRepos('octocat');
+    const assertion = expect(promise).rejects.toThrow();
+    await vi.advanceTimersByTimeAsync(3500);
+    await assertion;
+  });
+
+  it('throws on a rate-limited GraphQL 200 response instead of returning []', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse({ errors: [{ type: 'RATE_LIMITED', message: 'API rate limit exceeded' }] })
+    );
+
+    const promise = fetchContributedRepos('octocat');
+    const assertion = expect(promise).rejects.toThrow('API Rate Limit Exceeded');
+    await vi.advanceTimersByTimeAsync(3500);
+    await assertion;
+  });
+
+  it('does not cache the failure: a later call refetches and can succeed', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 500 }));
+
+    const failing = fetchContributedRepos('octocat');
+    const assertion = expect(failing).rejects.toThrow();
+    await vi.advanceTimersByTimeAsync(3500);
+    await assertion;
+
+    const mockNodes = [{ name: 'r1', nameWithOwner: 'o/r1' }];
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse({ data: { user: { repositoriesContributedTo: { nodes: mockNodes } } } })
+    );
+
+    const result = await fetchContributedRepos('octocat');
+    expect(result).toEqual(mockNodes);
   });
 });
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1151,7 +1151,7 @@ export async function fetchContributedRepos(
       }
     `;
 
-    const res = await fetchWithRetry(GITHUB_GRAPHQL_URL, {
+    const res = await fetchGraphQLWithRetry(GITHUB_GRAPHQL_URL, {
       method: 'POST',
       headers: getHeaders(),
       body: JSON.stringify({
@@ -1162,10 +1162,29 @@ export async function fetchContributedRepos(
       signal: options.signal,
     });
 
-    if (!res.ok) return [];
+    if (!res.ok) {
+      throwIfRateLimited(res);
+      throw new Error(
+        `GitHub GraphQL API returned status ${res.status} after ${MAX_RETRIES} retries`
+      );
+    }
+
     const data = await res.json();
-    const result = data?.data?.user?.repositoriesContributedTo?.nodes || [];
-    return result;
+
+    if (data?.errors !== undefined) {
+      if (Array.isArray(data.errors)) {
+        const isRateLimit = data.errors.some((e: unknown) => {
+          const err = e as { message?: string; type?: string };
+          return err?.message?.toLowerCase().includes('rate limit') || err?.type === 'RATE_LIMITED';
+        });
+        if (isRateLimit) {
+          throw new Error('API Rate Limit Exceeded');
+        }
+      }
+      throw new Error(getGraphQLErrorMessage(data.errors));
+    }
+
+    return data?.data?.user?.repositoriesContributedTo?.nodes || [];
   };
 
   if (options.bypassCache) return load();


### PR DESCRIPTION
## Description

Fixes #3762

`fetchContributedRepos` built the dashboard's contributed-repositories graph and swallowed failures by returning an empty array, which `getOrSet` then cached for 5 minutes. A single transient error (5xx, 403/429, or a GitHub 200 carrying a RATE_LIMITED error body) therefore poisoned the graph with "0 contributed repos" for every viewer of that profile.

Changes (in `lib/github.ts`):

- Switched the loader to `fetchGraphQLWithRetry` (parity with the contributions path, including body-level RATE_LIMITED backoff).
- On `!res.ok` it now calls `throwIfRateLimited` and throws; on a GraphQL `errors` body it throws (detecting rate limits). Failures propagate instead of being cached.
- `getFullDashboardData` already tolerates a rejected contributed-repos fetch via `Promise.allSettled` (it falls back to `[]` per request), so the dashboard still renders and the next request retries instead of serving a cached-empty graph.

Added tests: throws on failure, throws on a rate-limited 200, and does-not-cache-the-failure (a later call refetches and succeeds).

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

Not applicable. Backend caching and error-handling change.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (138 github tests pass, including 3 new ones; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable, no SVG output in this change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
