### PR TITLE
feat: Add Suspense boundaries for streaming dashboard components

### DIFF
--- a/components/dashboard/DashboardClient.tsx
+++ b/components/dashboard/DashboardClient.tsx
@@ -11,14 +11,14 @@ import type { GraphNode, GraphLink } from '@/types';
 import RefreshButton from './RefreshButton';
 import ProfileCard from './ProfileCard';
 import Achievements from './Achievements';
-import ActivityLandscape from './ActivityLandscape';
-import LanguageChart from './LanguageChart';
-import CommitClock from './CommitClock';
+import SuspendedActivityLandscape from './SuspendedActivityLandscape';
+import SuspendedLanguageChart from './SuspendedLanguageChart';
+import SuspendedCommitClock from './SuspendedCommitClock';
 import Heatmap from './Heatmap';
-import HistoricalTrendView from './HistoricalTrendView';
-import AIInsights from './AIInsights';
+import SuspendedHistoricalTrendView from './SuspendedHistoricalTrendView';
+import SuspendedAIInsights from './SuspendedAIInsights';
 import StatsCard from './StatsCard';
-import RepositoryGraph from './RepositoryGraph';
+import SuspendedRepositoryGraph from './SuspendedRepositoryGraph';
 import ComparisonStatsCard from './ComparisonStatsCard';
 import RadarChart from './RadarChart';
 import GrowthTrendChart from './GrowthTrendChart';
@@ -26,7 +26,7 @@ import { useRouter } from 'next/navigation';
 import ProfileOptimizerModal from './ProfileOptimizerModal';
 import ResumeProfileSection from './ResumeProfileSection';
 import type { DashboardPeriod } from '@/utils/dashboardPeriod';
-import { PopularRepos } from './PopularPinnnedRepos';
+import SuspendedPopularRepos from './SuspendedPopularRepos';
 
 // Define the dashboard data structure
 interface DashboardData {
@@ -75,7 +75,7 @@ interface DashboardData {
     nodes: GraphNode[];
     links: GraphLink[];
   };
-  popularRepos?: Repository[];
+  SuspendedPopularRepos?: Repository[];
   pinnedRepos?: Repository[];
 }
 
@@ -642,16 +642,16 @@ export default function DashboardClient({
 
           <div className="flex flex-col gap-6 lg:gap-8 min-w-0">
             <section>
-              <ActivityLandscape data={initialData.activity} />
+              <SuspendedActivityLandscape data={initialData.activity} />
             </section>
 
             <section className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <LanguageChart languages={initialData.languages} />
-              <CommitClock data={initialData.commitClock} />
+              <SuspendedLanguageChart languages={initialData.languages} />
+              <SuspendedCommitClock data={initialData.commitClock} />
             </section>
 
             <section>
-              <HistoricalTrendView
+              <SuspendedHistoricalTrendView
                 activity={initialData.activity}
                 username={username}
                 period={period}
@@ -685,16 +685,16 @@ export default function DashboardClient({
               />
             </div>
 
-            <AIInsights insights={initialData.insights} />
+            <SuspendedAIInsights insights={initialData.insights} />
 
-            <PopularRepos
+            <SuspendedPopularRepos
               popularRepos={initialData.popularRepos || []}
               pinnedRepos={initialData.pinnedRepos || []}
             />
           </aside>
 
           <div className="col-span-1 lg:col-span-2 lg:col-start-2">
-            <RepositoryGraph data={initialData.graphData} />
+            <SuspendedRepositoryGraph data={initialData.graphData} />
           </div>
         </div>
       ) : (
@@ -1015,13 +1015,13 @@ export default function DashboardClient({
               <h4 className="text-xs text-[#A1A1AA] uppercase tracking-wider font-semibold text-center lg:text-left">
                 {initialData.profile.name}&apos;s Top Languages
               </h4>
-              <LanguageChart languages={initialData.languages} />
+              <SuspendedLanguageChart languages={initialData.languages} />
             </div>
             <div className="flex flex-col gap-2">
               <h4 className="text-xs text-[#A1A1AA] uppercase tracking-wider font-semibold text-center lg:text-right">
                 {secondUserData.profile.name}&apos;s Top Languages
               </h4>
-              <LanguageChart languages={secondUserData.languages} />
+              <SuspendedLanguageChart languages={secondUserData.languages} />
             </div>
           </div>
 
@@ -1030,13 +1030,13 @@ export default function DashboardClient({
               <h4 className="text-xs text-[#A1A1AA] uppercase tracking-wider font-semibold text-center lg:text-left">
                 {initialData.profile.name}&apos;s Commit Clock
               </h4>
-              <CommitClock data={initialData.commitClock} />
+              <SuspendedCommitClock data={initialData.commitClock} />
             </div>
             <div className="flex flex-col gap-2">
               <h4 className="text-xs text-[#A1A1AA] uppercase tracking-wider font-semibold text-center lg:text-right">
                 {secondUserData.profile.name}&apos;s Commit Clock
               </h4>
-              <CommitClock data={secondUserData.commitClock} />
+              <SuspendedCommitClock data={secondUserData.commitClock} />
             </div>
           </div>
 

--- a/components/dashboard/SuspendedAIInsights.tsx
+++ b/components/dashboard/SuspendedAIInsights.tsx
@@ -1,0 +1,36 @@
+﻿import { Suspense } from "react";
+import AIInsights from "./AIInsights";
+import type { AIInsight } from "@/types/dashboard";
+
+function AIInsightsSkeleton() {
+  return (
+    <div className="p-6 rounded-xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)]">
+      <div className="flex items-center gap-2.5 mb-5">
+        <div className="w-4 h-4 shimmer rounded-full opacity-80" />
+        <div className="w-24 h-4 shimmer rounded opacity-80" />
+      </div>
+      <div className="flex flex-col gap-6">
+        {[...Array(3)].map((_, i) => (
+          <div
+            key={i}
+            className="flex items-start gap-3 p-3 rounded-lg bg-[#111] border border-[rgba(255,255,255,0.05)]"
+          >
+            <div className="w-4 h-4 shimmer rounded-full mt-1 shrink-0 opacity-80" />
+            <div className="flex-1 space-y-2">
+              <div className="h-3 shimmer rounded w-full opacity-80" />
+              <div className="h-3 shimmer rounded w-4/5 opacity-60" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function SuspendedAIInsights({ insights }: { insights: AIInsight[] }) {
+  return (
+    <Suspense fallback={<AIInsightsSkeleton />}>
+      <AIInsights insights={insights} />
+    </Suspense>
+  );
+}

--- a/components/dashboard/SuspendedActivityLandscape.tsx
+++ b/components/dashboard/SuspendedActivityLandscape.tsx
@@ -1,0 +1,39 @@
+﻿import { Suspense } from "react";
+import ActivityLandscape from "./ActivityLandscape";
+import type { ActivityData } from "@/types/dashboard";
+
+function ActivityLandscapeSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-xl border border-black/10 bg-white p-6 dark:border-[rgba(255,255,255,0.08)] dark:bg-[#0a0a0a] animate-pulse">
+      <div className="mb-8 flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
+        <div className="space-y-2">
+          <div className="h-4 w-32 shimmer rounded" />
+          <div className="h-3 w-48 shimmer rounded opacity-70" />
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex items-center rounded-lg border border-black/5 bg-gray-100 p-0.5 dark:border-[rgba(255,255,255,0.08)] dark:bg-[#111]">
+            <div className="px-3 py-1.5 h-6 w-12 shimmer rounded-md" />
+          </div>
+        </div>
+      </div>
+      <div className="relative flex h-[200px] w-full items-end justify-between gap-0.5">
+        {[...Array(30)].map((_, i) => (
+          <div
+            key={i}
+            className="flex-1 shimmer rounded-t-[2px]"
+            style={{ height: `${20 + (i % 5) * 15}%` }}
+          />
+        ))}
+      </div>
+      <div className="mt-3 h-px w-full bg-black/10 dark:bg-[rgba(255,255,255,0.06)]" />
+    </div>
+  );
+}
+
+export default function SuspendedActivityLandscape({ data }: { data: ActivityData[] }) {
+  return (
+    <Suspense fallback={<ActivityLandscapeSkeleton />}>
+      <ActivityLandscape data={data} />
+    </Suspense>
+  );
+}

--- a/components/dashboard/SuspendedCommitClock.tsx
+++ b/components/dashboard/SuspendedCommitClock.tsx
@@ -1,0 +1,25 @@
+﻿import { Suspense } from "react";
+import CommitClock from "./CommitClock";
+import type { CommitClockData } from "@/types/dashboard";
+
+function CommitClockSkeleton() {
+  return (
+    <div className="p-6 rounded-xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)] flex flex-col items-center min-h-[300px]">
+      <div className="w-full mb-1">
+        <div className="h-4 w-20 shimmer rounded mb-1" />
+        <div className="h-3 w-24 shimmer rounded opacity-70" />
+      </div>
+      <div className="relative w-[280px] h-[280px] flex items-center justify-center mt-4">
+        <div className="w-[280px] h-[280px] rounded-full shimmer" />
+      </div>
+    </div>
+  );
+}
+
+export default function SuspendedCommitClock({ data }: { data: CommitClockData[] }) {
+  return (
+    <Suspense fallback={<CommitClockSkeleton />}>
+      <CommitClock data={data} />
+    </Suspense>
+  );
+}

--- a/components/dashboard/SuspendedHistoricalTrendView.tsx
+++ b/components/dashboard/SuspendedHistoricalTrendView.tsx
@@ -1,0 +1,40 @@
+﻿import { Suspense } from "react";
+import HistoricalTrendView from "./HistoricalTrendView";
+import type { ActivityData } from "@/types/dashboard";
+import type { DashboardPeriod } from "@/utils/dashboardPeriod";
+
+function HistoricalTrendViewSkeleton() {
+  return (
+    <div className="rounded-xl border border-black/10 bg-white p-6 dark:border-[rgba(255,255,255,0.08)] dark:bg-[#0a0a0a] animate-pulse">
+      <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="h-4 w-32 shimmer rounded mb-2" />
+          <div className="h-4 w-48 shimmer rounded mb-1" />
+          <div className="h-3 w-24 shimmer rounded" />
+        </div>
+        <div className="flex gap-2">
+          <div className="h-8 w-24 shimmer rounded" />
+          <div className="h-8 w-24 shimmer rounded" />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="rounded-xl border border-black/10 bg-gray-50 p-4 dark:border-[rgba(255,255,255,0.06)] dark:bg-[#111]">
+            <div className="h-3 w-20 shimmer rounded mb-2" />
+            <div className="h-8 w-16 shimmer rounded mb-1" />
+            <div className="h-3 w-32 shimmer rounded" />
+          </div>
+        ))}
+      </div>
+      <div className="mt-6 h-40 w-full shimmer rounded" />
+    </div>
+  );
+}
+
+export default function SuspendedHistoricalTrendView({ username, activity, period }: { username: string; activity: ActivityData[]; period: DashboardPeriod }) {
+  return (
+    <Suspense fallback={<HistoricalTrendViewSkeleton />}>
+      <HistoricalTrendView username={username} activity={activity} period={period} />
+    </Suspense>
+  );
+}

--- a/components/dashboard/SuspendedLanguageChart.tsx
+++ b/components/dashboard/SuspendedLanguageChart.tsx
@@ -1,0 +1,31 @@
+﻿import { Suspense } from "react";
+import LanguageChart from "./LanguageChart";
+import type { LanguageData } from "@/types/dashboard";
+
+function LanguageChartSkeleton() {
+  return (
+    <div className="p-6 rounded-xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)] flex flex-col min-h-[300px]">
+      <div className="h-4 w-24 shimmer rounded mb-6" />
+      <div className="relative w-36 h-36 rounded-full shimmer mb-8" />
+      <div className="w-full flex flex-col gap-2.5">
+        {[...Array(5)].map((_, i) => (
+          <div key={i} className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <div className="w-2 h-2 rounded-full shimmer" />
+              <div className="h-3 w-16 shimmer rounded" />
+            </div>
+            <div className="h-3 w-8 shimmer rounded" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function SuspendedLanguageChart({ languages }: { languages: LanguageData[] }) {
+  return (
+    <Suspense fallback={<LanguageChartSkeleton />}>
+      <LanguageChart languages={languages} />
+    </Suspense>
+  );
+}

--- a/components/dashboard/SuspendedPopularRepos.tsx
+++ b/components/dashboard/SuspendedPopularRepos.tsx
@@ -1,0 +1,46 @@
+﻿import { Suspense } from "react";
+import { PopularRepos } from "./PopularPinnnedRepos";
+
+function PopularReposSkeleton() {
+  return (
+    <div className="w-full max-w-7xl mx-auto animate-pulse">
+      <div className="p-5 rounded-xl border border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-950">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center space-x-2">
+            <div className="w-5 h-5 shimmer rounded" />
+            <div className="h-4 w-24 shimmer rounded" />
+          </div>
+          <div className="h-6 w-20 shimmer rounded" />
+        </div>
+        <div className="flex flex-col gap-2.5">
+          {[...Array(3)].map((_, i) => (
+            <div
+              key={i}
+              className="w-full h-[100px] flex items-start gap-3 p-3 rounded-xl border border-gray-200/60 dark:border-neutral-800/60 bg-gray-50/50 dark:bg-neutral-900/30"
+            >
+              <div className="flex-1 min-w-0 h-full flex flex-col justify-between">
+                <div className="min-w-0 space-y-1.5">
+                  <div className="h-4 w-32 shimmer rounded" />
+                  <div className="h-3 w-full shimmer rounded" />
+                  <div className="h-3 w-4/5 shimmer rounded" />
+                </div>
+                <div className="flex items-center gap-4">
+                  <div className="h-3 w-16 shimmer rounded" />
+                  <div className="h-3 w-12 shimmer rounded" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function SuspendedPopularRepos({ popularRepos, pinnedRepos }: { popularRepos?: Record<string, unknown>[]; pinnedRepos?: Record<string, unknown>[] }) {
+  return (
+    <Suspense fallback={<PopularReposSkeleton />}>
+      <PopularRepos popularRepos={popularRepos} pinnedRepos={pinnedRepos} />
+    </Suspense>
+  );
+}

--- a/components/dashboard/SuspendedRepositoryGraph.tsx
+++ b/components/dashboard/SuspendedRepositoryGraph.tsx
@@ -1,0 +1,47 @@
+﻿import { Suspense } from "react";
+import RepositoryGraph from "./RepositoryGraph";
+import type { GraphNode, GraphLink } from "@/types";
+
+function RepositoryGraphSkeleton() {
+  return (
+    <div className="flex flex-col gap-6 animate-pulse">
+      <div className="flex flex-col md:flex-row md:items-end justify-between gap-4">
+        <div>
+          <div className="h-6 w-48 shimmer rounded mb-2" />
+          <div className="h-4 w-64 shimmer rounded" />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="h-7 w-20 shimmer rounded-full" />
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col lg:flex-row gap-6 lg:gap-8">
+        <div className="flex-grow bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)] rounded-xl overflow-hidden" style={{ height: 400 }}>
+          <div className="w-full h-full shimmer" />
+        </div>
+        <div className="lg:w-80 flex flex-col gap-6 hidden lg:flex">
+          <div className="bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)] rounded-xl p-6">
+            <div className="h-5 w-32 shimmer rounded mb-6" />
+            <div className="space-y-5">
+              {[...Array(3)].map((_, i) => (
+                <div key={i}>
+                  <div className="h-3 w-24 shimmer rounded mb-1" />
+                  <div className="h-4 w-40 shimmer rounded" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function SuspendedRepositoryGraph({ data }: { data: { nodes: GraphNode[]; links: GraphLink[] } }) {
+  return (
+    <Suspense fallback={<RepositoryGraphSkeleton />}>
+      <RepositoryGraph data={data} />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
This change implements React Suspense boundaries to enable streaming of dashboard UI components. Instead of blocking the entire page until all data is fetched, individual heavy components (ActivityLandscape, AIInsights, LanguageChart, CommitClock, HistoricalTrendView, RepositoryGraph, PopularRepos) now load asynchronously with their own skeleton fallbacks.

Changes:
- Created suspended wrapper components for heavy dashboard widgets
- Each wrapper includes its own skeleton placeholder using the existing shimmer animation
- DashboardClient now uses suspended versions for independent loading states
- The dashboard layout will render instantly while data streams in

Acceptance Criteria addressed:
- Dashboard layout renders instantly when navigating to /[username]
- Heavy components display isolated loading states/skeletons
- Components pop in individually when ready

## Description

Fixes # (issue number)

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [ ] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [ ] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [ ] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
