### PR TITLE
test(lang-pt): verify Portuguese translation labels

### DIFF
--- a/lib/i18n/languages/pt.test.ts
+++ b/lib/i18n/languages/pt.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getLabels, labels } from '../badgeLabels';
+
+const requiredKeys = [
+  'CURRENT_STREAK',
+  'ANNUAL_SYNC_TOTAL',
+  'PEAK_STREAK',
+  'COMMITS_THIS_MONTH',
+  'VS_LAST_MONTH',
+] as const;
+
+const expectedPortugueseLabels = {
+  CURRENT_STREAK: 'SÉRIE_ATUAL',
+  ANNUAL_SYNC_TOTAL: 'TOTAL_ANUAL',
+  PEAK_STREAK: 'SÉRIE_MÁXIMA',
+  COMMITS_THIS_MONTH: 'COMMITS ESTE MÊS',
+  VS_LAST_MONTH: 'vs mês passado',
+};
+
+function renderMockBadge(lang: string) {
+  const badgeLabels = getLabels(lang);
+
+  return `
+    <svg role="img" data-lang="${lang}">
+      <text>${badgeLabels.CURRENT_STREAK}</text>
+      <text>${badgeLabels.ANNUAL_SYNC_TOTAL}</text>
+      <text>${badgeLabels.PEAK_STREAK}</text>
+      <text>${badgeLabels.COMMITS_THIS_MONTH}</text>
+      <text>${badgeLabels.VS_LAST_MONTH}</text>
+    </svg>
+  `;
+}
+
+describe('Portuguese badge labels', () => {
+  it('includes the pt language key in the labels dictionary', () => {
+    expect(labels.pt).toBeDefined();
+  });
+
+  it('returns the exact Portuguese translation mapping through getLabels', () => {
+    expect(getLabels('pt')).toEqual(expectedPortugueseLabels);
+  });
+
+  it('returns the Portuguese mapping when lang code casing differs', () => {
+    expect(getLabels('PT')).toEqual(expectedPortugueseLabels);
+  });
+
+  it('sets every required Portuguese label to a non-empty string', () => {
+    const portugueseLabels = getLabels('pt');
+
+    for (const key of requiredKeys) {
+      expect(typeof portugueseLabels[key]).toBe('string');
+      expect(portugueseLabels[key].trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('renders a mock SVG with Portuguese translated labels', () => {
+    const svg = renderMockBadge('pt');
+
+    expect(svg).toContain('data-lang="pt"');
+
+    for (const value of Object.values(expectedPortugueseLabels)) {
+      expect(svg).toContain(value);
+    }
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2334 


## Summary

- Added `lib/i18n/languages/pt.test.ts`
- Verified the `pt` language key exists
- Verified `getLabels('pt')` returns expected translations
- Verified required labels are non-empty strings
- Verified translated labels render in a mock SVG

## Testing

npx vitest lib/i18n/languages/pt.test.ts
## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
