### PR TITLE
Skip stale unassignment when the issue has an open PR referencing it

### DIFF
--- a/.github/scripts/issue-management/stale-assignment.js
+++ b/.github/scripts/issue-management/stale-assignment.js
@@ -29,6 +29,7 @@ async function handleStaleAssignments({ github, context, core }) {
 
       if (timeSinceUpdate > TWO_DAYS_MS) {
         const currentAssignees = issue.assignees.map((a) => a.login);
+        if (currentAssignees.length === 0) continue;
 
         // Check if any open PRs reference this issue before unassigning
         const { data: searchResult } = await github.rest.search.issuesAndPullRequests({
@@ -46,24 +47,22 @@ async function handleStaleAssignments({ github, context, core }) {
           `Issue #${issue.number} has been inactive since ${issue.updated_at}. Removing assignees.`
         );
 
-        if (currentAssignees.length > 0) {
-          await github.rest.issues.removeAssignees({
-            owner,
-            repo,
-            issue_number: issue.number,
-            assignees: currentAssignees,
-          });
+        await github.rest.issues.removeAssignees({
+          owner,
+          repo,
+          issue_number: issue.number,
+          assignees: currentAssignees,
+        });
 
-          // 2. Post a comment
-          await github.rest.issues.createComment({
-            owner,
-            repo,
-            issue_number: issue.number,
-            body: `⚠️ Assignment automatically removed due to inactivity.\nFeel free to reclaim the issue if you want to continue working on it.`,
-          });
+        // 2. Post a comment
+        await github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: issue.number,
+          body: `⚠️ Assignment automatically removed due to inactivity.\nFeel free to reclaim the issue if you want to continue working on it.`,
+        });
 
-          staleCount++;
-        }
+        staleCount++;
       }
     }
 

--- a/.github/scripts/issue-management/stale-assignment.js
+++ b/.github/scripts/issue-management/stale-assignment.js
@@ -28,12 +28,24 @@ async function handleStaleAssignments({ github, context, core }) {
       const timeSinceUpdate = now.getTime() - updatedAt.getTime();
 
       if (timeSinceUpdate > TWO_DAYS_MS) {
+        const currentAssignees = issue.assignees.map((a) => a.login);
+
+        // Check if any open PRs reference this issue before unassigning
+        const { data: searchResult } = await github.rest.search.issuesAndPullRequests({
+          q: `"#${issue.number}" is:pr is:open repo:${owner}/${repo}`,
+        });
+
+        if (searchResult.total_count > 0) {
+          console.log(
+            `Issue #${issue.number} has open PR(s) referencing it. Skipping stale unassignment.`
+          );
+          continue;
+        }
+
         console.log(
           `Issue #${issue.number} has been inactive since ${issue.updated_at}. Removing assignees.`
         );
 
-        // 1. Remove all assignees
-        const currentAssignees = issue.assignees.map((a) => a.login);
         if (currentAssignees.length > 0) {
           await github.rest.issues.removeAssignees({
             owner,


### PR DESCRIPTION
## What this fixes

The `handleStaleAssignments` function in `.github/scripts/issue-management/stale-assignment.js` unassigns contributors from issues where `issue.updated_at` is older than 2 days. Since `issue.updated_at` is only updated by events on the issue itself (comments, label changes, assignment changes) and never by PR activity (commits, reviews, CI checks), a contributor who submits a PR within hours of claiming an issue gets unassigned days later purely because the maintainer has not yet reviewed their PR. The contributor is penalized for delays in the review process rather than their own inactivity.

## Root cause

At `.github/scripts/issue-management/stale-assignment.js:27-28`, the stale check only examines `issue.updated_at`. When a PR references the issue (e.g., via "Closes #N" in the PR body), GitHub does not increment `issue.updated_at`. So from the checker's perspective, the issue appears inactive even though the assignee has already completed the work and is waiting for review. The entire unassignment path has no awareness of whether any open PR exists for the issue.

## What changed

**`.github/scripts/issue-management/stale-assignment.js`** — Added a check before the unassignment block that uses `github.rest.search.issuesAndPullRequests` to find any open PRs in the repo that reference the current issue number. If at least one open PR is found, the unassignment is skipped with a log message.

## How to verify

1. Find an open issue with an assignee
2. Submit a PR referencing the issue (e.g., "Closes #N" in the body)
3. Wait for the stale assignment cron to run, or trigger the `stale-assignments.yml` workflow manually via `workflow_dispatch`
4. Confirm the assignee is still assigned and the workflow log shows the skip message

Negative case:
1. Find an open issue with an assignee but no linked PR that has been inactive for 2+ days
2. Run the workflow — the assignee should be removed as before

## Edge cases considered

- **Merged or closed PR**: `is:open` excludes these, so unassignment proceeds correctly
- **Issue number in an unrelated PR**: A false positive (keeping assignment) is harmless compared to a false negative (unassigning someone with a real PR)
- **Multiple PRs referencing the same issue**: If even one is open, unassignment is skipped
- **Assignee is not the PR author**: The original assignee stays assigned, preventing duplicate work confusion

Closes #4001