### PR TITLE
test(GrowthTrendChart): verify counts map onto chart coordinates

### DIFF
--- a/components/dashboard/GrowthTrendChart.responsive-breakpoints.test.tsx
+++ b/components/dashboard/GrowthTrendChart.responsive-breakpoints.test.tsx
@@ -146,4 +146,30 @@ describe('GrowthTrendChart - Responsive Multi-device Columns & Mobile Viewport L
     expect(screen.getByText('User A')).toBeDefined();
     expect(screen.getByText('User B')).toBeDefined();
   });
+
+  it('maps contribution counts onto the chart: zero counts sit on the baseline and larger counts rise above it', () => {
+    const now = new Date();
+    const inWindowDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-15`;
+
+    const { container } = render(
+      <GrowthTrendChart
+        activityA={[]}
+        activityB={[{ date: inWindowDate, count: 400 }]}
+        labelA="User A"
+        labelB="User B"
+      />
+    );
+
+    const yCoordsOf = (d: string) =>
+      Array.from(d.matchAll(/[ML]\s[\d.]+\s([\d.]+)/g)).map((m) => parseFloat(m[1]));
+
+    const pathYs = Array.from(container.querySelectorAll('path'))
+      .map((p) => yCoordsOf(p.getAttribute('d') ?? ''))
+      .filter((ys) => ys.length > 0);
+
+    const BASELINE = 155;
+
+    expect(pathYs.some((ys) => ys.every((y) => y === BASELINE))).toBe(true);
+    expect(pathYs.some((ys) => ys.some((y) => y < BASELINE))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Description

Closes #1518

Gradient defs, area/stroke paths, the viewBox, and monthly aggregation are already covered. This locks the **uncovered scaling math** in `getCoordinates`: a zero-count series stays pinned to the chart baseline (`y=155`) while a populated series rises above it (higher count → smaller y). If the `count / maxVal` projection regresses (e.g. collapses both series), the test fails.