### PR TITLE
test(sanitizer): add edge-case validation for isValidHex

### DIFF
--- a/lib/svg/sanitizer.test.ts
+++ b/lib/svg/sanitizer.test.ts
@@ -41,6 +41,22 @@ describe('SVG Sanitizer Utilities', () => {
       expect(isValidHex(null as unknown as string)).toBe(false);
       expect(isValidHex('')).toBe(false);
     });
+
+    it('returns false for an empty string', () => {
+      expect(isValidHex('')).toBe(false);
+    });
+
+    it('returns false for just a hash symbol', () => {
+      expect(isValidHex('#')).toBe(false);
+    });
+
+    it('returns false for undefined input', () => {
+      expect(isValidHex(undefined)).toBe(false);
+    });
+
+    it('returns false for invalid length (7 characters)', () => {
+      expect(isValidHex('fffffff')).toBe(false);
+    });
   });
 
   describe('hexColor', () => {


### PR DESCRIPTION
## Description

Fixes #734

**Note for the maintainer:** This PR addresses the missing test coverage for the `isValidHex` utility in `lib/svg/sanitizer.test.ts`. I have added strict edge-case validations to ensure it correctly returns `false` for empty strings, hash-only strings (`#`), undefined inputs, and invalid length hex codes (e.g., 7 characters). All existing and new sanitizer tests pass successfully.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — This is a backend testing implementation.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.