### PR TITLE
feat(generator): Improves monolith height scaling for high-contribution profiles

### DIFF
--- a/lib/svg/constants.ts
+++ b/lib/svg/constants.ts
@@ -2,7 +2,7 @@ export const SVG_WIDTH = 600;
 export const SVG_HEIGHT = 420;
 
 export const GHOST_HEIGHT_PX = 4;
-export const LOG_SCALE_MULTIPLIER = 12;
+export const LOG_SCALE_MULTIPLIER = 20;
 export const LINEAR_SCALE_MULTIPLIER = 5;
 export const MAX_LOG_HEIGHT = 80;
 export const MAX_LINEAR_HEIGHT = 50;

--- a/lib/svg/layout.ts
+++ b/lib/svg/layout.ts
@@ -73,7 +73,7 @@ export function computeTowerHeight(
   if (count === 0 && shouldShowGhostCity) return GHOST_HEIGHT_PX;
   if (count === 0) return 0;
   return scale === 'log'
-    ? Math.min(Math.log2(count + 1) * LOG_SCALE_MULTIPLIER, MAX_LOG_HEIGHT)
+    ? Math.min(Math.log10(count + 1) * LOG_SCALE_MULTIPLIER, MAX_LOG_HEIGHT)
     : Math.min(count * LINEAR_SCALE_MULTIPLIER, MAX_LINEAR_HEIGHT);
 }
 


### PR DESCRIPTION
## Description

Fixes #6436

Improves monolith height scaling for high-contribution profiles by refining the logarithmic tower height calculation used during SVG generation.

### Changes

* Updated logarithmic tower scaling from `Math.log2()` to `Math.log10()`
* Adjusted `LOG_SCALE_MULTIPLIER` to maintain balanced visual proportions
* Preserved existing SVG dimensions, layout, and visual design

### Benefits

* Prevents highly active profiles from reaching maximum tower height too quickly
* Improves visual differentiation across a wider range of contribution counts
* Produces a more informative and readable SVG visualization while maintaining CommitPulse aesthetics

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [x] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

<img width="818" height="263" alt="image" src="https://github.com/user-attachments/assets/64c6b25f-565f-4532-aa25-ba5b442e9fb0" />


## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
