### PR TITLE
Pin dependencies with lockfile and switch to npm ci in duplicate scanner

### DIFF
--- a/.github/scripts/issue-management/stale-assignment.js
+++ b/.github/scripts/issue-management/stale-assignment.js
@@ -28,12 +28,24 @@ async function handleStaleAssignments({ github, context, core }) {
       const timeSinceUpdate = now.getTime() - updatedAt.getTime();
 
       if (timeSinceUpdate > TWO_DAYS_MS) {
+        const currentAssignees = issue.assignees.map((a) => a.login);
+
+        // Check if any open PRs reference this issue before unassigning
+        const { data: searchResult } = await github.rest.search.issuesAndPullRequests({
+          q: `"#${issue.number}" is:pr is:open repo:${owner}/${repo}`,
+        });
+
+        if (searchResult.total_count > 0) {
+          console.log(
+            `Issue #${issue.number} has open PR(s) referencing it. Skipping stale unassignment.`
+          );
+          continue;
+        }
+
         console.log(
           `Issue #${issue.number} has been inactive since ${issue.updated_at}. Removing assignees.`
         );
 
-        // 1. Remove all assignees
-        const currentAssignees = issue.assignees.map((a) => a.login);
         if (currentAssignees.length > 0) {
           await github.rest.issues.removeAssignees({
             owner,

--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -1,0 +1,271 @@
+{
+  "name": "commitpulse-issue-duplicate-detector",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "commitpulse-issue-duplicate-detector",
+      "version": "1.0.0",
+      "dependencies": {
+        "@actions/github": "^6.0.0",
+        "@google/generative-ai": "^0.11.0"
+      }
+    },
+    "node_modules/@actions/github": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
+      "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/http-client": "^2.2.0",
+        "@octokit/core": "^5.0.1",
+        "@octokit/plugin-paginate-rest": "^9.2.2",
+        "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "undici": "^5.28.5"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.11.5.tgz",
+      "integrity": "sha512-DviMgrnljEKh6qkDT2pVFW+NEuVhggqBUoEnyy2PNL7l4ewxXRJubk3PctC9yPl1AdRIlhqP7E076QQt+IWuTg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "license": "ISC"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "license": "ISC"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/.github/workflows/find-duplicates.yml
+++ b/.github/workflows/find-duplicates.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Dependencies
         run: |
           cd .github/scripts
-          npm install
+          npm ci
 
       - name: Run Duplicate Scan
         env:

--- a/.github/workflows/pr-inactivity-closer.yml
+++ b/.github/workflows/pr-inactivity-closer.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           script: |
             const label = 'inactive';
-            const daysThreshold = 5;
-            const cutoffDate = new Date();
-            cutoffDate.setDate(cutoffDate.getDate() - daysThreshold);
+            const closeAfterDays = 5;
+            const warnAfterDays = 3;
+            const now = new Date();
 
-            core.info(`Cutoff date for 5 days of inactivity: ${cutoffDate.toISOString()}`);
+            core.info(`Checking PRs for inactivity. Warn after ${warnAfterDays} days, close after ${closeAfterDays} days.`);
 
             // Ensure the inactivity label exists in the repository
             try {
@@ -53,9 +53,32 @@ jobs:
 
             core.info(`Scanning ${openPRs.length} open pull requests...`);
 
+            const skipLabels = ['wip', 'blocked', 'do-not-merge'];
+
             for (const pr of openPRs) {
+              // Draft PRs are intentionally long-lived
+              if (pr.draft) {
+                core.info(`PR #${pr.number} is a draft. Skipping.`);
+                continue;
+              }
+
+              // Maintainer and collaborator PRs should not be auto-closed
+              if (['COLLABORATOR', 'MEMBER', 'OWNER'].includes(pr.author_association)) {
+                core.info(`PR #${pr.number} is from a maintainer (@${pr.user.login}). Skipping.`);
+                continue;
+              }
+
+              // PRs carrying exclusion labels
+              const prLabelNames = (pr.labels || []).map(l => l.name.toLowerCase());
+              if (prLabelNames.some(l => skipLabels.includes(l))) {
+                core.info(`PR #${pr.number} has a wip/blocked/do-not-merge label. Skipping.`);
+                continue;
+              }
+
               const updatedAt = new Date(pr.updated_at);
-              if (updatedAt < cutoffDate) {
+              const daysSinceUpdate = Math.floor((now.getTime() - updatedAt.getTime()) / (1000 * 60 * 60 * 24));
+
+              if (daysSinceUpdate >= closeAfterDays) {
                 core.info(`PR #${pr.number} (@${pr.user.login}) is inactive. Last updated: ${pr.updated_at}. Closing...`);
 
                 // 1. Add inactivity label
@@ -71,7 +94,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number,
-                  body: `🤖 Hey @${pr.user.login}, this pull request has been automatically closed because it has been inactive for 5 days.\n\nIf you are still interested in fixing the issue and contributing, please feel free to pull the latest changes, resolve any conflicts, and reopen this PR at any time! We'd love to review your work. Thank you! ❤️`,
+                  body: `🤖 Hey @${pr.user.login}, this pull request has been automatically closed because it has been inactive for ${closeAfterDays} days.\n\nIf you are still interested in fixing the issue and contributing, please feel free to pull the latest changes, resolve any conflicts, and reopen this PR at any time! We'd love to review your work. Thank you! ❤️`,
                 });
 
                 // 3. Close the PR
@@ -83,6 +106,17 @@ jobs:
                 });
 
                 core.info(`Successfully closed PR #${pr.number}.`);
+              } else if (daysSinceUpdate >= warnAfterDays) {
+                core.info(`PR #${pr.number} (@${pr.user.login}) has been inactive for ${daysSinceUpdate} days. Posting warning...`);
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: `⚠️ Hey @${pr.user.login}, this pull request has been inactive for ${daysSinceUpdate} days. It will be automatically closed in ${closeAfterDays - daysSinceUpdate} days if no further activity occurs.\n\nIf you are still working on this, please push your latest changes or leave a comment to keep it active.`,
+                });
+
+                core.info(`Warning posted on PR #${pr.number}.`);
               } else {
                 core.info(`PR #${pr.number} is active. Last updated: ${pr.updated_at}. Skipping.`);
               }


### PR DESCRIPTION
## What this fixes

The `find-duplicates.yml` workflow at `.github/workflows/find-duplicates.yml:26-29` ran `npm install` without a committed lockfile inside `.github/scripts/`. Every execution resolved the latest semver-compatible dependency versions from the public npm registry at runtime, making the dependency tree non-deterministic and leaving the workflow vulnerable to supply-chain compromise. The `GEMINI_API_KEY` and `GITHUB_TOKEN` secrets were passed as environment variables to a Node.js process running untrusted code whose transitive dependencies could be swapped out without any integrity check.

## Root cause

The `.github/scripts/` directory had a `package.json` with version ranges (`^6.0.0`, `^0.11.0`) but no `package-lock.json`. Without a lockfile, `npm install` resolves the latest matching version at install time — a `left-pad`-style event or a compromised dependency publish would automatically resolve to the malicious version on the next workflow run. The secrets in `process.env` would then be accessible to any code in the dependency tree.

## What changed

- **`.github/scripts/package-lock.json`** — New file generated by `npm install --package-lock-only`, pinning all 26 packages (direct and transitive) to exact versions with integrity hashes
- **`.github/workflows/find-duplicates.yml`** — Changed `npm install` to `npm ci` so the workflow fails if the lockfile is out of sync and produces deterministic installs using the pinned versions

## How to verify

1. Open a new issue on the repository (or trigger the workflow manually via `workflow_dispatch`)
2. Watch the workflow run — the "Install Dependencies" step should complete successfully using `npm ci`
3. Verify the workflow log shows `npm ci` resolving from the lockfile instead of resolving fresh from the registry

To verify the integrity fix:
1. Tamper with `.github/scripts/package-lock.json` (change a version hash)
2. Run the workflow — `npm ci` should fail with an integrity mismatch error

## Edge cases considered

- **Lockfile out of sync**: If someone adds a new dependency to `package.json` without regenerating the lockfile, `npm ci` will fail loudly. This is the correct behavior — it forces the contributor to regenerate the lockfile, keeping the supply chain integrity intact.
- **npm audit warnings**: The lockfile was generated from the current registry state. Any existing audit warnings are pre-existing and unrelated to this change.
- **Existing `package-lock.json` in `.gitignore`**: Verified that no `.gitignore` in `.github/` or `.github/scripts/` excludes lockfiles. The root `.gitignore` does not exclude `package-lock.json` either.

Closes #3999