### PR TITLE
fix: use correct cache key in RateLimiter.reset()

### DIFF
--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -216,4 +216,27 @@ describe('RateLimiter', () => {
     // Window should have expired — count resets, request is allowed
     expect(await limiter.check(ip)).toBe(true);
   });
+
+  it('reset() clears the counter and restores the full request allowance', async () => {
+    // Verifies that reset() uses the correct cache key (raw IP) so the
+    // rate limit state is actually deleted and subsequent requests succeed.
+    const limiter = new RateLimiter(3, 60000);
+    const ip = '7.7.7.7';
+
+    // Exhaust the limit
+    await limiter.check(ip);
+    await limiter.check(ip);
+    await limiter.check(ip);
+    expect(await limiter.check(ip)).toBe(false);
+
+    // Reset should clear the counter
+    await limiter.reset(ip);
+
+    // After reset, remaining should be back to the full limit
+    expect(await limiter.remaining(ip)).toBe(3);
+
+    // And requests should be allowed again
+    expect(await limiter.check(ip)).toBe(true);
+    expect(await limiter.remaining(ip)).toBe(2);
+  });
 });

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -141,7 +141,7 @@ export class RateLimiter {
    * rateLimiter.reset("192.168.1.1");
    */
   async reset(ip: string): Promise<void> {
-    await this.cache.delete(`ratelimit:${ip}`);
+    await this.cache.delete(ip);
   }
 
   /**


### PR DESCRIPTION
The reset() method was prefixing the IP with 'ratelimit:' before deleting from the cache, but all other methods (check, remaining) use the raw IP as the key. This mismatch meant reset() silently deleted a non-existent key, leaving the rate limit state intact.

- Remove the erroneous 'ratelimit:' prefix in reset()
- Add regression test verifying reset() restores full request allowance

## Description

Fixes #3753

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
