### PR TITLE
fix(rate-limit): standardize 429 responses across API endpoints

### DIFF
--- a/app/api/notify/route.test.ts
+++ b/app/api/notify/route.test.ts
@@ -14,6 +14,12 @@ vi.mock('@/models/Notification', () => ({
 vi.mock('@/lib/rate-limit', () => ({
   notifyRateLimiter: {
     check: vi.fn().mockResolvedValue(true),
+    checkWithResult: vi.fn().mockResolvedValue({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      reset: Date.now() + 60000,
+    }),
   },
 }));
 vi.mock('@/services/github/validate-user', () => ({
@@ -102,9 +108,18 @@ describe('POST /api/notify', () => {
   // ── Rate limiting ────────────────────────────────────────────────────────
 
   it('returns 429 when rate limited', async () => {
-    vi.mocked(notifyRateLimiter.check).mockResolvedValue(false);
+    const reset = Date.now() + 60000;
+    vi.mocked(notifyRateLimiter.checkWithResult).mockResolvedValueOnce({
+      success: false,
+      limit: 5,
+      remaining: 0,
+      reset,
+    });
     const res = await POST(makeRequest('POST', { username: 'testuser', email: 'a@b.com' }));
     expect(res.status).toBe(429);
+    expect(res.headers.get('x-ratelimit-limit')).toBe('5');
+    expect(res.headers.get('x-ratelimit-remaining')).toBe('0');
+    expect(res.headers.get('x-ratelimit-reset')).toBe(reset.toString());
   });
 
   // ── Per-username write cooldown ───────────────────────────────────────────
@@ -231,9 +246,18 @@ describe('GET /api/notify', () => {
   // ── Rate limiting ────────────────────────────────────────────────────────
 
   it('returns 429 when rate limited', async () => {
-    vi.mocked(notifyRateLimiter.check).mockResolvedValue(false);
+    const reset = Date.now() + 60000;
+    vi.mocked(notifyRateLimiter.checkWithResult).mockResolvedValueOnce({
+      success: false,
+      limit: 5,
+      remaining: 0,
+      reset,
+    });
     const res = await GET(makeRequest('GET', undefined, 'user=testuser'));
     expect(res.status).toBe(429);
+    expect(res.headers.get('x-ratelimit-limit')).toBe('5');
+    expect(res.headers.get('x-ratelimit-remaining')).toBe('0');
+    expect(res.headers.get('x-ratelimit-reset')).toBe(reset.toString());
   });
 
   // ── MONGODB_URI handling ──────────────────────────────────────────────────

--- a/app/api/notify/route.test.ts
+++ b/app/api/notify/route.test.ts
@@ -12,6 +12,11 @@ vi.mock('@/models/Notification', () => ({
   },
 }));
 vi.mock('@/lib/rate-limit', () => ({
+  getRateLimitHeaders: vi.fn((result) => ({
+    'X-RateLimit-Limit': result.limit.toString(),
+    'X-RateLimit-Remaining': result.remaining.toString(),
+    'X-RateLimit-Reset': result.reset.toString(),
+  })),
   notifyRateLimiter: {
     check: vi.fn().mockResolvedValue(true),
     checkWithResult: vi.fn().mockResolvedValue({

--- a/app/api/notify/route.ts
+++ b/app/api/notify/route.ts
@@ -2,10 +2,10 @@ import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/mongodb';
 import { Notification } from '@/models/Notification';
 import { notifyPostSchema, notifyGetSchema } from '@/lib/validations';
-import { notifyRateLimiter } from '@/lib/rate-limit';
 import { getClientIp } from '@/utils/getClientIp';
 import { DistributedCache } from '@/lib/cache';
 import { gitHubUserValidator } from '@/services/github/validate-user';
+import { getRateLimitHeaders, notifyRateLimiter } from '@/lib/rate-limit';
 
 const notifyWriteCache = new DistributedCache<number>(5000, 60000);
 const NOTIFY_WRITE_COOLDOWN_MS = 5 * 60 * 1000;
@@ -42,13 +42,13 @@ export async function POST(req: Request) {
   const ip = getClientIp(req);
 
   // fallback ensures rate limit is ALWAYS applied
-  const rateLimitKey =
-    ip && ip !== 'unknown' ? ip : `unknown:${req.headers.get('user-agent') ?? 'no-agent'}`;
+  const rateLimitKey = ip && ip !== 'unknown' ? ip : `unknown:${req.headers.get('user-agent') ?? 'no-agent'}`;
+  const rateLimitResult = await notifyRateLimiter.checkWithResult(rateLimitKey);
 
-  if (!(await notifyRateLimiter.check(rateLimitKey))) {
+  if (!rateLimitResult.success) {
     return NextResponse.json(
       { success: false, message: 'Too many requests, please try again later.' },
-      { status: 429 }
+      { status: 429, headers: getRateLimitHeaders(rateLimitResult) }
     );
   }
 
@@ -178,11 +178,15 @@ export async function GET(req: Request) {
   // Rate limiting
   const ip = getClientIp(req);
 
-  if (ip !== 'unknown' && !(await notifyRateLimiter.check(ip))) {
-    return NextResponse.json(
-      { success: false, message: 'Too many requests, please try again later.' },
-      { status: 429 }
-    );
+  if (ip !== 'unknown') {
+    const rateLimitResult = await notifyRateLimiter.checkWithResult(ip);
+
+    if (!rateLimitResult.success) {
+      return NextResponse.json(
+        { success: false, message: 'Too many requests, please try again later.' },
+        { status: 429, headers: getRateLimitHeaders(rateLimitResult) }
+      );
+    }
   }
 
   // Validate query params with Zod

--- a/app/api/notify/route.ts
+++ b/app/api/notify/route.ts
@@ -42,7 +42,8 @@ export async function POST(req: Request) {
   const ip = getClientIp(req);
 
   // fallback ensures rate limit is ALWAYS applied
-  const rateLimitKey = ip && ip !== 'unknown' ? ip : `unknown:${req.headers.get('user-agent') ?? 'no-agent'}`;
+  const rateLimitKey =
+    ip && ip !== 'unknown' ? ip : `unknown:${req.headers.get('user-agent') ?? 'no-agent'}`;
   const rateLimitResult = await notifyRateLimiter.checkWithResult(rateLimitKey);
 
   if (!rateLimitResult.success) {

--- a/app/api/track-user/route.test.ts
+++ b/app/api/track-user/route.test.ts
@@ -2,11 +2,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { POST } from './route';
 import { User } from '@/models/User';
 import dbConnect from '@/lib/mongodb';
+import { trackUserRateLimiter } from '@/lib/rate-limit';
 
 // Mock dependencies
 vi.mock('@/lib/rate-limit', () => ({
   trackUserRateLimiter: {
     check: vi.fn().mockResolvedValue(true),
+    checkWithResult: vi.fn().mockResolvedValue({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      reset: Date.now() + 60000,
+    }),
   },
 }));
 
@@ -143,6 +150,23 @@ describe('POST /api/track-user', () => {
       const data = await response.json();
       expect(data.success).toBe(false);
     });
+  });
+
+    it('returns 429 with rate limit headers when rate limited', async () => {
+    const reset = Date.now() + 60000;
+    vi.mocked(trackUserRateLimiter.checkWithResult).mockResolvedValueOnce({
+      success: false,
+      limit: 5,
+      remaining: 0,
+      reset,
+    });
+
+    const response = await POST(makeRequest({ username: 'valid-user' }));
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('x-ratelimit-limit')).toBe('5');
+    expect(response.headers.get('x-ratelimit-remaining')).toBe('0');
+    expect(response.headers.get('x-ratelimit-reset')).toBe(reset.toString());
   });
 
   describe('Without MONGODB_URI (Local Development Bypass)', () => {

--- a/app/api/track-user/route.test.ts
+++ b/app/api/track-user/route.test.ts
@@ -6,6 +6,11 @@ import { trackUserRateLimiter } from '@/lib/rate-limit';
 
 // Mock dependencies
 vi.mock('@/lib/rate-limit', () => ({
+  getRateLimitHeaders: vi.fn((result) => ({
+    'X-RateLimit-Limit': result.limit.toString(),
+    'X-RateLimit-Remaining': result.remaining.toString(),
+    'X-RateLimit-Reset': result.reset.toString(),
+  })),
   trackUserRateLimiter: {
     check: vi.fn().mockResolvedValue(true),
     checkWithResult: vi.fn().mockResolvedValue({
@@ -41,10 +46,10 @@ import { fetchUserProfile } from '@/lib/github';
 import { trackUserProtection } from '@/services/security/track-user-protection';
 import { gitHubUserValidator } from '@/services/github/validate-user';
 
-function makeRequest(body: Record<string, unknown>): Request {
+function makeRequest(body: Record<string, unknown>, headers?: HeadersInit): Request {
   return new Request('http://localhost/api/track-user', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...headers },
     body: JSON.stringify(body),
   });
 }
@@ -152,7 +157,7 @@ describe('POST /api/track-user', () => {
     });
   });
 
-    it('returns 429 with rate limit headers when rate limited', async () => {
+  it('returns 429 with rate limit headers when rate limited', async () => {
     const reset = Date.now() + 60000;
     vi.mocked(trackUserRateLimiter.checkWithResult).mockResolvedValueOnce({
       success: false,
@@ -161,7 +166,9 @@ describe('POST /api/track-user', () => {
       reset,
     });
 
-    const response = await POST(makeRequest({ username: 'valid-user' }));
+    const response = await POST(
+      makeRequest({ username: 'valid-user' }, { 'x-real-ip': '198.51.100.10' })
+    );
 
     expect(response.status).toBe(429);
     expect(response.headers.get('x-ratelimit-limit')).toBe('5');

--- a/app/api/track-user/route.ts
+++ b/app/api/track-user/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/mongodb';
 import { User } from '@/models/User';
-import { trackUserRateLimiter } from '@/lib/rate-limit';
 import { getClientIp } from '@/utils/getClientIp';
+import { getRateLimitHeaders, trackUserRateLimiter } from '@/lib/rate-limit';
 import { trackUserProtection } from '@/services/security/track-user-protection';
 
 export async function POST(req: Request) {
@@ -11,11 +11,15 @@ export async function POST(req: Request) {
 
   const rateLimitKey = ip === 'unknown' ? 'unknown-client' : ip;
 
-  if (ip !== '127.0.0.1' && !(await trackUserRateLimiter.check(rateLimitKey))) {
-    return NextResponse.json(
-      { success: false, error: 'Too many requests, please try again later.' },
-      { status: 429 }
-    );
+  if (ip !== '127.0.0.1') {
+    const rateLimitResult = await trackUserRateLimiter.checkWithResult(rateLimitKey);
+
+    if (!rateLimitResult.success) {
+      return NextResponse.json(
+        { success: false, error: 'Too many requests, please try again later.' },
+        { status: 429, headers: getRateLimitHeaders(rateLimitResult) }
+      );
+    }
   }
 
   let body: unknown;

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -301,3 +301,11 @@ export async function rateLimit(
     reset: tracker.resetAt,
   };
 }
+
+export function getRateLimitHeaders(result: RateLimitResult) {
+  return {
+    'X-RateLimit-Limit': result.limit.toString(),
+    'X-RateLimit-Remaining': result.remaining.toString(),
+    'X-RateLimit-Reset': result.reset.toString(),
+  };
+}


### PR DESCRIPTION
## Description

This PR fixes inconsistent rate-limit enforcement behavior across API endpoints by standardizing the metadata returned in `429 Too Many Requests` responses.

Previously, middleware-protected routes exposed rate-limit headers such as:

* `X-RateLimit-Limit`
* `X-RateLimit-Remaining`
* `X-RateLimit-Reset`

However, route-specific limiters (e.g. `/api/track-user` and `/api/notify`) returned only a `429` response without the same metadata. This made client-side retry and backoff logic unreliable and resulted in inconsistent API behavior.

## Changes Made

* Added consistent rate-limit headers to route-level throttled responses.
* Unified `429 Too Many Requests` response behavior across API endpoints.
* Ensured clients can reliably determine when requests may be retried.
* Improved API consistency and developer experience.

## Testing

* Verified middleware-based rate limiting continues to return rate-limit metadata.
* Triggered route-specific rate limiters and confirmed the same headers are now included in responses.
* Confirmed consistent behavior across all throttled endpoints.

## Issue

Fixes #3127 
