### PR TITLE
fix(ui): prevent markdown panel overflow for long unbroken text

### DIFF
--- a/app/generator/components/PreviewPanel.tsx
+++ b/app/generator/components/PreviewPanel.tsx
@@ -130,7 +130,13 @@ export function PreviewPanel({ markdown }: PreviewPanelProps) {
           </div>
         ) : (
           <div className="relative h-full">
-            <pre className="p-5 text-xs font-mono leading-relaxed text-gray-700 dark:text-white/70 whitespace-pre-wrap break-words overflow-auto h-full select-all">
+            <pre
+              className="p-5 text-xs font-mono leading-relaxed text-gray-700 dark:text-white/70 whitespace-pre-wrap overflow-auto h-full select-all"
+              style={{
+                overflowWrap: 'anywhere',
+                wordBreak: 'break-word',
+              }}
+            >
               {markdown}
             </pre>
           </div>


### PR DESCRIPTION
## Description

Fixes #3959

This PR fixes the horizontal overflow issue in the README Generator Markdown panel when rendering long unbroken text, URLs, badges, or generated markdown content.

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

### Before
##### Preview Panel works correctly
<img width="1725" height="862" alt="Image" src="https://github.com/user-attachments/assets/8e25769b-c251-4d84-854e-b78e6d35a993" />

##### Horizontal overflow in Markdown Panel
<img width="1812" height="852" alt="Image" src="https://github.com/user-attachments/assets/44e658d8-e67e-4339-b80d-a8c4172578da" />
<img width="1871" height="900" alt="Image" src="https://github.com/user-attachments/assets/9c5106e2-bbb1-4745-a578-d5a86332e005" />

### After
##### Prevent Markdown Panel Overflow
<img width="1710" height="870" alt="image" src="https://github.com/user-attachments/assets/e24037cd-a82a-41df-abab-9031ff38d4ec" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

