### PR TITLE
fix: the Twitter branding to X

### DIFF
--- a/app/components/Footer.test.tsx
+++ b/app/components/Footer.test.tsx
@@ -103,7 +103,7 @@ describe('Footer Component', () => {
     expect(connectHeading).toBeInTheDocument();
 
     // Check for social links
-    expect(screen.getByRole('link', { name: /Twitter\/X/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Creator on X/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /LinkedIn/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Discord/i })).toBeInTheDocument();
   });

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -53,9 +53,9 @@ const socialLinks: SocialLink[] = [
     icon: 'discord',
   },
   {
-    label: 'Twitter',
-    href: 'https://twitter.com/JhaSourav07',
-    ariaLabel: 'Creator on Twitter/X',
+    label: 'X',
+    href: 'https://x.com/JhaSourav07',
+    ariaLabel: 'Creator on X',
     icon: 'twitter',
   },
   {


### PR DESCRIPTION
## Description
Replaced the Twitter branding with X in the footer social links section to reflect the platform's current branding.  

Fixes #3541 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="215" height="267" alt="image" src="https://github.com/user-attachments/assets/c7a57d3e-3006-44af-925a-c326fe41c033" />


## Checklist before requesting a review:

- [ ] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [ ] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [ ] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
