### PR TITLE
test(Navbar): dismiss mobile menu when a dropdown link is tapped

### DIFF
--- a/app/components/navbar.test.tsx
+++ b/app/components/navbar.test.tsx
@@ -200,4 +200,25 @@ describe('Navbar responsive breakpoints', () => {
       'false'
     );
   });
+
+  it('dismisses the open mobile menu when a dropdown link is tapped', () => {
+    window.innerWidth = 375;
+    mockMatchMedia(false);
+
+    render(<Navbar />);
+
+    fireEvent.click(screen.getByRole('button', { name: /open menu/i }));
+    expect(screen.getByText('Language / Bhasha')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /close menu/i }).getAttribute('aria-expanded')).toBe(
+      'true'
+    );
+
+    const compareLinks = screen.getAllByRole('link', { name: /compare/i });
+    fireEvent.click(compareLinks[compareLinks.length - 1]);
+
+    expect(screen.queryByText('Language / Bhasha')).toBeNull();
+    expect(screen.getByRole('button', { name: /open menu/i }).getAttribute('aria-expanded')).toBe(
+      'false'
+    );
+  });
 });


### PR DESCRIPTION
## Description

Closes #1545

The toggle-button open/close path is already covered (`opens menu on button click`, `closes menu on second click`, the "toggling smoothly" variation). This adds the **uncovered** behavior: tapping a link inside the open mobile dropdown fires its `onClick` (`setOpen(false)`) and collapses the menu, so a user isn't stranded on the menu after navigating.

Asserted via the dropdown-only "Language / Bhasha" row appearing then disappearing, and `aria-expanded` returning to `false`. Remove the link's `onClick` and the test fails. No redundant toggle re-assertions.