### PR TITLE
test(lang-de): verify German translation labels

### DIFF
--- a/lib/i18n/languages/de.test.ts
+++ b/lib/i18n/languages/de.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getLabels, labels } from '../badgeLabels';
+
+const requiredKeys = [
+  'CURRENT_STREAK',
+  'ANNUAL_SYNC_TOTAL',
+  'PEAK_STREAK',
+  'COMMITS_THIS_MONTH',
+  'VS_LAST_MONTH',
+] as const;
+
+const expectedGermanLabels = {
+  CURRENT_STREAK: 'AKTUELLE_SERIE',
+  ANNUAL_SYNC_TOTAL: 'JAHRES_GESAMT',
+  PEAK_STREAK: 'SPITZEN_SERIE',
+  COMMITS_THIS_MONTH: 'COMMITS DIESEN MONAT',
+  VS_LAST_MONTH: 'im Vgl. zum Vormonat',
+};
+
+function renderMockBadge(lang: string) {
+  const badgeLabels = getLabels(lang);
+
+  return `
+    <svg role="img" data-lang="${lang}">
+      <text>${badgeLabels.CURRENT_STREAK}</text>
+      <text>${badgeLabels.ANNUAL_SYNC_TOTAL}</text>
+      <text>${badgeLabels.PEAK_STREAK}</text>
+      <text>${badgeLabels.COMMITS_THIS_MONTH}</text>
+      <text>${badgeLabels.VS_LAST_MONTH}</text>
+    </svg>
+  `;
+}
+
+describe('German badge labels', () => {
+  it('includes the de language key in the labels dictionary', () => {
+    expect(labels.de).toBeDefined();
+  });
+
+  it('returns the exact German translation mapping through getLabels', () => {
+    expect(getLabels('de')).toEqual(expectedGermanLabels);
+  });
+
+  it('returns the German mapping when lang code casing differs', () => {
+    expect(getLabels('DE')).toEqual(expectedGermanLabels);
+  });
+
+  it('sets every required German label to a non-empty string', () => {
+    const germanLabels = getLabels('de');
+
+    for (const key of requiredKeys) {
+      expect(typeof germanLabels[key]).toBe('string');
+      expect(germanLabels[key].trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('renders a mock SVG with German translated labels', () => {
+    const svg = renderMockBadge('de');
+
+    expect(svg).toContain('data-lang="de"');
+
+    for (const value of Object.values(expectedGermanLabels)) {
+      expect(svg).toContain(value);
+    }
+  });
+});


### PR DESCRIPTION
## Description

This PR implements focused unit tests validating the German (`de`) localization strings within the translation dictionary. As CommitPulse scales its internationalization (i18n), it is critical that no required translation key is missing or empty, which could lead to severe SVG rendering regressions on localized badges.

Specifically, we tested:
- **Key Presence:** Verified that the `de` language key properly exists in the base `labels` dictionary.
- **Mapping Accuracy:** Asserted that `getLabels('de')` returns the exact expected German translation mapping, and correctly handles case-insensitivity (e.g., `'DE'`).
- **Data Integrity:** Dynamically iterated through all required keys (`CURRENT_STREAK`, `ANNUAL_SYNC_TOTAL`, `PEAK_STREAK`, `COMMITS_THIS_MONTH`, `VS_LAST_MONTH`) to ensure every German label is populated with a non-empty string.
- **SVG Render Compatibility:** Passed the `de` translations into a mocked SVG builder and strictly matched the output string against the expected German translations to simulate badge generation without regression.

Fixes #2338 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs, i18n)

## Visual Preview
N/A - Unit Testing

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
