### PR TITLE
fix: resolve wrapped card export failure caused by unsupported oklch …

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -101,6 +101,7 @@ export async function GET(request: Request) {
       format,
       days,
       badges,
+      entrance,
     } = parseResult.data;
     const normalizedView = view as 'default' | 'monthly' | 'heatmap' | 'pulse';
     const themeName = theme || 'dark';
@@ -233,6 +234,7 @@ export async function GET(request: Request) {
       glow,
       animate,
       badges,
+      entrance,
     };
 
     let calendar;

--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -43,7 +43,7 @@ import {
   Camera,
   Share2,
 } from 'lucide-react';
-import html2canvas from 'html2canvas';
+import { toPng } from 'html-to-image';
 
 /* ── types ────────────────────────────────────────────────────────────── */
 
@@ -146,8 +146,7 @@ function StatBattle({
   return (
     <motion.div
       initial={{ opacity: 0, y: 12 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true }}
+      animate={{ opacity: 1, y: 0 }}
       className="p-5 rounded-xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)] hover:border-black/20 dark:hover:border-[rgba(255,255,255,0.14)] transition-all duration-200"
     >
       <div className="flex items-center gap-2 mb-4">
@@ -323,12 +322,10 @@ function CompareProfileCard({ user, side }: { user: CompareUserData; side: 'left
 
         {/* Animated Developer Persona Badge */}
         <motion.div
-          initial={{ opacity: 0, y: 10, scale: 0.9 }}
-          animate={{ opacity: 1, y: 0, scale: 1 }}
+          initial={{ opacity: 0, y: 5 }}
+          animate={{ opacity: 1, y: 0 }}
           transition={{
-            type: 'spring',
-            stiffness: 200,
-            damping: 15,
+            duration: 0.4,
             delay: side === 'left' ? 0.3 : 0.4,
           }}
           whileHover={{ scale: 1.05 }}
@@ -426,8 +423,7 @@ function LanguageComparison({
   return (
     <motion.div
       initial={{ opacity: 0, y: 12 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true }}
+      animate={{ opacity: 1, y: 0 }}
       className="p-6 rounded-xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)]"
     >
       <h3 className="text-xs text-[#A1A1AA] uppercase tracking-widest font-medium mb-5">
@@ -552,8 +548,7 @@ function CodingHabitCard({
   return (
     <motion.div
       initial={{ opacity: 0, x: side === 'left' ? -20 : 20 }}
-      whileInView={{ opacity: 1, x: 0 }}
-      viewport={{ once: true }}
+      animate={{ opacity: 1, x: 0 }}
       whileHover={{ scale: 1.02 }}
       className={`relative overflow-hidden p-6 rounded-2xl border ${bgClass} ${glowClass} transition-all duration-300 flex flex-col items-center justify-center text-center h-full min-h-[140px]`}
     >
@@ -656,8 +651,7 @@ function CodeVolumeShowdown({ user1, user2 }: { user1: CompareUserData; user2: C
           <motion.div
             key={side}
             initial={{ opacity: 0, x: side === 'left' ? -20 : 20 }}
-            whileInView={{ opacity: 1, x: 0 }}
-            viewport={{ once: true }}
+            animate={{ opacity: 1, x: 0 }}
             whileHover={{ scale: 1.01 }}
             className="relative overflow-hidden p-6 rounded-2xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)] transition-all duration-300"
           >
@@ -673,7 +667,7 @@ function CodeVolumeShowdown({ user1, user2 }: { user1: CompareUserData; user2: C
                 </span>
                 <motion.span
                   initial={{ opacity: 0 }}
-                  whileInView={{ opacity: 1 }}
+                  animate={{ opacity: 1 }}
                   className="text-sm font-bold text-emerald-500"
                 >
                   +{loc.add.toLocaleString()}
@@ -682,8 +676,7 @@ function CodeVolumeShowdown({ user1, user2 }: { user1: CompareUserData; user2: C
               <div className="w-full h-3 bg-gray-100 dark:bg-[#111] rounded-full overflow-hidden border border-black/5 dark:border-[rgba(255,255,255,0.04)]">
                 <motion.div
                   initial={{ width: 0 }}
-                  whileInView={{ width: `${(loc.add / maxAdd) * 100}%` }}
-                  viewport={{ once: true }}
+                  animate={{ width: `${(loc.add / maxAdd) * 100}%` }}
                   transition={{ duration: 1.2, ease: [0.16, 1, 0.3, 1], delay: 0.2 }}
                   className="h-full rounded-full bg-gradient-to-r from-emerald-500 to-emerald-400 shadow-[0_0_10px_rgba(16,185,129,0.3)]"
                 />
@@ -698,7 +691,7 @@ function CodeVolumeShowdown({ user1, user2 }: { user1: CompareUserData; user2: C
                 </span>
                 <motion.span
                   initial={{ opacity: 0 }}
-                  whileInView={{ opacity: 1 }}
+                  animate={{ opacity: 1 }}
                   className="text-sm font-bold text-rose-500"
                 >
                   -{loc.del.toLocaleString()}
@@ -707,8 +700,7 @@ function CodeVolumeShowdown({ user1, user2 }: { user1: CompareUserData; user2: C
               <div className="w-full h-3 bg-gray-100 dark:bg-[#111] rounded-full overflow-hidden border border-black/5 dark:border-[rgba(255,255,255,0.04)]">
                 <motion.div
                   initial={{ width: 0 }}
-                  whileInView={{ width: `${(loc.del / maxDel) * 100}%` }}
-                  viewport={{ once: true }}
+                  animate={{ width: `${(loc.del / maxDel) * 100}%` }}
                   transition={{ duration: 1.2, ease: [0.16, 1, 0.3, 1], delay: 0.4 }}
                   className="h-full rounded-full bg-gradient-to-r from-rose-500 to-rose-400 shadow-[0_0_10px_rgba(244,63,94,0.3)]"
                 />
@@ -722,8 +714,7 @@ function CodeVolumeShowdown({ user1, user2 }: { user1: CompareUserData; user2: C
               </span>
               <motion.span
                 initial={{ scale: 0 }}
-                whileInView={{ scale: 1 }}
-                viewport={{ once: true }}
+                animate={{ scale: 1 }}
                 transition={{ type: 'spring', stiffness: 300, damping: 20, delay: 0.6 }}
                 className={`text-lg font-black tracking-tight ${loc.net >= 0 ? 'text-emerald-500' : 'text-rose-500'}`}
               >
@@ -815,8 +806,7 @@ function DeveloperSkillsRadar({
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true }}
+      animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6 }}
     >
       <h2 className="text-xs text-[#A1A1AA] uppercase tracking-widest font-medium mb-4 flex items-center gap-2">
@@ -900,6 +890,7 @@ export default function CompareClient() {
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<CompareResponse | null>(null);
   const [isExporting, setIsExporting] = useState(false);
+  const [monolithKey, setMonolithKey] = useState(0);
 
   const captureRef = useRef<HTMLDivElement>(null);
 
@@ -911,16 +902,52 @@ export default function CompareClient() {
       // Small delay to allow export overlay/scanning UI to render first
       await new Promise((res) => setTimeout(res, 300));
 
-      const canvas = await html2canvas(captureRef.current, {
-        scale: 2, // higher resolution
+      // Pre-fetch every monolith SVG and convert to base64 data: URLs.
+      // This completely bypasses html-to-image's internal URL-keyed image cache
+      // (which persists across toPng() calls in the same browser session and
+      // caused stale images). Data URLs are self-contained strings — no network
+      // request is ever made for them by the library.
+      const monolithImgs = Array.from(
+        captureRef.current.querySelectorAll<HTMLImageElement>('[data-monolith-img]')
+      );
+      const originalSrcs = monolithImgs.map((img) => img.src);
+
+      await Promise.all(
+        monolithImgs.map(async (img) => {
+          try {
+            const freshUrl = img.src.replace(/&refresh=(true|false)/, '') + '&refresh=true';
+            const res = await fetch(freshUrl, { cache: 'no-store' });
+            const svgText = await res.text();
+            // Encode SVG text as a base64 data URL (handles unicode correctly)
+            const b64 = btoa(unescape(encodeURIComponent(svgText)));
+            img.src = `data:image/svg+xml;base64,${b64}`;
+          } catch {
+            // On fetch failure keep original src so export can still proceed
+          }
+        })
+      );
+
+      const image = await toPng(captureRef.current, {
+        pixelRatio: 2,
+        cacheBust: true,
+        fetchRequestInit: { cache: 'no-store' },
         backgroundColor: document.documentElement.classList.contains('dark')
           ? '#000000'
           : '#ffffff',
-        useCORS: true,
-        logging: false,
+        filter: (el) => {
+          if (el instanceof HTMLElement) {
+            if (el.id === 'compare-share-button') return false;
+            if (el.id === 'compare-export-overlay') return false;
+          }
+          return true;
+        },
       });
 
-      const image = canvas.toDataURL('image/png');
+      // Restore original src attributes so the page display is unaffected
+      monolithImgs.forEach((img, i) => {
+        img.src = originalSrcs[i];
+      });
+
       const link = document.createElement('a');
       link.href = image;
       link.download = `commitpulse-battle-${data.user1.profile.username}-vs-${data.user2.profile.username}.png`;
@@ -962,6 +989,7 @@ export default function CompareClient() {
         }
 
         setData(json);
+        setMonolithKey((k) => k + 1);
       } catch {
         setError('Network error. Please try again.');
       } finally {
@@ -1250,8 +1278,7 @@ export default function CompareClient() {
                       <motion.div
                         key={side}
                         initial={{ opacity: 0, y: 12 }}
-                        whileInView={{ opacity: 1, y: 0 }}
-                        viewport={{ once: true }}
+                        animate={{ opacity: 1, y: 0 }}
                         className="p-5 rounded-xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)]"
                       >
                         <h3 className="text-xs text-[#A1A1AA] uppercase tracking-widest font-medium mb-3">
@@ -1268,12 +1295,14 @@ export default function CompareClient() {
                       3D Monolith Comparison
                     </h2>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                      {[d1, d2].map((user) => (
+                      {[
+                        { user: d1, side: 'left' as const },
+                        { user: d2, side: 'right' as const },
+                      ].map(({ user, side }) => (
                         <motion.div
-                          key={user.profile.username}
+                          key={side}
                           initial={{ opacity: 0, y: 12 }}
-                          whileInView={{ opacity: 1, y: 0 }}
-                          viewport={{ once: true }}
+                          animate={{ opacity: 1, y: 0 }}
                           className="rounded-xl overflow-hidden border border-black/10 dark:border-[rgba(255,255,255,0.08)] bg-white dark:bg-[#0a0a0a]"
                         >
                           <div className="p-3 border-b border-black/5 dark:border-white/5">
@@ -1283,10 +1312,11 @@ export default function CompareClient() {
                           </div>
                           {/* eslint-disable-next-line @next/next/no-img-element */}
                           <img
-                            src={`${BASE_URL}/api/streak?user=${encodeURIComponent(user.profile.username)}&theme=neon`}
+                            data-monolith-img="true"
+                            key={`${user.profile.username}-${monolithKey}`}
+                            src={`${BASE_URL}/api/streak?user=${encodeURIComponent(user.profile.username)}&theme=neon&entrance=none&_k=${monolithKey}`}
                             alt={`${user.profile.username}'s CommitPulse monolith`}
                             className="w-full"
-                            loading="lazy"
                           />
                         </motion.div>
                       ))}
@@ -1296,6 +1326,7 @@ export default function CompareClient() {
 
                 {/* Floating Share Button */}
                 <motion.div
+                  id="compare-share-button"
                   initial={{ opacity: 0, y: 50 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ type: 'spring', bounce: 0.5, delay: 1 }}
@@ -1325,6 +1356,7 @@ export default function CompareClient() {
                 <AnimatePresence>
                   {isExporting && (
                     <motion.div
+                      id="compare-export-overlay"
                       initial={{ opacity: 0 }}
                       animate={{ opacity: 1 }}
                       exit={{ opacity: 0 }}


### PR DESCRIPTION
…colors

## Description
Fixes multiple issues with Wrapped Card export on the comparison page:

* Replaced unsupported `oklch()` colors with export-compatible values to prevent image generation failures.
* Ensured all sections render during export, including Code Volume, Skills Radar, and 3D Monolith.
* Fixed 3D Monolith snapshots by disabling the entrance animation during export.
* Prevented stale or incorrect monolith images by bypassing image cache and using fresh Base64-encoded SVGs.

These changes ensure exports are generated reliably with complete and accurate content.

Fixes #3942 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

https://github.com/user-attachments/assets/142d398c-6785-427a-92e4-c2bbb4a00d61


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
