### PR TITLE
test(ActivityLandscape-massive-scaling): verify Massive Data Sets and Extreme High Bounds Scaling (Variation 2)

### DIFF
--- a/components/dashboard/ActivityLandscape.massive-scaling.test.tsx
+++ b/components/dashboard/ActivityLandscape.massive-scaling.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { getFilteredData } from './ActivityLandscape';
+import type { ActivityData } from '@/types/dashboard';
+
+const generateData = (count: number): ActivityData[] =>
+  Array.from({ length: count }, (_, i) => ({
+    date: new Date(Date.now() - (count - i) * 86400000).toISOString().split('T')[0],
+    count: Math.floor(Math.random() * 100),
+    locAdditions: Math.floor(Math.random() * 500),
+    locDeletions: Math.floor(Math.random() * 200),
+  }));
+
+describe('ActivityLandscape – Massive Data Sets and Extreme High Bounds Scaling', () => {
+  it('handles 10,000 data points without crashing', () => {
+    const data = generateData(10000);
+    const result = getFilteredData(data, '1Y');
+    expect(result.length).toBeLessThanOrEqual(60);
+  });
+
+  it('downsamples massive datasets to max 60 bars', () => {
+    const data = generateData(5000);
+    const result = getFilteredData(data, '3M');
+    expect(result.length).toBeLessThanOrEqual(60);
+  });
+
+  it('handles extreme high commit counts', () => {
+    const data: ActivityData[] = Array.from({ length: 365 }, (_, i) => ({
+      date: new Date(Date.now() - (365 - i) * 86400000).toISOString().split('T')[0],
+      count: 999999,
+      locAdditions: 999999,
+      locDeletions: 999999,
+    }));
+    const result = getFilteredData(data, '1Y');
+    expect(result.every((d) => d.count === 999999)).toBe(true);
+  });
+
+  it('returns correct slice for 1W tab with large dataset', () => {
+    const data = generateData(10000);
+    const result = getFilteredData(data, '1W');
+    expect(result.length).toBeLessThanOrEqual(7);
+  });
+
+  it('returns correct slice for 1M tab with large dataset', () => {
+    const data = generateData(10000);
+    const result = getFilteredData(data, '1M');
+    expect(result.length).toBeLessThanOrEqual(30);
+  });
+
+  it('handles empty data array gracefully', () => {
+    const result = getFilteredData([], '1Y');
+    expect(result).toEqual([]);
+  });
+
+  it('handles single data point', () => {
+    const data = generateData(1);
+    const result = getFilteredData(data, '1Y');
+    expect(result.length).toBe(1);
+  });
+
+  it('handles data with all zero counts', () => {
+    const data: ActivityData[] = Array.from({ length: 1000 }, (_, i) => ({
+      date: new Date(Date.now() - (1000 - i) * 86400000).toISOString().split('T')[0],
+      count: 0,
+      locAdditions: 0,
+      locDeletions: 0,
+    }));
+    const result = getFilteredData(data, '3M');
+    expect(result.every((d) => d.count === 0)).toBe(true);
+  });
+});

--- a/components/dashboard/ActivityLandscape.massive-scaling.test.tsx
+++ b/components/dashboard/ActivityLandscape.massive-scaling.test.tsx
@@ -6,6 +6,7 @@ const generateData = (count: number): ActivityData[] =>
   Array.from({ length: count }, (_, i) => ({
     date: new Date(Date.now() - (count - i) * 86400000).toISOString().split('T')[0],
     count: Math.floor(Math.random() * 100),
+    intensity: Math.floor(Math.random() * 5) as 0 | 1 | 2 | 3 | 4,
     locAdditions: Math.floor(Math.random() * 500),
     locDeletions: Math.floor(Math.random() * 200),
   }));
@@ -27,6 +28,7 @@ describe('ActivityLandscape – Massive Data Sets and Extreme High Bounds Scalin
     const data: ActivityData[] = Array.from({ length: 365 }, (_, i) => ({
       date: new Date(Date.now() - (365 - i) * 86400000).toISOString().split('T')[0],
       count: 999999,
+      intensity: 4,
       locAdditions: 999999,
       locDeletions: 999999,
     }));
@@ -61,6 +63,7 @@ describe('ActivityLandscape – Massive Data Sets and Extreme High Bounds Scalin
     const data: ActivityData[] = Array.from({ length: 1000 }, (_, i) => ({
       date: new Date(Date.now() - (1000 - i) * 86400000).toISOString().split('T')[0],
       count: 0,
+      intensity: 0,
       locAdditions: 0,
       locDeletions: 0,
     }));


### PR DESCRIPTION
Fixes #2484

This PR creates a new test file `components/dashboard/ActivityLandscape.massive-scaling.test.tsx` targeting Massive Data Sets and Extreme High Bounds Scaling for the ActivityLandscape component.

Replaces #3913

## Visual Preview
N/A — Test file only, no UI changes.

## Checklist before requesting a review:
- [x] I have read the CONTRIBUTING.md file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have made sure that I have only one commit to merge in this PR.