### PR TITLE
test(GrowthTrendChart-empty-fallback): verify Edge Cases & Empty/Missing Inputs Verification (Variation 1)

### DIFF
--- a/components/dashboard/GrowthTrendChart.empty-fallback.test.tsx
+++ b/components/dashboard/GrowthTrendChart.empty-fallback.test.tsx
@@ -49,11 +49,9 @@ describe('GrowthTrendChart Edge Cases & Empty/Missing Inputs Verification', () =
       <GrowthTrendChart activityA={[]} activityB={[]} labelA="User A" labelB="User B" />
     );
 
-    const chartContainer = container.querySelector(
-      '.relative.w-full.h-\\[180px\\].overflow-hidden'
-    );
+    const chartContainer = screen.getByTestId('growth-trend-chart-container');
 
-    expect(chartContainer).not.toBeNull();
+    expect(chartContainer).toBeInTheDocument();
 
     const svg = container.querySelector('svg');
     expect(svg).toHaveAttribute('viewBox', '0 0 500 180');

--- a/components/dashboard/GrowthTrendChart.empty-fallback.test.tsx
+++ b/components/dashboard/GrowthTrendChart.empty-fallback.test.tsx
@@ -1,0 +1,94 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import GrowthTrendChart from './GrowthTrendChart';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, className, style, ...props }: any) => {
+      delete props.initial;
+      delete props.animate;
+      delete props.whileInView;
+      delete props.viewport;
+      delete props.transition;
+
+      return (
+        <div className={className} style={style} {...props}>
+          {children}
+        </div>
+      );
+    },
+
+    path: ({ children, className, style, ...props }: any) => {
+      delete props.initial;
+      delete props.animate;
+      delete props.transition;
+
+      return (
+        <path className={className} style={style} {...props}>
+          {children}
+        </path>
+      );
+    },
+  },
+}));
+
+describe('GrowthTrendChart Edge Cases & Empty/Missing Inputs Verification', () => {
+  it('renders successfully with empty activity arrays', () => {
+    const { container } = render(
+      <GrowthTrendChart activityA={[]} activityB={[]} labelA="User A" labelB="User B" />
+    );
+
+    expect(screen.getByText('Contribution Growth Trend')).toBeInTheDocument();
+
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('maintains default layout styling in empty state', () => {
+    const { container } = render(
+      <GrowthTrendChart activityA={[]} activityB={[]} labelA="User A" labelB="User B" />
+    );
+
+    const chartContainer = container.querySelector(
+      '.relative.w-full.h-\\[180px\\].overflow-hidden'
+    );
+
+    expect(chartContainer).not.toBeNull();
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('viewBox', '0 0 500 180');
+    expect(svg?.getAttribute('class')).toContain('w-full');
+  });
+
+  it('renders expected empty timeline markers without runtime errors', () => {
+    render(<GrowthTrendChart activityA={[]} activityB={[]} labelA="User A" labelB="User B" />);
+
+    const tieBadges = screen.getAllByText('Tie');
+
+    expect(tieBadges.length).toBeGreaterThan(0);
+  });
+
+  it('renders key DOM structures when datasets are empty', () => {
+    const { container } = render(
+      <GrowthTrendChart activityA={[]} activityB={[]} labelA="User A" labelB="User B" />
+    );
+
+    expect(container.querySelector('svg')).not.toBeNull();
+    expect(container.querySelector('defs')).not.toBeNull();
+
+    const paths = container.querySelectorAll('path');
+    expect(paths.length).toBeGreaterThanOrEqual(4);
+
+    const lines = container.querySelectorAll('line');
+    expect(lines.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('renders labels and timeline section with empty input data', () => {
+    render(<GrowthTrendChart activityA={[]} activityB={[]} labelA="Empty A" labelB="Empty B" />);
+
+    expect(screen.getByText('Empty A')).toBeInTheDocument();
+    expect(screen.getByText('Empty B')).toBeInTheDocument();
+
+    expect(screen.getByText('⚔️ Commit Battle Timeline')).toBeInTheDocument();
+  });
+});

--- a/components/dashboard/GrowthTrendChart.tsx
+++ b/components/dashboard/GrowthTrendChart.tsx
@@ -125,7 +125,10 @@ export default function GrowthTrendChart({
       </div>
 
       {/* SVG Line Chart */}
-      <div className="relative w-full h-[180px] overflow-hidden">
+      <div
+        data-testid="growth-trend-chart-container"
+        className="relative w-full h-[180px] overflow-hidden"
+      >
         <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-full overflow-visible">
           <defs>
             <linearGradient id={`${instanceId}-gradient-area-a`} x1="0" y1="0" x2="0" y2="1">


### PR DESCRIPTION
## Description

Fixes #2543 

Added empty and missing input test coverage for GrowthTrendChart.

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

- N/A (test-only change)


## Checklist before requesting a review:

- [x] I have read the CONTRIBUTING.md file.
- [x] I have run npm run format and npm run lint locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., feat(themes): ..., fix(calculate): ...).
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.


## Changes Made

- Created components/dashboard/GrowthTrendChart.empty-fallback.test.tsx
- Added coverage for empty activity arrays
- Verified chart renders safely with missing contribution data
- Verified timeline markers render correctly in fallback state
- Verified key SVG structures remain available in empty layouts
- Verified labels and timeline sections remain visible with empty inputs


## Result

- Improves resilience coverage for GrowthTrendChart
- Verifies empty and missing data scenarios render safely
- Helps prevent regressions when contribution datasets are unavailable
- Confirms chart structure remains stable in fallback states
- All newly added tests pass successfully