### PR TITLE
test(InteractiveViewer): show and update the tower hover tooltip

### DIFF
--- a/components/InteractiveViewer.test.tsx
+++ b/components/InteractiveViewer.test.tsx
@@ -309,6 +309,39 @@ describe('InteractiveViewer', () => {
     expect(contentDiv.style.transform).toContain('translate(20px, 20px) scale(1)');
   });
 
+  it('shows a tooltip with the formatted date when hovering a tower and updates it across towers', () => {
+    render(
+      <InteractiveViewer>
+        <div
+          className="interactive-tower"
+          data-date="2025-06-15"
+          data-count="42"
+          data-metric="commits"
+          data-testid="tower-a"
+        >
+          Tower A
+        </div>
+        <div
+          className="interactive-tower"
+          data-date="2025-01-01"
+          data-count="7"
+          data-metric="commits"
+          data-testid="tower-b"
+        >
+          Tower B
+        </div>
+      </InteractiveViewer>
+    );
+
+    fireEvent.pointerMove(screen.getByTestId('tower-a'), { clientX: 100, clientY: 100 });
+    expect(screen.getByRole('tooltip')).toBeTruthy();
+    expect(screen.getByText('Jun 15, 2025')).toBeTruthy();
+
+    fireEvent.pointerMove(screen.getByTestId('tower-b'), { clientX: 200, clientY: 100 });
+    expect(screen.getByText('Jan 1, 2025')).toBeTruthy();
+    expect(screen.queryByText('Jun 15, 2025')).toBeNull();
+  });
+
   it('updates mousePos and particle shifts on pointerMove when not dragging', () => {
     const { container } = render(
       <InteractiveViewer>


### PR DESCRIPTION
## Description

Closes #1531

Drag-pan, ctrl+wheel zoom, and WASD/arrow/reset keyboard handling are already covered, and those handlers are viewport-independent (so "at mobile width" adds nothing). The **tooltip path had zero coverage**, so this exercises it: hovering a `.interactive-tower` renders the `VisualizationTooltip` with the formatted `data-date`, and moving onto a second tower updates the title (the date-change branch in `handlePointerMove`).