### PR TITLE
test(generator-deterministicRandom): create isolated helper unit test for deterministicRandom

### DIFF
--- a/lib/svg/generator.deterministicRandom.test.ts
+++ b/lib/svg/generator.deterministicRandom.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { deterministicRandom } from './generator';
+
+describe('Helper Function: deterministicRandom', () => {
+  it('Test 1: should return deterministic values for standard seeds', () => {
+    // FNV-1a produces completely deterministic hashes based on identical strings.
+    const run1 = deterministicRandom('commitpulse-seed');
+    const run2 = deterministicRandom('commitpulse-seed');
+
+    expect(run1).toBe(run2);
+    expect(run1).toBeGreaterThanOrEqual(0);
+    expect(run1).toBeLessThan(1);
+
+    // Exact assertion to lock down the hash algorithm preventing future regressions.
+    // If the hash algorithm changes, this will fail.
+    expect(deterministicRandom('commitpulse')).toBeCloseTo(0.431545, 5);
+  });
+
+  it('Test 2: should produce distinct values for distinct seeds', () => {
+    const val1 = deterministicRandom('seed:A');
+    const val2 = deterministicRandom('seed:B');
+    expect(val1).not.toBe(val2);
+  });
+
+  it('Test 3: should handle empty strings robustly', () => {
+    const val = deterministicRandom('');
+    expect(val).toBeTypeOf('number');
+    expect(val).toBeGreaterThanOrEqual(0);
+    expect(val).toBeLessThan(1);
+  });
+
+  it('Test 4: should handle null and undefined safely falling back to an empty string', () => {
+    const emptyVal = deterministicRandom('');
+    const nullVal = deterministicRandom(null);
+    const undefinedVal = deterministicRandom(undefined);
+
+    expect(nullVal).toBe(emptyVal);
+    expect(undefinedVal).toBe(emptyVal);
+  });
+
+  it('Test 5: should execute predictably and rapidly within standard timing expectations', () => {
+    const startTime = performance.now();
+    for (let i = 0; i < 10000; i++) {
+      deterministicRandom(`stress-test-${i}`);
+    }
+    const endTime = performance.now();
+
+    const duration = endTime - startTime;
+    // 10,000 FNV-1a hashes should easily complete under 50ms on modern hardware
+    expect(duration).toBeLessThan(50);
+  });
+});

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -68,10 +68,11 @@ export function truncateUsername(username: string): string {
   return username.length > 12 ? `${username.slice(0, 12)}...` : username;
 }
 
-export function deterministicRandom(seed: string): number {
+export function deterministicRandom(seed?: string | null): number {
+  const safeSeed = seed || '';
   let hash = 2166136261;
-  for (let i = 0; i < seed.length; i++) {
-    hash ^= seed.charCodeAt(i);
+  for (let i = 0; i < safeSeed.length; i++) {
+    hash ^= safeSeed.charCodeAt(i);
     hash = Math.imul(hash, 16777619);
   }
   return (hash >>> 0) / 4294967296;


### PR DESCRIPTION
## Description

This PR implements isolated, dedicated unit tests for the `deterministicRandom` helper function within the SVG generator layer (`lib/svg/generator.ts`). Additionally, it refactors the function signature to safely handle runtime edge cases.

Specifically, we tested and resolved:
- **Null safety:** The `deterministicRandom` helper now natively accepts `seed?: string | null` and gracefully falls back to an empty string (`""`). This prevents fatal `TypeError: Cannot read properties of undefined (reading 'length')` crashes if malformed data enters the SVG generator pipeline.
- **Algorithm Hash Verification:** A hardcoded float assertion (for seed `"commitpulse"`) locks down the 32-bit FNV-1a math operations. Any future structural alterations to the multiplier `16777619` or offset basis `2166136261` will predictably fail this test, preventing accidental algorithm regressions.
- **Determinism validation:** Assertions confirm identical seeds yield strictly identical floats, and varying seeds yield distinct output.
- **Rapid Execution bounds:** Verified via `performance.now()` that the hash evaluates extremely quickly, resolving $10,000$ consecutive calculations well within strict 50ms CI/CD timing bounds.

Fixes #2366 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs, tests)

## Visual Preview
N/A - Internal Testing & Runtime safety.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`vitest run`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
