### PR TITLE
test: add AIInsights empty fallback coverage

### DIFF
--- a/components/dashboard/AIInsights.empty-fallback.test.tsx
+++ b/components/dashboard/AIInsights.empty-fallback.test.tsx
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AIInsights from './AIInsights';
+import type { AIInsight } from '@/types/dashboard';
+
+// Mock framer-motion
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({
+      children,
+      whileHover,
+      whileTap,
+      whileInView,
+      initial,
+      animate,
+      exit,
+      transition,
+      viewport,
+      layoutId,
+      ...props
+    }: any) => (
+      <div {...props} data-testid="motion-div">
+        {children}
+      </div>
+    ),
+  },
+}));
+
+// Mock lucide-react
+vi.mock('lucide-react', () => ({
+  Sparkles: (props: any) => <div data-testid="icon-sparkles" {...props} />,
+  Moon: (props: any) => <div data-testid="icon-moon" {...props} />,
+  Sun: (props: any) => <div data-testid="icon-sun" {...props} />,
+  Zap: (props: any) => <div data-testid="icon-zap" {...props} />,
+  Calendar: (props: any) => <div data-testid="icon-calendar" {...props} />,
+  Flame: (props: any) => <div data-testid="icon-flame" {...props} />,
+  Code: (props: any) => <div data-testid="icon-code" {...props} />,
+  Star: (props: any) => <div data-testid="icon-star" {...props} />,
+  LucideIcon: () => null,
+}));
+
+describe('AIInsights', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders with an empty insights array', () => {
+    render(<AIInsights insights={[]} />);
+
+    expect(screen.getByText('AI Insights')).toBeDefined();
+  });
+
+  it('renders only the header sparkles icon when insights array is empty', () => {
+    render(<AIInsights insights={[]} />);
+
+    const sparklesIcons = screen.getAllByTestId('icon-sparkles');
+    expect(sparklesIcons).toHaveLength(1);
+  });
+
+  it('renders heading when insights is undefined', () => {
+    render(<AIInsights insights={undefined as unknown as AIInsight[]} />);
+
+    expect(screen.getByText('AI Insights')).toBeDefined();
+  });
+
+  it('renders heading when insights is null', () => {
+    render(<AIInsights insights={null as unknown as AIInsight[]} />);
+
+    expect(screen.getByText('AI Insights')).toBeDefined();
+  });
+
+  it('renders only the header sparkles icon when insights is undefined', () => {
+    render(<AIInsights insights={undefined as unknown as AIInsight[]} />);
+
+    expect(screen.getByText('AI Insights')).toBeDefined();
+    expect(screen.getAllByTestId('icon-sparkles')).toHaveLength(1);
+  });
+});

--- a/components/dashboard/AIInsights.tsx
+++ b/components/dashboard/AIInsights.tsx
@@ -23,7 +23,7 @@ export default function AIInsights({ insights }: { insights: AIInsight[] }) {
       </div>
 
       <div className="flex flex-col gap-6">
-        {insights.map((insight, i) => {
+        {(insights ?? []).map((insight, i) => {
           const Icon = iconMap[insight.icon] || Sparkles;
 
           return (


### PR DESCRIPTION
## Description

Fixes #2493

Added a new test file `AIInsights.empty-fallback.test.tsx` to verify edge cases and empty/missing input handling for the AIInsights component.

### Changes made

* Added test coverage for empty insights arrays.
* Added test coverage for `undefined` insights input.
* Added test coverage for `null` insights input.
* Verified that the component continues to render correctly under missing-input conditions.
* Fixed a runtime crash caused by calling `.map()` on `undefined` or `null` by safely handling missing insights data with a fallback array.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test coverage and stability improvement)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
