### PR TITLE
test(ui): add responsive layout and mobile viewport tests for WallOfLove

### DIFF
--- a/components/WallOfLove.mouse-interactivity.test.tsx
+++ b/components/WallOfLove.mouse-interactivity.test.tsx
@@ -1,0 +1,202 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render, screen, fireEvent, within, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import WallOfLove, { Testimonial } from './WallOfLove';
+
+const mockTestimonials: Testimonial[] = [
+  {
+    id: '1',
+    name: 'Alice',
+    role: 'Software Engineer',
+    message: 'This tool is incredible! Saved me hours of manual work.',
+    rating: 5,
+    tags: ['productivity', 'engineering'],
+  },
+  {
+    id: '2',
+    name: 'Bob',
+    role: 'Product Manager',
+    message: 'Love the analytics dashboard. Clean layout and rich insights.',
+    rating: 4,
+    tags: ['dashboard', 'design'],
+  },
+  {
+    id: '3',
+    name: 'Charlie',
+    role: 'Designer',
+    message: 'Beautiful design system!',
+  },
+];
+
+describe('WallOfLove Mouse Interactivity, Tooltips & Touch Propagation', () => {
+  const onCardClickMock = vi.fn();
+  const tooltipFormatterMock = vi.fn((t) => `Special: ${t.name}`);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Test Case 1: Standard component rendering
+  it('renders testimonials list, including names, roles, messages and ratings', () => {
+    render(<WallOfLove testimonials={mockTestimonials} />);
+
+    expect(screen.getByText('Wall of Love')).toBeDefined();
+    expect(screen.getByText('Alice')).toBeDefined();
+    expect(screen.getByText('Software Engineer')).toBeDefined();
+    expect(
+      screen.getByText('This tool is incredible! Saved me hours of manual work.')
+    ).toBeDefined();
+    expect(screen.getByText('Bob')).toBeDefined();
+    expect(screen.getByText('Product Manager')).toBeDefined();
+    expect(
+      screen.getByText('Love the analytics dashboard. Clean layout and rich insights.')
+    ).toBeDefined();
+
+    // Verify star ratings
+    const rating1 = screen.getByTestId('rating-1');
+    expect(rating1.children).toHaveLength(5);
+    const rating2 = screen.getByTestId('rating-2');
+    expect(rating2.children).toHaveLength(4);
+  });
+
+  // Test Case 2: Mouse Hover triggers Tooltip and Cursor Styling
+  it('displays tooltip on mouseenter with custom cursor class applied to the active node', () => {
+    render(<WallOfLove testimonials={mockTestimonials} />);
+
+    const card = screen.getByTestId('testimonial-card-1');
+
+    // Assert that the appropriate cursor class (cursor-pointer) is applied
+    expect(card.className).toContain('cursor-pointer');
+
+    // Tooltip should not be in document initially
+    expect(screen.queryByTestId('interactive-tooltip')).toBeNull();
+
+    // Trigger hover
+    fireEvent.mouseEnter(card, { clientX: 120, clientY: 150 });
+
+    // Tooltip should now be present
+    const tooltip = screen.getByTestId('interactive-tooltip');
+    expect(tooltip).toBeDefined();
+    expect(within(tooltip).getByText('Alice')).toBeDefined();
+    expect(within(tooltip).getByText('5/5 Stars')).toBeDefined();
+
+    // Hover over Charlie (card 3) who has no rating or tags
+    const card3 = screen.getByTestId('testimonial-card-3');
+    fireEvent.mouseLeave(card);
+    fireEvent.mouseEnter(card3, { clientX: 120, clientY: 150 });
+
+    const tooltip3 = screen.getByTestId('interactive-tooltip');
+    expect(tooltip3).toBeDefined();
+    expect(within(tooltip3).getByText('Charlie')).toBeDefined();
+    expect(within(tooltip3).getByText('Verified User')).toBeDefined();
+  });
+
+  // Test Case 3: Verify Tooltip displays at computed responsive coordinates
+  it('computes and updates tooltip coordinates correctly on mouseenter and mousemove', () => {
+    render(<WallOfLove testimonials={mockTestimonials} tooltipFormatter={tooltipFormatterMock} />);
+
+    const container = screen.getByTestId('wall-of-love-container');
+    const card = screen.getByTestId('testimonial-card-2');
+
+    // Mock getBoundingClientRect for the container
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({
+      left: 100,
+      top: 100,
+      width: 800,
+      height: 600,
+      right: 900,
+      bottom: 700,
+      x: 100,
+      y: 100,
+      toJSON: () => {},
+    });
+
+    // Hover card at client coordinates (150, 200)
+    // Formula: clientX - containerRect.left + 15 => 150 - 100 + 15 = 65px
+    // Formula: clientY - containerRect.top + 15 => 200 - 100 + 15 = 115px
+    fireEvent.mouseEnter(card, { clientX: 150, clientY: 200 });
+
+    const tooltip = screen.getByTestId('interactive-tooltip');
+    expect(tooltip.style.left).toBe('65px');
+    expect(tooltip.style.top).toBe('115px');
+    expect(screen.getByText('Special: Bob')).toBeDefined();
+    expect(tooltipFormatterMock).toHaveBeenCalledWith(mockTestimonials[1]);
+
+    // Move mouse to different coordinates (200, 250)
+    // Formula: 200 - 100 + 15 = 115px, 250 - 100 + 15 = 165px
+    fireEvent.mouseMove(card, { clientX: 200, clientY: 250 });
+
+    expect(tooltip.style.left).toBe('115px');
+    expect(tooltip.style.top).toBe('165px');
+  });
+
+  // Test Case 4: Touch events, tooltips, and click propagation
+  it('supports touch gestures, computes touch coordinates, and propagates click/touch callbacks correctly', async () => {
+    vi.useFakeTimers();
+    render(<WallOfLove testimonials={mockTestimonials} onCardClick={onCardClickMock} />);
+
+    const container = screen.getByTestId('wall-of-love-container');
+    const card = screen.getByTestId('testimonial-card-1');
+
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({
+      left: 50,
+      top: 50,
+      width: 500,
+      height: 500,
+      right: 550,
+      bottom: 550,
+      x: 50,
+      y: 50,
+      toJSON: () => {},
+    });
+
+    // Simulate custom touch start gesture at (120, 180)
+    // Formula: 120 - 50 + 15 = 85px, 180 - 50 + 15 = 145px
+    fireEvent.touchStart(card, {
+      touches: [{ clientX: 120, clientY: 180 } as any],
+    });
+
+    const tooltip = screen.getByTestId('interactive-tooltip');
+    expect(tooltip.style.left).toBe('85px');
+    expect(tooltip.style.top).toBe('145px');
+
+    // Simulate touch end gesture
+    const touchEndEvent = {
+      changedTouches: [{ clientX: 120, clientY: 180 } as any],
+    };
+    fireEvent.touchEnd(card, touchEndEvent);
+
+    // Verify touchEnd callback propagation
+    expect(onCardClickMock).toHaveBeenCalledTimes(1);
+    expect(onCardClickMock).toHaveBeenCalledWith(mockTestimonials[0], expect.any(Object));
+
+    // Fast-forward timers to run the setHoveredCardId cleanup in setTimeout
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    // Tooltip should be hidden after timer
+    expect(screen.queryByTestId('interactive-tooltip')).toBeNull();
+
+    vi.useRealTimers();
+
+    // Simulate standard click and verify propagation
+    fireEvent.click(card);
+    expect(onCardClickMock).toHaveBeenCalledTimes(2);
+    expect(onCardClickMock).toHaveBeenLastCalledWith(mockTestimonials[0], expect.any(Object));
+  });
+
+  // Test Case 5: MouseLeave hides tooltip visuals
+  it('removes the interactive tooltip overlay from the DOM on mouseleave', () => {
+    render(<WallOfLove testimonials={mockTestimonials} />);
+
+    const card = screen.getByTestId('testimonial-card-1');
+
+    // Hover to show tooltip
+    fireEvent.mouseEnter(card, { clientX: 100, clientY: 100 });
+    expect(screen.getByTestId('interactive-tooltip')).toBeDefined();
+
+    // Leave to hide tooltip
+    fireEvent.mouseLeave(card);
+    expect(screen.queryByTestId('interactive-tooltip')).toBeNull();
+  });
+});

--- a/components/WallOfLove.responsive-breakpoints.test.tsx
+++ b/components/WallOfLove.responsive-breakpoints.test.tsx
@@ -1,0 +1,204 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render, screen, fireEvent, within, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import WallOfLove, { Testimonial } from './WallOfLove';
+
+const mockTestimonials: Testimonial[] = [
+  {
+    id: '1',
+    name: 'Alice Developer',
+    role: 'Staff Engineer',
+    message: 'Highly responsive and beautifully structured grid components!',
+    rating: 5,
+    tags: ['web', 'react', 'responsive', 'ux', 'mobile', 'frontend'],
+  },
+  {
+    id: '2',
+    name: 'Bob Product',
+    role: 'Director of Product',
+    message: 'Excellent presentation and clean mobile reflow behavior.',
+    rating: 4,
+    tags: ['mobile-first', 'design'],
+  },
+];
+
+describe('WallOfLove Responsive Breakpoints & Mobile Viewport Layouts', () => {
+  const onCardClickMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // Test Case 1: Mock standard mobile-width media coordinates
+  it('mocks standard mobile-width viewport dimensions successfully', () => {
+    // Set viewport to a standard mobile width of 375px
+    vi.stubGlobal('innerWidth', 375);
+    vi.stubGlobal('innerHeight', 667);
+    window.dispatchEvent(new Event('resize'));
+
+    expect(window.innerWidth).toBe(375);
+    expect(window.innerHeight).toBe(667);
+  });
+
+  // Test Case 2: Assert columns reflow into standard vertical layout (grid-cols-1)
+  it('asserts that grid columns reflow into single-column layout (grid-cols-1) on mobile devices', () => {
+    vi.stubGlobal('innerWidth', 375);
+    window.dispatchEvent(new Event('resize'));
+
+    render(<WallOfLove testimonials={mockTestimonials} />);
+
+    const grid = screen.getByTestId('testimonials-grid');
+
+    // Check for standard Tailwind layout classes that reflow on different viewports
+    expect(grid.className).toContain('grid');
+    expect(grid.className).toContain('grid-cols-1');
+    expect(grid.className).toContain('md:grid-cols-2');
+    expect(grid.className).toContain('lg:grid-cols-3');
+  });
+
+  // Test Case 3: Verify styling values are responsive and not absolute widths causing horizontal scrollbars
+  it('verifies container and card styling do not use absolute widths that could cause horizontal scrollbars', () => {
+    render(<WallOfLove testimonials={mockTestimonials} />);
+
+    const container = screen.getByTestId('wall-of-love-container');
+    const card1 = screen.getByTestId('testimonial-card-1');
+    const card2 = screen.getByTestId('testimonial-card-2');
+
+    // 1. Verify container is set to fill width responsively
+    expect(container.className).toContain('w-full');
+    expect(container.style.width).not.toContain('px'); // No absolute hardcoded inline pixel width
+
+    // 2. Ensure cards do not contain hardcoded pixel width classes (e.g., w-[500px]) or style properties
+    expect(card1.className).not.toMatch(/\bw-\[\d+px\]/);
+    expect(card2.className).not.toMatch(/\bw-\[\d+px\]/);
+    expect(card1.style.width).toBe('');
+    expect(card2.style.width).toBe('');
+  });
+
+  // Test Case 4: Check that tag elements and tooltips scale down and wrap gracefully
+  it('checks that interactive tooltip and tags scale down gracefully and wrap without clipping', () => {
+    render(<WallOfLove testimonials={mockTestimonials} />);
+
+    const card = screen.getByTestId('testimonial-card-1');
+
+    // Hover to trigger tooltip
+    fireEvent.mouseEnter(card, { clientX: 100, clientY: 100 });
+
+    const tooltip = screen.getByTestId('interactive-tooltip');
+
+    // 1. Verify tooltip size is constrained to avoid overflowing mobile screen edges
+    expect(tooltip.className).toContain('max-w-xs'); // limits width responsively
+    expect(tooltip.className).toContain('text-xs'); // uses compact text sizes on mobile
+
+    // 2. Verify tag elements container inside tooltip wraps gracefully
+    const tagsContainer = tooltip.querySelector('.flex-wrap');
+    expect(tagsContainer).not.toBeNull();
+    expect(tagsContainer?.className).toContain('flex-wrap'); // flex-wrap allows items to wrap to next line instead of overflowing
+    expect(tagsContainer?.className).toContain('gap-1');
+
+    // 3. Verify tag elements themselves are styled compactly
+    const tagElements = tooltip.querySelectorAll('.px-1\\.5');
+    expect(tagElements.length).toBeGreaterThan(0);
+    tagElements.forEach((tag) => {
+      expect(tag.className).toContain('text-[10px]'); // extremely compact text
+    });
+  });
+
+  // Test Case 5: Assert mobile-specific toggle states respond cleanly
+  it('asserts mobile-specific touch interaction toggles tooltip state cleanly with timers', () => {
+    vi.useFakeTimers();
+    render(<WallOfLove testimonials={mockTestimonials} onCardClick={onCardClickMock} />);
+
+    const container = screen.getByTestId('wall-of-love-container');
+    const card = screen.getByTestId('testimonial-card-1');
+
+    // Mock container boundary for coordinate calculations
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({
+      left: 10,
+      top: 10,
+      width: 350,
+      height: 400,
+      right: 360,
+      bottom: 410,
+      x: 10,
+      y: 10,
+      toJSON: () => {},
+    });
+
+    // Touch start triggers tooltip displaying at custom responsive mobile coordinates
+    // Formula: 120 - 10 + 15 = 125px, 150 - 10 + 15 = 155px
+    fireEvent.touchStart(card, {
+      touches: [{ clientX: 120, clientY: 150 } as any],
+    });
+
+    // Tooltip must be shown immediately on touch
+    let tooltip = screen.queryByTestId('interactive-tooltip');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip!.style.left).toBe('125px');
+    expect(tooltip!.style.top).toBe('155px');
+
+    // Touch end fires callback and starts timeout to clear tooltip
+    fireEvent.touchEnd(card, {
+      changedTouches: [{ clientX: 120, clientY: 150 } as any],
+    });
+
+    expect(onCardClickMock).toHaveBeenCalledTimes(1);
+
+    // Tooltip should still be visible right after touchEnd (during the 1s delay)
+    tooltip = screen.queryByTestId('interactive-tooltip');
+    expect(tooltip).not.toBeNull();
+
+    // Advance timer by 1000ms to clear it
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // Tooltip should be hidden after 1000ms delay
+    tooltip = screen.queryByTestId('interactive-tooltip');
+    expect(tooltip).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  // Test Case 6: Assert clean toggling between multiple cards under touch interactions
+  it('toggles active cards and tooltips cleanly when switching touch focus on mobile devices', () => {
+    render(<WallOfLove testimonials={mockTestimonials} />);
+
+    const container = screen.getByTestId('wall-of-love-container');
+    const card1 = screen.getByTestId('testimonial-card-1');
+    const card2 = screen.getByTestId('testimonial-card-2');
+
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      width: 375,
+      height: 500,
+      right: 375,
+      bottom: 500,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    // Touch first card
+    fireEvent.touchStart(card1, {
+      touches: [{ clientX: 50, clientY: 100 } as any],
+    });
+
+    let tooltip = screen.getByTestId('interactive-tooltip');
+    expect(within(tooltip).getByText('Alice Developer')).toBeDefined();
+
+    // Touch second card immediately - active card should switch immediately
+    fireEvent.touchStart(card2, {
+      touches: [{ clientX: 50, clientY: 250 } as any],
+    });
+
+    tooltip = screen.getByTestId('interactive-tooltip');
+    expect(within(tooltip).getByText('Bob Product')).toBeDefined();
+    expect(within(tooltip).queryByText('Alice Developer')).toBeNull();
+  });
+});

--- a/components/WallOfLove.tsx
+++ b/components/WallOfLove.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import React, { useState, useRef } from 'react';
+
+export interface Testimonial {
+  id: string | number;
+  name: string;
+  role: string;
+  message: string;
+  rating?: number;
+  tags?: string[];
+}
+
+export interface WallOfLoveProps {
+  testimonials: Testimonial[];
+  onCardClick?: (testimonial: Testimonial, event: React.MouseEvent | React.TouchEvent) => void;
+  tooltipFormatter?: (testimonial: Testimonial) => string;
+}
+
+export default function WallOfLove({
+  testimonials,
+  onCardClick,
+  tooltipFormatter,
+}: WallOfLoveProps) {
+  const [hoveredCardId, setHoveredCardId] = useState<string | number | null>(null);
+  const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!containerRef.current) return;
+    const containerRect = containerRef.current.getBoundingClientRect();
+    // Compute coordinates relative to the container for responsive rendering
+    const x = e.clientX - containerRect.left + 15;
+    const y = e.clientY - containerRect.top + 15;
+    setTooltipPos({ x, y });
+  };
+
+  const handleMouseEnter = (e: React.MouseEvent, id: string | number) => {
+    setHoveredCardId(id);
+    if (!containerRef.current) return;
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const x = e.clientX - containerRect.left + 15;
+    const y = e.clientY - containerRect.top + 15;
+    setTooltipPos({ x, y });
+  };
+
+  const handleMouseLeave = () => {
+    setHoveredCardId(null);
+  };
+
+  const handleTouchStart = (e: React.TouchEvent, testimonial: Testimonial) => {
+    if (!containerRef.current) return;
+    const touch = e.touches[0];
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const x = touch.clientX - containerRect.left + 15;
+    const y = touch.clientY - containerRect.top + 15;
+
+    setHoveredCardId(testimonial.id);
+    setTooltipPos({ x, y });
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent, testimonial: Testimonial) => {
+    // If click/touch action is requested, trigger callback
+    if (onCardClick) {
+      onCardClick(testimonial, e);
+    }
+    // Set a timeout to clear the tooltip on touch devices to let user see it momentarily
+    setTimeout(() => {
+      setHoveredCardId((current) => (current === testimonial.id ? null : current));
+    }, 1000);
+  };
+
+  const handleCardClick = (e: React.MouseEvent, testimonial: Testimonial) => {
+    if (onCardClick) {
+      onCardClick(testimonial, e);
+    }
+  };
+
+  const activeTestimonial = testimonials.find((t) => t.id === hoveredCardId);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative w-full min-h-[400px] p-6 bg-slate-900 text-white rounded-2xl overflow-hidden shadow-2xl"
+      data-testid="wall-of-love-container"
+    >
+      <h2 className="text-3xl font-extrabold tracking-tight text-center mb-8 bg-gradient-to-r from-pink-500 via-red-500 to-yellow-500 bg-clip-text text-transparent">
+        Wall of Love
+      </h2>
+
+      <div
+        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+        data-testid="testimonials-grid"
+      >
+        {testimonials.map((testimonial) => {
+          const isHovered = hoveredCardId === testimonial.id;
+          return (
+            <div
+              key={testimonial.id}
+              data-testid={`testimonial-card-${testimonial.id}`}
+              className={`p-6 rounded-xl border transition-all duration-300 transform cursor-pointer ${
+                isHovered
+                  ? 'bg-slate-800 border-pink-500 scale-105 shadow-[0_0_15px_rgba(236,72,153,0.3)]'
+                  : 'bg-slate-800/50 border-slate-700 hover:border-slate-600'
+              }`}
+              onMouseEnter={(e) => handleMouseEnter(e, testimonial.id)}
+              onMouseMove={handleMouseMove}
+              onMouseLeave={handleMouseLeave}
+              onTouchStart={(e) => handleTouchStart(e, testimonial)}
+              onTouchEnd={(e) => handleTouchEnd(e, testimonial)}
+              onClick={(e) => handleCardClick(e, testimonial)}
+              role="button"
+              tabIndex={0}
+            >
+              <div className="flex items-center space-x-4 mb-4">
+                <div className="w-10 h-10 rounded-full bg-gradient-to-br from-pink-500 to-yellow-500 flex items-center justify-center font-bold text-lg text-white">
+                  {testimonial.name.charAt(0)}
+                </div>
+                <div>
+                  <h3 className="font-semibold text-lg leading-tight">{testimonial.name}</h3>
+                  <p className="text-sm text-slate-400">{testimonial.role}</p>
+                </div>
+              </div>
+              <p className="text-slate-300 text-sm leading-relaxed mb-4">{testimonial.message}</p>
+              {testimonial.rating && (
+                <div
+                  className="flex items-center space-x-1"
+                  data-testid={`rating-${testimonial.id}`}
+                >
+                  {Array.from({ length: testimonial.rating }).map((_, i) => (
+                    <span key={i} className="text-yellow-400 text-sm">
+                      ★
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Responsive interactive tooltip overlay */}
+      {hoveredCardId !== null && activeTestimonial && (
+        <div
+          data-testid="interactive-tooltip"
+          className="absolute z-50 pointer-events-none p-3 bg-slate-950 border border-pink-500/50 rounded-lg shadow-xl text-xs max-w-xs transition-opacity duration-150 animate-fade-in"
+          style={{
+            left: `${tooltipPos.x}px`,
+            top: `${tooltipPos.y}px`,
+            transform: 'translate3d(0, 0, 0)',
+          }}
+        >
+          <div className="font-bold text-pink-400 mb-1">
+            {tooltipFormatter ? tooltipFormatter(activeTestimonial) : activeTestimonial.name}
+          </div>
+          <p className="text-slate-300">
+            {activeTestimonial.rating ? `${activeTestimonial.rating}/5 Stars` : 'Verified User'}
+          </p>
+          {activeTestimonial.tags && activeTestimonial.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-2">
+              {activeTestimonial.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="px-1.5 py-0.5 bg-pink-900/40 text-pink-300 rounded text-[10px]"
+                >
+                  #{tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,6 +138,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -468,6 +469,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -516,29 +518,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2575,8 +2557,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2623,6 +2604,7 @@
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2633,6 +2615,7 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2643,6 +2626,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2707,6 +2691,7 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -3314,6 +3299,7 @@
       "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.7",
@@ -3443,6 +3429,7 @@
       "integrity": "sha512-TP6utB2yX6rsJNVRo2qAlsi48i1YwFTrLV2tnTtWqJaYX7m4lRCCLirZBjU6xC5m0RsPHr+L2+N+eIPhgEzFfw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.7",
         "fflate": "^0.8.2",
@@ -3494,6 +3481,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3550,7 +3538,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3584,7 +3571,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3941,6 +3927,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4369,7 +4356,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4401,8 +4387,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4727,6 +4712,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4928,6 +4914,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7015,7 +7002,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7458,6 +7444,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
       "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
@@ -7975,6 +7962,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -8023,7 +8011,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8039,7 +8026,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8052,8 +8038,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8119,6 +8104,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8128,6 +8114,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9140,6 +9127,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9277,6 +9265,7 @@
       "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -9401,6 +9390,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9554,6 +9544,7 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -9645,6 +9636,7 @@
       "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.7",
         "@vitest/mocker": "4.1.7",
@@ -10011,6 +10003,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Description

This PR introduces the `WallOfLove` component along with a comprehensive test suite specifically targeting its responsive behaviors, mobile viewport reflows, styling constraints, and mobile-specific touch interaction toggle states.

## Fixes #2779 

### Key Changes
1. **Added Component**:
   - `components/WallOfLove.tsx`: A Wall of Love component to display user testimonials with hover/touch interactive tooltips.
2. **Added Responsive Breakpoint Tests**:
   - `components/WallOfLove.responsive-breakpoints.test.tsx`: A new test suite featuring 6 comprehensive test cases verifying:
     - Stubbing of standard mobile viewports (e.g., 375px width).
     - Column reflow behavior into a single column (`grid-cols-1`).
     - Absence of fixed absolute widths on key containers and cards to prevent horizontal scrollbars.
     - Graceful scaling and layout wrapping of tag lists and tooltips on small screens.
     - Clean toggle state transitions under mobile touch interactions (using fake timers to verify `onTouchStart`, `onTouchEnd` delay mechanisms).
     - Smooth active state transition when switching touch focus between multiple cards.
3. **Added Interactivity Tests**:
   - `components/WallOfLove.mouse-interactivity.test.tsx`: Mouse hover, coordinate computation, and touch event propagation tests.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs, testing)

## Visual Preview
N/A (Testing files added)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.