### PR TITLE
fix: leaderboard rows now open contributor GitHub profile on click

### DIFF
--- a/components/Leaderboard.mouse-interactivity.test.tsx
+++ b/components/Leaderboard.mouse-interactivity.test.tsx
@@ -59,11 +59,10 @@ describe('Leaderboard - Mouse Interactivity & Touch Events (Issue #2757 Equivale
     expect(listEntries.length).toBe(1); // user4
   });
 
-  it('Event Propagation to DOM Targets (Touch Propagation Equivalent): fires document scroll bounds safely on click', () => {
-    const scrollIntoViewMock = vi.fn();
-    document.getElementById = vi.fn().mockReturnValue({
-      scrollIntoView: scrollIntoViewMock,
-    });
+  it('Event Propagation to DOM Targets (Touch Propagation Equivalent): fires window.open with contributor profile URL on click', () => {
+    const openMock = vi.fn();
+    const originalOpen = window.open;
+    window.open = openMock;
 
     const { container } = render(<Leaderboard contributors={mockData} />);
 
@@ -72,9 +71,10 @@ describe('Leaderboard - Mouse Interactivity & Touch Events (Issue #2757 Equivale
     ) as HTMLElement;
     fireEvent.click(listItem);
 
-    // Verifies the target scroll view was intercepted and fired
-    expect(document.getElementById).toHaveBeenCalledWith('contributors');
-    expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth' });
+    // Verifies the contributor's GitHub profile is opened in a new tab
+    expect(openMock).toHaveBeenCalledWith('', '_blank', 'noopener,noreferrer');
+
+    window.open = originalOpen;
   });
 
   it('Hover State Visibility (Tooltips Equivalent): transitions text and background colors via group-hover structurally', () => {

--- a/components/Leaderboard.responsive-breakpoints.test.tsx
+++ b/components/Leaderboard.responsive-breakpoints.test.tsx
@@ -99,10 +99,9 @@ describe('Leaderboard - Responsive Breakpoints & Mobile Layouts (Issue #2759 Equ
   });
 
   it('Mobile Touch Target Scaling (Navigation Scaling Equivalent): preserves large click zones for touch devices even on mobile', () => {
-    const scrollIntoViewMock = vi.fn();
-    document.getElementById = vi.fn().mockReturnValue({
-      scrollIntoView: scrollIntoViewMock,
-    });
+    const openMock = vi.fn();
+    const originalOpen = window.open;
+    window.open = openMock;
 
     const { container } = render(<Leaderboard contributors={mockData} />);
 
@@ -112,8 +111,9 @@ describe('Leaderboard - Responsive Breakpoints & Mobile Layouts (Issue #2759 Equ
 
     fireEvent.click(listItem as Element);
 
-    // Verify the simulated 'navigation' click still functions
-    expect(document.getElementById).toHaveBeenCalledWith('contributors');
-    expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth' });
+    // Verify click opens contributor's GitHub profile in a new tab
+    expect(openMock).toHaveBeenCalledWith('', '_blank', 'noopener,noreferrer');
+
+    window.open = originalOpen;
   });
 });

--- a/components/Leaderboard.test.tsx
+++ b/components/Leaderboard.test.tsx
@@ -123,14 +123,10 @@ describe('Leaderboard Component', () => {
     expect(screen.getByText('#5')).toBeInTheDocument();
   });
 
-  it('scrolls to contributors container when list entry is clicked', () => {
-    const scrollIntoViewMock = vi.fn();
-
-    // Create elements mock to verify scrollIntoView behavior
-    const originalGetElementById = document.getElementById;
-    document.getElementById = vi.fn().mockReturnValue({
-      scrollIntoView: scrollIntoViewMock,
-    });
+  it('opens contributor GitHub profile in new tab when list entry is clicked', () => {
+    const openMock = vi.fn();
+    const originalOpen = window.open;
+    window.open = openMock;
 
     render(<Leaderboard contributors={mockContributors} />);
 
@@ -139,11 +135,14 @@ describe('Leaderboard Component', () => {
 
     fireEvent.click(entryElement!);
 
-    expect(document.getElementById).toHaveBeenCalledWith('contributors');
-    expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth' });
+    expect(openMock).toHaveBeenCalledWith(
+      'https://github.com/runner4_dev',
+      '_blank',
+      'noopener,noreferrer'
+    );
 
-    // Restore original getElementById
-    document.getElementById = originalGetElementById;
+    // Restore original window.open
+    window.open = originalOpen;
   });
 
   //since sorted array is passes to leaderboard

--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -90,9 +90,12 @@ export default function Leaderboard({ contributors }: LeaderboardProps) {
             role="button"
             tabIndex={0}
             className="flex items-center justify-between p-4 rounded-xl bg-black/[0.03] dark:bg-white/[0.03] border border-black/5 dark:border-white/[0.05] hover:bg-black/[0.06] dark:hover:bg-white/[0.06] hover:border-black/10 dark:hover:border-white/10 transition-all duration-300 cursor-pointer group"
-            onClick={() => {
-              const el = document.getElementById('contributors');
-              el?.scrollIntoView({ behavior: 'smooth' });
+            onClick={() => window.open(contributor.html_url, '_blank', 'noopener,noreferrer')}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                window.open(contributor.html_url, '_blank', 'noopener,noreferrer');
+              }
             }}
           >
             <div className="flex items-center gap-4">


### PR DESCRIPTION
Description
Fixes #4066

Leaderboard contributor rows below the podium had an incorrect onClick handler that scrolled the page to #contributors instead of opening the contributor's GitHub profile. The html_url field was available on the Contributor type but never used.

Changes made:

Replace scrollIntoView('#contributors') onClick with window.open(contributor.html_url, '_blank', 'noopener,noreferrer')
Add onKeyDown handler for Enter/Space keys to fix keyboard accessibility (required since the element uses role="button")
Pillar
 🎨 Pillar 1 — New Theme Design
 📐 Pillar 2 — Geometric SVG Improvement
 🕐 Pillar 3 — Timezone Logic Optimization
 🛠️ Other (Bug fix, refactoring, docs)
Visual Preview
No visual change — this is a behavior/navigation fix. Clicking a contributor row now opens their GitHub profile (https://github.com/<login>) in a new tab instead of scrolling the page.

Checklist before requesting a review:
 I have read the CONTRIBUTING.md file.
 I have tested these changes locally (localhost:3000/api/streak?user=YOUR_USERNAME).
 I have run npm run format and npm run lint locally and resolved all errors (CI will fail otherwise).
 My commits follow the Conventional Commits format (e.g., feat(themes): ..., fix(calculate): ...).
 I have updated README.md if I added a new theme or URL parameter.
 I have started the repo.
 I have made sure that i have only one commit to merge in this PR.
 The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
