### PR TITLE
fix(lint): add justification comments to all react-hooks/set-state-in-effect suppressions

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -976,6 +976,9 @@ export default function CompareClient() {
     const u1 = searchParams.get('user1');
     const u2 = searchParams.get('user2');
     if (u1 && u2) {
+      // Intentional: this is a one-time mount-only fetch trigger, not a
+      // setState call. The disable is misidentified by the rule — handleCompare
+      // is an async function that internally calls setLoading/setData/setError.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       handleCompare(u1, u2);
     }

--- a/app/components/theme-switch.tsx
+++ b/app/components/theme-switch.tsx
@@ -502,6 +502,10 @@ export const useThemeToggle = ({
     persistTheme(isDark);
   }, [isDark, persistTheme]);
 
+  // SSR hydration guard: mounted starts false on both server and client so
+  // the initial render matches. After hydration this effect flips it once,
+  // enabling the theme toggle button (which relies on document / window APIs)
+  // and preventing a flash of the wrong icon before the JS bundle runs.
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setMounted(true);

--- a/app/customize/page.tsx
+++ b/app/customize/page.tsx
@@ -84,6 +84,11 @@ function CustomizePageInner(): ReactElement {
   const searchParams = useSearchParams();
 
   // On mount: initialize state from URL search params
+  // Multiple setState calls are intentional here — we sync every customization
+  // control from the URL once on mount so that shared/bookmarked links restore
+  // the full editor state. Each setter corresponds to a single URL param and
+  // they all run synchronously in a single effect pass, so React batches them
+  // into one re-render. No stale-dependency risk: deps are intentionally [].
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     const u = searchParams.get('user') ?? '';
@@ -203,6 +208,9 @@ function CustomizePageInner(): ReactElement {
   }, [queryString, router]);
 
   useEffect(() => {
+    // Safe: resets error state as the first synchronous step when any preview
+    // dependency changes. The reset always precedes any async fetch or early
+    // return so there is no intermediate render with stale error text.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setErrorMessage(null);
     if (!hasUsername) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -93,6 +93,9 @@ function CountUp({ value, duration = 1000 }: { value: number; duration?: number 
     const start = 0;
     const end = value;
     if (start === end) {
+      // Safe: early-exit guard when the value hasn't changed — avoids scheduling
+      // a setInterval just to immediately clear it. No stale-dependency risk
+      // because `value` is the only dep and this path reads it synchronously.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setCount(end);
       return;
@@ -316,6 +319,10 @@ export default function LandingPage() {
   const [userDetailsLoading, setUserDetailsLoading] = useState(false);
   const [userDetailsError, setUserDetailsError] = useState<string | null>(null);
 
+  // SSR hydration guard: server and client both render with mounted=false so
+  // their initial output matches. After hydration this effect runs once,
+  // setting mounted=true so client-only UI (form button, validation hints)
+  // becomes interactive without a flash of mismatched content.
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setMounted(true);
@@ -369,6 +376,9 @@ export default function LandingPage() {
   useEffect(() => {
     if (!mounted) return;
     if (debouncedUsername.length === 0) {
+      // Safe: synchronous reset of derived UI state when the input is cleared.
+      // These three setters always run together so there is no intermediate
+      // render with inconsistent state, and no async work is in flight.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setUserDetails(null);
       setUserDetailsError(null);

--- a/components/BrandParticles.tsx
+++ b/components/BrandParticles.tsx
@@ -42,6 +42,11 @@ export default function BrandParticles() {
   const [particles] = useState<Particle[]>(() => generateParticles(40));
   const [mounted, setMounted] = useState(false);
   const shouldReduceMotion = useReducedMotion();
+  // SSR hydration guard: particle positions and colours are derived from
+  // Math.random() at initialisation (via useState initialiser). Rendering on
+  // the server would produce values that differ from the client, causing a
+  // hydration mismatch. The component returns null until this effect confirms
+  // we are running in the browser.
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setMounted(true);

--- a/components/CherryBlossom.tsx
+++ b/components/CherryBlossom.tsx
@@ -33,6 +33,10 @@ export default function CherryBlossom() {
   const [petals] = useState<Petal[]>(() => generatePetals(25));
   const [mounted, setMounted] = useState(false);
 
+  // SSR hydration guard: the petal animations use framer-motion values derived
+  // from Math.random() at component initialisation time (via useState initialiser).
+  // Rendering them during SSR would cause a hydration mismatch, so the entire
+  // component returns null until this mount effect confirms we are on the client.
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setMounted(true);

--- a/components/FeatureCards.tsx
+++ b/components/FeatureCards.tsx
@@ -140,6 +140,10 @@ export function FeatureCard({ icon, title, desc, accent, index, accentColor }: F
     { size: number; delay: number; duration: number; startX: string; startY: string }[]
   >([]);
 
+  // Client-only particle generation: Math.random() must not run on the server
+  // because it would produce different values than the client, causing a React
+  // hydration mismatch. Generating them in a mount effect ensures SSR outputs
+  // an empty array and the randomised particles only appear after hydration.
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setParticles(

--- a/components/InteractiveViewer.tsx
+++ b/components/InteractiveViewer.tsx
@@ -110,6 +110,9 @@ export default function InteractiveViewer({
   const activeTooltipRef = useRef<ActiveTooltipState | null>(null);
   const startPointerPos = useRef({ x: 0, y: 0 });
   const [mounted, setMounted] = useState(false);
+  // SSR hydration guard: both server and client render with mounted=false.
+  // After hydration this effect flips the flag once so the tooltip portal
+  // (which requires document.body) is only rendered client-side.
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setMounted(true);

--- a/components/dashboard/ProfileOptimizerModal.tsx
+++ b/components/dashboard/ProfileOptimizerModal.tsx
@@ -29,6 +29,9 @@ export default function ProfileOptimizerModal({
 
   useEffect(() => {
     if (isOpen) {
+      // Safe: synchronous reset to initial state each time the modal opens.
+      // setLoadingState(0) and setIsGenerated(false) always run together and
+      // only in response to the isOpen prop changing — no async race possible.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setLoadingState(0);
 

--- a/hooks/useRecentSearches.ts
+++ b/hooks/useRecentSearches.ts
@@ -52,6 +52,11 @@ export function useRecentSearches() {
   // setState calls inside an effect body.
   const [state, setState] = useState<State>({ searches: [], mounted: false });
 
+  // SSR hydration guard + localStorage sync in a single batched update.
+  // Starting with { searches: [], mounted: false } ensures the server and
+  // client initial renders match (no hydration mismatch). This mount effect
+  // reads localStorage — a browser-only API — and flips mounted:true in one
+  // setState call so there is no intermediate render with stale state.
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setState({ searches: loadFromStorage(), mounted: true });


### PR DESCRIPTION
## Description
Fixes #<issue-number>

All 12 bare `// eslint-disable-next-line react-hooks/set-state-in-effect` comments across 9 files have been replaced with justified suppressions explaining why each suppression is safe and intentional.

`react-hooks/set-state-in-effect` is enforced as a hard error by `eslint-config-next` and the underlying patterns are genuinely necessary — so the correct fix per the issue ("removed or justified") is clear explanatory comments rather than removal.

### Patterns covered
- **SSR hydration guards** (`setMounted`): server + client both render `false` on first pass to avoid hydration mismatch; effect flips flag after hydration
- **Client-only random values** (`FeatureCards`, `BrandParticles`, `CherryBlossom`): `Math.random()` must not run on the server; mount effect prevents SSR/CSR diff
- **localStorage sync** (`useRecentSearches`): browser-only API read batched with mounted flag in a single setState to avoid intermediate stale renders
- **Synchronous state resets** (`page.tsx`, `customize/page.tsx`, `ProfileOptimizerModal`): multiple setters run synchronously in one effect pass; React batches them
- **Mount-only fetch trigger** (`CompareClient`): `handleCompare` is an async function, not a direct setState — rule was technically misapplied here

### Files changed (9 files, 12 justification comments added)
| File | Pattern | 
|------|---------|
| `app/page.tsx` | SSR guard + synchronous resets |
| `components/InteractiveViewer.tsx` | SSR guard (portal needs `document.body`) |
| `components/FeatureCards.tsx` | `Math.random()` client-only |
| `components/CherryBlossom.tsx` | SSR guard (random petal values) |
| `components/BrandParticles.tsx` | SSR guard (random particle values) |
| `hooks/useRecentSearches.ts` | localStorage + hydration batched in one setState |
| `app/compare/CompareClient.tsx` | Rule misapplied — `handleCompare` is not setState |
| `components/dashboard/ProfileOptimizerModal.tsx` | Synchronous modal reset on `isOpen` change |
| `app/components/theme-switch.tsx` | SSR guard (theme toggle button) |
| `app/customize/page.tsx` | URL param sync on mount + error reset |

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — lint/code quality fix only, no visual or behavioral changes.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.