### PR TITLE
git push origin test/query-param-debounce-boundary-variation-4

### DIFF
--- a/hooks/useDebounce.test.ts
+++ b/hooks/useDebounce.test.ts
@@ -101,4 +101,36 @@ describe('useDebounce', () => {
       vi.useRealTimers();
     }
   });
+
+  it('resolves exactly once when rapid inputs include boundary empty-string values', () => {
+    vi.useFakeTimers();
+    const onResolved = vi.fn();
+
+    try {
+      const { rerender } = renderHook(
+        ({ value }: { value: string }) => useObservedDebounce(value, onResolved),
+        { initialProps: { value: '' } }
+      );
+
+      onResolved.mockClear();
+
+      rerender({ value: '' });
+      rerender({ value: 'g' });
+      rerender({ value: 'gh' });
+      rerender({ value: 'g' });
+
+      act(() => {
+        vi.advanceTimersByTime(299);
+      });
+      expect(onResolved).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(onResolved).toHaveBeenCalledTimes(1);
+      expect(onResolved).toHaveBeenCalledWith('g');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
Closes #1587

## What this PR does
Adds a new test case to `hooks/useDebounce.test.ts` that verifies the debounce utility resolves exactly once after the timer expires when rapid synchronous inputs include boundary empty-string values.

## Changes
- `hooks/useDebounce.test.ts`: added one new `it` block covering the boundary variation

## Test
- Rapid inputs: `''` → `'g'` → `'gh'` → `'g'`
- Asserts `onResolved` is not called before the 300ms timer expires
- Asserts `onResolved` is called exactly once with the final value after the timer fires