### PR TITLE
fix: restore current streak and annual sync values in live preview

### DIFF
--- a/app/customize/page.tsx
+++ b/app/customize/page.tsx
@@ -233,6 +233,7 @@ function CustomizePageInner(): ReactElement {
         // while preserving the necessary layout and structural attributes our SVG requires.
         const sanitized = DOMPurify.sanitize(text, {
           USE_PROFILES: { svg: true },
+          ADD_TAGS: ['filter', 'feGaussianBlur', 'feMerge', 'feMergeNode', 'feComposite'],
           ADD_ATTR: [
             'viewBox',
             'd',
@@ -248,6 +249,15 @@ function CustomizePageInner(): ReactElement {
             'font-size',
             'font-weight',
             'fill-opacity',
+            'filter',
+            'stdDeviation',
+            'result',
+            'in',
+            'in2',
+            'operator',
+            'x',
+            'y',
+            'id',
           ],
         });
 


### PR DESCRIPTION
## Description
This PR fixes an issue on the Customize page where the live preview displayed the Current Streak and Annual Sync Total labels but failed to render their corresponding values.

The root cause was the client-side SVG sanitization step used for the live preview. Certain SVG filter elements and attributes required by the generated badge were being removed by DOMPurify, causing parts of the SVG to render incorrectly in the preview even though the API was returning the correct data.

This PR updates the DOMPurify SVG allowlist to preserve the required filter-related tags and attributes, ensuring that the live preview renders the badge consistently with the generated SVG output.

Result
Current Streak value is displayed in the live preview.
Annual Sync Total value is displayed in the live preview.
SVG filter elements required for rendering are preserved during sanitization.
Preview output remains consistent with the generated SVG output.

Fixes #4145 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

<img width="1919" height="1079" alt="Screenshot 2026-06-06 180943" src="https://github.com/user-attachments/assets/fb1dd7bf-6ae5-4c5c-b880-1cf374cdd1d3" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
