### PR TITLE
test(githubwrapped): add type compiler coverage

### DIFF
--- a/components/dashboard/GithubWrapped.type-compiler.test.tsx
+++ b/components/dashboard/GithubWrapped.type-compiler.test.tsx
@@ -4,14 +4,20 @@ import type { WrappedStats, UserProfile } from '@/types/dashboard';
 
 describe('GithubWrapped type compiler validation', () => {
   const profile: UserProfile = {
-    username: 'Anvi',
+    username: 'anvidev',
     name: 'Anvi Gupta',
     avatarUrl: 'https://example.com/avatar.png',
-    bio: null,
-    followers: 10,
-    following: 5,
-    publicRepos: 20,
+    isPro: false,
+    bio: 'Open source contributor',
+    location: 'India',
+    joinedDate: '2024-01-01',
     developerScore: 85,
+    stats: {
+      repositories: 20,
+      followers: 10,
+      following: 5,
+      stars: 100,
+    },
   };
 
   const wrappedData: WrappedStats = {
@@ -21,6 +27,10 @@ describe('GithubWrapped type compiler validation', () => {
     mostActiveDate: '2026-06-04',
     busiestMonth: '2026-06',
     weekendRatio: 30,
+    calendar: {
+      totalContributions: 1200,
+      weeks: [],
+    },
   };
 
   it('accepts valid GithubWrapped props', () => {
@@ -37,18 +47,22 @@ describe('GithubWrapped type compiler validation', () => {
     expectTypeOf(profile.username).toBeString();
     expectTypeOf(profile.name).toBeString();
     expectTypeOf(profile.avatarUrl).toBeString();
+    expectTypeOf(profile.isPro).toBeBoolean();
     expectTypeOf(profile.developerScore).toBeNumber();
   });
 
-  it('enforces WrappedStats numeric fields', () => {
+  it('enforces nested UserProfile stats field types', () => {
+    expectTypeOf(profile.stats.repositories).toBeNumber();
+    expectTypeOf(profile.stats.followers).toBeNumber();
+    expectTypeOf(profile.stats.following).toBeNumber();
+    expectTypeOf(profile.stats.stars).toBeNumber();
+  });
+
+  it('enforces WrappedStats field types', () => {
     expectTypeOf(wrappedData.totalContributions).toBeNumber();
     expectTypeOf(wrappedData.highestDailyCount).toBeNumber();
     expectTypeOf(wrappedData.weekendRatio).toBeNumber();
-  });
-
-  it('enforces WrappedStats string fields', () => {
     expectTypeOf(wrappedData.topLanguage).toBeString();
-    expectTypeOf(wrappedData.mostActiveDate).toBeString();
     expectTypeOf(wrappedData.busiestMonth).toBeString();
   });
 

--- a/components/dashboard/GithubWrapped.type-compiler.test.tsx
+++ b/components/dashboard/GithubWrapped.type-compiler.test.tsx
@@ -4,14 +4,13 @@ import type { WrappedStats, UserProfile } from '@/types/dashboard';
 
 describe('GithubWrapped type compiler validation', () => {
   const profile: UserProfile = {
-    username: 'riddhima',
-    name: 'Riddhima Gupta',
+    username: 'Anvi',
+    name: 'Anvi Gupta',
     avatarUrl: 'https://example.com/avatar.png',
     bio: null,
-    publicRepos: 12,
-    followers: 100,
-    following: 50,
-    createdAt: '2024-01-01T00:00:00Z',
+    followers: 10,
+    following: 5,
+    publicRepos: 20,
     developerScore: 85,
   };
 
@@ -21,37 +20,43 @@ describe('GithubWrapped type compiler validation', () => {
     highestDailyCount: 42,
     mostActiveDate: '2026-06-04',
     busiestMonth: '2026-06',
-    weekendRatio: 28,
+    weekendRatio: 30,
   };
 
-  it('accepts valid UserProfile type shape', () => {
-    expectTypeOf(profile).toMatchTypeOf<UserProfile>();
-    expect(profile.username).toBe('riddhima');
-  });
-
-  it('accepts valid WrappedStats type shape', () => {
-    expectTypeOf(wrappedData).toMatchTypeOf<WrappedStats>();
-    expect(wrappedData.totalContributions).toBe(1200);
-  });
-
-  it('enforces GithubWrapped component prop contract', () => {
-    expectTypeOf(GithubWrapped).parameter(0).toMatchTypeOf<{
+  it('accepts valid GithubWrapped props', () => {
+    expectTypeOf({
+      profile,
+      wrappedData,
+    }).toMatchTypeOf<{
       profile: UserProfile;
       wrappedData: WrappedStats;
     }>();
   });
 
-  it('requires numeric contribution and ratio fields', () => {
-    expectTypeOf(wrappedData.totalContributions).toEqualTypeOf<number>();
-    expectTypeOf(wrappedData.highestDailyCount).toEqualTypeOf<number>();
-    expectTypeOf(wrappedData.weekendRatio).toEqualTypeOf<number>();
+  it('enforces UserProfile field types', () => {
+    expectTypeOf(profile.username).toBeString();
+    expectTypeOf(profile.name).toBeString();
+    expectTypeOf(profile.avatarUrl).toBeString();
+    expectTypeOf(profile.developerScore).toBeNumber();
   });
 
-  it('requires string metadata fields for display rendering', () => {
-    expectTypeOf(profile.username).toEqualTypeOf<string>();
-    expectTypeOf(profile.name).toEqualTypeOf<string>();
-    expectTypeOf(profile.avatarUrl).toEqualTypeOf<string>();
-    expectTypeOf(wrappedData.topLanguage).toEqualTypeOf<string>();
-    expectTypeOf(wrappedData.busiestMonth).toEqualTypeOf<string>();
+  it('enforces WrappedStats numeric fields', () => {
+    expectTypeOf(wrappedData.totalContributions).toBeNumber();
+    expectTypeOf(wrappedData.highestDailyCount).toBeNumber();
+    expectTypeOf(wrappedData.weekendRatio).toBeNumber();
+  });
+
+  it('enforces WrappedStats string fields', () => {
+    expectTypeOf(wrappedData.topLanguage).toBeString();
+    expectTypeOf(wrappedData.mostActiveDate).toBeString();
+    expectTypeOf(wrappedData.busiestMonth).toBeString();
+  });
+
+  it('exposes GithubWrapped as a callable React component', () => {
+    expect(GithubWrapped).toBeTypeOf('function');
+    expectTypeOf(GithubWrapped).parameter(0).toMatchTypeOf<{
+      profile: UserProfile;
+      wrappedData: WrappedStats;
+    }>();
   });
 });

--- a/components/dashboard/GithubWrapped.type-compiler.test.tsx
+++ b/components/dashboard/GithubWrapped.type-compiler.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import GithubWrapped from './GithubWrapped';
+import type { WrappedStats, UserProfile } from '@/types/dashboard';
+
+describe('GithubWrapped type compiler validation', () => {
+  const profile: UserProfile = {
+    username: 'riddhima',
+    name: 'Riddhima Gupta',
+    avatarUrl: 'https://example.com/avatar.png',
+    bio: null,
+    publicRepos: 12,
+    followers: 100,
+    following: 50,
+    createdAt: '2024-01-01T00:00:00Z',
+    developerScore: 85,
+  };
+
+  const wrappedData: WrappedStats = {
+    totalContributions: 1200,
+    topLanguage: 'TypeScript',
+    highestDailyCount: 42,
+    mostActiveDate: '2026-06-04',
+    busiestMonth: '2026-06',
+    weekendRatio: 28,
+  };
+
+  it('accepts valid UserProfile type shape', () => {
+    expectTypeOf(profile).toMatchTypeOf<UserProfile>();
+    expect(profile.username).toBe('riddhima');
+  });
+
+  it('accepts valid WrappedStats type shape', () => {
+    expectTypeOf(wrappedData).toMatchTypeOf<WrappedStats>();
+    expect(wrappedData.totalContributions).toBe(1200);
+  });
+
+  it('enforces GithubWrapped component prop contract', () => {
+    expectTypeOf(GithubWrapped).parameter(0).toMatchTypeOf<{
+      profile: UserProfile;
+      wrappedData: WrappedStats;
+    }>();
+  });
+
+  it('requires numeric contribution and ratio fields', () => {
+    expectTypeOf(wrappedData.totalContributions).toEqualTypeOf<number>();
+    expectTypeOf(wrappedData.highestDailyCount).toEqualTypeOf<number>();
+    expectTypeOf(wrappedData.weekendRatio).toEqualTypeOf<number>();
+  });
+
+  it('requires string metadata fields for display rendering', () => {
+    expectTypeOf(profile.username).toEqualTypeOf<string>();
+    expectTypeOf(profile.name).toEqualTypeOf<string>();
+    expectTypeOf(profile.avatarUrl).toEqualTypeOf<string>();
+    expectTypeOf(wrappedData.topLanguage).toEqualTypeOf<string>();
+    expectTypeOf(wrappedData.busiestMonth).toEqualTypeOf<string>();
+  });
+});

--- a/components/dashboard/GithubWrapped.type-compiler.test.tsx
+++ b/components/dashboard/GithubWrapped.type-compiler.test.tsx
@@ -22,11 +22,11 @@ describe('GithubWrapped type compiler validation', () => {
 
   const wrappedData: WrappedStats = {
     totalContributions: 1200,
-    topLanguage: 'TypeScript',
-    highestDailyCount: 42,
     mostActiveDate: '2026-06-04',
+    highestDailyCount: 42,
     busiestMonth: '2026-06',
     weekendRatio: 30,
+    topLanguage: 'TypeScript',
     calendar: {
       totalContributions: 1200,
       weeks: [],
@@ -48,10 +48,13 @@ describe('GithubWrapped type compiler validation', () => {
     expectTypeOf(profile.name).toBeString();
     expectTypeOf(profile.avatarUrl).toBeString();
     expectTypeOf(profile.isPro).toBeBoolean();
+    expectTypeOf(profile.bio).toBeString();
+    expectTypeOf(profile.location).toBeString();
+    expectTypeOf(profile.joinedDate).toBeString();
     expectTypeOf(profile.developerScore).toBeNumber();
   });
 
-  it('enforces nested UserProfile stats field types', () => {
+  it('enforces nested stats field types', () => {
     expectTypeOf(profile.stats.repositories).toBeNumber();
     expectTypeOf(profile.stats.followers).toBeNumber();
     expectTypeOf(profile.stats.following).toBeNumber();
@@ -63,11 +66,14 @@ describe('GithubWrapped type compiler validation', () => {
     expectTypeOf(wrappedData.highestDailyCount).toBeNumber();
     expectTypeOf(wrappedData.weekendRatio).toBeNumber();
     expectTypeOf(wrappedData.topLanguage).toBeString();
+    expectTypeOf(wrappedData.mostActiveDate).toBeString();
     expectTypeOf(wrappedData.busiestMonth).toBeString();
+    expectTypeOf(wrappedData.calendar).toBeObject();
   });
 
   it('exposes GithubWrapped as a callable React component', () => {
     expect(GithubWrapped).toBeTypeOf('function');
+
     expectTypeOf(GithubWrapped).parameter(0).toMatchTypeOf<{
       profile: UserProfile;
       wrappedData: WrappedStats;


### PR DESCRIPTION
## Description

Fixes #2542

Added TypeScript compiler validation tests for `GithubWrapped` to ensure prop contracts and schema constraints remain stable during future updates.

### Covered Scenarios

* Validation of `UserProfile` type structure
* Validation of `WrappedStats` type structure
* Verification of `GithubWrapped` component prop contract
* Enforcement of numeric field types for contribution metrics
* Enforcement of string field types for display metadata

### Testing

* Added 5 dedicated type-validation test cases using `expectTypeOf`
* Verified component prop compatibility with exported dashboard types
* Confirmed compile-time type safety for critical fields
* Added regression protection against accidental schema changes

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if required.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The changes are focused and do not introduce regressions.
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
