### PR TITLE
test(api validation): check query validation boundaries for ?date=` query parameter (Variation 2)

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -1913,4 +1913,49 @@ describe('GET /api/streak', () => {
       expect(body).toContain('<svg');
     });
   });
+
+  describe('date parameter validation (Variation 2)', () => {
+    it('returns 400 Bad Request when ?date= is "2026-15-40" (malformed ISO 8601)', async () => {
+      // Arrange: month 15 and day 40 are both impossible calendar values
+      const response = await GET(makeRequest({ user: 'octocat', date: '2026-15-40' }));
+
+      // Assert: endpoint must reject before calling GitHub API
+      expect(response.status).toBe(400);
+    });
+
+    it('returns a structured error body containing \'Invalid "date" format\' for "2026-15-40"', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', date: '2026-15-40' }));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('Invalid parameters');
+      expect(body.details.fieldErrors.date[0]).toContain('Invalid "date" format');
+    });
+
+    it('does not call fetchGitHubContributions when ?date= is malformed', async () => {
+      await GET(makeRequest({ user: 'octocat', date: '2026-15-40' }));
+
+      expect(fetchGitHubContributions).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for ?date= with invalid month value "2026-13-01"', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', date: '2026-13-01' }));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.details.fieldErrors.date[0]).toContain('Invalid "date" format');
+    });
+
+    it('returns 400 for a freeform string ?date=not-a-date', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', date: 'not-a-date' }));
+
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 200 for a valid ?date= in ISO 8601 format', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', date: '2026-05-30' }));
+
+      expect(response.status).toBe(200);
+    });
+  });
 });

--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -1393,3 +1393,59 @@ describe('streakParamsSchema — layout query validation boundaries (Variation 4
     }
   });
 });
+
+/* ==========================================================================
+ * DATE PARAMETER — QUERY VALIDATION BOUNDARIES (VARIATION 2)
+ * ========================================================================== */
+
+describe('streakParamsSchema — date query validation boundaries (Variation 2)', () => {
+  it('rejects the invalid date "2026-15-40" and returns an error containing \'Invalid "date" format\'', () => {
+    // Arrange: month 15 and day 40 are both out of range — clearly not ISO 8601
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      date: '2026-15-40',
+    });
+
+    // Assert: schema must reject malformed date
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message).join(' ');
+      expect(messages).toContain('Invalid "date" format');
+    }
+  });
+
+  it('accepts a well-formed ISO 8601 date like "2026-05-30"', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      date: '2026-05-30',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a date with invalid month (month 13)', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      date: '2026-13-01',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message).join(' ');
+      expect(messages).toContain('Invalid "date" format');
+    }
+  });
+
+  it('rejects a freeform text string instead of a date', () => {
+    const result = streakParamsSchema.safeParse({
+      user: 'octocat',
+      date: 'not-a-date',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const flat = result.error.flatten().fieldErrors;
+      expect(flat.date).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1443

Adds schema-level and HTTP endpoint-level validation tests for the `?date=` query parameter (Variation 2). Tests verify that malformed ISO 8601 dates like `'2026-15-40'` are rejected with a `400 Bad Request` and an error message containing `'Invalid "date" format'`, while valid dates like `'2026-05-30'` are accepted.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — This PR adds test coverage only. No UI or SVG output is changed.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.