### PR TITLE
test: add type compiler validation tests for ComparisonStatsCard

### DIFF
--- a/components/dashboard/ComparisonStatsCard.tsx
+++ b/components/dashboard/ComparisonStatsCard.tsx
@@ -22,7 +22,7 @@ const iconMap: Record<string, LucideIcon> = {
   Award,
 };
 
-interface ComparisonStatsCardProps {
+export interface ComparisonStatsCardProps {
   title: string;
   valueA: number;
   valueB: number;

--- a/components/dashboard/ComparisonStatsCard.type-compiler.test.tsx
+++ b/components/dashboard/ComparisonStatsCard.type-compiler.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type { ComparisonStatsCardProps } from './ComparisonStatsCard';
+
+describe('ComparisonStatsCard TypeScript compiler validation', () => {
+  it('accepts valid props shape', () => {
+    expectTypeOf<ComparisonStatsCardProps>().toMatchTypeOf({
+      title: '',
+      valueA: 0,
+      valueB: 0,
+      labelA: '',
+      labelB: '',
+      icon: '',
+    });
+  });
+
+  it('enforces string fields', () => {
+    expectTypeOf<ComparisonStatsCardProps['title']>().toEqualTypeOf<string>();
+    expectTypeOf<ComparisonStatsCardProps['labelA']>().toEqualTypeOf<string>();
+    expectTypeOf<ComparisonStatsCardProps['labelB']>().toEqualTypeOf<string>();
+    expectTypeOf<ComparisonStatsCardProps['icon']>().toEqualTypeOf<string>();
+  });
+
+  it('enforces numeric value fields', () => {
+    expectTypeOf<ComparisonStatsCardProps['valueA']>().toEqualTypeOf<number>();
+    expectTypeOf<ComparisonStatsCardProps['valueB']>().toEqualTypeOf<number>();
+  });
+
+  it('requires all props', () => {
+    type RequiredKeys = keyof ComparisonStatsCardProps;
+
+    expectTypeOf<RequiredKeys>().toEqualTypeOf<
+      'title' | 'valueA' | 'valueB' | 'labelA' | 'labelB' | 'icon'
+    >();
+  });
+
+  it('supports valid component prop object assignment', () => {
+    const props: ComparisonStatsCardProps = {
+      title: 'Commits',
+      valueA: 10,
+      valueB: 15,
+      labelA: 'Alice',
+      labelB: 'Bob',
+      icon: 'GitCommit',
+    };
+
+    expectTypeOf(props).toMatchTypeOf<ComparisonStatsCardProps>();
+  });
+});


### PR DESCRIPTION
## Description

Add TypeScript compiler validation tests for `ComparisonStatsCard` to ensure prop type safety and schema stability.

Fixes #2522

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable)
* [x] (Recommended) I joined the CommitPulse Discord community.

## Test Evidence

```bash
RUN  v4.1.7 E:/Projects/commitpulse

✓ components/dashboard/ComparisonStatsCard.type-compiler.test.tsx (5 tests)

Test Files  1 passed (1)
Tests       5 passed (5)

Duration    2.60s
```

### Lint

```bash
npm run lint

✔ No lint errors
```
