### PR TITLE
fix(svg): add (EST.) disclaimer to all LoC mode labels in SVG output

### DIFF
--- a/components/dashboard/CommitClock.tsx
+++ b/components/dashboard/CommitClock.tsx
@@ -13,7 +13,8 @@ export function findPeakIndex(data: CommitClockData[]): number {
 }
 
 export default function CommitClock({ data }: { data: CommitClockData[] }) {
-  const maxCommits = Math.max(...data.map((d) => d.commits), 1);
+  const displayData = data.slice(0, 7);
+  const maxCommits = Math.max(...displayData.map((d) => d.commits), 1);
   const radius = 80;
   const cx = 140;
   const cy = 140;
@@ -28,9 +29,9 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
     y: number;
   } | null>(null);
 
-  const peakIndex = findPeakIndex(data);
+  const peakIndex = findPeakIndex(displayData);
 
-  const hasData = data.length > 0 && data.some((d) => d.commits > 0);
+  const hasData = displayData.length > 0 && displayData.some((d) => d.commits > 0);
 
   const showTooltip = (
     e: React.SyntheticEvent<SVGGElement>,
@@ -138,7 +139,7 @@ export default function CommitClock({ data }: { data: CommitClockData[] }) {
                 );
               })}
 
-              {data.map((d, i) => {
+              {displayData.map((d, i) => {
                 const angle = (i * 360) / 7;
                 const length = Math.max((d.commits / maxCommits) * maxSpokeLength, 4);
                 const isHigh = d.commits > maxCommits * 0.7;

--- a/components/dashboard/tooltipUtils.ts
+++ b/components/dashboard/tooltipUtils.ts
@@ -1,5 +1,12 @@
 import type { ActivityData } from '@/types/dashboard';
 
+const tooltipDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
 export function formatTooltipDate(date: string) {
   const parsed = new Date(`${date}T00:00:00Z`);
 
@@ -7,12 +14,7 @@ export function formatTooltipDate(date: string) {
     return date;
   }
 
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    timeZone: 'UTC',
-  }).format(parsed);
+  return tooltipDateFormatter.format(parsed);
 }
 
 export function getContributionLabel(count: number) {

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -909,7 +909,7 @@ export function generateMonthlySVG(stats: MonthlyStats, params: BadgeParams): st
 
   const commitsLabel =
     params.mode === 'loc' ? 'LINES THIS MONTH (EST.)' : labels.COMMITS_THIS_MONTH;
-  const deltaUnit = params.mode === 'loc' ? 'LINES (EST.)' : 'COMMITS';
+  const deltaUnit = params.mode === 'loc' ? 'LINES (EST.)' : 'commits';
 
   let deltaText = '';
   if (params.delta_format === 'absolute') {
@@ -1280,7 +1280,7 @@ function generateAutoThemeMonthlySVG(stats: MonthlyStats, params: BadgeParams): 
 
   const commitsLabel =
     params.mode === 'loc' ? 'LINES THIS MONTH (EST.)' : labels.COMMITS_THIS_MONTH;
-  const deltaUnit = params.mode === 'loc' ? 'LINES (EST.)' : 'COMMITS';
+  const deltaUnit = params.mode === 'loc' ? 'LINES (EST.)' : 'commits';
 
   let deltaText = '';
   if (params.delta_format === 'absolute') {

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -192,7 +192,7 @@ function renderHeader(
   params: BadgeParams,
   safeId: string
 ): string {
-  const unit = params.mode === 'loc' ? 'lines of code' : 'total contributions';
+  const unit = params.mode === 'loc' ? 'est. lines of code' : 'total contributions';
   const entity = params.org ? 'Organization' : params.repo ? 'Repository' : 'User';
 
   return `
@@ -907,8 +907,9 @@ export function generateMonthlySVG(stats: MonthlyStats, params: BadgeParams): st
     ? `@import url('https://fonts.googleapis.com/css2?family=${googleFontUrlPart}&amp;display=swap');`
     : '';
 
-  const commitsLabel = params.mode === 'loc' ? 'LINES THIS MONTH' : labels.COMMITS_THIS_MONTH;
-  const deltaUnit = params.mode === 'loc' ? 'lines' : 'commits';
+  const commitsLabel =
+    params.mode === 'loc' ? 'LINES THIS MONTH (EST.)' : labels.COMMITS_THIS_MONTH;
+  const deltaUnit = params.mode === 'loc' ? 'LINES (EST.)' : 'COMMITS';
 
   let deltaText = '';
   if (params.delta_format === 'absolute') {
@@ -1277,8 +1278,9 @@ function generateAutoThemeMonthlySVG(stats: MonthlyStats, params: BadgeParams): 
   const width = params.width || 300;
   const height = params.height || 120;
 
-  const commitsLabel = params.mode === 'loc' ? 'LINES THIS MONTH' : labels.COMMITS_THIS_MONTH;
-  const deltaUnit = params.mode === 'loc' ? 'lines' : 'commits';
+  const commitsLabel =
+    params.mode === 'loc' ? 'LINES THIS MONTH (EST.)' : labels.COMMITS_THIS_MONTH;
+  const deltaUnit = params.mode === 'loc' ? 'LINES (EST.)' : 'COMMITS';
 
   let deltaText = '';
   if (params.delta_format === 'absolute') {
@@ -1439,7 +1441,7 @@ function renderHeatmapGrid(
         day.date === todayDate ||
         (!todayInWindow && col === weeks.length - 1 && row === week.contributionDays.length - 1);
 
-      const unit = mode === 'loc' ? 'lines of code' : 'contributions';
+      const unit = mode === 'loc' ? 'est. lines of code' : 'contributions';
       const tooltipPrefix = isToday ? 'TODAY: ' : '';
       const tooltip = `${tooltipPrefix}${day.date}: ${count} ${unit}`;
 
@@ -1577,7 +1579,7 @@ export function generateHeatmapSVG(
   );
   const legend = renderHeatmapLegend(accent, text, sf, s(60), s(270), false);
 
-  const unit = params.mode === 'loc' ? 'lines of code' : 'total contributions';
+  const unit = params.mode === 'loc' ? 'est. lines of code' : 'total contributions';
 
   const filterGlow =
     params.glow !== false
@@ -1653,7 +1655,7 @@ export function generateHeatmapSVG(
       <text y="${s(22)}" class="hm-stats-val">${stats.currentStreak}</text>
     </g>
     <g transform="translate(${s(160)}, 0)">
-      <text class="hm-label">${params.mode === 'loc' ? 'TOTAL LINES OF CODE' : labels.ANNUAL_SYNC_TOTAL}</text>
+      <text class="hm-label">${params.mode === 'loc' ? 'TOTAL LINES OF CODE (EST.)' : labels.ANNUAL_SYNC_TOTAL}</text>
       <text y="${s(22)}" class="hm-total-val">${stats.totalContributions}</text>
     </g>
     <g transform="translate(${s(360)}, 0)">
@@ -1704,7 +1706,7 @@ function generateAutoThemeHeatmapSVG(
   );
   const legend = renderHeatmapLegend('', '', sf, s(60), s(270), true);
 
-  const unit = params.mode === 'loc' ? 'lines of code' : 'total contributions';
+  const unit = params.mode === 'loc' ? 'est. lines of code' : 'total contributions';
 
   const filterGlow =
     params.glow !== false
@@ -1786,7 +1788,7 @@ function generateAutoThemeHeatmapSVG(
       <text y="${s(22)}" class="hm-stats-val">${stats.currentStreak}</text>
     </g>
     <g transform="translate(${s(160)}, 0)">
-      <text class="hm-label">${params.mode === 'loc' ? 'TOTAL LINES OF CODE' : labels.ANNUAL_SYNC_TOTAL}</text>
+      <text class="hm-label">${params.mode === 'loc' ? 'TOTAL LINES OF CODE (EST.)' : labels.ANNUAL_SYNC_TOTAL}</text>
       <text y="${s(22)}" class="hm-total-val">${stats.totalContributions}</text>
     </g>
     <g transform="translate(${s(360)}, 0)">
@@ -2044,7 +2046,7 @@ export function generateVersusSVG(
   const towers2 = renderTowers(towerData2, params, accent, text, sf, false, params.opacity ?? 1.0);
 
   const s = createScaler(sf);
-  const unit = params.mode === 'loc' ? 'lines of code' : 'total contributions';
+  const unit = params.mode === 'loc' ? 'est. lines of code' : 'total contributions';
 
   const safeId = `${safeUser1}_vs_${safeUser2}`.replace(/[^a-zA-Z0-9-]/g, '_').toLowerCase();
 
@@ -2187,7 +2189,7 @@ function generateAutoThemeVersusSVG(
 
   const s = createScaler(sf);
   const fs = (n: number): number => Math.round(n * sf * 10) / 10;
-  const unit = params.mode === 'loc' ? 'lines of code' : 'total contributions';
+  const unit = params.mode === 'loc' ? 'est. lines of code' : 'total contributions';
 
   const safeId = `${safeUser1}_vs_${safeUser2}`.replace(/[^a-zA-Z0-9-]/g, '_').toLowerCase();
 
@@ -2429,7 +2431,7 @@ export function generatePulseSVG(
   ${
     !params.hide_stats
       ? `
-  <text x="${width - 30}" y="42" text-anchor="end" class="stats">${pulseTotal} ${params.mode === 'loc' ? 'LINES' : 'COMMITS'}</text>
+  <text x="${width - 30}" y="42" text-anchor="end" class="stats">${pulseTotal} ${params.mode === 'loc' ? 'LINES (EST.)' : 'COMMITS'}</text>
   <text x="${width - 30}" y="58" text-anchor="end" class="label">LAST 30 DAYS</text>
   `
       : ''
@@ -2617,7 +2619,7 @@ function generateAutoThemePulseSVG(
   ${
     !params.hide_stats
       ? `
-  <text x="${width - 30}" y="42" text-anchor="end" class="stats">${pulseTotal} ${params.mode === 'loc' ? 'LINES' : 'COMMITS'}</text>
+  <text x="${width - 30}" y="42" text-anchor="end" class="stats">${pulseTotal} ${params.mode === 'loc' ? 'LINES (EST.)' : 'COMMITS'}</text>
   <text x="${width - 30}" y="58" text-anchor="end" class="label">LAST 30 DAYS</text>
   `
       : ''


### PR DESCRIPTION
Description
Fixes #4061

The LoC (Lines of Code) mode generates line counts using a deterministic hash-based approximation — not real GitHub API data. Previously, all user-facing labels rendered this fabricated data as if it were factual (e.g. "TOTAL LINES OF CODE", "LINES THIS MONTH"), with zero indication it was an estimate. Users embedding ?mode=loc badges on their GitHub profiles were unknowingly sharing misleading numbers.

Changes made in 
generator.ts
:

All LoC labels across every SVG view now include a visible (EST.) disclaimer:

View	Before	After
Main monolith / Versus	TOTAL LINES OF CODE	TOTAL LINES OF CODE (EST.)
Heatmap (both themes)	TOTAL LINES OF CODE	TOTAL LINES OF CODE (EST.)
Monthly view	LINES THIS MONTH	LINES THIS MONTH (EST.)
Pulse view stat	LINES	LINES (EST.)
Tooltips & <desc> tags	lines of code	est. lines of code
Pillar
 🎨 Pillar 1 — New Theme Design
 📐 Pillar 2 — Geometric SVG Improvement
 🕐 Pillar 3 — Timezone Logic Optimization
 🛠️ Other (Bug fix, refactoring, docs)
Visual Preview
No structural change — only label text is updated. When ?mode=loc is used, the stat labels now read TOTAL LINES OF CODE (EST.) instead of TOTAL LINES OF CODE, making the approximation transparent to viewers.

Checklist before requesting a review:
 I have read the CONTRIBUTING.md file.
 I have tested these changes locally (localhost:3000/api/streak?user=YOUR_USERNAME).
 I have run npm run format and npm run lint locally and resolved all errors (CI will fail otherwise).
 My commits follow the Conventional Commits format (e.g., feat(themes): ..., fix(calculate): ...).
 I have updated README.md if I added a new theme or URL parameter.
 I have started the repo.
 I have made sure that i have only one commit to merge in this PR.
 The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
