### PR TITLE
test(api-streak-scale): create specific integration test for streak scale parameter

### DIFF
--- a/app/api/streak/tests/scale.test.ts
+++ b/app/api/streak/tests/scale.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi, beforeAll, afterAll } from 'vitest';
+import { GET } from '../route';
+
+describe('Integration Test: API Streak Scale Parameter Group', () => {
+  beforeAll(() => {
+    // 1. Safely stub the environment variables
+    vi.stubEnv('GITHUB_TOKEN', 'mock_test_token_123');
+    vi.stubEnv('GITHUB_PAT', 'mock_test_token_123');
+
+    // 2. Intercept the network request and return a true native Web Response
+    // We mix low and high counts to ensure log vs linear output drastically differs.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        const mockBody = JSON.stringify({
+          data: {
+            user: {
+              contributionsCollection: {
+                contributionCalendar: {
+                  totalContributions: 105,
+                  weeks: [
+                    {
+                      contributionDays: [
+                        { contributionCount: 5, date: '2026-01-01' },
+                        { contributionCount: 100, date: '2026-01-02' },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        });
+
+        return Promise.resolve(
+          new Response(mockBody, {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        );
+      })
+    );
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('Test 1: should return 200 OK for valid scale=log', async () => {
+    const req = new Request('http://localhost/api/streak?user=JhaSourav07&scale=log');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('Test 2: should return 200 OK for valid scale=linear', async () => {
+    const req = new Request('http://localhost/api/streak?user=JhaSourav07&scale=linear');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('Test 3: should render different SVGs for linear vs log scaling', async () => {
+    const reqLinear = new Request('http://localhost/api/streak?user=JhaSourav07&scale=linear');
+    const resLinear = await GET(reqLinear);
+    const svgLinear = await resLinear.text();
+
+    const reqLog = new Request('http://localhost/api/streak?user=JhaSourav07&scale=log');
+    const resLog = await GET(reqLog);
+    const svgLog = await resLog.text();
+
+    // The rendered dimensions/coordinates of rects will differ based on the scaling formula
+    expect(svgLinear).not.toEqual(svgLog);
+
+    // We expect valid SVG structure for both
+    expect(svgLinear).toContain('</svg>');
+    expect(svgLog).toContain('</svg>');
+  });
+
+  it('Test 4: should fallback gracefully to linear behavior for invalid scale inputs', async () => {
+    const reqInvalid = new Request(
+      'http://localhost/api/streak?user=JhaSourav07&scale=unknown_scale_value'
+    );
+    const resInvalid = await GET(reqInvalid);
+    const svgInvalid = await resInvalid.text();
+
+    const reqLinear = new Request('http://localhost/api/streak?user=JhaSourav07&scale=linear');
+    const resLinear = await GET(reqLinear);
+    const svgLinear = await resLinear.text();
+
+    // The fallback should perfectly match linear behavior
+    expect(resInvalid.status).toBe(200);
+    expect(svgInvalid).toEqual(svgLinear);
+  });
+
+  it('Test 5: should return appropriate HTTP headers for SVG rendering', async () => {
+    const req = new Request('http://localhost/api/streak?user=JhaSourav07&scale=log');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toMatch(/image\/svg\+xml/);
+    expect(res.headers.get('Cache-Control')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description

This PR implements isolated, dedicated integration tests focusing specifically on the `scale` parameter group for the `/api/streak` route. As the streak rendering logic scales, it is crucial to ensure strict validation parsing and accurate SVG scaling variations natively within the Next.js Web `Request` / `Response` environment.

Specifically, we tested:
- **Native Routing Integration:** Aligned the test architecture with existing patterns by using native `Request` and `GET()` handler invocations, negating the outdated requirement for `node-mocks-http`.
- **Dynamic Scale Formatting:** Mixed high and low `contributionCount` stubs across the global `fetch` intercept to guarantee that SVG string outputs differ drastically between `scale=log` and `scale=linear`.
- **Graceful Linear Fallbacks:** Asserted that passing an invalid/unknown scale parameter gracefully falls back to the default linear scaling template, preventing crashes and HTTP 500 errors.
- **Valid 200 HTTP Headers:** Validated that both `linear` and `log` valid variations result in a 200 status code, whilst asserting the returned headers correctly declare `image/svg+xml`.

Fixes #2341 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs, tests)

## Visual Preview
N/A - Integration Testing

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
