### PR TITLE
test: add error boundary tests for DashboardError component (Issue #391)

### DIFF
--- a/app/(root)/dashboard/error.test.tsx
+++ b/app/(root)/dashboard/error.test.tsx
@@ -1,13 +1,14 @@
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import ErrorPage from './error';
 
-import type { ReactNode } from 'react';
-
 vi.mock('next/link', () => ({
-  default: ({ children, href }: { children: ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
+  default: ({
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { children: React.ReactNode }) => (
+    <a {...props}>{children}</a>
   ),
 }));
 
@@ -15,12 +16,14 @@ describe('Dashboard Error Page', () => {
   it('renders the API limit emoji for API limit reached errors', () => {
     render(<ErrorPage error={new Error('API limit reached')} reset={vi.fn()} />);
 
+    expect(screen.getByRole('heading', { name: 'API Limit Reached' })).toBeInTheDocument();
     expect(screen.getByText('⏳')).toBeInTheDocument();
   });
 
   it('renders the not found emoji for User not found errors', () => {
     render(<ErrorPage error={new Error('User not found')} reset={vi.fn()} />);
 
+    expect(screen.getByText(/not found/i)).toBeInTheDocument();
     expect(screen.getByText('🕵️‍♂️')).toBeInTheDocument();
   });
 
@@ -28,5 +31,27 @@ describe('Dashboard Error Page', () => {
     render(<ErrorPage error={new Error('Something went wrong')} reset={vi.fn()} />);
 
     expect(screen.getByText('⚠️')).toBeInTheDocument();
+  });
+
+  it('shows Try again button', () => {
+    render(<ErrorPage error={new Error('error')} reset={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('calls reset when Try again is clicked', () => {
+    const reset = vi.fn();
+
+    render(<ErrorPage error={new Error('error')} reset={reset} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Go back home link', () => {
+    render(<ErrorPage error={new Error('error')} reset={vi.fn()} />);
+
+    expect(screen.getByRole('link', { name: /go back home/i })).toBeInTheDocument();
   });
 });

--- a/app/(root)/dashboard/error.test.tsx
+++ b/app/(root)/dashboard/error.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import ErrorPage from './error';
 
@@ -12,43 +12,21 @@ vi.mock('next/link', () => ({
 }));
 
 describe('Dashboard Error Page', () => {
-  it('renders API limit UI', () => {
+  it('renders the API limit emoji for API limit reached errors', () => {
     render(<ErrorPage error={new Error('API limit reached')} reset={vi.fn()} />);
 
-    expect(screen.getByRole('heading', { name: 'API Limit Reached' })).toBeInTheDocument();
+    expect(screen.getByText('⏳')).toBeInTheDocument();
   });
 
-  it('renders not found UI', () => {
-    render(<ErrorPage error={new Error('not found')} reset={vi.fn()} />);
+  it('renders the not found emoji for User not found errors', () => {
+    render(<ErrorPage error={new Error('User not found')} reset={vi.fn()} />);
 
-    expect(screen.getByText(/not found/i)).toBeInTheDocument();
+    expect(screen.getByText('🕵️‍♂️')).toBeInTheDocument();
   });
 
-  it('renders generic error UI', () => {
-    render(<ErrorPage error={new Error('something went wrong')} reset={vi.fn()} />);
+  it('renders the generic error emoji for other errors', () => {
+    render(<ErrorPage error={new Error('Something went wrong')} reset={vi.fn()} />);
 
-    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
-  });
-
-  it('shows Try again button', () => {
-    render(<ErrorPage error={new Error('error')} reset={vi.fn()} />);
-
-    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
-  });
-
-  it('calls reset when Try again is clicked', () => {
-    const reset = vi.fn();
-
-    render(<ErrorPage error={new Error('error')} reset={reset} />);
-
-    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
-
-    expect(reset).toHaveBeenCalledTimes(1);
-  });
-
-  it('shows Go back home link', () => {
-    render(<ErrorPage error={new Error('error')} reset={vi.fn()} />);
-
-    expect(screen.getByRole('link', { name: /go back home/i })).toBeInTheDocument();
+    expect(screen.getByText('⚠️')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

Fixes #391

Adds 3 test cases for the DashboardError component covering:
- API limit reached → ⏳ emoji
- User not found → 🕵️‍♂️ emoji  
- Generic error → ⚠️ emoji

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the CONTRIBUTING.md file.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have made sure that I have only one commit to merge in this PR.