### PR TITLE
test(cache): add null key validation coverage for TTLCache (Variation 2)

### DIFF
--- a/lib/cache.test.ts
+++ b/lib/cache.test.ts
@@ -688,6 +688,37 @@ describe('TTLCache', () => {
 
       cache.destroy();
     });
+    it('verify TTLCache behavior for null keys (Variation 2)', () => {
+      const cache = new TTLCache<string>();
+
+      // Null key should be rejected
+      expect(() => {
+        cache.set(null as unknown as string, 'boundary-value', 60_000);
+      }).toThrow(TypeError);
+
+      // Cache should remain empty
+      expect(cache.size()).toBe(0);
+
+      // Null key should not exist
+      // has() should reject null keys
+      expect(() => {
+        cache.has(null as unknown as string);
+      }).toThrow(TypeError);
+
+      // get() should reject null keys
+      expect(() => {
+        cache.get(null as unknown as string);
+      }).toThrow(TypeError);
+
+      // Normal cache operations must still work afterwards
+      cache.set('valid-key', 'valid-value', 60_000);
+
+      expect(cache.get('valid-key')).toBe('valid-value');
+      expect(cache.has('valid-key')).toBe(true);
+      expect(cache.size()).toBe(1);
+
+      cache.destroy();
+    });
   });
 
   it('stores and retrieves values with unicode and emoji cache keys', () => {


### PR DESCRIPTION
## Description

Adds a dedicated test case to verify that TTLCache correctly rejects null cache keys and preserves cache integrity after invalid input attempts.

## Changes Made

- Added a new test: "verify TTLCache behavior for null keys (Variation 2)"
- Verified that cache.set(null, value, ttl) throws a TypeError
- Updated assertions to match the cache implementation's validation behavior
- Confirmed that cache state remains unchanged after invalid key operations
- Verified normal cache operations continue to function after a rejected null key

Fixes #1401 

## Pillar

- [x] 📐 Pillar 2 — Geometric SVG Improvement

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
