### PR TITLE
fix(rate-limit): use pipeline DEL for KV reset in RateLimiter.reset()

### DIFF
--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -249,4 +249,32 @@ describe('RateLimiter', () => {
     expect(await limiter.check(ip)).toBe(true);
     expect(await limiter.remaining(ip)).toBe(2);
   });
+
+  it('reset() sends DEL via pipeline to KV using ratelimit_class:<ip> key', async () => {
+    // Verifies that when KV env vars are set, reset() uses the pipeline endpoint
+    // with the correct key prefix — matching the key used in checkWithResult().
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [{ result: 1 }] });
+    vi.stubGlobal('fetch', fetchMock);
+
+    process.env.KV_REST_API_URL = 'https://fake-kv.example.com';
+    process.env.KV_REST_API_TOKEN = 'fake-token';
+
+    const limiter = new RateLimiter(3, 60000);
+    const ip = '8.8.8.8';
+
+    await limiter.reset(ip);
+
+    const resetCall = fetchMock.mock.calls.find(
+      ([url]: [string]) => typeof url === 'string' && url.includes('/pipeline')
+    );
+    expect(resetCall).toBeTruthy();
+
+    const body = JSON.parse(resetCall[1].body as string) as unknown[][];
+    expect(body).toEqual([['DEL', `ratelimit_class:${ip}`]]);
+
+    // Cleanup
+    delete process.env.KV_REST_API_URL;
+    delete process.env.KV_REST_API_TOKEN;
+    vi.unstubAllGlobals();
+  });
 });

--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -265,11 +265,11 @@ describe('RateLimiter', () => {
     await limiter.reset(ip);
 
     const resetCall = fetchMock.mock.calls.find(
-      ([url]: [string]) => typeof url === 'string' && url.includes('/pipeline')
+      (args: unknown[]) => typeof args[0] === 'string' && (args[0] as string).includes('/pipeline')
     );
     expect(resetCall).toBeTruthy();
 
-    const body = JSON.parse(resetCall[1].body as string) as unknown[][];
+    const body = JSON.parse((resetCall![1] as { body: string }).body) as unknown[][];
     expect(body).toEqual([['DEL', `ratelimit_class:${ip}`]]);
 
     // Cleanup

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -146,11 +146,13 @@ export class RateLimiter {
 
     if (url && token) {
       try {
-        await fetch(`${url}/del/ratelimit_class:${ip}`, {
+        await fetch(`${url}/pipeline`, {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
           },
+          body: JSON.stringify([['DEL', `ratelimit_class:${ip}`]]),
         });
       } catch (error) {
         console.error('RateLimiter KV reset error:', error);


### PR DESCRIPTION
Description
Fixes #4064

RateLimiter.reset() was attempting to delete the KV record using a path-style Upstash REST URL (${url}/del/ratelimit_class:${ip}) with method: 'POST'. The Upstash REST API path-based commands expect GET, not POST — so the delete call was silently failing with no error thrown (the fetch itself resolved without throwing, just returning a non-OK response that was never checked).

The result: in any production deployment with KV_REST_API_URL and KV_REST_API_TOKEN configured, calling reset(ip) would never actually clear the rate limit record in Redis. The IP would remain blocked for the full window duration regardless of the reset call. The in-memory fallback (used in dev/test) worked correctly, which masked the bug locally.

Root cause: Inconsistent KV deletion approach — every other KV operation in the file (checkWithResult, DistributedCache.delete) uses POST /pipeline with a JSON command body, but reset() used a one-off path-style URL with the wrong HTTP method.

Fix: Replaced the path-style fetch in reset() with the same pipeline approach used everywhere else in the codebase:

// Before — wrong HTTP method for path-style Upstash REST command
await fetch(`${url}/del/ratelimit_class:${ip}`, { method: 'POST', ... });

// After — consistent with the rest of the codebase
await fetch(`${url}/pipeline`, {
  method: 'POST',
  headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
  body: JSON.stringify([['DEL', `ratelimit_class:${ip}`]]),
});
Also added a test that mocks fetch, sets the KV env vars, calls reset(), and asserts the pipeline endpoint is called with ['DEL', 'ratelimit_class:<ip>'] — directly covering the KV code path that had no test coverage before.

Files changed:

rate-limit.ts
 — fixed reset() KV deletion
rate-limit.test.ts
 — added KV pipeline assertion test for reset()
Pillar
 🛠️ Other (Bug fix, refactoring, docs)
Visual Preview
No visual changes — this is a backend rate limiting bug fix.

Checklist before requesting a review:
 I have read the CONTRIBUTING.md file.
 I have tested these changes locally.
 I have run npm run format and npm run lint locally and resolved all errors.
 My commits follow the Conventional Commits format (fix(rate-limit): use pipeline DEL for KV reset in RateLimiter.reset()).
 I have updated README.md if I added a new theme or URL parameter. 
 I have made sure that I have only one commit to merge in this PR.
 The SVG output matches the CommitPulse "premium quality" aesthetic standard. 