### PR TITLE
fix(validations): cap versus username at 39 characters

### DIFF
--- a/lib/validations.streakParamsSchema.test.ts
+++ b/lib/validations.streakParamsSchema.test.ts
@@ -186,4 +186,22 @@ describe('streakParamsSchema', () => {
       expect(result.data.hide_background).toBe(true);
     }
   });
+
+  it('accepts a valid versus username', () => {
+    const result = streakParamsSchema.safeParse({ user: 'octocat', versus: 'torvalds' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.versus).toBe('torvalds');
+    }
+  });
+
+  it('rejects a versus username longer than 39 characters', () => {
+    const result = streakParamsSchema.safeParse({ user: 'octocat', versus: 'a'.repeat(40) });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a versus username with invalid characters', () => {
+    const result = streakParamsSchema.safeParse({ user: 'octocat', versus: 'bad user!' });
+    expect(result.success).toBe(false);
+  });
 });

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -304,6 +304,7 @@ const baseStreakParamsSchema = z.object({
     .transform((val) => (val ? sanitizeHexColor(val, '7f8c8d') : undefined)),
   versus: z
     .string()
+    .max(39, { message: 'GitHub username cannot exceed 39 characters' })
     .optional()
     .refine(
       (val) => {


### PR DESCRIPTION
## Description

Fixes #3764

The `versus` opponent-username parameter on `/api/streak` validated only the GitHub username format with an unbounded regex, so unlike every other username field (which caps at 39 characters) it accepted arbitrarily long values and passed them straight to `fetchGitHubContributions`.

Change (in `lib/validations.ts`): added `.max(39, { message: 'GitHub username cannot exceed 39 characters' })` to the `versus` field, matching the message and behavior of the other username fields.

Added 3 tests (accepts a valid versus, rejects over-39, rejects invalid characters).

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

Not applicable. Input validation.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (validations suite passes, including 3 new `versus` tests; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable, no SVG output in this change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
