### PR TITLE
fix(api): use sanitizeRadius in buildErrorResponse instead of hardcod…

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -16,7 +16,7 @@ import { getSecondsUntilUTCMidnight, getSecondsUntilMidnightInTimezone } from '@
 import type { BadgeParams, ContributionCalendar } from '@/types';
 import { themes } from '@/lib/svg/themes';
 import { streakParamsSchema } from '@/lib/validations';
-import { sanitizeHexColor } from '@/lib/svg/sanitizer';
+import { sanitizeHexColor, sanitizeRadius } from '@/lib/svg/sanitizer';
 
 const SVG_CSP_HEADER =
   "default-src 'none'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src https://fonts.gstatic.com;";
@@ -438,12 +438,7 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
     undefined;
   const errAccent = `#${sanitizeHexColor(errAccentRaw, '58a6ff')}`;
   const errText = `#${sanitizeHexColor(parseResult.success ? parseResult.data.text : undefined, 'c9d1d9')}`;
-  const errRadius = parseResult.success
-    ? (() => {
-        const r = Number(parseResult.data.radius);
-        return Number.isFinite(r) ? Math.min(32, Math.max(0, r)) : 8;
-      })()
-    : 8;
+  const errRadius = sanitizeRadius(parseResult.success ? parseResult.data.radius : undefined, 8);
   const errSpeed = (parseResult.success && parseResult.data.speed) || '8s';
 
   if (isRateLimit) {


### PR DESCRIPTION


## Description

Fixes #3932 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [X] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Before fix —> ?user=thisuserdoesnotexist99999&radius=40 rendered rx="32"
After fix —> same request now correctly renders rx="40

## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [X] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [X] I have started the repo.
- [X] I have made sure that i have only one commit to merge in this PR.
- [X] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [X] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
