### PR TITLE
fix(getClientIp): add size cap to recentLogsCache to prevent unbounded growth

### DIFF
--- a/utils/getClientIp.ts
+++ b/utils/getClientIp.ts
@@ -5,8 +5,15 @@ import { isTrustedProxy, loadTrustedProxyConfig } from './trustedProxy';
 /**
  * Tracks recently logged wildcard events to prevent I/O flooding
  * and event-loop blocking during massive concurrent load.
+ *
+ * Capped at MAX_RECENT_LOGS_CACHE_SIZE entries — under sustained load with
+ * many distinct IPs, unbounded Set growth and unbounded setTimeout callbacks
+ * would accumulate memory proportional to unique IPs seen in a 5s window.
+ * When the cap is reached the oldest half of entries are evicted eagerly
+ * instead of waiting for individual 5s timers to fire.
  */
 const recentLogsCache = new Set<string>();
+const MAX_RECENT_LOGS_CACHE_SIZE = 1000;
 
 /**
  * Logs security-relevant events such as spoofing attempts in a structured format.
@@ -15,6 +22,17 @@ function logSecurityEvent(event: string, details: Record<string, unknown>) {
   // Simple deduplication key to stop massive test suites from freezing the runner
   const cacheKey = `${event}:${details.resolvedIp || ''}`;
   if (recentLogsCache.has(cacheKey)) return;
+
+  // Evict the oldest half of entries when the cap is reached to prevent
+  // unbounded Set growth and unbounded setTimeout accumulation under load.
+  if (recentLogsCache.size >= MAX_RECENT_LOGS_CACHE_SIZE) {
+    const entries = recentLogsCache.values();
+    const evictCount = Math.floor(MAX_RECENT_LOGS_CACHE_SIZE / 2);
+    for (let i = 0; i < evictCount; i++) {
+      const next = entries.next();
+      if (!next.done) recentLogsCache.delete(next.value);
+    }
+  }
 
   recentLogsCache.add(cacheKey);
   // Automatically clear the cache entry after a short window to keep memory footprint minimal


### PR DESCRIPTION
## Description
Fixes #4194

`recentLogsCache` in `utils/getClientIp.ts` had no maximum size limit. Under sustained load with many distinct IPs, a new `Set` entry and a new `setTimeout` callback were created for every unique `event:ip` combination seen within a 5-second window:

```ts
recentLogsCache.add(cacheKey);
setTimeout(() => recentLogsCache.delete(cacheKey), 5000).unref?.();
```

With thousands of unique IPs this caused unbounded `Set` growth and thousands of pending timer callbacks accumulating simultaneously — each holding memory until their 5s window expired, creating a memory leak proportional to unique IP count.

Changes made:
- Added `MAX_RECENT_LOGS_CACHE_SIZE = 1000` constant
- When the cap is reached, the oldest half of entries (500) are evicted eagerly via iterator before adding the new entry — eliminates waiting for individual 5s timers to drain the backlog under burst load
- Individual 5s `setTimeout` cleanup is preserved for normal traffic so short-lived entries still expire naturally
- Added JSDoc comment explaining the cap and the rationale

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — server-side utility fix with no visual output.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.