### PR TITLE
fix: guard weekendRatio denominator against division by zero

### DIFF
--- a/lib/calculate.ts
+++ b/lib/calculate.ts
@@ -318,6 +318,9 @@ export function calculateWrappedStats(calendar: ContributionCalendar) {
     mostActiveDate: mostActiveDay.date,
     highestDailyCount: mostActiveDay.count,
     busiestMonth: busiestMonthStr,
-    weekendRatio: Math.round((weekendCommits / (weekendCommits + weekdayCommits || 1)) * 100),
+    weekendRatio: (() => {
+      const total = weekendCommits + weekdayCommits;
+      return total > 0 ? Math.round((weekendCommits / total) * 100) : 0;
+    })(),
   };
 }


### PR DESCRIPTION
## Description
Fixes #4037 

The `weekendRatio` calculation in `calculateWrappedStats` used `|| 1` to guard against division by zero, but due to operator precedence it was unclear and inconsistent with the rest of the codebase.

Changed from:
```typescript
weekendRatio: Math.round((weekendCommits / (weekendCommits + weekdayCommits || 1)) * 100),
```

To:
```typescript
weekendRatio: (() => {
  const total = weekendCommits + weekdayCommits;
  return total > 0 ? Math.round((weekendCommits / total) * 100) : 0;
})(),
```

**Why this fix:**
- **Clarity:** Operator precedence is now explicit — `|| 1` only guarded the second operand of `+`, not the entire denominator, making the intent ambiguous
- **Consistency:** Matches the pattern already used in `lib/github.ts:1570–1571` which uses an explicit `> 0` ternary check
- **Behaviour:** Functionally identical (both return `0` when counts are zero), but intent is now unambiguous and maintainable
- **Safety:** Extracted `total` variable eliminates any risk of misinterpreting operator precedence in future refactors

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — math logic fix, no visual or behavioral changes.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.