### PR TITLE
fix(rate-limit): RateLimiter.reset() now clears KV Redis key

### DIFF
--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -141,6 +141,22 @@ export class RateLimiter {
    * rateLimiter.reset("192.168.1.1");
    */
   async reset(ip: string): Promise<void> {
+    const url = process.env.KV_REST_API_URL;
+    const token = process.env.KV_REST_API_TOKEN;
+
+    if (url && token) {
+      try {
+        await fetch(`${url}/del/ratelimit_class:${ip}`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+      } catch (error) {
+        console.error('RateLimiter KV reset error:', error);
+      }
+    }
+
     await this.cache.delete(ip);
   }
 


### PR DESCRIPTION
Closes #3706

## Problem
`RateLimiter.reset()` only called `this.cache.delete(ip)`, which clears
the in-memory cache but does nothing when Upstash Redis / Vercel KV is
configured. The KV key `ratelimit_class:<ip>` was never deleted, so the
rate limit counter persisted even after reset() was called.

## Fix
`reset()` now checks for KV credentials and sends a DEL request to
`ratelimit_class:<ip>` before clearing the in-memory cache, matching
the key format used in `checkWithResult()`.

## Changes
- `lib/rate-limit.ts`: updated `reset()` to also delete the KV Redis key