### PR TITLE
test(lang-zh): verify Chinese translation labels

### DIFF
--- a/lib/i18n/languages/zh.test.ts
+++ b/lib/i18n/languages/zh.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getLabels, labels } from '../badgeLabels';
+
+const requiredKeys = [
+  'CURRENT_STREAK',
+  'ANNUAL_SYNC_TOTAL',
+  'PEAK_STREAK',
+  'COMMITS_THIS_MONTH',
+  'VS_LAST_MONTH',
+] as const;
+
+const expectedChineseLabels = {
+  CURRENT_STREAK: '当前连续记录',
+  ANNUAL_SYNC_TOTAL: '年度总计',
+  PEAK_STREAK: '最长连续记录',
+  COMMITS_THIS_MONTH: '本月提交次数',
+  VS_LAST_MONTH: '较上个月',
+};
+
+function renderMockBadge(lang: string) {
+  const badgeLabels = getLabels(lang);
+
+  return `
+    <svg role="img" data-lang="${lang}">
+      <text>${badgeLabels.CURRENT_STREAK}</text>
+      <text>${badgeLabels.ANNUAL_SYNC_TOTAL}</text>
+      <text>${badgeLabels.PEAK_STREAK}</text>
+      <text>${badgeLabels.COMMITS_THIS_MONTH}</text>
+      <text>${badgeLabels.VS_LAST_MONTH}</text>
+    </svg>
+  `;
+}
+
+describe('Chinese badge labels', () => {
+  it('includes the zh language key in the labels dictionary', () => {
+    expect(labels.zh).toBeDefined();
+  });
+
+  it('returns the exact Chinese translation mapping through getLabels', () => {
+    expect(getLabels('zh')).toEqual(expectedChineseLabels);
+  });
+
+  it('returns the Chinese mapping when lang code casing differs', () => {
+    expect(getLabels('ZH')).toEqual(expectedChineseLabels);
+  });
+
+  it('sets every required Chinese label to a non-empty string', () => {
+    const chineseLabels = getLabels('zh');
+
+    for (const key of requiredKeys) {
+      expect(typeof chineseLabels[key]).toBe('string');
+      expect(chineseLabels[key].trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('renders a mock SVG with Chinese translated labels', () => {
+    const svg = renderMockBadge('zh');
+
+    expect(svg).toContain('data-lang="zh"');
+
+    for (const value of Object.values(expectedChineseLabels)) {
+      expect(svg).toContain(value);
+    }
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2332 
## Summary

* Added `lib/i18n/languages/zh.test.ts`
* Verified the `zh` language key exists in the labels dictionary
* Verified `getLabels('zh')` returns the expected Chinese translations
* Verified all required translation properties are non-empty strings
* Verified language code casing is handled correctly
* Verified translated labels render correctly in a mock SVG

## Testing

```bash
npx vitest lib/i18n/languages/zh.test.ts
```

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
