### PR TITLE
git add app/customize/types.mouse-interactivity.test.ts git commit -m "test(customize-types): add mouse interactivity metadata coverage" git push -u origin test-customize-types-mouse-interactivity-4697

### DIFF
--- a/app/customize/types.mouse-interactivity.test.ts
+++ b/app/customize/types.mouse-interactivity.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DELTA_FORMATS,
+  FONTS,
+  LANGUAGES,
+  SIZES,
+  SPEEDS,
+  THEME_KEYS,
+  TIMEZONES,
+  VIEW_MODES,
+} from './types';
+
+function getValues<T extends readonly { value: string; label: string }[]>(items: T) {
+  return items.map((item) => item.value);
+}
+
+describe('CustomizeTypes mouse interactivity metadata (Variation 5)', () => {
+  it('exposes theme options used by interactive theme controls', () => {
+    expect(THEME_KEYS).toContain('auto');
+    expect(THEME_KEYS).toContain('random');
+    expect(THEME_KEYS.length).toBeGreaterThan(2);
+  });
+
+  it('keeps speed options label-rich for hoverable/selectable controls', () => {
+    SPEEDS.forEach((speed) => {
+      expect(speed.value).toMatch(/s$/);
+      expect(speed.label.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('keeps size options stable for pointer-driven selection controls', () => {
+    expect(getValues(SIZES)).toEqual(['small', 'medium', 'large']);
+
+    SIZES.forEach((size) => {
+      expect(size.label).toBeTruthy();
+    });
+  });
+
+  it('keeps customize option groups free from duplicate selectable values', () => {
+    const optionGroups = [FONTS, VIEW_MODES, DELTA_FORMATS, LANGUAGES, TIMEZONES];
+
+    optionGroups.forEach((group) => {
+      const values = getValues(group);
+      expect(new Set(values).size).toBe(values.length);
+    });
+  });
+
+  it('provides timezone labels for touch and select interaction menus', () => {
+    expect(getValues(TIMEZONES)).toContain('UTC');
+    expect(getValues(TIMEZONES)).toContain('Asia/Kolkata');
+
+    TIMEZONES.forEach((timezone) => {
+      expect(timezone.label).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4697

Added dedicated test coverage for `app/customize/types.ts` to validate the integrity and consistency of interactive customization option metadata used throughout the customization workflow.

### What was added?

Created:

* `app/customize/types.mouse-interactivity.test.ts`

### Test Coverage Added

Implemented 5 test cases covering:

1. Theme option availability (`auto`, `random`, and registered themes)
2. Speed option metadata validation
3. Size selection option integrity
4. Duplicate value protection across interactive option groups
5. Timezone option availability and label consistency

### Validation

* Verified theme option collections remain valid.
* Verified selectable customization options expose valid labels.
* Verified interactive configuration groups do not contain duplicate values.
* Verified timezone and selection metadata remain stable for UI interactions.

### Test Results

```txt
✓ app/customize/types.mouse-interactivity.test.ts

Test Files  1 passed (1)
Tests       5 passed (5)
```

cc: @Aamod007 @souravjhahind @JhaSourav07

Kindly review and assign the appropriate labels for this contribution.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Testing)

## Visual Preview

N/A (Test-only contribution)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [x] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
