### PR TITLE
test(mongodb): verify User schema behaviors under connection state 0 (Variation 5)

### DIFF
--- a/models/User.connection-state-0-v5.test.ts
+++ b/models/User.connection-state-0-v5.test.ts
@@ -1,0 +1,119 @@
+import mongoose from 'mongoose';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { User } from './User';
+
+describe('User Model Schema Behaviors under Connection State 0 (Variation 5)', () => {
+  let originalReadyState: number;
+
+  beforeEach(() => {
+    originalReadyState = mongoose.connection.readyState;
+  });
+
+  afterEach(() => {
+    // Restore settings
+    mongoose.set('bufferCommands', true);
+    User.schema.set('bufferCommands', true);
+
+    // Restore readyState
+    Object.defineProperty(mongoose.connection, 'readyState', {
+      value: originalReadyState,
+      configurable: true,
+      writable: true,
+    });
+
+    vi.clearAllMocks();
+  });
+
+  it('rejects delete operations immediately when connection is in state 0 (disconnected) and bufferCommands is disabled', async () => {
+    mongoose.set('bufferCommands', false);
+    User.schema.set('bufferCommands', false);
+
+    Object.defineProperty(mongoose.connection, 'readyState', {
+      value: 0,
+      configurable: true,
+      writable: true,
+    });
+
+    expect(mongoose.connection.readyState).toBe(0);
+
+    // Operation must reject immediately due to disabled bufferCommands
+    await expect(async () => {
+      await User.deleteOne({ username: 'testuser' }).exec();
+    }).rejects.toThrow();
+  });
+
+  it('rejects aggregation operations immediately when connection is in state 0 (disconnected) and bufferCommands is disabled', async () => {
+    mongoose.set('bufferCommands', false);
+    User.schema.set('bufferCommands', false);
+
+    Object.defineProperty(mongoose.connection, 'readyState', {
+      value: 0,
+      configurable: true,
+      writable: true,
+    });
+
+    expect(mongoose.connection.readyState).toBe(0);
+
+    // Aggregate query must reject immediately
+    await expect(async () => {
+      await User.aggregate([{ $match: { username: 'testuser' } }]).exec();
+    }).rejects.toThrow();
+  });
+
+  it('rejects document counting operations immediately when connection is in state 0 (disconnected) and bufferCommands is disabled', async () => {
+    mongoose.set('bufferCommands', false);
+    User.schema.set('bufferCommands', false);
+
+    Object.defineProperty(mongoose.connection, 'readyState', {
+      value: 0,
+      configurable: true,
+      writable: true,
+    });
+
+    expect(mongoose.connection.readyState).toBe(0);
+
+    // countDocuments must reject immediately
+    await expect(async () => {
+      await User.countDocuments({}).exec();
+    }).rejects.toThrow();
+  });
+
+  it('rejects index creation operations immediately when connection is in state 0 (disconnected) and bufferCommands is disabled', async () => {
+    mongoose.set('bufferCommands', false);
+    User.schema.set('bufferCommands', false);
+
+    Object.defineProperty(mongoose.connection, 'readyState', {
+      value: 0,
+      configurable: true,
+      writable: true,
+    });
+
+    expect(mongoose.connection.readyState).toBe(0);
+
+    // Index creation must reject immediately
+    await expect(async () => {
+      await User.createIndexes();
+    }).rejects.toThrow();
+  });
+
+  it('allows registering and triggering connection event hooks successfully under connection state 0', () => {
+    Object.defineProperty(mongoose.connection, 'readyState', {
+      value: 0,
+      configurable: true,
+      writable: true,
+    });
+
+    expect(mongoose.connection.readyState).toBe(0);
+
+    const listener = vi.fn();
+    mongoose.connection.on('disconnected', listener);
+
+    // Emit disconnected event to verify callback triggers under state 0
+    mongoose.connection.emit('disconnected');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // Clean up listener
+    mongoose.connection.off('disconnected', listener);
+  });
+});


### PR DESCRIPTION
test(mongodb): verify User schema behaviors under connection state 0 (Variation 5)

## Description

Fixes #1424

Adds 5 robust unit tests in `models/User.connection-state-0-v5.test.ts` to verify the behavior of the Mongoose `User` schema and model under connection state 0 (disconnected) with `bufferCommands` disabled.

### Test Cases Added:
1. **Delete rejection**: Verifies delete operations (e.g., `deleteOne`) reject immediately when the connection is disconnected (state 0) and `bufferCommands` is false.
2. **Aggregation rejection**: Verifies aggregation queries (e.g., `aggregate`) reject immediately when the connection is disconnected (state 0) and `bufferCommands` is false.
3. **Count rejection**: Verifies document counting queries (e.g., `countDocuments`) reject immediately when the connection is disconnected (state 0) and `bufferCommands` is false.
4. **Index generation rejection**: Verifies index creation operations (e.g., `createIndexes`) reject immediately when the connection is disconnected (state 0) and `bufferCommands` is false.
5. **Connection events verification**: Verifies that connection event hook listeners (like subscribing to `'disconnected'` on `mongoose.connection`) can be successfully attached and trigger callback execution under state 0.

## Pillar


- [x] 🛠️ Other (Bug fix, refactoring, docs / Testing)

## Visual Preview

N/A (Backend Database Unit Tests)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npx vitest run models/User.connection-state-0-v5.test.ts`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
