### PR TITLE
[Critical] fix(generator): use centralized buildTowerPaths for language SVG towers to fix distorted geometry

### DIFF
--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -2824,15 +2824,10 @@ export function generateLanguagesSVG(
     const scaledY = H / 2 + (50 + lang.coord.y) * sf;
     const h = Math.max(30, (lang.percentage / maxPercent) * 140) * sf;
 
-    // Scale up the tower base size
-    const tw = 16 * TOWER_SCALE * sf; // half-width
-    const th = 10 * TOWER_SCALE * sf; // half-height
-
-    const paths = {
-      left: `M0 ${-h} L0 ${th} L${-tw} 0 L${-tw} ${-h - th} Z`,
-      right: `M0 ${-h} L0 ${th} L${tw} 0 L${tw} ${-h - th} Z`,
-      top: `M0 ${-h - th} L${tw} ${-h} L0 ${-h + th} L${-tw} ${-h} Z`,
-    };
+    // Use the centralized tower path builder for consistent isometric geometry
+    const towerScale = TOWER_SCALE * sf;
+    const paths = buildTowerPaths(h, towerScale);
+    const th = 10 * towerScale; // half-height, used for text label positioning
 
     const hexColor = lang.color.startsWith('#') ? lang.color : `#${lang.color}`;
     const delay = (idx * 0.15).toFixed(3);


### PR DESCRIPTION
## Description

Fixes #4131

## Pillar

- [ ] Pillar 1 - New Theme Design
- [X] Pillar 2 - Geometric SVG Improvement
- [ ] Pillar 3 - Timezone Logic Optimization
- [ ] Pillar 4 - Other (Bug fix, refactoring, docs)

## Visual Preview

The language towers in `?view=languages` will now match the same isometric geometry as contribution towers in all other views (heatmap, pulse, versus). The fix corrects:

- Left/right faces that were shifted `th` pixels too low
- Top face that rendered as a diamond instead of a proper isometric parallelogram

Before: Distorted language towers with squashed top faces and overly tall side walls
After: Consistent isometric tower geometry matching all other SVG views

## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [X] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [X] I have started the repo.
- [X] I have made sure that i have only one commit to merge in this PR.
- [X] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
