### PR TITLE
test(ui): verify responsive rendering and elements of CustomizeCTA (Variation 2)

### DIFF
--- a/app/components/CustomizeCTA.responsive-v2.test.tsx
+++ b/app/components/CustomizeCTA.responsive-v2.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CustomizeCTA } from './CustomizeCTA';
+
+const { mockMotionDiv, mockLink } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require('react');
+
+  const mockMotionDiv = React.forwardRef(
+    (props: React.HTMLAttributes<HTMLDivElement>, ref: React.Ref<HTMLDivElement>) =>
+      React.createElement('div', { ref, ...props })
+  );
+  mockMotionDiv.displayName = 'mockMotionDiv';
+
+  const mockLink = React.forwardRef(
+    (
+      props: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string },
+      ref: React.Ref<HTMLAnchorElement>
+    ) => React.createElement('a', { ref, ...props })
+  );
+  mockLink.displayName = 'mockLink';
+
+  return { mockMotionDiv, mockLink };
+});
+
+// Mock framer-motion to simplify layout rendering and inspect attributes
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: mockMotionDiv,
+  },
+}));
+
+// Mock next/link to simplify anchor expectations
+vi.mock('next/link', () => ({
+  default: mockLink,
+}));
+
+describe('CustomizeCTA — responsive rendering and elements (Variation 2)', () => {
+  it('applies the correct responsive spacing and layout bounds to the main container', () => {
+    const { container } = render(<CustomizeCTA />);
+
+    const mainContainer = container.querySelector('#customization-studio');
+    expect(mainContainer).toBeInTheDocument();
+    expect(mainContainer).toHaveClass('max-w-4xl', 'mx-auto', 'mb-16');
+  });
+
+  it('toggles flex layout directions between column on mobile and row on desktop viewports', () => {
+    const { container } = render(<CustomizeCTA />);
+
+    const flexContainer = container.querySelector('.relative.z-10');
+    expect(flexContainer).toBeInTheDocument();
+    expect(flexContainer).toHaveClass('flex', 'flex-col', 'md:flex-row');
+  });
+
+  it('aligns text content centrally on mobile and shifts to left alignment on desktop', () => {
+    const { container } = render(<CustomizeCTA />);
+
+    const textWrapper = container.querySelector('.flex-1');
+    expect(textWrapper).toBeInTheDocument();
+    expect(textWrapper).toHaveClass('text-center', 'md:text-left');
+  });
+
+  it('renders the section header using responsive font sizes from mobile text-2xl to desktop md:text-3xl', () => {
+    render(<CustomizeCTA />);
+
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveClass('text-2xl', 'md:text-3xl');
+  });
+
+  it('adjusts CTA button horizontal padding size responsively between mobile px-4 and desktop md:px-7', () => {
+    const { container } = render(<CustomizeCTA />);
+
+    const buttonSpan = container.querySelector('[class*="px-4"]');
+    expect(buttonSpan).toBeInTheDocument();
+    expect(buttonSpan).toHaveClass('px-4', 'md:px-7');
+  });
+});


### PR DESCRIPTION
test(ui): verify responsive rendering and elements of CustomizeCTA (Variation 2)

## Description

Fixes #1526

Adds 5 robust unit tests in `app/components/CustomizeCTA.responsive-v2.test.tsx` to verify the responsive styling and layout elements of the `CustomizeCTA` component across multiple viewports.

### Test Cases Added:
1. **Container responsive class matching**: Verifies that the outer container has the correct responsive margin/width class structure (`max-w-4xl mx-auto mb-16`).
2. **Inner flex layout direction classes**: Verifies that the inner layout container transitions between flex-col for mobile and md:flex-row for desktop (`flex flex-col md:flex-row`).
3. **Text alignment responsiveness**: Verifies that the text parent element has classes for center alignment on mobile and left alignment on desktop (`text-center md:text-left`).
4. **Heading font sizing responsiveness**: Verifies that the section header has responsive sizing classes for smaller text on mobile and larger text on desktop (`text-2xl md:text-3xl`).
5. **CTA Button padding responsiveness**: Verifies that the span inside the link utilizes responsive horizontal padding classes (`px-4 md:px-7`).

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs / Testing)

## Visual Preview

N/A (UI Unit Tests)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npx vitest run app/components/CustomizeCTA.responsive-v2.test.tsx`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
