### PR TITLE
fix: update broken Table of Contents anchor links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,22 @@
 
 ## 📖 Table of Contents
 
-- [Design Philosophy](#the-isometric-monolith--design-philosophy)
-- [Live Demo](#live-demo)
-- [Deep Customization](#deep-customization--url-parameters)
+- [Design Philosophy](#️-the-isometric-monolith--design-philosophy)
+- [Live Demo](#-live-demo)
+- [Deep Customization](#-deep-customization--url-parameters)
   - [Parameter Reference](#parameter-reference)
   - [Grace Period Examples](#grace-period-examples)
   - [Theme Presets](#theme-presets)
-- [Theme Preview Gallery](#theme-preview-gallery)
-- [Real-Time Accuracy](#real-time-accuracy--the-contribution-count-problem)
-- [Architecture & Tech Stack](#architecture--tech-stack)
-- [Self-Hosting](#self-hosting-in-4-steps)
-- [Automated Contributor Workflow](#automated-contributor-workflow)
-- [FAQ](#faq)
-- [Contributing](#contributing)
-- [License](#license)
-- [Themes](#themes)
-- [Contributors](#contributors)
+- [Theme Preview Gallery](#-theme-preview-gallery)
+- [Real-Time Accuracy](#-real-time-accuracy--the-contribution-count-problem)
+- [Architecture & Tech Stack](#️-architecture--tech-stack)
+- [Self-Hosting](#-self-hosting-in-4-steps)
+- [Automated Contributor Workflow](#-automated-contributor-workflow)
+- [FAQ](#-faq)
+- [Contributing](#-contributing)
+- [License](#-license)
+- [Themes](#-themes)
+- [Contributors](#-contributors)
 
 ---
 


### PR DESCRIPTION
## Description
Fixes #3785

Fixed broken anchor links in the README Table of Contents. Several ToC links 
were not navigating to their respective sections due to mismatched 
GitHub-generated anchors. Updated the anchor hrefs to match the correct slugs 
while keeping the existing emoji-based headings intact.

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — Documentation fix only (no visual changes)

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format (e.g., `docs(readme): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [x] (Recommended) I joined the CommitPulse Discord community.
