### PR TITLE
fix(github): replace partial delta sync with a full-window refresh

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -1633,15 +1633,82 @@ describe('GitHub API cache behavior', () => {
     expect(fetch).toHaveBeenCalledTimes(2);
   });
 
-  it('cache expiry: expired entry triggers a delta sync fetch', async () => {
+  it('cache expiry: refresh re-queries the full window with authoritative totals, no collapse or accumulation or partial overwrite', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const buildResponse = (total: number, prs: number, issues: number, languages: string[]) =>
+      mockResponse({
+        data: {
+          user: {
+            contributionsCollection: {
+              totalPullRequestContributions: prs,
+              totalIssueContributions: issues,
+              contributionCalendar: {
+                totalContributions: total,
+                weeks: [
+                  {
+                    contributionDays: [
+                      { contributionCount: total, date: '2025-12-31', color: '#216e39' },
+                    ],
+                  },
+                ],
+              },
+              commitContributionsByRepository: languages.map((name) => ({
+                repository: { primaryLanguage: { name } },
+                contributions: { totalCount: total },
+              })),
+            },
+          },
+        },
+      });
+
+    // Full window (from undefined) returns authoritative annual data; a narrow window returns partial data.
+    vi.mocked(fetch).mockImplementation(async (_url, init) => {
+      const body = JSON.parse((init as RequestInit).body as string);
+      return body.variables.from === undefined
+        ? buildResponse(120, 12, 6, ['TypeScript', 'Go', 'Rust', 'Python'])
+        : buildResponse(5, 1, 2, ['TypeScript']);
+    });
+
+    const first = await fetchGitHubContributions('octocat');
+    expect(first.calendar.totalContributions).toBe(120);
+    expect(first.totalPRs).toBe(12);
+    expect(first.totalIssues).toBe(6);
+    expect(first.repoContributions).toHaveLength(4);
+
+    vi.setSystemTime(Date.now() + GITHUB_CACHE_TTL_MS + 1);
+    const refreshed = await fetchGitHubContributions('octocat');
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    // The refresh must query the full window, never a narrow delta window.
+    const secondCallBody = JSON.parse(vi.mocked(fetch).mock.calls[1][1]!.body as string);
+    expect(secondCallBody.variables.from).toBeUndefined();
+
+    // Full-window values survive the refresh: no collapse, no accumulation, no delta-only repo overwrite.
+    expect(refreshed.calendar.totalContributions).toBe(120);
+    expect(refreshed.totalPRs).toBe(12);
+    expect(refreshed.totalIssues).toBe(6);
+    expect(
+      refreshed.repoContributions.map((r) => r.repository.primaryLanguage?.name).sort()
+    ).toEqual(['Go', 'Python', 'Rust', 'TypeScript']);
+  });
+
+  it('historical fixed-window refresh re-queries the requested window, never from > to', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const from = '2023-01-01T00:00:00.000Z';
+    const to = '2023-12-31T23:59:59.000Z';
 
     vi.mocked(fetch).mockImplementation(async () =>
       mockResponse({
         data: {
           user: {
             contributionsCollection: {
+              totalPullRequestContributions: 0,
+              totalIssueContributions: 0,
               contributionCalendar: mockCalendar,
               commitContributionsByRepository: [],
             },
@@ -1650,20 +1717,22 @@ describe('GitHub API cache behavior', () => {
       })
     );
 
-    await fetchGitHubContributions('octocat');
+    await fetchGitHubContributions('octocat', { from, to });
 
     vi.setSystemTime(Date.now() + GITHUB_CACHE_TTL_MS + 1);
-    await fetchGitHubContributions('octocat');
+    const refreshed = await fetchGitHubContributions('octocat', { from, to });
 
     expect(fetch).toHaveBeenCalledTimes(2);
 
     const secondCallBody = JSON.parse(vi.mocked(fetch).mock.calls[1][1]!.body as string);
-    expect(secondCallBody.variables.from).toBeDefined();
+    expect(secondCallBody.variables.from).toBe(from);
+    expect(secondCallBody.variables.to).toBe(to);
+    expect(new Date(secondCallBody.variables.from).getTime()).toBeLessThanOrEqual(
+      new Date(secondCallBody.variables.to).getTime()
+    );
 
-    // Delta sync subtracts 1 day from the last synced date (which was 2026-01-01)
-    const expectedFrom = new Date('2026-01-01T00:00:00.000Z');
-    expectedFrom.setUTCDate(expectedFrom.getUTCDate() - 1);
-    expect(secondCallBody.variables.from).toBe(expectedFrom.toISOString());
+    // The refresh reflects the requested window's authoritative total, not a delta remnant.
+    expect(refreshed.calendar.totalContributions).toBe(mockCalendar.totalContributions);
   });
 
   it('cache hit: second profile call uses cached value', async () => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -3,7 +3,6 @@ import type {
   ContributionDay,
   ExtendedContributionData,
   RepoContribution,
-  ContributionWeek,
   GraphNode,
   GraphLink,
 } from '@/types';
@@ -537,50 +536,6 @@ export function displayName(profile: GitHubUserProfile): string {
  * DATA FETCHING
  * ========================================================================== */
 
-function mergeCalendars(
-  oldCal: ContributionCalendar,
-  newCal: ContributionCalendar,
-  authoritativeTotal?: number
-): ContributionCalendar {
-  const dayMap = new Map<string, ContributionDay>();
-
-  for (const week of oldCal.weeks) {
-    for (const day of week.contributionDays) {
-      dayMap.set(day.date, day);
-    }
-  }
-
-  for (const week of newCal.weeks) {
-    for (const day of week.contributionDays) {
-      dayMap.set(day.date, day);
-    }
-  }
-
-  const sortedDays = Array.from(dayMap.values()).sort((a, b) => a.date.localeCompare(b.date));
-
-  const mergedWeeks: ContributionWeek[] = [];
-  let currentWeek: ContributionWeek = { contributionDays: [] };
-
-  for (const day of sortedDays) {
-    const dateObj = new Date(day.date);
-    if (currentWeek.contributionDays.length > 0 && dateObj.getUTCDay() === 0) {
-      mergedWeeks.push(currentWeek);
-      currentWeek = { contributionDays: [] };
-    }
-    currentWeek.contributionDays.push(day);
-  }
-  if (currentWeek.contributionDays.length > 0) {
-    mergedWeeks.push(currentWeek);
-  }
-
-  const calculatedTotal = sortedDays.reduce((sum, d) => sum + d.contributionCount, 0);
-
-  return {
-    totalContributions: authoritativeTotal ?? calculatedTotal,
-    weeks: mergedWeeks,
-  };
-}
-
 export async function fetchGitHubContributions(
   username: string,
   options: FetchOptions = {}
@@ -595,13 +550,11 @@ export async function fetchGitHubContributions(
       : true;
   };
 
-  const load = async (cached: ExtendedContributionData | null) => {
-    return fetchContributionsUncached(username, key, options, cached);
-  };
+  const load = () => fetchContributionsUncached(username, key, options);
 
   if (options.bypassCache || options.forceRefresh) {
     try {
-      return await load(null);
+      return await load();
     } catch (err: unknown) {
       const staleData = await contributionsCache.get(key);
       if (staleData) {
@@ -639,18 +592,8 @@ export async function fetchGitHubContributions(
 async function fetchContributionsUncached(
   username: string,
   key: string,
-  options: FetchOptions,
-  cached: ExtendedContributionData | null
+  options: FetchOptions
 ): Promise<ExtendedContributionData> {
-  const isDeltaSync = cached && cached.calendar.lastSyncedAt && !options.bypassCache;
-  let queryFrom = options.from;
-
-  if (isDeltaSync) {
-    const lastSyncedDate = new Date(cached.calendar.lastSyncedAt!);
-    lastSyncedDate.setUTCDate(lastSyncedDate.getUTCDate() - 1);
-    queryFrom = lastSyncedDate.toISOString();
-  }
-
   const query = `
       query($login: String!, $from: DateTime, $to: DateTime) {
         user(login: $login) {
@@ -687,7 +630,7 @@ async function fetchContributionsUncached(
     headers: getHeaders(),
     body: JSON.stringify({
       query,
-      variables: { login: username, from: queryFrom, to: options.to },
+      variables: { login: username, from: options.from, to: options.to },
     }),
     cache: 'no-store',
     signal: options.signal,
@@ -738,18 +681,9 @@ async function fetchContributionsUncached(
     };
   }
 
-  let totalPRs = data.data.user.contributionsCollection?.totalPullRequestContributions || 0;
-  let totalIssues = data.data.user.contributionsCollection?.totalIssueContributions || 0;
+  const totalPRs = data.data.user.contributionsCollection?.totalPullRequestContributions || 0;
+  const totalIssues = data.data.user.contributionsCollection?.totalIssueContributions || 0;
 
-  if (isDeltaSync && cached) {
-    calendar = mergeCalendars(
-      cached.calendar,
-      calendar,
-      data.data.user.contributionsCollection.contributionCalendar.totalContributions
-    );
-    totalPRs += cached.totalPRs || 0;
-    totalIssues += cached.totalIssues || 0;
-  }
   // Inject deterministic Lines of Code (LoC) approximation
   calendar.weeks.forEach((week) => {
     week.contributionDays.forEach((day) => {
@@ -780,7 +714,7 @@ async function fetchContributionsUncached(
 
   calendar.lastSyncedAt = new Date().toISOString();
 
-  // Cache for 7 days to enable delta syncs, staleness is handled logically
+  // Cache for 7 days so a failed refresh can fall back to stale data; freshness is enforced via lastSyncedAt
   const LONG_CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
   if (!options.bypassCache) {
     await contributionsCache.set(


### PR DESCRIPTION
## Description

Fixes #3555

After the 5-minute freshness window, `fetchContributionsUncached` (`lib/github.ts`) issued a "delta sync": it re-queried only `[lastSyncedAt - 1 day, to]` and then treated that narrow window as if it were the full window. That produced four defects:

1. `totalContributions` collapsed: `mergeCalendars` was given the narrow window's `totalContributions` as the authoritative value (regression from #2447), so the headline total dropped to the partial-window figure.
2. `totalPRs` / `totalIssues` drifted upward: the narrow-window totals were added on top of the cached totals (`+=`) on every refresh, double-counting the overlapping boundary day and growing without bound.
3. `repoContributions` was overwritten with delta-only data, collapsing the repository and language breakdown to the last day or two.
4. For historical requests (`?year=`, or `from` + `to`), `queryFrom` was overridden to `lastSyncedAt - 1 day` while keeping the original `to`, which could produce an invalid `from > to` query.

These aggregates are window-scoped and cannot be reconciled from delta data alone (the boundary day overlaps and there is no per-day PR/issue/repo breakdown to subtract), so the correct source is a full-window query. This change removes the delta-sync path: every refresh now re-queries the full requested window (`from = options.from`, never rewritten), so `totalContributions`, `totalPRs`, `totalIssues`, and `repoContributions` come straight from GitHub's authoritative full-window response. `mergeCalendars` is removed as it is no longer used.

This also satisfies #2439 (the headline total is GitHub's authoritative value and is never recomputed from merged days), and removes the `from > to` break. `lastSyncedAt` is still stamped on every fetch and still drives the 5-minute freshness check and the background-refresh staleness check; the 7-day cache still backs the offline/stale fallback. A GraphQL `contributionsCollection` query costs the same regardless of window, so there is no rate-limit cost to querying the full window.

Behavior note: the cached calendar is now exactly the window GitHub returns for each request and no longer accumulates days across refreshes, so days that roll out of GitHub's trailing window are dropped on refresh rather than retained. The default streak, stats, OG, and dashboard views only ever display the trailing window, so this is the intended result of the fix.

Added tests in `lib/github.test.ts` that drive a refresh after expiry and assert the full window is re-queried with authoritative totals (no collapse, no accumulation, no partial repo overwrite), and that a historical fixed-window refresh re-queries the requested window and never produces `from > to`. Both tests were verified to fail against the previous delta-sync code.

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

Not applicable. Backend data-fetch and caching logic change with no UI output.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (full Vitest suite passes; `lib/github.test.ts` 144 tests pass including the new ones; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable, no SVG output in this change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
