### PR TITLE
fix(github): make background refresh persist via write-back and after()

### DIFF
--- a/app/api/github/route.test.ts
+++ b/app/api/github/route.test.ts
@@ -6,6 +6,17 @@ vi.mock('../../../lib/github', () => ({
   getFullDashboardData: vi.fn(),
 }));
 
+// Run after() callbacks synchronously in tests (outside a request scope it is otherwise a no-op).
+vi.mock('next/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next/server')>();
+  return {
+    ...actual,
+    after: (fn: () => unknown) => {
+      void fn();
+    },
+  };
+});
+
 import { getFullDashboardData } from '../../../lib/github';
 import { quotaMonitor } from '@/services/github/quota-monitor';
 import { refreshPolicy } from '@/services/github/refresh-policy';

--- a/app/api/github/route.ts
+++ b/app/api/github/route.ts
@@ -1,6 +1,6 @@
 // app/api/github/route.ts
 
-import { NextResponse } from 'next/server';
+import { NextResponse, after } from 'next/server';
 import { getFullDashboardData } from '@/lib/github';
 import { githubParamsSchema } from '@/lib/validations';
 import { getClientIp } from '@/utils/getClientIp';
@@ -111,7 +111,8 @@ export async function GET(request: Request) {
     if (!shouldBypassCache) {
       const lastSynced = data.lastSyncedAt;
       if (backgroundRefresh.isStale(lastSynced)) {
-        backgroundRefresh.triggerRefresh(username);
+        // Run after the response is sent so Vercel does not freeze the function mid-refresh.
+        after(() => backgroundRefresh.triggerRefresh(username));
       }
     }
 

--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -844,6 +844,62 @@ describe('fetchContributedRepos', () => {
   });
 });
 
+describe('forceRefresh write-back', () => {
+  beforeEach(() => vi.spyOn(global, 'fetch'));
+  afterEach(() => vi.restoreAllMocks());
+
+  it('fetchGitHubContributions: forceRefresh writes back so a later normal read is a cache hit', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse({
+        data: { user: { contributionsCollection: { contributionCalendar: mockCalendar } } },
+      })
+    );
+
+    await fetchGitHubContributions('octocat', { forceRefresh: true });
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    const result = await fetchGitHubContributions('octocat');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.calendar.totalContributions).toBe(mockCalendar.totalContributions);
+  });
+
+  it('fetchUserProfile: forceRefresh writes back so a later normal read is a cache hit', async () => {
+    const profile = {
+      login: 'octocat',
+      name: 'Octo',
+      avatar_url: '',
+      public_repos: 1,
+      followers: 1,
+      following: 1,
+      created_at: '2020-01-01T00:00:00Z',
+      bio: null,
+      location: null,
+    };
+    vi.mocked(fetch).mockResolvedValue(mockResponse(profile));
+
+    await fetchUserProfile('octocat', { forceRefresh: true });
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    const result = await fetchUserProfile('octocat');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result.login).toBe('octocat');
+  });
+
+  it('fetchContributedRepos: forceRefresh writes back so a later normal read is a cache hit', async () => {
+    const nodes = [{ name: 'r1', nameWithOwner: 'o/r1' }];
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse({ data: { user: { repositoriesContributedTo: { nodes } } } })
+    );
+
+    await fetchContributedRepos('octocat', { forceRefresh: true });
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    const result = await fetchContributedRepos('octocat');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(nodes);
+  });
+});
+
 describe('computeDeveloperScore', () => {
   it('returns 0 for a brand new account with no activity', () => {
     expect(

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -322,6 +322,8 @@ function getGraphQLErrorMessage(errors: unknown): string {
 
 type FetchOptions = {
   bypassCache?: boolean;
+  // Skip the cache read but still write the fresh result back (used by background refresh).
+  forceRefresh?: boolean;
   from?: string;
   to?: string;
   rangeLabel?: string;
@@ -523,7 +525,7 @@ export async function fetchGitHubContributions(
     return fetchContributionsUncached(username, key, options, cached);
   };
 
-  if (options.bypassCache) {
+  if (options.bypassCache || options.forceRefresh) {
     try {
       return await load(null);
     } catch (err: unknown) {
@@ -737,7 +739,7 @@ export async function fetchUserProfile(
     return fetchProfileUncached(encodedUsername, key, options);
   };
 
-  if (options.bypassCache) return load();
+  if (options.bypassCache || options.forceRefresh) return load();
   return profileCache.getOrSet(key, load, GITHUB_CACHE_TTL_MS);
 }
 
@@ -781,7 +783,7 @@ export async function fetchUserRepos(
     return fetchReposUncached(encodedUsername, key, options);
   };
 
-  if (options.bypassCache) return load();
+  if (options.bypassCache || options.forceRefresh) return load();
   return reposCache.getOrSet(key, load, GITHUB_CACHE_TTL_MS);
 }
 
@@ -1169,6 +1171,11 @@ export async function fetchContributedRepos(
   };
 
   if (options.bypassCache) return load();
+  if (options.forceRefresh) {
+    const fresh = await load();
+    await contributedReposCache.set(key, fresh, GITHUB_CACHE_TTL_MS);
+    return fresh;
+  }
   return contributedReposCache.getOrSet(key, load, GITHUB_CACHE_TTL_MS);
 }
 

--- a/services/github/background-refresh.mock-integrations.test.ts
+++ b/services/github/background-refresh.mock-integrations.test.ts
@@ -23,7 +23,7 @@ describe('BackgroundRefresh Mock Integrations', () => {
     service.triggerRefresh('john_doe');
 
     expect(service.isJobActive('john_doe')).toBe(true);
-    expect(getFullDashboardData).toHaveBeenCalledWith('john_doe', { bypassCache: true });
+    expect(getFullDashboardData).toHaveBeenCalledWith('john_doe', { forceRefresh: true });
   });
 
   it('tests service loading paths to ensure pending state overlays render', async () => {

--- a/services/github/background-refresh.responsive-breakpoints.test.ts
+++ b/services/github/background-refresh.responsive-breakpoints.test.ts
@@ -27,7 +27,7 @@ describe('BackgroundRefresh - Responsive Breakpoints (Multi-device Columns & Mob
 
     // No overflow — job clears cleanly with no stuck state
     expect(refresher.isJobActive('a')).toBe(false);
-    expect(getFullDashboardData).toHaveBeenCalledWith('a', { bypassCache: true });
+    expect(getFullDashboardData).toHaveBeenCalledWith('a', { forceRefresh: true });
   });
 
   it('Column Reflow: multiple concurrent jobs for different users queue independently without collapsing into one', () => {

--- a/services/github/background-refresh.test.ts
+++ b/services/github/background-refresh.test.ts
@@ -47,7 +47,7 @@ describe('BackgroundRefresh Unit Tests', () => {
       service.triggerRefresh('  TestUser  ');
 
       expect(service.isJobActive('testuser')).toBe(true);
-      expect(getFullDashboardData).toHaveBeenCalledWith('  TestUser  ', { bypassCache: true });
+      expect(getFullDashboardData).toHaveBeenCalledWith('  TestUser  ', { forceRefresh: true });
 
       // Allow promise microtask to resolve
       await new Promise((resolve) => setTimeout(resolve, 0));

--- a/services/github/background-refresh.ts
+++ b/services/github/background-refresh.ts
@@ -35,20 +35,21 @@ export class BackgroundRefresh {
   /**
    * Triggers an asynchronous, non-blocking cache backfill for the given username.
    */
-  public triggerRefresh(username: string): void {
+  public triggerRefresh(username: string): Promise<void> {
     const sanitized = username.trim().toLowerCase();
 
     // Avoid duplicate background jobs for the same user concurrently
     if (this.activeJobs.has(sanitized)) {
-      return;
+      return Promise.resolve();
     }
 
     this.activeJobs.add(sanitized);
 
     console.info(`[BackgroundRefresh] Starting background refresh for: ${sanitized}`);
 
-    // Trigger update asynchronously (non-blocking Promise execution)
-    getFullDashboardData(username, { bypassCache: true })
+    // forceRefresh refetches and writes back to the cache; the returned promise lets the
+    // caller keep the function alive (e.g. via after()) until the refresh completes.
+    return getFullDashboardData(username, { forceRefresh: true })
       .then(() => {
         console.info(
           `[BackgroundRefresh] Successfully completed background refresh for: ${sanitized}`

--- a/services/github/background-refresh.type-compiler.test.ts
+++ b/services/github/background-refresh.type-compiler.test.ts
@@ -14,7 +14,7 @@ describe('BackgroundRefresh type compiler validation', () => {
     expectTypeOf(backgroundRefresh.isStale).returns.toEqualTypeOf<boolean>();
 
     expectTypeOf(backgroundRefresh.triggerRefresh).parameters.toEqualTypeOf<[username: string]>();
-    expectTypeOf(backgroundRefresh.triggerRefresh).returns.toEqualTypeOf<void>();
+    expectTypeOf(backgroundRefresh.triggerRefresh).returns.toEqualTypeOf<Promise<void>>();
 
     expectTypeOf(backgroundRefresh.isJobActive).parameters.toEqualTypeOf<[username: string]>();
     expectTypeOf(backgroundRefresh.isJobActive).returns.toEqualTypeOf<boolean>();


### PR DESCRIPTION
## Description

Fixes #3763

The stale-while-revalidate background refresh on `/api/github` never actually refreshed the cache. It was fire-and-forget (no `after()` / `waitUntil`, so Vercel could freeze the function before it finished) and it fetched with `bypassCache: true`, which skips the cache write-back in every fetcher, so even when it ran it persisted nothing and `lastSyncedAt` never advanced.

Changes:

- Added a `forceRefresh` option to `FetchOptions` (`lib/github.ts`) meaning "skip the read but still write the result back", distinct from `bypassCache` (which keeps the existing `?refresh` semantics untouched). Threaded it through the four cache-using fetchers.
- `triggerRefresh` (`services/github/background-refresh.ts`) now uses `forceRefresh: true` and returns its promise.
- The route (`app/api/github/route.ts`) wraps the trigger in `after(() => backgroundRefresh.triggerRefresh(username))` so it runs after the response is sent.

Added 3 `forceRefresh` write-back tests (a forced refresh populates the cache so a later normal read is a hit), updated the background-refresh tests to expect `forceRefresh`, the type-compiler return type to `Promise<void>`, and the route test to run `after()` synchronously.

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

Not applicable. Backend caching change.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (github, route, and the full background-refresh suite pass; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable, no SVG output in this change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
