### PR TITLE
test: add massive scaling tests for ResumeUpload

### DIFF
--- a/components/dashboard/ResumeUpload.massive-scaling.test.tsx
+++ b/components/dashboard/ResumeUpload.massive-scaling.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ResumeUpload from './ResumeUpload';
+import type { ReactNode, HTMLAttributes } from 'react';
+import '@testing-library/jest-dom';
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: HTMLAttributes<HTMLDivElement> & { children?: ReactNode }) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+describe('ResumeUpload - Massive Scaling', () => {
+  const onParsed = vi.fn();
+  const onError = vi.fn();
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it('handles PDF files just below the 5MB limit', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        fileName: 'large.pdf',
+        data: { name: 'John Doe' },
+      }),
+    }) as typeof fetch;
+
+    render(<ResumeUpload onParsed={onParsed} onError={onError} />);
+
+    const input = screen.getByLabelText('Upload resume');
+
+    const file = new File([new Uint8Array(4 * 1024 * 1024)], 'large.pdf', {
+      type: 'application/pdf',
+    });
+
+    fireEvent.change(input, {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => {
+      expect(onParsed).toHaveBeenCalled();
+    });
+  });
+
+  it('handles DOCX files just below the 5MB limit', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        fileName: 'large.docx',
+        data: { name: 'John Doe' },
+      }),
+    }) as typeof fetch;
+    render(<ResumeUpload onParsed={onParsed} onError={onError} />);
+
+    const input = screen.getByLabelText('Upload resume');
+
+    const file = new File([new Uint8Array(4 * 1024 * 1024)], 'large.docx', {
+      type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    });
+
+    fireEvent.change(input, {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => {
+      expect(onParsed).toHaveBeenCalled();
+    });
+  });
+
+  it('handles large parsed resume payloads', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        fileName: 'resume.pdf',
+        data: {
+          name: 'John Doe',
+          skills: Array(1000).fill('Python'),
+        },
+      }),
+    }) as typeof fetch;
+    render(<ResumeUpload onParsed={onParsed} onError={onError} />);
+
+    const input = screen.getByLabelText('Upload resume');
+
+    fireEvent.change(input, {
+      target: {
+        files: [
+          new File(['pdf'], 'resume.pdf', {
+            type: 'application/pdf',
+          }),
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(onParsed).toHaveBeenCalled();
+    });
+  });
+
+  it('handles extremely long filenames', async () => {
+    const longName = `${'A'.repeat(200)}.pdf`;
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        fileName: longName,
+        data: { name: 'John Doe' },
+      }),
+    }) as typeof fetch;
+
+    render(<ResumeUpload onParsed={onParsed} onError={onError} />);
+
+    const input = screen.getByLabelText('Upload resume');
+    fireEvent.change(input, {
+      target: {
+        files: [
+          new File(['pdf'], longName, {
+            type: 'application/pdf',
+          }),
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(onParsed).toHaveBeenCalled();
+    });
+  });
+
+  it('handles multiple rapid uploads', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        fileName: 'resume.pdf',
+        data: { name: 'John Doe' },
+      }),
+    }) as typeof fetch;
+
+    render(<ResumeUpload onParsed={onParsed} onError={onError} />);
+
+    const input = screen.getByLabelText('Upload resume');
+
+    for (let i = 0; i < 3; i++) {
+      fireEvent.change(input, {
+        target: {
+          files: [
+            new File(['pdf'], `resume${i}.pdf`, {
+              type: 'application/pdf',
+            }),
+          ],
+        },
+      });
+    }
+    await waitFor(() => {
+      expect(onParsed).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2714

This PR adds massive-scaling test coverage for the ResumeUpload component.

Added test cases for:

* PDF uploads just below the 5MB limit
* DOCX uploads just below the 5MB limit
* Large parsed resume payload handling
* Extremely long filename handling
* Multiple rapid upload events

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the CONTRIBUTING.md file.
* [x] I have tested these changes locally.
* [x] My changes are limited to test coverage.
* [x] I have linked the related issue.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] My commits follow the Conventional Commits format.
