### PR TITLE
[Critical] fix(route): handle comma-separated ETag lists in if-none-match header — closes #4042

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -357,14 +357,17 @@ export async function GET(request: Request) {
       const weakEtag = `W/"${etag}"`;
       const ifNoneMatch = request.headers.get('if-none-match');
 
-      if (ifNoneMatch === weakEtag || ifNoneMatch === `"${etag}"`) {
-        return new NextResponse(null, {
-          status: 304,
-          headers: {
-            'Cache-Control': cacheControl,
-            ETag: weakEtag,
-          },
-        });
+      if (ifNoneMatch) {
+        const etags = ifNoneMatch.split(',').map(e => e.trim());
+        if (etags.includes(weakEtag) || etags.includes(`"${etag}"`)) {
+          return new NextResponse(null, {
+            status: 304,
+            headers: {
+              'Cache-Control': cacheControl,
+              ETag: weakEtag,
+            },
+          });
+        }
       }
 
       return new NextResponse(jsonPayload, {
@@ -416,14 +419,17 @@ export async function GET(request: Request) {
     const weakEtag = `W/"${etag}"`;
     const ifNoneMatch = request.headers.get('if-none-match');
 
-    if (ifNoneMatch === weakEtag || ifNoneMatch === `"${etag}"`) {
-      return new NextResponse(null, {
-        status: 304,
-        headers: {
-          'Cache-Control': cacheControl,
-          ETag: weakEtag,
-        },
-      });
+    if (ifNoneMatch) {
+      const etags = ifNoneMatch.split(',').map(e => e.trim());
+      if (etags.includes(weakEtag) || etags.includes(`"${etag}"`)) {
+        return new NextResponse(null, {
+          status: 304,
+          headers: {
+            'Cache-Control': cacheControl,
+            ETag: weakEtag,
+          },
+        });
+      }
     }
 
     return new NextResponse(svg, {

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -358,7 +358,7 @@ export async function GET(request: Request) {
       const ifNoneMatch = request.headers.get('if-none-match');
 
       if (ifNoneMatch) {
-        const etags = ifNoneMatch.split(',').map(e => e.trim());
+        const etags = ifNoneMatch.split(',').map((e) => e.trim());
         if (etags.includes(weakEtag) || etags.includes(`"${etag}"`)) {
           return new NextResponse(null, {
             status: 304,
@@ -420,7 +420,7 @@ export async function GET(request: Request) {
     const ifNoneMatch = request.headers.get('if-none-match');
 
     if (ifNoneMatch) {
-      const etags = ifNoneMatch.split(',').map(e => e.trim());
+      const etags = ifNoneMatch.split(',').map((e) => e.trim());
       if (etags.includes(weakEtag) || etags.includes(`"${etag}"`)) {
         return new NextResponse(null, {
           status: 304,


### PR DESCRIPTION
## Description

Fixes #4042

The ETag caching logic used strict equality (`===`) to compare the `if-none-match` header, which fails when CDNs, reverse proxies, or browsers send **multiple ETags** in a comma-separated list (e.g. `W/"abc", "def"`). The strict comparison would never match a multi-value header, causing the server to always return a full 200 response instead of 304 Not Modified.

**Root cause:** HTTP spec allows clients to send multiple ETags in a single `if-none-match` header, delimited by commas. The code compared the entire string against a single ETag.

**Fix:** When `if-none-match` is present, split it on commas, trim each entry, and check if any of them match the expected weak or strong ETag.

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — backend caching logic fix (no visual change).

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
