### PR TITLE
test(lang-ko): verify Korean translation labels

### DIFF
--- a/lib/i18n/languages/ko.test.ts
+++ b/lib/i18n/languages/ko.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getLabels, labels } from '../badgeLabels';
+
+const requiredKeys = [
+  'CURRENT_STREAK',
+  'ANNUAL_SYNC_TOTAL',
+  'PEAK_STREAK',
+  'COMMITS_THIS_MONTH',
+  'VS_LAST_MONTH',
+] as const;
+
+const expectedKoreanLabels = {
+  CURRENT_STREAK: '현재_연속',
+  ANNUAL_SYNC_TOTAL: '연간_총계',
+  PEAK_STREAK: '최고_연속',
+  COMMITS_THIS_MONTH: '이번 달 커밋',
+  VS_LAST_MONTH: '지난달 대비',
+};
+
+function renderMockBadge(lang: string) {
+  const badgeLabels = getLabels(lang);
+
+  return `
+    <svg role="img" data-lang="${lang}">
+      <text>${badgeLabels.CURRENT_STREAK}</text>
+      <text>${badgeLabels.ANNUAL_SYNC_TOTAL}</text>
+      <text>${badgeLabels.PEAK_STREAK}</text>
+      <text>${badgeLabels.COMMITS_THIS_MONTH}</text>
+      <text>${badgeLabels.VS_LAST_MONTH}</text>
+    </svg>
+  `;
+}
+
+describe('Korean badge labels', () => {
+  it('includes the ko language key in the labels dictionary', () => {
+    expect(labels.ko).toBeDefined();
+  });
+
+  it('returns the exact Korean translation mapping through getLabels', () => {
+    expect(getLabels('ko')).toEqual(expectedKoreanLabels);
+  });
+
+  it('returns the Korean mapping when lang code casing differs', () => {
+    expect(getLabels('KO')).toEqual(expectedKoreanLabels);
+  });
+
+  it('sets every required Korean label to a non-empty string', () => {
+    const koreanLabels = getLabels('ko');
+
+    for (const key of requiredKeys) {
+      expect(typeof koreanLabels[key]).toBe('string');
+      expect(koreanLabels[key].trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('renders a mock SVG with Korean translated labels', () => {
+    const svg = renderMockBadge('ko');
+
+    expect(svg).toContain('data-lang="ko"');
+
+    for (const value of Object.values(expectedKoreanLabels)) {
+      expect(svg).toContain(value);
+    }
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2335 

## Summary

- Added `lib/i18n/languages/ko.test.ts`
- Verified the `ko` language key exists
- Verified `getLabels('ko')` returns expected Korean translations
- Verified language code casing is handled correctly
- Verified all required translation properties are non-empty strings
- Verified translated labels render correctly in a mock SVG

## Testing

npx vitest lib/i18n/languages/ko.test.ts
## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
