### PR TITLE
a11y: restore keyboard focus ring in InteractiveViewer to meet WCAG 2.1 SC 2.4.7

### DIFF
--- a/components/InteractiveViewer.tsx
+++ b/components/InteractiveViewer.tsx
@@ -312,7 +312,7 @@ export default function InteractiveViewer({
     <div
       ref={containerRef}
       tabIndex={0}
-      className={`relative overflow-hidden touch-none cursor-grab active:cursor-grabbing select-none focus:outline-none ${className}`}
+      className={`relative overflow-hidden touch-none cursor-grab active:cursor-grabbing select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 ${className}`}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}


### PR DESCRIPTION
## Description
Fixes #4055 

The InteractiveViewer container had `tabIndex={0}` and `onKeyDown` handlers (for arrow keys, zoom), making it keyboard-navigable, but `focus:outline-none` removed the visible focus indicator. This violates WCAG 2.1 Success Criterion 2.4.7 (Focus Visible), which requires keyboard focus to be clearly visible.

### Changes made

Replaced:
```tsx
className={`... focus:outline-none ...`}
```

With:
```tsx
className={`... focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 ...`}
```

### How it works

- **`focus:outline-none`** — Suppresses the default browser outline on all focus events
- **`focus-visible:ring-2 focus-visible:ring-emerald-500`** — Restores a 2px emerald ring only when focus is triggered via keyboard

Browsers don't set `:focus-visible` on pointer interactions, so:
- **Keyboard users** → See a clear 2px emerald ring (accessible) ✅
- **Mouse users** → No ring visible (good UX) ✅
- **Screen readers** → Unaffected ✅

### WCAG Compliance

This change resolves:
- **SC 2.4.7 (Focus Visible):** Keyboard focus is now clearly visible
- **SC 2.4.3 (Focus Order):** Already compliant; no changes to tab order

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — accessibility improvement, keyboard focus ring now visible on Tab navigation.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.