### PR TITLE
fix(dashboard): remove RadarChart fake language axis padding

### DIFF
--- a/components/dashboard/RadarChart.empty-fallback.test.tsx
+++ b/components/dashboard/RadarChart.empty-fallback.test.tsx
@@ -50,47 +50,43 @@ describe('RadarChart - Edge Cases & Empty/Missing Inputs (Variation 1)', () => {
       <RadarChart languagesA={[]} languagesB={[]} labelA="User A" labelB="User B" />
     );
 
-    // No <circle> elements should exist because every padded language has 0% (pct > 0 check fails)
+    // No <circle> elements should exist because the empty state renders no chart vertices
     const circles = container.querySelectorAll('circle');
     expect(circles.length).toBe(0);
   });
 
-  it('falls back to padding languages (TypeScript, JavaScript, Python) to guarantee >= 3 axes', () => {
+  it('does not invent TypeScript/JavaScript/Python axes when there is no language data', () => {
     const { container } = render(
       <RadarChart languagesA={[]} languagesB={[]} labelA="Empty A" labelB="Empty B" />
     );
 
-    // All three pad languages must appear as axis labels in the SVG
-    expect(screen.getAllByText('TypeScript').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('JavaScript').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Python').length).toBeGreaterThan(0);
+    // No fabricated language axis labels should appear
+    expect(screen.queryByText('TypeScript')).toBeNull();
+    expect(screen.queryByText('JavaScript')).toBeNull();
+    expect(screen.queryByText('Python')).toBeNull();
 
-    // Exactly 3 axis lines (one per padded language) must be rendered
+    // No axis lines are drawn for invented languages
     const axisLines = container.querySelectorAll('line[stroke-dasharray="2,2"]');
-    expect(axisLines.length).toBe(3);
+    expect(axisLines.length).toBe(0);
+
+    // An explicit empty state is shown instead
+    expect(screen.getByText('No language data to compare yet')).toBeInTheDocument();
   });
 
-  it('keeps standard SVG layout structure intact (grid rings, filters, svg dimensions) with empty inputs', () => {
+  it('renders the empty state without the chart SVG when there are no languages', () => {
     const { container } = render(
       <RadarChart languagesA={[]} languagesB={[]} labelA="A" labelB="B" />
     );
 
-    // SVG should be rendered with the fixed dimensions defined in the component
-    const svg = container.querySelector('svg');
-    expect(svg).toBeInTheDocument();
-    expect(svg).toHaveAttribute('width', '320');
-    expect(svg).toHaveAttribute('height', '300');
+    // No radar SVG is drawn for empty data; the empty-state message replaces it
+    expect(container.querySelector('svg')).toBeNull();
+    expect(screen.getByText('No language data to compare yet')).toBeInTheDocument();
 
-    // 4 concentric grid polygons (levels: 25, 50, 75, 100) must always exist
-    const gridPolygons = container.querySelectorAll('polygon[fill="none"]');
-    expect(gridPolygons.length).toBe(4);
-
-    // 2 glow filters (cyan + purple) must remain defined even with no data
-    const filters = container.querySelectorAll('filter');
-    expect(filters.length).toBe(2);
+    // The header (title) still renders so the card stays informative
+    expect(screen.getByText('Language Dominance')).toBeInTheDocument();
   });
 
-  it('maintains container styling and legend even when both label sets are empty arrays', () => {
+  it('maintains container styling and legend, showing the empty state, when both inputs are empty', () => {
     const { container } = render(
       <RadarChart languagesA={[]} languagesB={[]} labelA="Solo A" labelB="Solo B" />
     );
@@ -105,8 +101,8 @@ describe('RadarChart - Edge Cases & Empty/Missing Inputs (Variation 1)', () => {
     expect(screen.getByText('Solo A')).toBeInTheDocument();
     expect(screen.getByText('Solo B')).toBeInTheDocument();
 
-    // Stats table at the bottom exists (grid-cols-2 layout marker)
-    const statsTable = container.querySelector('.grid.grid-cols-2');
-    expect(statsTable).toBeInTheDocument();
+    // The chart stats table is replaced by the empty state
+    expect(container.querySelector('.grid.grid-cols-2')).toBeNull();
+    expect(screen.getByText('No language data to compare yet')).toBeInTheDocument();
   });
 });

--- a/components/dashboard/RadarChart.error-resilience.test.tsx
+++ b/components/dashboard/RadarChart.error-resilience.test.tsx
@@ -193,10 +193,8 @@ describe('RadarChart - Error Resilience & Exception Safety', () => {
     expect(screen.getByText('Empty User A')).toBeInTheDocument();
     expect(screen.getByText('Empty User B')).toBeInTheDocument();
 
-    // Verify SVG structure is rendered correctly
-    const svg = container.querySelector('svg');
-    expect(svg).toBeInTheDocument();
-    expect(svg).toHaveAttribute('width', '320');
-    expect(svg).toHaveAttribute('height', '300');
+    // With no language data the empty state is shown instead of an invented radar
+    expect(container.querySelector('svg')).toBeNull();
+    expect(screen.getByText('No language data to compare yet')).toBeInTheDocument();
   });
 });

--- a/components/dashboard/RadarChart.mock-integrations.test.tsx
+++ b/components/dashboard/RadarChart.mock-integrations.test.tsx
@@ -80,7 +80,7 @@ describe('RadarChart mock integrations', () => {
     expect(screen.getByText('Fallback')).toBeDefined();
   });
 
-  it('handles delayed or partial data using padding logic', () => {
+  it('renders the single provided language without inventing extra axes', () => {
     render(
       <RadarChart
         languagesA={[
@@ -96,7 +96,9 @@ describe('RadarChart mock integrations', () => {
       />
     );
 
-    expect(screen.getAllByText('TypeScript')).toBeDefined();
+    expect(screen.getAllByText('TypeScript').length).toBeGreaterThan(0);
+    expect(screen.queryByText('JavaScript')).toBeNull();
+    expect(screen.queryByText('Python')).toBeNull();
   });
 
   it('renders consistently when cache and remote datasets differ', () => {

--- a/components/dashboard/RadarChart.test.tsx
+++ b/components/dashboard/RadarChart.test.tsx
@@ -58,24 +58,30 @@ describe('RadarChart', () => {
     expect(screen.getAllByText('JavaScript')).toBeDefined();
   });
 
-  it('handles empty input arrays cleanly using pad languages', () => {
+  it('renders an empty state without inventing languages when both inputs are empty', () => {
     render(<RadarChart languagesA={[]} languagesB={[]} labelA="User A" labelB="User B" />);
 
-    expect(screen.getAllByText('TypeScript')).toBeDefined();
-    expect(screen.getAllByText('JavaScript')).toBeDefined();
-    expect(screen.getAllByText('Python')).toBeDefined();
+    expect(screen.queryByText('TypeScript')).toBeNull();
+    expect(screen.queryByText('JavaScript')).toBeNull();
+    expect(screen.queryByText('Python')).toBeNull();
+    expect(screen.getByText('No language data to compare yet')).toBeInTheDocument();
   });
 
-  it('verify at least 3 axes are always shown via padding when fewer are provided', () => {
+  it('renders only the real languages without padding to three axes', () => {
     const singleLang = [{ name: 'TypeScript', percentage: 100, color: '#3178c6' }];
 
-    render(
+    const { container } = render(
       <RadarChart languagesA={singleLang} languagesB={singleLang} labelA="User A" labelB="User B" />
     );
 
-    expect(screen.getAllByText('TypeScript')).toBeDefined();
-    expect(screen.getAllByText('JavaScript')).toBeDefined();
-    expect(screen.getAllByText('Python')).toBeDefined();
+    // The real language is shown
+    expect(screen.getAllByText('TypeScript').length).toBeGreaterThan(0);
+    // No fabricated JavaScript/Python axes
+    expect(screen.queryByText('JavaScript')).toBeNull();
+    expect(screen.queryByText('Python')).toBeNull();
+    // Exactly one axis line for the single real language
+    const axisLines = container.querySelectorAll('line[stroke-dasharray="2,2"]');
+    expect(axisLines.length).toBe(1);
   });
 
   it('renders chart elements and layout structure visible across viewport sizes', () => {

--- a/components/dashboard/RadarChart.tsx
+++ b/components/dashboard/RadarChart.tsx
@@ -16,17 +16,7 @@ export default function RadarChart({ languagesA, languagesB, labelA, labelB }: R
     new Set([...languagesA.map((l) => l.name), ...languagesB.map((l) => l.name)])
   ).slice(0, 6); // Cap at 6 languages for clean layout
 
-  // Pad with common languages if there are fewer than 3 axes
-  const padLangs = ['TypeScript', 'JavaScript', 'Python'];
-  while (combinedLanguages.length < 3) {
-    const nextPad = padLangs.find((l) => !combinedLanguages.includes(l));
-    if (nextPad) {
-      combinedLanguages.push(nextPad);
-    } else {
-      combinedLanguages.push(`Lang ${combinedLanguages.length + 1}`);
-    }
-  }
-
+  const hasLanguages = combinedLanguages.length > 0;
   const N = combinedLanguages.length;
   const cx = 160;
   const cy = 160;
@@ -103,143 +93,151 @@ export default function RadarChart({ languagesA, languagesB, labelA, labelB }: R
         </div>
       </div>
 
-      <div className="relative w-[320px] h-[300px] flex items-center justify-center">
-        <svg width="320" height="300" className="overflow-visible">
-          <defs>
-            <filter id="glow-cyan" x="-20%" y="-20%" width="140%" height="140%">
-              <feGaussianBlur stdDeviation="3" result="blur" />
-              <feComposite in="SourceGraphic" in2="blur" operator="over" />
-            </filter>
-            <filter id="glow-purple" x="-20%" y="-20%" width="140%" height="140%">
-              <feGaussianBlur stdDeviation="3" result="blur" />
-              <feComposite in="SourceGraphic" in2="blur" operator="over" />
-            </filter>
-          </defs>
+      {hasLanguages ? (
+        <>
+          <div className="relative w-[320px] h-[300px] flex items-center justify-center">
+            <svg width="320" height="300" className="overflow-visible">
+              <defs>
+                <filter id="glow-cyan" x="-20%" y="-20%" width="140%" height="140%">
+                  <feGaussianBlur stdDeviation="3" result="blur" />
+                  <feComposite in="SourceGraphic" in2="blur" operator="over" />
+                </filter>
+                <filter id="glow-purple" x="-20%" y="-20%" width="140%" height="140%">
+                  <feGaussianBlur stdDeviation="3" result="blur" />
+                  <feComposite in="SourceGraphic" in2="blur" operator="over" />
+                </filter>
+              </defs>
 
-          {/* Grid Polygons */}
-          {gridPolygons.map((points, idx) => (
-            <polygon
-              key={`grid-${idx}`}
-              points={points}
-              fill="none"
-              stroke="rgba(120, 120, 120, 0.12)"
-              strokeWidth="1"
-            />
-          ))}
-
-          {/* Axis lines and labels */}
-          {combinedLanguages.map((lang, i) => {
-            const outerCoord = getCoordinates(i, 100);
-            const labelDist = r + 18;
-            const angle = outerCoord.angle;
-            const labelX = cx + labelDist * Math.cos(angle);
-            const labelY = cy + labelDist * Math.sin(angle);
-
-            // Determine text alignment based on angle to avoid chart overlap
-            const cos = Math.cos(angle);
-            const textAnchor = Math.abs(cos) < 0.1 ? 'middle' : cos > 0 ? 'start' : 'end';
-
-            return (
-              <g key={`axis-${i}`}>
-                {/* Axis line */}
-                <line
-                  x1={cx}
-                  y1={cy}
-                  x2={outerCoord.x}
-                  y2={outerCoord.y}
-                  stroke="rgba(120, 120, 120, 0.16)"
+              {/* Grid Polygons */}
+              {gridPolygons.map((points, idx) => (
+                <polygon
+                  key={`grid-${idx}`}
+                  points={points}
+                  fill="none"
+                  stroke="rgba(120, 120, 120, 0.12)"
                   strokeWidth="1"
-                  strokeDasharray="2,2"
                 />
+              ))}
 
-                {/* Axis label text */}
-                <text
-                  x={labelX}
-                  y={labelY + 4}
-                  fill="rgba(161, 161, 170, 0.9)"
-                  fontSize="9"
-                  fontWeight="600"
-                  textAnchor={textAnchor}
-                  className="font-sans tracking-wide"
-                >
-                  {lang}
-                </text>
-              </g>
-            );
-          })}
+              {/* Axis lines and labels */}
+              {combinedLanguages.map((lang, i) => {
+                const outerCoord = getCoordinates(i, 100);
+                const labelDist = r + 18;
+                const angle = outerCoord.angle;
+                const labelX = cx + labelDist * Math.cos(angle);
+                const labelY = cy + labelDist * Math.sin(angle);
 
-          {/* User A Area Polygon */}
-          <motion.polygon
-            initial={{ points: zeroPointsStr }}
-            animate={{ points: pointsStrA }}
-            transition={{ duration: 1.0, ease: [0.16, 1, 0.3, 1] }}
-            fill="rgba(6, 182, 212, 0.08)"
-            stroke="#06b6d4"
-            strokeWidth="1.8"
-            filter="url(#glow-cyan)"
-          />
+                // Determine text alignment based on angle to avoid chart overlap
+                const cos = Math.cos(angle);
+                const textAnchor = Math.abs(cos) < 0.1 ? 'middle' : cos > 0 ? 'start' : 'end';
 
-          {/* User B Area Polygon */}
-          <motion.polygon
-            initial={{ points: zeroPointsStr }}
-            animate={{ points: pointsStrB }}
-            transition={{ duration: 1.0, ease: [0.16, 1, 0.3, 1], delay: 0.15 }}
-            fill="rgba(168, 85, 247, 0.08)"
-            stroke="#a855f7"
-            strokeWidth="1.8"
-            filter="url(#glow-purple)"
-          />
+                return (
+                  <g key={`axis-${i}`}>
+                    {/* Axis line */}
+                    <line
+                      x1={cx}
+                      y1={cy}
+                      x2={outerCoord.x}
+                      y2={outerCoord.y}
+                      stroke="rgba(120, 120, 120, 0.16)"
+                      strokeWidth="1"
+                      strokeDasharray="2,2"
+                    />
 
-          {/* Dots on Vertices (User A) */}
-          {pointsDataA.map(
-            (p, i) =>
-              p.pct > 0 && (
-                <circle
-                  key={`dot-a-${i}`}
-                  cx={p.x}
-                  cy={p.y}
-                  r="3"
-                  fill="#06b6d4"
-                  className="drop-shadow-[0_0_4px_rgba(6,182,212,0.6)]"
-                />
-              )
-          )}
+                    {/* Axis label text */}
+                    <text
+                      x={labelX}
+                      y={labelY + 4}
+                      fill="rgba(161, 161, 170, 0.9)"
+                      fontSize="9"
+                      fontWeight="600"
+                      textAnchor={textAnchor}
+                      className="font-sans tracking-wide"
+                    >
+                      {lang}
+                    </text>
+                  </g>
+                );
+              })}
 
-          {/* Dots on Vertices (User B) */}
-          {pointsDataB.map(
-            (p, i) =>
-              p.pct > 0 && (
-                <circle
-                  key={`dot-b-${i}`}
-                  cx={p.x}
-                  cy={p.y}
-                  r="3"
-                  fill="#a855f7"
-                  className="drop-shadow-[0_0_4px_rgba(168,85,247,0.6)]"
-                />
-              )
-          )}
-        </svg>
-      </div>
+              {/* User A Area Polygon */}
+              <motion.polygon
+                initial={{ points: zeroPointsStr }}
+                animate={{ points: pointsStrA }}
+                transition={{ duration: 1.0, ease: [0.16, 1, 0.3, 1] }}
+                fill="rgba(6, 182, 212, 0.08)"
+                stroke="#06b6d4"
+                strokeWidth="1.8"
+                filter="url(#glow-cyan)"
+              />
 
-      {/* Language percentages side-by-side overview */}
-      <div className="w-full mt-4 grid grid-cols-2 gap-x-6 gap-y-1.5 border-t border-black/5 dark:border-white/5 pt-4 text-[10px]">
-        {combinedLanguages.slice(0, 4).map((lang) => {
-          const pctA = languagesA.find((l) => l.name === lang)?.percentage || 0;
-          const pctB = languagesB.find((l) => l.name === lang)?.percentage || 0;
+              {/* User B Area Polygon */}
+              <motion.polygon
+                initial={{ points: zeroPointsStr }}
+                animate={{ points: pointsStrB }}
+                transition={{ duration: 1.0, ease: [0.16, 1, 0.3, 1], delay: 0.15 }}
+                fill="rgba(168, 85, 247, 0.08)"
+                stroke="#a855f7"
+                strokeWidth="1.8"
+                filter="url(#glow-purple)"
+              />
 
-          return (
-            <div key={lang} className="flex justify-between items-center py-0.5">
-              <span className="text-[#A1A1AA] truncate font-medium max-w-[70px]">{lang}</span>
-              <div className="flex gap-3 font-mono font-bold">
-                <span className="text-cyan-500">{pctA}%</span>
-                <span className="text-zinc-600 dark:text-zinc-500">|</span>
-                <span className="text-purple-500">{pctB}%</span>
-              </div>
-            </div>
-          );
-        })}
-      </div>
+              {/* Dots on Vertices (User A) */}
+              {pointsDataA.map(
+                (p, i) =>
+                  p.pct > 0 && (
+                    <circle
+                      key={`dot-a-${i}`}
+                      cx={p.x}
+                      cy={p.y}
+                      r="3"
+                      fill="#06b6d4"
+                      className="drop-shadow-[0_0_4px_rgba(6,182,212,0.6)]"
+                    />
+                  )
+              )}
+
+              {/* Dots on Vertices (User B) */}
+              {pointsDataB.map(
+                (p, i) =>
+                  p.pct > 0 && (
+                    <circle
+                      key={`dot-b-${i}`}
+                      cx={p.x}
+                      cy={p.y}
+                      r="3"
+                      fill="#a855f7"
+                      className="drop-shadow-[0_0_4px_rgba(168,85,247,0.6)]"
+                    />
+                  )
+              )}
+            </svg>
+          </div>
+
+          {/* Language percentages side-by-side overview */}
+          <div className="w-full mt-4 grid grid-cols-2 gap-x-6 gap-y-1.5 border-t border-black/5 dark:border-white/5 pt-4 text-[10px]">
+            {combinedLanguages.slice(0, 4).map((lang) => {
+              const pctA = languagesA.find((l) => l.name === lang)?.percentage || 0;
+              const pctB = languagesB.find((l) => l.name === lang)?.percentage || 0;
+
+              return (
+                <div key={lang} className="flex justify-between items-center py-0.5">
+                  <span className="text-[#A1A1AA] truncate font-medium max-w-[70px]">{lang}</span>
+                  <div className="flex gap-3 font-mono font-bold">
+                    <span className="text-cyan-500">{pctA}%</span>
+                    <span className="text-zinc-600 dark:text-zinc-500">|</span>
+                    <span className="text-purple-500">{pctB}%</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      ) : (
+        <div className="flex flex-1 items-center justify-center py-12 text-center">
+          <p className="text-xs font-medium text-[#A1A1AA]">No language data to compare yet</p>
+        </div>
+      )}
     </motion.div>
   );
 }


### PR DESCRIPTION
## Description

Fixes #4752

The compare-view "Language Dominance" radar (`components/dashboard/RadarChart.tsx`) padded the combined language set with hardcoded `TypeScript`, `JavaScript`, and `Python` (or `Lang N`) whenever the two developers shared fewer than three distinct languages. Those languages are not used by either developer, so they rendered as fabricated axes pinned at 0%, showing language data that does not exist.

This change removes the padding and renders only the real combined language set (deduplicated, capped at six):

- 3 or more combined languages: the radar renders as before.
- 1 or 2 combined languages: only those real axes render (a degenerate but honest radar that reflects the actual data).
- 0 combined languages: an explicit empty state ("No language data to compare yet") is shown inside the same card, with the title and legend preserved and no chart drawn.

No language is ever invented.

Updated the RadarChart tests that previously asserted the padding behavior (empty-fallback, error-resilience empty case, the single-language cases, and the dedicated padding tests) to assert the new behavior: no fabricated TypeScript / JavaScript / Python axes, an empty state for no data, and a single real axis for a single language. Added assertions that no extra axes are invented. The null/undefined error-boundary tests are unchanged (the component still throws on corrupted input).

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

No new UI element. For users with fewer than three combined languages the radar no longer shows TypeScript / JavaScript / Python at 0%; with no language data it shows a short "No language data to compare yet" message instead of an invented radar.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (all 9 RadarChart test files pass, 51 tests; DashboardClient parent tests pass; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Dashboard component, not the badge SVG output.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
