### PR TITLE
docs: standardize GITHUB_TOKEN as canonical env var name (fixes #3792)

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ npm install
 cat > .env.local << 'EOF'
 GITHUB_TOKEN=your_github_pat_here
 
+# GITHUB_PAT is also accepted as an alias for GITHUB_TOKEN
 # Optional — enables user tracking (see below)
 # MONGODB_URI=mongodb+srv://...
 EOF
@@ -528,9 +529,11 @@ For production (Vercel), add `MONGODB_URI` to your project's **Environment Varia
 
 ## 🌐 Deploy Your Own
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/JhaSourav07/commitpulse&env=GITHUB_PAT&envDescription=GitHub%20Personal%20Access%20Token%20with%20read%3Auser%20scope)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/JhaSourav07/commitpulse&env=GITHUB_TOKEN&envDescription=GitHub%20Personal%20Access%20Token%20with%20read%3Auser%20scope)
 
-Set the `GITHUB_PAT` environment variable in your Vercel project settings, and you're live.
+Set the `GITHUB_TOKEN` environment variable in your Vercel project settings, and you're live.
+
+> **Note:** Both `GITHUB_TOKEN` and `GITHUB_PAT` are accepted. `GITHUB_TOKEN` is the canonical name used throughout the codebase; `GITHUB_PAT` works as an alias for backwards compatibility.
 
 ---
 


### PR DESCRIPTION
## Description
Fixes #3792 

The README was inconsistently using both `GITHUB_TOKEN` and `GITHUB_PAT` across different sections, causing confusion for self-hosters about which variable name is actually required. Standardized on `GITHUB_TOKEN` (the canonical name used throughout the codebase) and documented `GITHUB_PAT` as a backwards-compatible alias.

### Changes made

| Location | Before | After |
|----------|--------|-------|
| `.env.local` example | `GITHUB_TOKEN=your_github_pat_here` with no explanation | Added inline comment clarifying `GITHUB_PAT` is also accepted as an alias |
| Vercel deploy button URL | `env=GITHUB_PAT` | `env=GITHUB_TOKEN` — one-click deploy now prompts for the canonical variable name |
| Deploy section prose | "Set the `GITHUB_PAT` environment variable" | "Set the `GITHUB_TOKEN` environment variable" with an added callout note explaining both are accepted |
| Troubleshooting section | Already using `GITHUB_TOKEN` correctly | No change needed |

### Callout note added to deploy section
> **Note:** Both `GITHUB_TOKEN` and `GITHUB_PAT` are accepted. `GITHUB_TOKEN` is the canonical name used throughout the codebase; `GITHUB_PAT` works as an alias for backwards compatibility.

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — documentation change only, no code or visual changes.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.