### PR TITLE
test(github): verify GITHUB_TOKEN fallback header value

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -292,6 +292,29 @@ describe('fetchGitHubContributions', () => {
       Authorization: 'bearer actions-token',
     });
   });
+  it('verifies Authorization header uses GITHUB_TOKEN value in fallback path', async () => {
+    delete process.env.GITHUB_PAT;
+    process.env.GITHUB_TOKEN = 'my-actions-token';
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse({
+        data: {
+          user: {
+            contributionsCollection: {
+              contributionCalendar: mockCalendar,
+              commitContributionsByRepository: [],
+            },
+          },
+        },
+      })
+    );
+
+    await fetchGitHubContributions('octocat');
+
+    const [, options] = vi.mocked(fetch).mock.calls[0];
+    expect(options?.headers).toMatchObject({
+      Authorization: 'bearer my-actions-token',
+    });
+  });
 
   it('throws before fetching when no GitHub token is configured', async () => {
     delete process.env.GITHUB_PAT;


### PR DESCRIPTION
Closes #1106

## What this PR does
Adds 1 new test in `lib/github.test.ts`

- Deletes `GITHUB_PAT`, sets `GITHUB_TOKEN = 'my-actions-token'`
- Mocks a successful response
- Calls `fetchGitHubContributions('octocat')`
- Asserts `Authorization` header is `'bearer my-actions-token'`

## Checklist
- [x] Follows existing plugin patterns
- [x] All existing tests pass
- [x] 1 new assertion added for GITHUB_TOKEN fallback path