### PR TITLE
test(generator-getSizeScale): create isolated helper unit test for getSizeScale

### DIFF
--- a/lib/svg/generator.getSizeScale.test.ts
+++ b/lib/svg/generator.getSizeScale.test.ts
@@ -1,27 +1,30 @@
-import { describe, expect, it } from 'vitest';
-
-import { SVG_WIDTH } from './generatorConstants';
+import { describe, it, expect } from 'vitest';
 import { getSizeScale } from './generator';
+import { SVG_WIDTH } from './generatorConstants';
 
 describe('getSizeScale', () => {
-  it('returns small scale factor for size=small', () => {
+  it('returns the correct scale for "small"', () => {
     expect(getSizeScale('small')).toBe(400 / SVG_WIDTH);
   });
 
-  it('returns default scale factor for size=medium', () => {
-    expect(getSizeScale('medium')).toBe(1);
-  });
-
-  it('returns large scale factor for size=large', () => {
+  it('returns the correct scale for "large"', () => {
     expect(getSizeScale('large')).toBe(800 / SVG_WIDTH);
   });
 
-  it('returns default scale factor when size is undefined', () => {
-    expect(getSizeScale()).toBe(1);
+  it('returns 1 for "medium"', () => {
+    expect(getSizeScale('medium')).toBe(1);
   });
 
-  it('falls back to default scale factor for unknown values', () => {
-    expect(getSizeScale('' as unknown as 'small')).toBe(1);
-    expect(getSizeScale('xlarge' as unknown as 'small')).toBe(1);
+  it('returns 1 when size is undefined', () => {
+    expect(getSizeScale(undefined)).toBe(1);
+  });
+
+  it('returns 1 for out-of-bounds or invalid string parameters', () => {
+    // @ts-expect-error testing invalid parameter
+    expect(getSizeScale('extra-large')).toBe(1);
+    // @ts-expect-error testing invalid parameter
+    expect(getSizeScale('')).toBe(1);
+    // @ts-expect-error testing invalid parameter
+    expect(getSizeScale(null)).toBe(1);
   });
 });


### PR DESCRIPTION


## Description

Fixes #2364

This PR adds isolated and comprehensive test coverage for the `getSizeScale` helper inside `lib/svg/generator.ts`. The tests verify correct logic for scaling values ("small", "medium", "large"), handling `undefined`, and failing safely for out-of-bounds parameters.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
*(No visual changes as this is purely a test coverage improvement)*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.