### PR TITLE
fix: apply stricter rate limit for cache-bypass refresh requests

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -7,6 +7,20 @@ vi.mock('@/lib/rate-limit', () => ({
   rateLimit: vi.fn(),
 }));
 
+// Helper: build a rateLimit mock that returns success for the first call
+// and a given result for the second call (used when both limiters fire).
+function mockBothLimiters(
+  refreshResult: Awaited<ReturnType<typeof rateLimit>>,
+  generalSuccess = true
+) {
+  vi.mocked(rateLimit).mockResolvedValueOnce(refreshResult).mockResolvedValueOnce({
+    success: generalSuccess,
+    limit: 60,
+    remaining: 59,
+    reset: 123456789,
+  });
+}
+
 describe('middleware', () => {
   let originalEnv: string | undefined;
 
@@ -67,7 +81,7 @@ describe('middleware', () => {
     });
   });
 
-  it('calls rateLimit with fixed policy values (60 requests / 60000ms)', async () => {
+  it('calls rateLimit with fixed policy values (60 requests / 60000ms) for normal requests', async () => {
     vi.mocked(rateLimit).mockResolvedValue({
       success: true,
       limit: 60,
@@ -236,5 +250,139 @@ describe('middleware', () => {
   it('includes wrapped and student API matchers in middleware config', () => {
     expect(config.matcher).toContain('/api/wrapped/:path*');
     expect(config.matcher).toContain('/api/student/:path*');
+  });
+
+  // ─── ?refresh=true rate-limit tests ───────────────────────────────────────
+
+  describe('?refresh=true cache-bypass rate limit', () => {
+    it('applies the refresh limiter (5 req/min) before the general limiter', async () => {
+      // Both limiters succeed
+      mockBothLimiters({ success: true, limit: 5, remaining: 4, reset: 123456789 });
+
+      const request = new NextRequest('http://localhost:3000/api/streak?user=octocat&refresh=true');
+      await middleware(request);
+
+      // First call must be the refresh limiter with the prefixed key
+      expect(rateLimit).toHaveBeenNthCalledWith(1, 'refresh:127.0.0.1', 5, 60000);
+      // Second call must be the general limiter with the bare IP
+      expect(rateLimit).toHaveBeenNthCalledWith(2, '127.0.0.1', 60, 60000);
+    });
+
+    it('returns 429 with refresh-specific message when refresh limit is exceeded', async () => {
+      mockBothLimiters({ success: false, limit: 5, remaining: 0, reset: 123456789 });
+
+      const request = new NextRequest('http://localhost:3000/api/streak?user=octocat&refresh=true');
+      const response = await middleware(request);
+
+      expect(response.status).toBe(429);
+      const body = await response.json();
+      expect(body.error).toContain('refresh');
+    });
+
+    it('response limit header is 5 (not 60) when the refresh rate limit is exceeded', async () => {
+      vi.mocked(rateLimit).mockResolvedValueOnce({
+        success: false,
+        limit: 5,
+        remaining: 0,
+        reset: 123456789,
+      });
+
+      const request = new NextRequest('http://localhost:3000/api/streak?user=octocat&refresh=true');
+      const response = await middleware(request);
+
+      // The refresh limiter has limit=5, so the header must reflect that — not 60
+      expect(response.headers.get('X-RateLimit-Limit')).toBe('5');
+      expect(response.status).toBe(429);
+    });
+
+    it('does NOT invoke the general limiter when the refresh limit is exceeded', async () => {
+      // Only the refresh limiter fires (returns fail); general limiter must not be called.
+      vi.mocked(rateLimit).mockResolvedValueOnce({
+        success: false,
+        limit: 5,
+        remaining: 0,
+        reset: 123456789,
+      });
+
+      const request = new NextRequest('http://localhost:3000/api/streak?user=octocat&refresh=true');
+      await middleware(request);
+
+      // The general-limiter call always uses (bare IP, 60, 60000) — it must not appear.
+      expect(rateLimit).not.toHaveBeenCalledWith('127.0.0.1', 60, 60000);
+    });
+
+    it('sets X-RateLimit-Limit to 5 on a blocked refresh request', async () => {
+      vi.mocked(rateLimit).mockResolvedValueOnce({
+        success: false,
+        limit: 5,
+        remaining: 0,
+        reset: 999999,
+      });
+
+      const request = new NextRequest('http://localhost:3000/api/streak?user=octocat&refresh=true');
+      const response = await middleware(request);
+
+      expect(response.headers.get('X-RateLimit-Limit')).toBe('5');
+      expect(response.headers.get('X-RateLimit-Remaining')).toBe('0');
+    });
+
+    it('skips the refresh limiter when refresh param is absent', async () => {
+      vi.mocked(rateLimit).mockResolvedValue({
+        success: true,
+        limit: 60,
+        remaining: 59,
+        reset: 123456789,
+      });
+
+      const request = new NextRequest('http://localhost:3000/api/streak?user=octocat');
+      await middleware(request);
+
+      // Only the general limiter should be called
+      expect(rateLimit).toHaveBeenCalledTimes(1);
+      expect(rateLimit).toHaveBeenCalledWith('127.0.0.1', 60, 60000);
+    });
+
+    it('skips the refresh limiter when refresh=false', async () => {
+      vi.mocked(rateLimit).mockResolvedValue({
+        success: true,
+        limit: 60,
+        remaining: 59,
+        reset: 123456789,
+      });
+
+      const request = new NextRequest(
+        'http://localhost:3000/api/streak?user=octocat&refresh=false'
+      );
+      await middleware(request);
+
+      expect(rateLimit).toHaveBeenCalledTimes(1);
+      expect(rateLimit).not.toHaveBeenCalledWith(expect.stringContaining('refresh:'), 5, 60000);
+    });
+
+    it('still applies general limiter when refresh succeeds', async () => {
+      mockBothLimiters({ success: true, limit: 5, remaining: 3, reset: 123456789 });
+
+      const request = new NextRequest('http://localhost:3000/api/streak?user=octocat&refresh=true');
+      const response = await middleware(request);
+
+      // Both limiters ran and overall request succeeded
+      expect(rateLimit).toHaveBeenCalledTimes(2);
+      expect(response.status).toBe(200);
+    });
+
+    it('returns 429 from general limiter even when refresh succeeds', async () => {
+      // refresh OK, general fails
+      vi.mocked(rateLimit)
+        .mockResolvedValueOnce({ success: true, limit: 5, remaining: 2, reset: 123456789 })
+        .mockResolvedValueOnce({ success: false, limit: 60, remaining: 0, reset: 123456789 });
+
+      const request = new NextRequest('http://localhost:3000/api/streak?user=octocat&refresh=true');
+      const response = await middleware(request);
+
+      expect(response.status).toBe(429);
+      const body = await response.json();
+      // The general-limiter error body does NOT mention "refresh"
+      expect(body.error).toBe('Too many requests');
+    });
   });
 });

--- a/middleware.ts
+++ b/middleware.ts
@@ -17,14 +17,40 @@ import { getClientIp } from './utils/getClientIp';
  * - /api/wrapped
  * - /api/student
  *
- * Limit: 60 requests per minute per IP.
+ * General limit : 60 requests per minute per IP.
+ * Refresh limit : 5 requests per minute per IP (when ?refresh=true).
+ *
+ * The refresh-specific limit is checked first. If it is exceeded the request
+ * is rejected immediately with a 429 and the general counter is NOT consumed,
+ * which avoids accidentally burning a user's normal quota on blocked refreshes.
  */
 export async function middleware(request: NextRequest) {
   // Secure client IP extraction
   const ip = getClientIp(request);
 
-  // Apply rate limiting
-  // 60 requests per 60,000ms (1 minute)
+  const isRefresh = request.nextUrl.searchParams.get('refresh') === 'true';
+
+  if (isRefresh) {
+    // Stricter limit: 5 cache-bypass requests per minute per IP.
+    // Uses a separate key prefix so it doesn't share counters with the
+    // general rate limiter.
+    const refreshResult = await rateLimit(`refresh:${ip}`, 5, 60000);
+
+    if (!refreshResult.success) {
+      // Return early — do NOT consume the general-limiter quota for a blocked refresh.
+      const resp = NextResponse.json(
+        { error: 'Too many refresh requests. Please wait before bypassing the cache again.' },
+        { status: 429 }
+      );
+      resp.headers.set('X-RateLimit-Limit', refreshResult.limit.toString());
+      resp.headers.set('X-RateLimit-Remaining', '0');
+      resp.headers.set('X-RateLimit-Reset', refreshResult.reset.toString());
+      resp.headers.set('X-RateLimit-Policy', 'refresh');
+      return resp;
+    }
+  }
+
+  // General limit: 60 requests per 60,000 ms (1 minute)
   const result = await rateLimit(ip, 60, 60000);
 
   if (!result.success) {


### PR DESCRIPTION
## Description

This PR fixes the security issue described in #3689 where repeated `?refresh=true` requests could bypass the caching layer and force direct GitHub API calls, potentially exhausting the server's GitHub API quota.

### Changes Made

* Added a dedicated rate limiter for requests using `?refresh=true`
* Limited cache-bypass requests to 5 requests per minute per IP
* Used a separate cache key (`refresh:<ip>`) to isolate refresh quotas from normal requests
* Added an early return when the refresh limit is exceeded, preventing consumption of the normal rate-limit quota
* Added comprehensive middleware tests covering refresh-specific rate-limiting behavior

Closes #3689

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)
* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization

## Checklist

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run linting and resolved errors.
* [x] My commits follow the Conventional Commits format.
* [x] I have made sure that I have only one commit to merge in this PR.
