### PR TITLE
test(DashboardClient-type-compiler): verify TypeScript Compiler Validation & Schema Constraints Stability

### DIFF
--- a/components/dashboard/DashboardClient.type-compiler.test.tsx
+++ b/components/dashboard/DashboardClient.type-compiler.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import React, { ComponentProps } from 'react';
+import DashboardClient, { ProfileMetrics, CoderProfile } from './DashboardClient';
+import type { DashboardPeriod } from '@/utils/dashboardPeriod';
+
+describe('DashboardClient - TypeScript Compiler Validation & Schema Constraints Stability (Variation 10)', () => {
+  it('Import the interfaces, types, or validation schemas associated with the file: Verify exported types', () => {
+    // Asserting the exact shape of exported interfaces
+    expectTypeOf<ProfileMetrics>().toEqualTypeOf<{
+      currentStreak: number;
+      commitClock: { day: string; commits: number }[];
+    }>();
+
+    expectTypeOf<CoderProfile>().toHaveProperty('peakHourStart').toBeNumber();
+    expectTypeOf<CoderProfile>().toHaveProperty('profileName').toBeString();
+  });
+
+  it('Use type-testing assertions (expectTypeOf) to enforce field property configurations: Infer unexported props', () => {
+    // Extracting the props from the component
+    type Props = ComponentProps<typeof DashboardClient>;
+
+    // Assert the required fields
+    expectTypeOf<Props>().toHaveProperty('username').toBeString();
+    expectTypeOf<Props>().toHaveProperty('period').toEqualTypeOf<DashboardPeriod>();
+
+    // Test the internal initialData structure
+    expectTypeOf<Props['initialData']>().toHaveProperty('profile').toBeObject();
+    expectTypeOf<Props['initialData']['profile']>().toHaveProperty('username').toBeString();
+  });
+
+  it('Assert that invalid prop parameters are blocked during static type checking: Rejects missing props', () => {
+    type Props = ComponentProps<typeof DashboardClient>;
+
+    // Missing 'username', 'initialData', 'period'
+    expectTypeOf<Record<string, never>>().not.toMatchTypeOf<Props>();
+
+    // 'username' must be a string, not a number
+    expectTypeOf<{
+      username: number;
+      initialData: Props['initialData'];
+      period: DashboardPeriod;
+    }>().not.toMatchTypeOf<Props>();
+  });
+
+  it('Verify custom types accept optional values without compile errors: compareData is optional or nullable', () => {
+    type Props = ComponentProps<typeof DashboardClient>;
+
+    // compareData should be optional or accept null/undefined
+    expectTypeOf<Props['compareData']>().toBeNullable();
+    expectTypeOf<Props>().toHaveProperty('compareData');
+
+    // This should compile fine (compareData omitted)
+    const validComponent = (
+      <DashboardClient
+        username="test"
+        initialData={{} as unknown as Props['initialData']}
+        period={{} as unknown as DashboardPeriod}
+      />
+    );
+    void validComponent;
+  });
+
+  it('Verify schema validation constraints return strict validation reports: CoderProfile strict unions', () => {
+    // profileName has a specific union of strings
+    expectTypeOf<CoderProfile['profileName']>().toEqualTypeOf<
+      'Early Builder ☀' | 'Weekend Warrior 🚀' | 'Consistent Runner 🏃‍♂️'
+    >();
+
+    // intensity in activity array has strict union 0 | 1 | 2 | 3 | 4
+    type Props = ComponentProps<typeof DashboardClient>;
+    type ActivityIntensity = Props['initialData']['activity'][0]['intensity'];
+    expectTypeOf<ActivityIntensity>().toEqualTypeOf<0 | 1 | 2 | 3 | 4>();
+  });
+});


### PR DESCRIPTION
## Description

This PR implements strict unit tests for TypeScript Compiler Validation and Schema Constraints Stability on the `DashboardClient.tsx` component.

Specifically, it utilizes Vitest's `expectTypeOf` utility to securely validate:
- **Exported Interfaces**: Ensures `ProfileMetrics` and `CoderProfile` accurately match specific primitive shapes.
- **Inferred Component Props**: Validates that standard implementation props (`initialData`, `username`, `period`) maintain their correct structural constraints.
- **Negative Rejection Validation**: Uses strict type-level negative assertions (`not.toMatchTypeOf`) to guarantee the compiler actively blocks invalid data inputs (e.g., passing a `number` instead of a `string` for `username`).
- **Union Constrains**: Statically confirms strict constraint schema definitions, like activity arrays (`0 | 1 | 2 | 3 | 4`) and literal string unions.

Fixes #2532

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A - This PR exclusively focuses on static analysis testing and compiler enforcement checks.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.