### PR TITLE
test(LanguageChart-accessibility): verify Accessibility Standards & Screen Reader Aria Compliance

### DIFF
--- a/components/dashboard/LanguageChart.accessibility.test.tsx
+++ b/components/dashboard/LanguageChart.accessibility.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import LanguageChart from './LanguageChart';
+import type { LanguageData } from '@/types/dashboard';
+
+// Mock IntersectionObserver for framer-motion's whileInView feature
+class IntersectionObserverMock {
+  constructor() {}
+  disconnect() {}
+  observe() {}
+  takeRecords() {
+    return [];
+  }
+  unobserve() {}
+}
+vi.stubGlobal('IntersectionObserver', IntersectionObserverMock);
+
+const mockLanguages: LanguageData[] = [
+  { name: 'TypeScript', color: '#3178c6', percentage: 60 },
+  { name: 'JavaScript', color: '#f1e05a', percentage: 30 },
+  { name: 'HTML', color: '#e34c26', percentage: 10 },
+];
+
+describe('LanguageChart - Accessibility Standards & Screen Reader Aria Compliance (Variation 4)', () => {
+  it('Inspect markup to check for correct use of accessible label coordinates (role, aria-labelledby, or aria-describedby): region role and labelledby', () => {
+    render(<LanguageChart languages={mockLanguages} />);
+
+    // Check main container region
+    const region = screen.getByRole('region', { name: 'Top Languages' });
+    expect(region).toBeInTheDocument();
+
+    // Check the donut chart image role
+    const donut = screen.getByRole('img', { name: /Donut chart showing top languages/i });
+    expect(donut).toBeInTheDocument();
+  });
+
+  it('Assert elements that accept key focus (buttons, interactive nodes) maintain visible outline behaviors: Tailwind focus-visible classes', () => {
+    const { container } = render(<LanguageChart languages={mockLanguages} />);
+
+    // The donut chart is focusable
+    const donut = screen.getByTestId('donut-chart');
+    expect(donut).toHaveClass('focus-visible:ring-2', 'focus-visible:ring-blue-500');
+
+    // The language items are focusable
+    const items = container.querySelectorAll('[title]');
+    expect(items.length).toBe(3);
+    items.forEach((item) => {
+      expect(item).toHaveClass('focus-visible:ring-2', 'focus-visible:ring-blue-500');
+    });
+  });
+
+  it('Verify tooltip labels are announced with correct accessibility descriptions: title and aria-label attributes exist', () => {
+    render(<LanguageChart languages={mockLanguages} />);
+
+    // Verify first language tooltip
+    const tsItem = screen.getByTitle('TypeScript makes up 60 percent of top languages');
+    expect(tsItem).toBeInTheDocument();
+    expect(tsItem).toHaveAttribute('aria-label', 'TypeScript: 60%');
+  });
+
+  it('Test keyboard control path selectors to ensure normal tab ordering: tabIndex=0 is set', () => {
+    const { container } = render(<LanguageChart languages={mockLanguages} />);
+
+    // Donut chart must be reachable via tab
+    const donut = screen.getByTestId('donut-chart');
+    expect(donut).toHaveAttribute('tabIndex', '0');
+
+    // List items must be reachable via tab
+    const items = container.querySelectorAll('[tabIndex="0"]');
+    // Donut chart (1) + 3 language items = 4 focusable elements
+    expect(items.length).toBe(4);
+  });
+
+  it('Confirm standard headings exist in the correct logical hierarchical order: h3 title', () => {
+    render(<LanguageChart languages={mockLanguages} />);
+
+    // H3 should exist and match the region name
+    const heading = screen.getByRole('heading', { level: 3 });
+    expect(heading).toHaveTextContent('Top Languages');
+    expect(heading).toHaveAttribute('id', 'language-chart-title');
+  });
+});

--- a/components/dashboard/LanguageChart.tsx
+++ b/components/dashboard/LanguageChart.tsx
@@ -30,7 +30,10 @@ export default function LanguageChart({ languages }: { languages: LanguageData[]
         transition={{ duration: 0.3 }}
         className="p-6 rounded-xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)] flex flex-col min-h-[300px]"
       >
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-white w-full text-left mb-6 tracking-tight">
+        <h3
+          id="language-chart-title"
+          className="text-sm font-semibold text-gray-900 dark:text-white w-full text-left mb-6 tracking-tight"
+        >
           Top Languages
         </h3>
 
@@ -45,13 +48,18 @@ export default function LanguageChart({ languages }: { languages: LanguageData[]
 
   return (
     <motion.div
+      role="region"
+      aria-labelledby="language-chart-title"
       initial={{ opacity: 0, y: 12 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.3 }}
       className="p-6 rounded-xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)] flex flex-col items-center justify-between min-h-[300px]"
     >
-      <h3 className="text-sm font-semibold text-gray-900 dark:text-white w-full text-left mb-6 tracking-tight">
+      <h3
+        id="language-chart-title"
+        className="text-sm font-semibold text-gray-900 dark:text-white w-full text-left mb-6 tracking-tight"
+      >
         Top Languages
       </h3>
 
@@ -59,10 +67,13 @@ export default function LanguageChart({ languages }: { languages: LanguageData[]
         {/* Donut */}
         <motion.div
           data-testid="donut-chart"
+          role="img"
+          aria-label={`Donut chart showing top languages. Primary is ${languages[0].name} at ${languages[0].percentage}%`}
+          tabIndex={0}
           initial={{ rotate: -90, scale: 0.8, opacity: 0 }}
           animate={{ rotate: 0, scale: 1, opacity: 1 }}
           transition={{ duration: 0.8, type: 'spring', stiffness: 80 }}
-          className="absolute inset-0 rounded-full"
+          className="absolute inset-0 rounded-full focus:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
           style={{
             background: `conic-gradient(${gradientStops})`,
             maskImage: 'radial-gradient(transparent 56%, black 57%)',
@@ -82,7 +93,13 @@ export default function LanguageChart({ languages }: { languages: LanguageData[]
 
       <div className="w-full mt-8 flex flex-col gap-2.5">
         {languages.map((lang) => (
-          <div key={lang.name} className="flex items-center justify-between text-xs">
+          <div
+            key={lang.name}
+            className="flex items-center justify-between text-xs focus:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 rounded-sm"
+            tabIndex={0}
+            title={`${lang.name} makes up ${lang.percentage} percent of top languages`}
+            aria-label={`${lang.name}: ${lang.percentage}%`}
+          >
             <div className="flex items-center gap-2">
               <div className="w-2 h-2 rounded-full" style={{ backgroundColor: lang.color }} />
               <span className="text-[#A1A1AA]">{lang.name}</span>


### PR DESCRIPTION
## Description

This PR ensures strict Accessibility Standards & Screen Reader Aria Compliance for the `LanguageChart.tsx` UI component, ensuring equal ease of use for assistive technologies. 

Specifically, we updated the component's underlying markup and strictly tested:
- **ARIA Label Coordinates:** Ensured the chart container uses `role="region"` and `aria-labelledby` referencing the `<h3>` title to map out the accessible UI region.
- **Key Focus / Tab Ordering:** Set explicit `tabIndex={0}` on the donut chart and each individual language item, enforcing a logical keyboard control path sequence for users operating via tab navigation.
- **Visible Outline Behaviors:** Enforced `focus-visible:ring-2 focus-visible:ring-blue-500` outline styles on all focusable elements (the chart and list items), ensuring visual indication during keyboard navigation.
- **Tooltip Labels / ARIA Data:** Attached descriptive tooltips via `title` and injected strictly formatted `aria-label`s on individual language bars to guarantee screen reader compatibility.
- **Heading Hierarchy:** Verified logical hierarchy starting with the `<h3>` element acting as the primary chart container title.

Fixes #2566 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A - Unit Testing & Screen Reader Compliance

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
