### PR TITLE
fix(github): treat a failed contributions fetch as a first-class error

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -1404,6 +1404,29 @@ describe('getFullDashboardData', () => {
     );
   });
 
+  it('throws if the contributions fetch fails, instead of returning zeroed stats', async () => {
+    vi.mocked(fetch).mockImplementation(async (url: RequestInfo | URL) => {
+      if (typeof url === 'string' && url.includes('/users/octocat/repos')) return mockResponse([]);
+      if (typeof url === 'string' && url.includes('/users/octocat')) {
+        return mockResponse({
+          login: 'octocat',
+          name: 'The Octocat',
+          avatar_url: 'avatar.png',
+          public_repos: 1,
+          followers: 1,
+          following: 1,
+          created_at: '2020-01-01T00:00:00Z',
+        });
+      }
+      // GraphQL contributions call returns no user, so the contributions fetch fails fast.
+      return mockResponse({ data: { user: null } });
+    });
+
+    await expect(getFullDashboardData('octocat')).rejects.toThrow(
+      '[GitHub API] Failed to fetch contributions for user "octocat"'
+    );
+  });
+
   it('formats joinedDate as MMM YYYY', async () => {
     vi.mocked(fetch).mockImplementation(async (url: RequestInfo | URL) => {
       if (typeof url === 'string' && url.includes('/users/testuser/repos')) return mockResponse([]);

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1396,6 +1396,13 @@ export async function getFullDashboardData(username: string, options: FetchOptio
       cause: profileResult.reason,
     });
 
+  // Treat a failed contributions fetch as a first-class error rather than silently
+  // returning zeroed stats, which would otherwise present a false "no activity" result.
+  if (calendarResult.status === 'rejected')
+    throw new Error(`[GitHub API] Failed to fetch contributions for user "${username}"`, {
+      cause: calendarResult.reason,
+    });
+
   const profileData = profileResult.value;
   const reposData = reposResult.status === 'fulfilled' ? reposResult.value : [];
   const calendarData =


### PR DESCRIPTION
## Description

Fixes #3956

`getFullDashboardData` fetched profile, repos, contributions, and more via `Promise.allSettled` but threw only when the profile fetch rejected. A rejected contributions (calendar) fetch silently became an empty calendar, zeroing all derived stats (streak, totals, activity, achievements). Through `/api/compare` this returned HTTP 200 with a populated profile but all-zero stats, presenting a false "no activity" head-to-head.

Change (in `lib/github.ts` `getFullDashboardData`): treat a rejected contributions fetch as a first-class error and throw (with `cause`), mirroring how a rejected profile fetch is handled. `/api/compare` and `/api/github` then return an appropriate error status instead of silently rendering zeroed stats.

Added a test asserting `getFullDashboardData` throws when the contributions fetch fails while the profile succeeds.

Related: #3760 addresses the same class of defect for a different route (`app/api/user-details/route.ts`); this is the `getFullDashboardData` / compare path, which is not covered there.

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

Not applicable. Backend data-fetch error-handling change.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (143 github tests pass, including 1 new one; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable, no SVG output in this change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
