### PR TITLE
type-safety: add `ContributedRepo` interface and type `fetchContributedRepos` return properly

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,6 +1,7 @@
 import type {
   ContributionCalendar,
   ContributionDay,
+  ContributedRepo,
   ExtendedContributionData,
   RepoContribution,
   GraphNode,
@@ -369,7 +370,7 @@ export const GITHUB_CACHE_TTL_MS = 5 * 60 * 1000;
 export const contributionsCache = new DistributedCache<ExtendedContributionData>(1000);
 const profileCache = new DistributedCache<GitHubUserProfile>(1000);
 const reposCache = new DistributedCache<GitHubRepo[]>(500);
-const contributedReposCache = new DistributedCache<Record<string, unknown>[]>(500);
+const contributedReposCache = new DistributedCache<ContributedRepo[]>(500);
 
 interface GitHubUserProfile {
   login: string;
@@ -1147,7 +1148,7 @@ export function buildCommitClock(allDays: ContributionDay[]) {
 export async function fetchContributedRepos(
   username: string,
   options: FetchOptions = {}
-): Promise<Record<string, unknown>[]> {
+): Promise<ContributedRepo[]> {
   const key = cacheKey('repos:contributed', username);
 
   const load = async () => {
@@ -1490,20 +1491,12 @@ export async function getFullDashboardData(username: string, options: FetchOptio
     });
     links.push({ source: profileData.login, target: r.name });
   });
-  contributedRepos.forEach((item) => {
-    const r = item as {
-      name: string;
-      nameWithOwner: string;
-      stargazerCount?: number;
-      forkCount?: number;
-      primaryLanguage?: { name: string } | null;
-      updatedAt?: string;
-    };
+  contributedRepos.forEach((r) => {
     nodes.push({
       id: r.nameWithOwner,
       name: r.name,
       type: 'Contribution',
-      val: Math.max(5, Math.min(20, (r.stargazerCount ?? 0) / 10 + 5)),
+      val: Math.max(5, Math.min(20, r.stargazerCount / 10 + 5)),
       color: '#22C55E',
       stats: {
         stars: r.stargazerCount,

--- a/types/index.ts
+++ b/types/index.ts
@@ -93,6 +93,33 @@ export interface RepoContribution {
 }
 
 /**
+ * A repository that the user has contributed to, as returned by the
+ * `repositoriesContributedTo` GraphQL query.
+ */
+export interface ContributedRepo {
+  /** Repository name (without owner prefix). */
+  name: string;
+
+  /** Full repository identifier including owner (e.g. "owner/repo"). */
+  nameWithOwner: string;
+
+  /** Owner of the repository. */
+  owner: { login: string };
+
+  /** Number of stars on the repository. */
+  stargazerCount: number;
+
+  /** Number of forks of the repository. */
+  forkCount: number;
+
+  /** Primary programming language of the repository, if any. */
+  primaryLanguage: { name: string } | null;
+
+  /** ISO 8601 timestamp of the last update. */
+  updatedAt: string;
+}
+
+/**
  * Extended contribution data including both the calendar and repository-specific contributions.
  */
 export interface ExtendedContributionData {


### PR DESCRIPTION
## Description
Fixes #4054 

The `fetchContributedRepos` function was returning `Promise<Record<string, unknown>[]>` — a completely untyped array with no compile-time safety or IDE autocomplete for consumers. Added a proper TypeScript interface for the returned object structure and updated all usages.

### Changes made

| File | Change |
|------|--------|
| `types/index.ts` | Added `ContributedRepo` interface with all 7 fields from the GraphQL query: `name`, `nameWithOwner`, `owner`, `stargazerCount`, `forkCount`, `primaryLanguage`, `updatedAt` |
| `lib/github.ts` L4 | Added `ContributedRepo` to the import from `@/types` |
| `lib/github.ts` L372 | Cache type: `DistributedCache<Record<string, unknown>[]>` → `DistributedCache<ContributedRepo[]>` |
| `lib/github.ts` L1150 | Function return type: `Promise<Record<string, unknown>[]>` → `Promise<ContributedRepo[]>` |
| `lib/github.ts` L1493–1515 | Removed unsafe inline `as { ... }` cast; loop variable is now directly typed as `ContributedRepo`, and `r.stargazerCount ?? 0` simplified to `r.stargazerCount` since field is required |

### Benefits
- **Full type safety:** Callers now have IDE autocomplete and compile-time checking for all response fields
- **Clear contract:** The interface documents exactly what data the function returns
- **Safer refactoring:** Changes to response shape are caught at compile time, not runtime
- **Consistency:** Matches the pattern used by other well-typed functions like `fetchUserProfile`

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — type safety improvement only, no runtime behavior changes.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.