### PR TITLE
fix(sharesheet): remove placeholder STL download functionality

### DIFF
--- a/components/dashboard/ShareSheet.test.tsx
+++ b/components/dashboard/ShareSheet.test.tsx
@@ -396,29 +396,11 @@ describe('ShareSheet', () => {
     expect(mockHandleDownloadSVG).toHaveBeenCalled();
   });
 
-  it('handles Download Printable 3D STL Monolith action', async () => {
-    const realSetTimeout = globalThis.setTimeout.bind(globalThis);
-    vi.spyOn(globalThis, 'setTimeout').mockImplementation(
-      (fn: any, delay?: any, ...args: any[]) => {
-        if (delay === 1200) {
-          fn(...args);
-          return 0 as any;
-        }
-        return realSetTimeout(fn, delay, ...args);
-      }
-    );
-
+  it('renders Download Printable 3D STL as disabled', () => {
     render(<ShareSheet {...defaultProps} />);
-    await act(async () => {
-      fireEvent.click(screen.getByText('Download Printable 3D STL Monolith').closest('button')!);
-    });
-
-    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
-    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
-
-    await waitFor(() => {
-      expect(screen.getByText('Saved Asset!')).toBeDefined();
-    });
+    const stlButton = screen.getByText('Download Printable 3D STL (Coming Soon)').closest('button');
+    expect(stlButton).toBeDefined();
+    expect(stlButton?.disabled).toBe(true);
   });
 
   // ── GitHub Wrapped ---------------------------------------------------------

--- a/components/dashboard/ShareSheet.tsx
+++ b/components/dashboard/ShareSheet.tsx
@@ -186,13 +186,6 @@ export default function ShareSheet({ username, isOpen, onClose, exportData }: Sh
     setTimeout(() => setToast((t) => (t?.id === id ? null : t)), 2400);
   }, []);
 
-  const setLocal = useCallback((key: string, state: OptionState) => {
-    setLocalStates((prev) => ({ ...prev, [key]: state }));
-    if (state === 'success' || state === 'error') {
-      setTimeout(() => setLocalStates((prev) => ({ ...prev, [key]: 'idle' })), 2500);
-    }
-  }, []);
-
   const handleLocalCopyLink = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -261,24 +254,6 @@ export default function ShareSheet({ username, isOpen, onClose, exportData }: Sh
     setMdCopied(true);
     showToast('✓ Markdown copied');
     setTimeout(() => setMdCopied(false), 2200);
-  };
-
-  const handleDownloadSTL = async () => {
-    setLocal('stl', 'loading');
-    try {
-      await new Promise((r) => setTimeout(r, 1200));
-      const stlContent = `solid commitpulse_monolith\n  facet normal 0 0 1\n    outer loop\n      vertex 0 0 0\n      vertex 10 0 0\n      vertex 10 10 0\n    endloop\n  endfacet\nendsolid commitpulse_monolith`;
-      const blob = new Blob([stlContent], { type: 'text/plain' });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.download = `${username}-monolith.stl`;
-      link.href = url;
-      link.click();
-      URL.revokeObjectURL(url);
-      setLocal('stl', 'success');
-    } catch {
-      setLocal('stl', 'error');
-    }
   };
 
   return (
@@ -468,16 +443,19 @@ export default function ShareSheet({ username, isOpen, onClose, exportData }: Sh
                     },
                     {
                       key: 'stl',
-                      label: 'Download Printable 3D STL Monolith',
-                      action: handleDownloadSTL,
+                      label: 'Download Printable 3D STL (Coming Soon)',
+                      action: () => {},
+                      disabled: true,
                     },
                   ].map((row) => {
                     const rowState = combinedStates[row.key] ?? 'idle';
+                    const isDisabled =
+                      'disabled' in row && row.disabled ? true : rowState === 'loading';
                     return (
                       <button
                         key={row.key}
                         onClick={row.action}
-                        disabled={rowState === 'loading'}
+                        disabled={isDisabled}
                         className="w-full p-2 bg-zinc-50 dark:bg-zinc-900 rounded-xl text-left flex items-center justify-between border border-transparent hover:border-zinc-200 disabled:opacity-50"
                       >
                         <div className="flex items-center gap-3">


### PR DESCRIPTION
## Description

Fixes #3702 

This PR removes the misleading placeholder behavior from the **Download Printable 3D STL Monolith** feature in `ShareSheet.tsx`.

### Problem

The existing button:
* Simulates a 1.2-second loading delay.
* Downloads a hardcoded STL file containing only a single triangle.
* Does not generate geometry from the user's contribution data.
* Creates the impression that a functional STL export exists when it does not.

### Changes Made

* Removed the fake STL generation and download workflow.
* Disabled the placeholder export functionality.
* Updated the UI to clearly indicate that STL export is **Coming Soon**.
* Prevented users from downloading non-functional STL files.

### Result

Users are no longer presented with a misleading export option. The interface now accurately reflects the current implementation status until a real procedural STL mesh generator is developed.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth aximations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
