### PR TITLE
fix(generator): prevent README preview overflow with long display names

### DIFF
--- a/app/generator/components/PreviewPanel.tsx
+++ b/app/generator/components/PreviewPanel.tsx
@@ -123,7 +123,7 @@ export function PreviewPanel({ markdown }: PreviewPanelProps) {
           <div className="p-6 min-h-full">
             <div className="rounded-xl border border-gray-200 dark:border-white/8 bg-white dark:bg-[#0d1117] p-6 min-h-[200px]">
               <div
-                className="readme-preview text-gray-800 dark:text-[#e6edf3] text-sm leading-relaxed"
+                className="readme-preview text-gray-800 dark:text-[#e6edf3] text-sm leading-relaxed wrap-break-word"
                 dangerouslySetInnerHTML={{ __html: previewHtml }}
               />
             </div>
@@ -154,6 +154,7 @@ export function PreviewPanel({ markdown }: PreviewPanelProps) {
         .readme-preview h1, .readme-preview h2, .readme-preview h3 { margin: 0.75rem 0 0.25rem; }
         .readme-preview hr { margin: 1rem 0; border-color: rgba(255,255,255,0.08); }
         .readme-preview a img { border-radius: 6px; }
+        .readme-preview { overflow-wrap: anywhere; word-break: break-word; }
       `}</style>
     </div>
   );


### PR DESCRIPTION
## Description

Fixes #3900

### Summary

This PR fixes an overflow issue in the README Generator preview when users enter very long display names without spaces.

Previously, long unbroken strings could exceed the preview container width, causing horizontal overflow on desktop and layout breakage on mobile devices. The preview became difficult to read and introduced unwanted scrolling behavior.

### Changes Made

* Added proper word-breaking support to the README preview container.
* Ensured long unbroken display names wrap within the available width.
* Prevented horizontal overflow caused by generated preview content.
* Improved responsiveness of the preview panel across desktop and mobile viewports.

### Testing

Tested locally with:

* Long unbroken display names (100+ characters)
* Desktop viewport
* Mobile viewport (Chrome DevTools)
* README Preview tab
* Markdown tab

Verified that:

* No horizontal overflow occurs.
* Long display names remain inside the preview card.
* Mobile layout remains readable and responsive.
* Existing README generation functionality is unaffected.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

### Before

* Long display names overflowed the preview container.
* Horizontal scrollbar appeared on desktop.
* Content could extend beyond card boundaries on mobile.

Desktop View
<img width="1920" height="1080" alt="Screenshot (1708)" src="https://github.com/user-attachments/assets/54dfc541-e81e-46ca-8ef9-c6bb17736ac1" />

Mobile View
<img width="497" height="657" alt="Screenshot 2026-06-05 090722" src="https://github.com/user-attachments/assets/5003c6b8-ce20-4ccd-bb1f-54d4fc67ddf2" />

### After

* Long display names wrap correctly.
* No horizontal scrolling caused by display names.
* Preview remains fully responsive on desktop and mobile.

Desktop View
<img width="1920" height="1080" alt="Screenshot (1709)" src="https://github.com/user-attachments/assets/adf7d210-15b3-4528-a94e-8657ea907b38" />

Mobile View
<img width="665" height="666" alt="Screenshot 2026-06-05 102016" src="https://github.com/user-attachments/assets/157ee4c6-e921-4109-af2f-a0fb565176c7" />

### Changes Made

Added word-breaking / overflow wrapping rules to the README preview container to handle long unbroken strings safely.


## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The fix maintains the existing UI and functionality while improving responsiveness.
