### PR TITLE
test(RefreshButton-empty-fallback): verify edge cases and empty input handling

### DIFF
--- a/components/dashboard/RefreshButton.empty-fallback.test.tsx
+++ b/components/dashboard/RefreshButton.empty-fallback.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RefreshButton from './RefreshButton';
+
+const { successMock, pushMock, replaceMock, refreshMock } = vi.hoisted(() => ({
+  successMock: vi.fn(),
+  pushMock: vi.fn(),
+  replaceMock: vi.fn(),
+  refreshMock: vi.fn(),
+}));
+
+let searchParams = new URLSearchParams();
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: successMock,
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: pushMock,
+    replace: replaceMock,
+    refresh: refreshMock,
+  }),
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock('lucide-react', () => ({
+  RefreshCw: ({ className }: { className?: string }) => (
+    <svg data-testid="refresh-icon" className={className} />
+  ),
+}));
+
+describe('RefreshButton - Empty Fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchParams = new URLSearchParams();
+  });
+
+  it('renders button when username is empty', () => {
+    render(<RefreshButton username="" />);
+
+    expect(
+      screen.getByRole('button', {
+        name: /refresh dashboard contribution data/i,
+      })
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Refresh Data')).toBeInTheDocument();
+  });
+
+  it('does not show success toast when refresh query is absent', () => {
+    render(<RefreshButton username="kanishka" />);
+
+    expect(successMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('shows success toast and cleans url when refresh=true exists', () => {
+    searchParams = new URLSearchParams('refresh=true');
+
+    render(<RefreshButton username="kanishka" />);
+
+    expect(successMock).toHaveBeenCalledWith('Dashboard refreshed successfully');
+
+    expect(replaceMock).toHaveBeenCalledWith('/dashboard/kanishka');
+  });
+
+  it('renders correct accessibility attributes', () => {
+    render(<RefreshButton username="test-user" />);
+
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveAttribute('aria-label', 'Refresh dashboard contribution data');
+
+    expect(button).toHaveAttribute('title', 'Refresh dashboard contribution data');
+  });
+
+  it('handles refresh click without runtime errors', () => {
+    render(<RefreshButton username="kanishka" />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(pushMock).toHaveBeenCalledWith('/dashboard/kanishka?refresh=true');
+
+    expect(refreshMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description


Adds isolated tests for RefreshButton edge-case and fallback behavior.

# Coverage
- empty username rendering
- missing refresh query handling
- refresh=true cleanup flow
- accessibility attributes
- refresh action execution

Fixes #2593 

## Pillar
- [x] 📐 Pillar 2 — Geometric SVG Improvement
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
