### PR TITLE
fix: prioritize Clipboard API with fallback support

### DIFF
--- a/app/customize/page.tsx
+++ b/app/customize/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { fallbackCopyToClipboard } from '@/utils/clipboard';
 import { useCallback, useEffect, useRef, useState, Suspense, type ReactElement } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { validateGitHubUsername } from '@/lib/validations';
@@ -278,30 +279,6 @@ function CustomizePageInner(): ReactElement {
 
   const exportSnippet = getExportSnippet(exportFormat, queryString);
 
-  const fallbackCopyToClipboard = (text: string): boolean => {
-    try {
-      const textArea = document.createElement('textarea');
-
-      textArea.value = text;
-      textArea.style.position = 'fixed';
-      textArea.style.opacity = '0';
-      textArea.style.pointerEvents = 'none';
-
-      document.body.appendChild(textArea);
-
-      textArea.focus();
-      textArea.select();
-
-      const successful = document.execCommand('copy');
-
-      document.body.removeChild(textArea);
-
-      return successful;
-    } catch {
-      return false;
-    }
-  };
-
   const announceCopyStatus = useCallback((message: string): void => {
     setCopyStatusMessage('');
     window.setTimeout(() => {
@@ -314,7 +291,15 @@ function CustomizePageInner(): ReactElement {
 
     try {
       if (navigator.clipboard && window.isSecureContext) {
-        await navigator.clipboard.writeText(exportSnippet);
+        try {
+          await navigator.clipboard.writeText(exportSnippet);
+        } catch {
+          const copiedSuccessfully = fallbackCopyToClipboard(exportSnippet);
+
+          if (!copiedSuccessfully) {
+            throw new Error('Fallback clipboard copy failed.');
+          }
+        }
       } else {
         const copiedSuccessfully = fallbackCopyToClipboard(exportSnippet);
 

--- a/app/generator/components/PreviewPanel.tsx
+++ b/app/generator/components/PreviewPanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { fallbackCopyToClipboard } from '@/utils/clipboard';
 import { useState, useCallback } from 'react';
 import { Copy, Check, Eye, Code2, Download } from 'lucide-react';
 
@@ -36,18 +37,28 @@ export function PreviewPanel({ markdown }: PreviewPanelProps) {
 
   const handleCopy = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(markdown);
+      if (navigator.clipboard && window.isSecureContext) {
+        try {
+          await navigator.clipboard.writeText(markdown);
+        } catch {
+          const copiedSuccessfully = fallbackCopyToClipboard(markdown);
+
+          if (!copiedSuccessfully) {
+            throw new Error('Clipboard copy failed');
+          }
+        }
+      } else {
+        const copiedSuccessfully = fallbackCopyToClipboard(markdown);
+
+        if (!copiedSuccessfully) {
+          throw new Error('Clipboard copy failed');
+        }
+      }
+
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      const ta = document.createElement('textarea');
-      ta.value = markdown;
-      document.body.appendChild(ta);
-      ta.select();
-      document.execCommand('copy');
-      document.body.removeChild(ta);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      setCopied(false);
     }
   }, [markdown]);
 

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -206,6 +206,12 @@ describe('LandingPage', () => {
     mockRecentSearches.clearSearches = vi.fn();
     mockRecentSearches.removeSearch = vi.fn();
 
+    Object.defineProperty(window, 'isSecureContext', {
+      value: true,
+      configurable: true,
+    });
+
+    // Mock navigator.clipboard
     Object.assign(navigator, {
       clipboard: {
         writeText: vi.fn().mockResolvedValue(undefined),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -487,18 +487,6 @@ export default function LandingPage() {
     } catch {
       setCopied(false);
     }
-
-    trackUser(trimmedUsername);
-    addSearch(trimmedUsername);
-    setCopied(true);
-
-    scrollToGuideTimeoutRef.current = setTimeout(() => {
-      guideRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }, 80);
-
-    resetCopiedTimeoutRef.current = setTimeout(() => {
-      setCopied(false);
-    }, 50000);
   };
 
   const selectDemoUser = (name: string) => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import Image from 'next/image';
+import { fallbackCopyToClipboard } from '@/utils/clipboard';
 import { trackUser } from '@/utils/tracking';
 
 import Link from 'next/link';
@@ -452,10 +453,39 @@ export default function LandingPage() {
     clearCopyTimers();
 
     try {
-      await navigator.clipboard.writeText(markdown);
+      if (navigator.clipboard && window.isSecureContext) {
+        try {
+          await navigator.clipboard.writeText(markdown);
+        } catch {
+          const copiedSuccessfully = fallbackCopyToClipboard(markdown);
+
+          if (!copiedSuccessfully) {
+            throw new Error('Clipboard copy failed');
+          }
+        }
+      } else {
+        const copiedSuccessfully = fallbackCopyToClipboard(markdown);
+
+        if (!copiedSuccessfully) {
+          throw new Error('Clipboard copy failed');
+        }
+      }
+
+      trackUser(trimmedUsername);
+      addSearch(trimmedUsername);
+
+      setCopied(true);
+
+      setTimeout(() => {
+        guideRef.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      }, 80);
+
+      setTimeout(() => setCopied(false), 3000);
     } catch {
       setCopied(false);
-      return;
     }
 
     trackUser(trimmedUsername);

--- a/components/dashboard/ShareSheet.tsx
+++ b/components/dashboard/ShareSheet.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { fallbackCopyToClipboard } from '@/utils/clipboard';
 import {
   useEffect,
   useRef,
@@ -233,15 +234,34 @@ export default function ShareSheet({ username, isOpen, onClose, exportData }: Sh
     setTimeout(() => setToast((t) => (t?.id === id ? null : t)), 2400);
   }, []);
 
-  const handleLocalCopyLink = (e: React.MouseEvent) => {
+  const handleLocalCopyLink = async (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (inputRef.current) {
-      inputRef.current.select();
-      document.execCommand('copy');
+
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        try {
+          await navigator.clipboard.writeText(profileUrl);
+        } catch {
+          const copiedSuccessfully = fallbackCopyToClipboard(profileUrl);
+
+          if (!copiedSuccessfully) {
+            throw new Error('Clipboard copy failed');
+          }
+        }
+      } else {
+        const copiedSuccessfully = fallbackCopyToClipboard(profileUrl);
+
+        if (!copiedSuccessfully) {
+          throw new Error('Clipboard copy failed');
+        }
+      }
+
       setLinkCopied(true);
       showToast('✓ Link copied');
       setTimeout(() => setLinkCopied(false), 2200);
+    } catch {
+      showToast('Unable to copy link');
     }
   };
 

--- a/utils/clipboard.ts
+++ b/utils/clipboard.ts
@@ -1,0 +1,23 @@
+export const fallbackCopyToClipboard = (text: string): boolean => {
+  const textArea = document.createElement('textarea');
+
+  try {
+    textArea.value = text;
+    textArea.style.position = 'fixed';
+    textArea.style.opacity = '0';
+    textArea.style.pointerEvents = 'none';
+
+    document.body.appendChild(textArea);
+
+    textArea.focus();
+    textArea.select();
+
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    if (document.body.contains(textArea)) {
+      document.body.removeChild(textArea);
+    }
+  }
+};


### PR DESCRIPTION
## Description

Fixes #3670 

Updated clipboard handling to prioritize the modern Clipboard API (`navigator.clipboard.writeText()`) while preserving `document.execCommand('copy')` as a fallback for unsupported environments.

### Changes

* Updated `app/generator/components/PreviewPanel.tsx`
* Updated `components/dashboard/ShareSheet.tsx`
* Added fallback clipboard helper functions
* Improved copy operation error handling
* Preserved existing copy functionality and user experience

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (clipboard handling refactor, no UI changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [ ] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
