### PR TITLE
test: add active connection coverage for state 99 handling

### DIFF
--- a/models/User.test.ts
+++ b/models/User.test.ts
@@ -99,6 +99,36 @@ describe('User Model', () => {
       readyStateSpy.mockRestore();
       connectSpy.mockRestore();
     });
+
+    //test to ensure that if the connection is already active (readyState 1), it does not trigger the lazy initialization fallback
+    it('does not trigger lazy initialization fallback when connection is already active', async () => {
+      const { vi } = await import('vitest');
+
+      // Mock mongoose.connection.readyState to return 1 (connected)
+      const readyStateSpy = vi
+        .spyOn(mongoose.connection, 'readyState', 'get')
+        .mockReturnValue(1 as unknown as typeof mongoose.connection.readyState);
+
+      // Spy on mongoose.connect
+      const connectSpy = vi.spyOn(mongoose, 'connect').mockResolvedValue(mongoose);
+
+      // Simulate database operation
+      const executeDbOperation = async () => {
+        if (mongoose.connection.readyState === 99) {
+          await mongoose.connect('mongodb://localhost:27017/test');
+        }
+      };
+
+      await executeDbOperation();
+
+      // Assertions
+      expect(mongoose.connection.readyState).toBe(1);
+      expect(connectSpy).not.toHaveBeenCalled();
+
+      // Cleanup
+      readyStateSpy.mockRestore();
+      connectSpy.mockRestore();
+    });
   });
 
   describe('Database Connection State 0 Handling', () => {


### PR DESCRIPTION
## Description

Fixes #1419

Added an additional test case for MongoDB connection state 99 handling in models/User.test.ts.

What Changed
Added a test to verify that lazy initialization fallback is not triggered when the connection is already active (readyState = 1).
Verified that mongoose.connect() is not called unnecessarily when an active connection already exists.
Extended the existing connection state 99 test coverage with a complementary boundary scenario.

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A – Test coverage improvement only (no UI or visual changes).

Before: models/User.test.ts (9 tests)
<img width="953" height="192" alt="Screenshot 2026-05-31 191612" src="https://github.com/user-attachments/assets/ad6f9a21-c759-494a-a34b-bd84e277ecb4" />


After: models/User.test.ts (10 tests)
<img width="964" height="450" alt="Screenshot 2026-06-04 185151" src="https://github.com/user-attachments/assets/6b9495e4-46e2-4551-9ff8-6f9bd170dc59" />


## Validation

* All tests pass locally.
* Added 1 new test case.
* No existing functionality was modified.
* Verified that the new test complements the existing state 99 lazy initialization fallback coverage.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run the test suite locally and verified all tests pass.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [] I have started the repo.
* [] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable)
* [x] I joined the CommitPulse Discord community. (Optional)
