### PR TITLE
test: replace broad eslint-disable banners with precise types

### DIFF
--- a/app/(root)/dashboard/[username]/page.test.tsx
+++ b/app/(root)/dashboard/[username]/page.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Metadata } from 'next';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import DashboardPage, { generateMetadata } from './page';
@@ -32,8 +32,13 @@ vi.mock('@/components/dashboard/ActivityLandscape', () => ({
   default: () => <div data-testid="activity-landscape">ActivityLandscape</div>,
 }));
 
+type StatsCardProps = {
+  title: string;
+  value: string | number;
+};
+
 vi.mock('@/components/dashboard/StatsCard', () => ({
-  default: ({ title, value }: any) => (
+  default: ({ title, value }: StatsCardProps) => (
     <div data-testid="stats-card">
       {title}: {value}
     </div>
@@ -132,7 +137,13 @@ describe('DashboardPage', () => {
         }),
       });
 
-      const openGraphImage = (metadata.openGraph?.images as any[])?.[0];
+      const openGraphImages = metadata.openGraph?.images as Array<{
+        url: string;
+        width: number;
+        height: number;
+        alt: string;
+      }>;
+      const openGraphImage = openGraphImages?.[0];
 
       expect(metadata.title).toBe("octocat's Commit Pulse");
       expect(metadata.description).toContain("octocat's GitHub contribution pulse");
@@ -148,7 +159,9 @@ describe('DashboardPage', () => {
       expect(openGraphImage.width).toBe(1200);
       expect(openGraphImage.height).toBe(630);
       expect(openGraphImage.alt).toContain(username);
-      expect((metadata.twitter as any)?.card).toBe('summary_large_image');
+      expect((metadata.twitter as Metadata['twitter'] & { card?: string })?.card).toBe(
+        'summary_large_image'
+      );
     });
   });
 

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,9 +1,16 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @next/next/no-img-element, jsx-a11y/alt-text */
+import type { HTMLAttributes, AnchorHTMLAttributes, ReactNode, ImgHTMLAttributes } from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import LandingPage from './page';
+
+type MockLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  children?: ReactNode;
+  href: string;
+};
+
+type MockImageProps = ImgHTMLAttributes<HTMLImageElement> & {
+  fill?: boolean;
+};
 
 // Mock child components to isolate LandingPage testing
 vi.mock('./components/CustomizeCTA', () => ({
@@ -26,14 +33,12 @@ vi.mock('@/components/DiscordButton', () => ({
 // rendered inline. The mock below keeps the import from erroring if any
 // other test file still imports it.
 vi.mock('next/image', () => ({
-  default: (props: any) => {
-    const { fill, ...rest } = props || {};
-    return <img {...rest} />;
-  },
+  // eslint-disable-next-line jsx-a11y/alt-text, @next/next/no-img-element
+  default: ({ fill: _fill, ...rest }: MockImageProps) => <img {...rest} />,
 }));
 
 vi.mock('next/link', () => ({
-  default: ({ children, href, ...props }: any) => (
+  default: ({ children, href, ...props }: MockLinkProps) => (
     <a href={href} {...props} data-testid="next-link">
       {children}
     </a>
@@ -58,7 +63,7 @@ vi.mock('gsap', () => {
     to: vi.fn().mockReturnValue(tween),
     fromTo: vi.fn().mockReturnValue(tween),
     timeline: vi.fn().mockReturnValue(timeline),
-    context: vi.fn((_fn: any) => ({ revert: vi.fn() })),
+    context: vi.fn((_fn: () => void) => ({ revert: vi.fn() })),
   };
   return {
     default: mockGsap,
@@ -79,23 +84,45 @@ vi.mock('gsap/ScrollTrigger', () => ({
   ScrollTrigger: {},
 }));
 
+type MotionBaseProps = HTMLAttributes<HTMLElement> & {
+  children?: ReactNode;
+  whileHover?: unknown;
+  whileTap?: unknown;
+  whileInView?: unknown;
+  initial?: unknown;
+  animate?: unknown;
+  exit?: unknown;
+  transition?: unknown;
+  viewport?: unknown;
+  layoutId?: string;
+};
+
+type MotionAnchorProps = MotionBaseProps & AnchorHTMLAttributes<HTMLAnchorElement>;
+
+type MotionImgProps = ImgHTMLAttributes<HTMLImageElement> & {
+  initial?: unknown;
+  animate?: unknown;
+  exit?: unknown;
+  transition?: unknown;
+};
+
 // Mock framer-motion
 vi.mock('framer-motion', () => ({
   motion: {
     div: ({
       children,
       className,
-      whileHover,
-      whileTap,
-      whileInView,
-      initial,
-      animate,
-      exit,
-      transition,
-      viewport,
-      layoutId,
+      whileHover: _wh,
+      whileTap: _wt,
+      whileInView: _wiv,
+      initial: _i,
+      animate: _a,
+      exit: _e,
+      transition: _tr,
+      viewport: _vp,
+      layoutId: _lid,
       ...props
-    }: any) => (
+    }: MotionBaseProps) => (
       <div className={className} data-testid="motion-div" {...props}>
         {children}
       </div>
@@ -103,17 +130,17 @@ vi.mock('framer-motion', () => ({
     p: ({
       children,
       className,
-      whileHover,
-      whileTap,
-      whileInView,
-      initial,
-      animate,
-      exit,
-      transition,
-      viewport,
-      layoutId,
+      whileHover: _wh,
+      whileTap: _wt,
+      whileInView: _wiv,
+      initial: _i,
+      animate: _a,
+      exit: _e,
+      transition: _tr,
+      viewport: _vp,
+      layoutId: _lid,
       ...props
-    }: any) => (
+    }: MotionBaseProps) => (
       <p className={className} data-testid="motion-p" {...props}>
         {children}
       </p>
@@ -122,38 +149,38 @@ vi.mock('framer-motion', () => ({
       children,
       className,
       href,
-      whileHover,
-      whileTap,
-      whileInView,
-      initial,
-      animate,
-      exit,
-      transition,
-      viewport,
-      layoutId,
+      whileHover: _wh,
+      whileTap: _wt,
+      whileInView: _wiv,
+      initial: _i,
+      animate: _a,
+      exit: _e,
+      transition: _tr,
+      viewport: _vp,
+      layoutId: _lid,
       ...props
-    }: any) => (
+    }: MotionAnchorProps) => (
       <a href={href} className={className} data-testid="motion-a" {...props}>
         {children}
       </a>
     ),
     img: ({
-      children,
       className,
       src,
       alt,
       onLoad,
       onError,
-      initial,
-      animate,
-      exit,
-      transition,
+      initial: _i,
+      animate: _a,
+      exit: _e,
+      transition: _tr,
       ...props
-    }: any) => (
+    }: MotionImgProps) => (
+      // eslint-disable-next-line @next/next/no-img-element
       <img className={className} src={src} alt={alt} onLoad={onLoad} onError={onError} {...props} />
     ),
   },
-  AnimatePresence: ({ children }: any) => <>{children}</>,
+  AnimatePresence: ({ children }: { children?: ReactNode }) => <>{children}</>,
 }));
 
 const mockRecentSearches = {


### PR DESCRIPTION
## Description
Fixes #3790 

Removed all broad file-level `eslint-disable` directives and replaced `any` types with proper TypeScript interfaces across 2 test files. All 28 tests continue to pass after the changes.

### `app/page.test.tsx`
- Removed 3 broad file-level `eslint-disable` banners
- Added typed interfaces: `MockLinkProps`, `MockImageProps`, `MotionBaseProps`, `MotionAnchorProps`, `MotionImgProps`
- `next/image` mock: `(props: any)` → `({ fill: _fill, ...rest }: MockImageProps)` with a surgical single-line disable only where strictly needed
- `next/link` mock: typed via `MockLinkProps`
- `gsap` context mock: `_fn: any` → `_fn: () => void`
- `framer-motion` mocks: unused props prefixed with `_` to satisfy `no-unused-vars` without a disable, typed via new interfaces
- `AnimatePresence` mock: `{ children }: any` → `{ children }: { children?: ReactNode }`

### `app/(root)/dashboard/[username]/page.test.tsx`
- Removed `/* eslint-disable @typescript-eslint/no-explicit-any */` banner
- Added `import type { Metadata } from 'next'`
- `StatsCard` mock: `any` → explicit `StatsCardProps` interface `{ title: string; value: string | number }`
- `openGraph.images` cast: `any[]` → `Array<{ url: string; width: number; height: number; alt: string }>`
- `twitter.card` cast: `any` → `Metadata['twitter'] & { card?: string }`

### `app/customize/page.test.tsx`
- Already clean — no changes needed

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — test file cleanup only, no visual or behavioral changes.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.