### PR TITLE
fix(dashboard): prevent month-end overflow when shifting the rolling period

### DIFF
--- a/utils/dashboardPeriod.test.ts
+++ b/utils/dashboardPeriod.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveDashboardPeriod } from './dashboardPeriod';
+import { resolveDashboardPeriod, shiftDashboardPeriod } from './dashboardPeriod';
 describe('resolveDashboardPeriod', () => {
   it('parses valid month period', () => {
     const result = resolveDashboardPeriod({
@@ -46,5 +46,38 @@ describe('resolveDashboardPeriod', () => {
     expect(result.kind).toBe('range');
     expect(result.from).toContain('2024-01-01');
     expect(result.to).toContain('2024-01-31');
+  });
+});
+
+describe('shiftDashboardPeriod', () => {
+  it('shifts a rolling window forward without month-end overflow', () => {
+    const now = new Date(Date.UTC(2026, 0, 15)); // Jan 15, 2026
+    const rolling = resolveDashboardPeriod({}, now);
+    expect(rolling.kind).toBe('rolling');
+
+    const next = shiftDashboardPeriod(rolling, 'next');
+    // Window moves Feb 2025..Jan 2026 -> Mar 2025..Feb 2026 (must NOT overflow to Mar 3, 2026).
+    expect(next.from).toBe(new Date(Date.UTC(2025, 2, 1, 0, 0, 0, 0)).toISOString());
+    expect(next.to).toBe(new Date(Date.UTC(2026, 1, 28, 23, 59, 59, 999)).toISOString());
+
+    const spanDays = (Date.parse(next.to) - Date.parse(next.from)) / 86_400_000;
+    expect(spanDays).toBeLessThan(367);
+  });
+
+  it('shifts a rolling window backward to an aligned 12-month range', () => {
+    const now = new Date(Date.UTC(2026, 0, 15)); // Jan 15, 2026
+    const rolling = resolveDashboardPeriod({}, now);
+
+    const prev = shiftDashboardPeriod(rolling, 'prev');
+    // Window moves to Jan 2025..Dec 2025.
+    expect(prev.from).toBe(new Date(Date.UTC(2025, 0, 1, 0, 0, 0, 0)).toISOString());
+    expect(prev.to).toBe(new Date(Date.UTC(2025, 11, 31, 23, 59, 59, 999)).toISOString());
+  });
+
+  it('shifts a month period to the previous calendar month', () => {
+    const month = resolveDashboardPeriod({ month: '2024-03' });
+    const prev = shiftDashboardPeriod(month, 'prev');
+    expect(prev.kind).toBe('month');
+    expect(prev.month).toBe('2024-02');
   });
 });

--- a/utils/dashboardPeriod.ts
+++ b/utils/dashboardPeriod.ts
@@ -29,9 +29,8 @@ function endOfMonthUtc(year: number, monthIndex: number): Date {
 }
 
 function addMonthsUtc(date: Date, offset: number): Date {
-  return new Date(
-    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + offset, date.getUTCDate(), 0, 0, 0, 0)
-  );
+  // Anchor on the first of the month so shifting never overflows (e.g. Jan 31 + 1mo -> Mar 3).
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + offset, 1, 0, 0, 0, 0));
 }
 
 function addDaysUtc(date: Date, offset: number): Date {
@@ -205,11 +204,16 @@ export function shiftDashboardPeriod(
     return resolveDashboardPeriod({ from: shiftedFrom.toISOString(), to: shiftedTo.toISOString() });
   }
 
-  const from = new Date(period.from);
-  const to = new Date(period.to);
-  const shiftedFrom = addMonthsUtc(from, offset);
-  const shiftedTo = addMonthsUtc(to, offset);
-  return resolveDashboardPeriod({ from: shiftedFrom.toISOString(), to: shiftedTo.toISOString() });
+  // Rolling window: shift by whole months and re-derive month boundaries so the end stays a
+  // valid month-end (avoids day-of-month overflow that would produce a misaligned >1-year range).
+  const fromBase = new Date(period.from);
+  const toBase = new Date(period.to);
+  const shiftedStart = startOfMonthUtc(fromBase.getUTCFullYear(), fromBase.getUTCMonth() + offset);
+  const shiftedEnd = endOfMonthUtc(toBase.getUTCFullYear(), toBase.getUTCMonth() + offset);
+  return resolveDashboardPeriod({
+    from: shiftedStart.toISOString(),
+    to: shiftedEnd.toISOString(),
+  });
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes #3765

Navigating the dashboard's default "Last 12 months" view with Prev/Next corrupted the window. `shiftDashboardPeriod` shifted the window's month-end `to` date with `addMonthsUtc`, which preserves the literal day-of-month, so shifting a 31-day month-end into a shorter month overflowed (for example `Jan 31 + 1 month` became `Feb 31` which JavaScript rolls to `Mar 3`). The result was a misaligned range longer than a year, which mis-fetches and can break the view.

Changes (in `utils/dashboardPeriod.ts`):

- Normalized `addMonthsUtc` to a first-of-month anchor so it can never overflow.
- Rewrote the rolling branch of `shiftDashboardPeriod` to shift the month and re-derive boundaries via `startOfMonthUtc` / `endOfMonthUtc` (which handle month overflow correctly), keeping the window aligned at 12 months.

Added 3 tests (rolling shift forward without overflow, rolling shift backward to an aligned 12-month range, and a month-period shift).

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [x] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

Not applicable. Date-window logic; no visual output change for valid windows.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (8 dashboardPeriod tests pass, including 3 new shift tests; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable, no SVG output in this change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
