### PR TITLE
refactor(validations): standardize toGraceValue to use parseFloat() — consistent with toOpacityValue

### DIFF
--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -3,6 +3,8 @@ import {
   githubParamsSchema,
   ogParamsSchema,
   streakParamsSchema,
+  toGraceValue,
+  toOpacityValue,
   validateGitHubUsername,
 } from './validations';
 
@@ -1451,5 +1453,76 @@ describe('streakParamsSchema — date query validation boundaries (Variation 2)'
       const flat = result.error.flatten().fieldErrors;
       expect(flat.date).toBeDefined();
     }
+  });
+});
+
+describe('toGraceValue — parseFloat standardization', () => {
+  it('returns default 1 when val is undefined', () => {
+    expect(toGraceValue(undefined)).toBe(1);
+  });
+
+  it('returns default 1 when val is empty string', () => {
+    expect(toGraceValue('')).toBe(1);
+  });
+
+  it('parses integer string correctly', () => {
+    expect(toGraceValue('2')).toBe(2);
+  });
+
+  it('parses float string and truncates to float (grace=1.7 → 1.7, clamped range 0-7)', () => {
+    expect(toGraceValue('1.7')).toBe(1.7);
+  });
+
+  it('clamps value below 0 to 0', () => {
+    expect(toGraceValue('-1')).toBe(0);
+  });
+
+  it('clamps value above 7 to 7', () => {
+    expect(toGraceValue('10')).toBe(7);
+  });
+
+  it('returns default 1 for non-numeric string "abc"', () => {
+    expect(toGraceValue('abc')).toBe(1);
+  });
+
+  it('parseFloat behavior: "2abc" parses as 2 (not NaN like Number would return)', () => {
+    expect(toGraceValue('2abc')).toBe(2);
+  });
+
+  it('returns 0 for grace=0 (strict mode)', () => {
+    expect(toGraceValue('0')).toBe(0);
+  });
+
+  it('returns 7 for grace=7 (maximum)', () => {
+    expect(toGraceValue('7')).toBe(7);
+  });
+});
+
+describe('toGraceValue and toOpacityValue — consistent parseFloat behavior', () => {
+  it('both return their default for undefined input', () => {
+    expect(toGraceValue(undefined)).toBe(1);
+    expect(toOpacityValue(undefined)).toBe(1.0);
+  });
+
+  it('both return their default for empty string input', () => {
+    expect(toGraceValue('')).toBe(1);
+    expect(toOpacityValue('')).toBe(1.0);
+  });
+
+  it('both return their default for non-numeric input', () => {
+    expect(toGraceValue('abc')).toBe(1);
+    expect(toOpacityValue('abc')).toBe(1.0);
+  });
+
+  it('both parse partial numeric strings via parseFloat — not NaN', () => {
+    expect(toGraceValue('2abc')).toBe(2);
+    expect(toOpacityValue('0.5abc')).toBe(0.5);
+  });
+
+  it('both clamp out-of-range values — no raw passthrough', () => {
+    expect(toGraceValue('100')).toBe(7);
+    expect(toOpacityValue('100')).toBe(1.0);
+    expect(toGraceValue('-5')).toBe(0);
+    expect(toOpacityValue('-5')).toBe(0.1);
   });
 });

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -42,9 +42,16 @@ export function toValidHexColor(defaultColor: string) {
     val && isValidHex(val) ? sanitizeHexColor(val, defaultColor) : undefined;
 }
 
+/**
+ * Parses the ?grace= URL parameter.
+ * Uses parseFloat() — the standard for all numeric URL param parsers in this
+ * file — so that partial strings like '2abc' parse as 2 rather than NaN,
+ * and empty string correctly returns NaN (triggering the default fallback).
+ * Clamps to [0, 7]. Default: 1.
+ */
 export function toGraceValue(val?: string): number {
   if (!val) return 1;
-  const parsed = Number(val);
+  const parsed = parseFloat(val);
   return isNaN(parsed) ? 1 : Math.max(0, Math.min(parsed, 7));
 }
 


### PR DESCRIPTION
## Description

Fixes #4184 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No visual change. This is a one-word code change in lib/validations.ts.

## What this PR does

Standardizes toGraceValue() to use parseFloat() instead of Number(),
making it consistent with toOpacityValue() which already uses parseFloat().

Number() vs parseFloat() edge case differences:
| Input  | Number() | parseFloat() | Impact on grace |
|--------|----------|--------------|-----------------|
| '2abc' | NaN → 1  | 2            | more forgiving  |
| ''     | 0        | NaN → 1      | guarded by !val |
| '0x10' | 16       | 0            | hex not valid   |

## Changes

| File | Change |
|------|--------|
| `lib/validations.ts` | `Number(val)` → `parseFloat(val)` in toGraceValue, added JSDoc |
| `lib/validations.test.ts` | Added 15 new tests for toGraceValue + consistency tests |

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse premium quality aesthetic standard.
- [x] (Recommended) I joined the CommitPulse Discord server.