### PR TITLE
feat: improve keyboard navigation and screen-reader accessibility for RepositoryGraph

### DIFF
--- a/components/dashboard/RepositoryGraph.accessibility.test.tsx
+++ b/components/dashboard/RepositoryGraph.accessibility.test.tsx
@@ -60,19 +60,12 @@ describe('RepositoryGraph - Accessibility Standards & Screen Reader Aria Complia
   });
 
   // 3. Tooltip Announcements
-  it('should announce tooltip labels with correct accessibility descriptions on hover/focus', async () => {
+  it('should render graph guidance text for accessibility', () => {
     render(<RepositoryGraph data={mockGraphData} />);
-    const user = userEvent.setup();
 
-    const chartNodes = screen.queryAllByRole('button');
-
-    if (chartNodes.length > 0) {
-      await user.hover(chartNodes[0]);
-
-      // Fallback description evaluation matching layout instructions text
-      const insightText = screen.getByText(/Hover over any node to view detailed statistics/i);
-      expect(insightText).toBeInTheDocument();
-    }
+    expect(
+      screen.getByText(/Hover over any node to view detailed statistics/i)
+    ).toBeInTheDocument();
   });
 
   // 4. Keyboard Control & Tab Ordering
@@ -107,5 +100,29 @@ describe('RepositoryGraph - Accessibility Standards & Screen Reader Aria Complia
         }
       });
     }
+  });
+
+  it('provides an accessible graph region', () => {
+    render(<RepositoryGraph data={mockGraphData} />);
+
+    expect(
+      screen.getByRole('region', {
+        name: /repository relationship graph/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('renders screen reader descriptions', () => {
+    render(<RepositoryGraph data={mockGraphData} />);
+
+    expect(screen.getByText(/interactive repository relationship graph/i)).toBeInTheDocument();
+  });
+
+  it('graph container is keyboard focusable', () => {
+    render(<RepositoryGraph data={mockGraphData} />);
+
+    const graph = screen.getByTestId('repository-graph-container');
+
+    expect(graph).toHaveAttribute('tabIndex', '0');
   });
 });

--- a/components/dashboard/RepositoryGraph.mouse-interactivity.test.tsx
+++ b/components/dashboard/RepositoryGraph.mouse-interactivity.test.tsx
@@ -66,7 +66,9 @@ describe('RepositoryGraph — Interactive Tooltips, Cursor Hovers & Touch Event 
   it('clicking an active filter button toggles it to inactive and removes its background colour', () => {
     render(<RepositoryGraph data={mockData} />);
 
-    const personalButton = screen.getByRole('button', { name: 'Personal' });
+    const personalButton = screen.getByRole('button', {
+      name: /toggle personal repositories/i,
+    });
 
     expect(personalButton.style.backgroundColor).toBe('rgb(59, 130, 246)');
 

--- a/components/dashboard/RepositoryGraph.tsx
+++ b/components/dashboard/RepositoryGraph.tsx
@@ -124,7 +124,20 @@ export default function RepositoryGraph({ data }: RepositoryGraphProps) {
   }
 
   return (
-    <div className="flex flex-col gap-6" id="repository-graph">
+    <div
+      className="flex flex-col gap-6"
+      id="repository-graph"
+      role="region"
+      aria-label="Repository relationship graph"
+      aria-describedby="repository-graph-description repository-graph-summary"
+    >
+      <p id="repository-graph-description" className="sr-only">
+        Interactive repository relationship graph showing repositories, contributions and forks.
+      </p>
+
+      <p id="repository-graph-summary" className="sr-only">
+        Graph contains {graphData.nodes.length} nodes and {graphData.links.length} relationships.
+      </p>
       {/* Header & Filters */}
       <div className="flex flex-col md:flex-row md:items-end justify-between gap-4">
         <div>
@@ -140,8 +153,10 @@ export default function RepositoryGraph({ data }: RepositoryGraphProps) {
           {Object.entries(filters).map(([key, value]) => (
             <button
               key={key}
+              aria-label={`Toggle ${key} repositories`}
+              aria-pressed={value}
               onClick={() => toggleFilter(key as keyof typeof filters)}
-              className={`px-3 py-1.5 text-xs font-semibold rounded-full border transition-all ${
+              className={`px-3 py-1.5 text-xs font-semibold rounded-full border transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 ${
                 value
                   ? 'text-black border-transparent shadow-sm'
                   : 'bg-transparent text-gray-500 border-gray-300 dark:border-zinc-700 hover:border-gray-500'
@@ -163,6 +178,9 @@ export default function RepositoryGraph({ data }: RepositoryGraphProps) {
         {/* Graph Container */}
         <div
           ref={containerRef}
+          tabIndex={0}
+          data-testid="repository-graph-container"
+          aria-label="Interactive repository graph canvas"
           className="flex-grow bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)] rounded-xl overflow-hidden relative shadow-sm"
           style={{ height: dimensions.height }}
         >


### PR DESCRIPTION
## Description

Fixes #4056 

Improves keyboard navigation and screen-reader accessibility for RepositoryGraph.
 
## Pillar

- [x] 🛠 Other (Bug fix, refactoring, docs)

## Visual Preview

- N/A (Accessibility improvement, no visual UI changes)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally.
- [x] My commits follow the Conventional Commits format.
- [x] I have started the repo.

### Changes Made

- Added ARIA labels and accessible descriptions for the graph container.
- Added screen-reader friendly graph summaries.
- Improved keyboard accessibility by making graph elements focusable.
- Added accessibility metadata for interactive controls.
- Updated accessibility tests to use stable DOM-based assertions instead of canvas hover interactions.
- Preserved existing graph functionality and behavior.