### PR TITLE
fix(customize): only emit valid hex and stop mislabeling 400 as user-not-found

### DIFF
--- a/app/customize/page.tsx
+++ b/app/customize/page.tsx
@@ -23,7 +23,7 @@ import type {
   Timezone,
 } from './types';
 import { useDebounce } from '@/hooks/useDebounce';
-import { getExportSnippet, buildQueryParams } from './utils';
+import { getExportSnippet, buildQueryParams, streakErrorMessage } from './utils';
 
 function readNumericSearchParam(
   searchParams: URLSearchParams,
@@ -217,13 +217,7 @@ function CustomizePageInner(): ReactElement {
         if (!res.ok) {
           setSvgContent('');
           setSvgState('error');
-          if (res.status === 404 || res.status === 400) {
-            setErrorMessage('GitHub user not found');
-          } else if (res.status === 429) {
-            setErrorMessage('Rate limit exceeded. Please try again later.');
-          } else {
-            setErrorMessage('Failed to load badge');
-          }
+          setErrorMessage(streakErrorMessage(res.status));
           return;
         }
         return text;

--- a/app/customize/utils.test.ts
+++ b/app/customize/utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { buildQueryParams, getExportSnippet, getPlaceholderSnippet } from './utils';
+import {
+  buildQueryParams,
+  getExportSnippet,
+  getPlaceholderSnippet,
+  streakErrorMessage,
+} from './utils';
 import type { CustomizeOptions } from './types';
 
 describe('Export Snippet utilities', () => {
@@ -177,6 +182,30 @@ describe('Export Snippet utilities', () => {
       expect(result).toBe('user=testuser&bg=ffffff&accent=ff0000&text=000000&font=Inter');
     });
 
+    it('omits partial or invalid hex colors and falls back to theme', () => {
+      // Lengths 1, 2 and 5 are the intermediate states while typing a 6-digit hex.
+      for (const partial of ['f', 'ff', 'ffaab']) {
+        const options = { ...defaultOptions, theme: 'dark', bgHex: partial };
+        const result = buildQueryParams(options);
+        expect(result).toBe('user=testuser&theme=dark&font=Inter');
+        expect(result).not.toContain('bg=');
+      }
+    });
+
+    it('emits only the valid hex colors when some inputs are still partial', () => {
+      const options = {
+        ...defaultOptions,
+        theme: 'dark',
+        bgHex: 'ffffff',
+        accentHex: 'ff',
+        textHex: '',
+      };
+      const result = buildQueryParams(options);
+      expect(result).toBe('user=testuser&bg=ffffff&font=Inter');
+      expect(result).not.toContain('accent=');
+      expect(result).not.toContain('theme=');
+    });
+
     it('forces theme parameter and ignores custom colors for virtual themes (auto/random)', () => {
       const optionsAuto = {
         ...defaultOptions,
@@ -226,5 +255,24 @@ describe('Export Snippet utilities', () => {
         'user=testuser&theme=dark&scale=log&speed=4s&font=fira&year=2023&radius=12&size=large&hide_title=true&hide_background=true&hide_stats=true&view=monthly&delta_format=absolute&width=600&height=400&grace=2&lang=es&tz=America%2FNew_York'
       );
     });
+  });
+});
+
+describe('streakErrorMessage', () => {
+  it('maps 404 to a user-not-found message', () => {
+    expect(streakErrorMessage(404)).toBe('GitHub user not found');
+  });
+
+  it('maps 400 to an invalid-options message rather than user-not-found', () => {
+    expect(streakErrorMessage(400)).toBe('Invalid customization options');
+    expect(streakErrorMessage(400)).not.toContain('not found');
+  });
+
+  it('maps 429 to a rate-limit message', () => {
+    expect(streakErrorMessage(429)).toBe('Rate limit exceeded. Please try again later.');
+  });
+
+  it('falls back to a generic message for other statuses', () => {
+    expect(streakErrorMessage(500)).toBe('Failed to load badge');
   });
 });

--- a/app/customize/utils.ts
+++ b/app/customize/utils.ts
@@ -23,6 +23,17 @@ export function getBadgeUrl(queryString: string): string {
   return `${BADGE_BASE_URL}?${queryString}`;
 }
 
+/**
+ * Maps a failed /api/streak preview response status to a user-facing message.
+ * A 400 means invalid parameters (for example a bad color), not a missing user.
+ */
+export function streakErrorMessage(status: number): string {
+  if (status === 404) return 'GitHub user not found';
+  if (status === 400) return 'Invalid customization options';
+  if (status === 429) return 'Rate limit exceeded. Please try again later.';
+  return 'Failed to load badge';
+}
+
 export function getExportSnippet(format: ExportFormat, queryString: string): string {
   const badgeUrl = getBadgeUrl(queryString);
 
@@ -224,15 +235,18 @@ export function buildQueryParams(options: CustomizeOptions): string {
     // Virtual themes always emit theme=<name> and skip custom color params.
     params.set('theme', options.theme);
   } else {
-    const hasCustomColors = options.bgHex || options.accentHex || options.textHex;
+    const hasValidBg = isValidHex(options.bgHex);
+    const hasValidAccent = isValidHex(options.accentHex);
+    const hasValidText = isValidHex(options.textHex);
+    const hasCustomColors = hasValidBg || hasValidAccent || hasValidText;
 
-    // Custom hex colors take priority over theme
+    // Only complete, valid hex colors take priority over theme; partial input falls back to theme.
     if (!hasCustomColors) {
       params.set('theme', options.theme);
     }
-    if (options.bgHex) params.set('bg', stripHash(options.bgHex));
-    if (options.accentHex) params.set('accent', stripHash(options.accentHex));
-    if (options.textHex) params.set('text', stripHash(options.textHex));
+    if (hasValidBg) params.set('bg', stripHash(options.bgHex));
+    if (hasValidAccent) params.set('accent', stripHash(options.accentHex));
+    if (hasValidText) params.set('text', stripHash(options.textHex));
   }
 
   if (options.scale !== 'linear') params.set('scale', options.scale);


### PR DESCRIPTION
## Description

Fixes #4747

On the Customize page, typing a hex color in a text input previously sent the partial value to `/api/streak` on intermediate keystrokes. The schema accepts hex of length 3, 4, 6, or 8, so the in-progress lengths 1, 2, and 5 returned HTTP 400, and the preview error handler mapped 400 to "GitHub user not found". The result was a false "GitHub user not found" flash while the user was simply typing a color.

This change fixes both halves in `app/customize`:

1. `buildQueryParams` (`utils.ts`) now emits `bg` / `accent` / `text` only when the value passes the existing `isValidHex` check (strict 6-digit, already used by the color controls). Partial input falls back to the selected theme, and `hasCustomColors` is computed from validity so a partial value no longer suppresses the `theme` param.
2. A small pure helper `streakErrorMessage(status)` replaces the inline error mapping in `page.tsx`: 404 maps to "GitHub user not found", 400 to "Invalid customization options", 429 to the rate-limit message, and anything else to the generic fallback. The key effect is that a 400 no longer resolves to the "GitHub user not found" string, so the preview routes it to the generic error state instead of the false user-not-found card (which keys specifically off that string).

Behavior notes:
- The Customize color inputs are 6-digit by design (the native picker yields 6 digits and the text input is `maxLength={6}`), and `buildQueryParams` always emits 6-digit values, so generated URLs are unaffected. A hand-edited URL containing a 3/4/8-digit hex now falls back to the theme in the preview rather than rendering, which also matches what the color swatch/picker already showed for those values.
- The generic error card retains its existing copy; this change only ensures a 400 stops being mislabeled as a missing user.

Added unit tests in `utils.test.ts`: `buildQueryParams` omits partial/invalid hex (lengths 1, 2, 5) and falls back to theme, emits only the valid colors in a mixed case, and `streakErrorMessage` maps 404/400/429/other correctly (400 is no longer reported as user-not-found).

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

No new UI. The change removes a false "GitHub user not found" flash while typing a color and shows "Invalid customization options" for genuine 400 responses.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (all `app/customize` tests pass, 91 tests; full suite green aside from a pre-existing flaky accessibility test that passes in isolation; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable, no SVG output change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
