### PR TITLE
fix( broken technologies icon link )

### DIFF
--- a/app/generator/utils/readmeGenerator.ts
+++ b/app/generator/utils/readmeGenerator.ts
@@ -43,8 +43,10 @@ export function generateReadme(state: GeneratorState): string {
         if (!tech) return null;
 
         if (tech.type === 'simpleicon') {
-          const dark = `https://cdn.simpleicons.org/${id}/ffffff`;
-          const light = `https://cdn.simpleicons.org/${id}/000000`;
+          // Extract the slug from the iconUrl (e.g. "https://cdn.simpleicons.org/solid" → "solid")
+          const slug = tech.iconUrl.split('/').pop() || id;
+          const dark = `https://cdn.simpleicons.org/${slug}/ffffff`;
+          const light = `https://cdn.simpleicons.org/${slug}/000000`;
           return [
             '<picture>',
             `  <source media="(prefers-color-scheme: dark)" srcset="${dark}" />`,


### PR DESCRIPTION
## Description
Some technology icons in the README Generator were not rendering correctly in either the Preview or generated Markdown output.

The fix extracts the correct slug directly from the technology's `iconUrl` and uses that value when generating icon URLs, ensuring all supported technology icons resolve correctly.

Fixes #3937

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

<img width="1919" height="1035" alt="Screenshot 2026-06-05 175043" src="https://github.com/user-attachments/assets/b77af5e1-5107-4103-97bc-17a4299b3501" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
