### PR TITLE
fix(dashboard): correct Longest Inactive Period highlight when a gap is 0

### DIFF
--- a/components/dashboard/DashboardClient.test.tsx
+++ b/components/dashboard/DashboardClient.test.tsx
@@ -245,6 +245,23 @@ describe('DashboardClient', () => {
     vi.clearAllMocks();
   };
 
+  it('does not paint the worse user green in "Longest Inactive Period" when the other gap is 0', async () => {
+    // mockInitialData has a zero-count day (gapA = 1); mockSecondData has none (gapB = 0).
+    await renderInCompareMode();
+
+    const label = await screen.findByText('Longest Inactive Period');
+    const block = label.closest('.flex.flex-col');
+    expect(block).toBeTruthy();
+    const grid = block!.querySelector('.grid');
+    expect(grid).toBeTruthy();
+    const [userADiv, userBDiv] = Array.from(grid!.children) as HTMLElement[];
+
+    // User A (gap 1) is the worse one: it must NOT be highlighted green just because gapB === 0.
+    expect(userADiv.className).not.toContain('emerald');
+    // User B (gap 0) is the better one and is highlighted.
+    expect(userBDiv.className).toContain('emerald');
+  });
+
   it('renders standard single profile view by default', () => {
     render(
       <DashboardClient initialData={mockInitialData} username="Shivangi1515" period={mockPeriod} />

--- a/components/dashboard/DashboardClient.tsx
+++ b/components/dashboard/DashboardClient.tsx
@@ -908,7 +908,7 @@ export default function DashboardClient({
                   <div className="grid grid-cols-2 gap-4 text-sm font-semibold mt-1">
                     <div
                       className={
-                        gapA < gapB || gapB === 0
+                        gapA < gapB
                           ? 'text-emerald-500 dark:text-emerald-400'
                           : 'text-gray-900 dark:text-white'
                       }
@@ -917,7 +917,7 @@ export default function DashboardClient({
                     </div>
                     <div
                       className={
-                        gapB < gapA || gapA === 0
+                        gapB < gapA
                           ? 'text-emerald-500 dark:text-emerald-400 text-right'
                           : 'text-gray-900 dark:text-white text-right'
                       }


### PR DESCRIPTION
## Description

Fixes #3964

In the dashboard compare view's "Longest Inactive Period" row, the green highlight used `gapA < gapB || gapB === 0` for user A (and the mirror `gapB < gapA || gapA === 0` for user B), while the trophy used the strict `gapA < gapB` / `gapB < gapA`. The `|| gapB === 0` / `|| gapA === 0` clauses keyed the highlight off the OTHER user's gap being 0, so when one user had a perfect record (gap 0) the other, strictly worse user was also painted green and the two indicators disagreed.

This change drops the `|| gapB === 0` / `|| gapA === 0` clauses in `components/dashboard/DashboardClient.tsx` so the color uses the same strict comparison as the trophy. A tie, including when one or both gaps are 0, is now neutral.

Added a test that renders the compare view with one user at a 0 gap and asserts the worse user is not tinted emerald while the gap-0 user is.

## Pillar

Other

## Visual Preview

For unequal, non-zero gaps the rendering is unchanged. The fix only affects the case where one user's gap is 0: that user's worse opponent is no longer tinted green, matching the trophy. A screenshot of the compare "Longest Inactive Period" row would illustrate the before/after.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
