### PR TITLE
test: add empty fallback tests for CopyRepoButton(#2803)

### DIFF
--- a/app/components/CopyRepoButton.empty-fallback.test.tsx
+++ b/app/components/CopyRepoButton.empty-fallback.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import CopyRepoButton from './CopyRepoButton';
+
+describe('CopyRepoButton empty fallback behavior', () => {
+  it('renders safely without props', () => {
+    render(<CopyRepoButton />);
+
+    expect(screen.getByRole('button', { name: /copy url/i })).toBeTruthy();
+  });
+
+  it('shows default button text in empty state', () => {
+    render(<CopyRepoButton />);
+
+    expect(screen.getByText('Copy URL')).toBeTruthy();
+  });
+
+  it('maintains default styling classes', () => {
+    render(<CopyRepoButton />);
+
+    const button = screen.getByRole('button');
+
+    expect(button.className).toContain('rounded-2xl');
+    expect(button.className).toContain('bg-white');
+  });
+
+  it('does not throw runtime errors during render', () => {
+    expect(() => render(<CopyRepoButton />)).not.toThrow();
+  });
+
+  it('renders expected DOM structure with icon and button text', () => {
+    render(<CopyRepoButton />);
+
+    const button = screen.getByRole('button');
+
+    expect(button).toBeTruthy();
+    expect(button.textContent).toContain('Copy URL');
+  });
+});


### PR DESCRIPTION
## Description

Fixes # (2803)

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

##summary
## Summary

Added a new test file to verify Edge Cases & Empty/Missing Inputs Verification for the CopyRepoButton component.

### Changes Made

* Created `app/components/CopyRepoButton.empty-fallback.test.tsx`
* Added 5 test cases covering:

  * Safe rendering without props
  * Default empty-state button text
  * Default styling preservation
  * No runtime errors during render
  * Expected DOM structure in fallback state

### Verification

* All 5 tests pass successfully with Vitest.
* No production code changes were made.

Fixes #2803

## Checklist before requesting a review:

- [ X] I have read the `CONTRIBUTING.md` file.
- [ X] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X ] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [X ] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
