### PR TITLE
fix(dashboard): aggregate ActivityLandscape downsampling by summing day buckets

### DIFF
--- a/components/dashboard/ActivityLandscape.massive-scaling.test.tsx
+++ b/components/dashboard/ActivityLandscape.massive-scaling.test.tsx
@@ -33,7 +33,12 @@ describe('ActivityLandscape – Massive Data Sets and Extreme High Bounds Scalin
       locDeletions: 999999,
     }));
     const result = getFilteredData(data, '1Y');
-    expect(result.every((d) => d.count === 999999)).toBe(true);
+
+    // Each bar sums a window of identical days, so counts stay finite positive multiples.
+    expect(result.every((d) => Number.isFinite(d.count) && d.count > 0)).toBe(true);
+    expect(result.every((d) => d.count % 999999 === 0)).toBe(true);
+    // No days are dropped: the bucketed total equals the full window total.
+    expect(result.reduce((sum, d) => sum + d.count, 0)).toBe(365 * 999999);
   });
 
   it('returns correct slice for 1W tab with large dataset', () => {

--- a/components/dashboard/ActivityLandscape.test.ts
+++ b/components/dashboard/ActivityLandscape.test.ts
@@ -27,12 +27,25 @@ describe('ActivityLandscape Filtering Logic', () => {
     expect(result[result.length - 1].count).toBe(39);
   });
 
-  it('filters 3M correctly (last 90 days, downsampled to <=60)', () => {
+  it('filters 3M correctly (last 90 days, aggregated to <=60)', () => {
     const data = generateData(100);
     const result = getFilteredData(data, '3M');
     expect(result.length).toBeLessThanOrEqual(60);
     expect(result.length).toBe(45);
-    expect(result[0].count).toBe(10);
+    // The last 90 days are counts 10..99 bucketed in pairs (step 2); the first bar sums 10 + 11.
+    expect(result[0].count).toBe(21);
+  });
+
+  it('aggregates buckets by summing days rather than dropping them', () => {
+    const data = generateData(100);
+    const recentTotal = data.slice(-90).reduce((sum, d) => sum + d.count, 0);
+    const result = getFilteredData(data, '3M');
+    const bucketedTotal = result.reduce((sum, d) => sum + d.count, 0);
+
+    // Bucketing preserves the full window total, unlike the old every-Nth-day sampling.
+    expect(bucketedTotal).toBe(recentTotal);
+    // A simple every-Nth-day sample of 45 of 90 days would total far less than the full window.
+    expect(bucketedTotal).toBeGreaterThan(recentTotal / 2);
   });
 
   it('filters 1Y correctly (last 365 days, downsampled to <=60)', () => {
@@ -40,6 +53,32 @@ describe('ActivityLandscape Filtering Logic', () => {
     const result = getFilteredData(data, '1Y');
     expect(result.length).toBeLessThanOrEqual(60);
     expect(result.length).toBe(53);
+  });
+
+  it('places the partial bucket at the oldest edge and keeps recent bars as full windows', () => {
+    const data = generateData(61); // counts 0..60; 3M -> step 2, remainder 1 -> 31 buckets
+    const result = getFilteredData(data, '3M');
+    expect(result.length).toBe(31);
+    // The leftover oldest day stays its own bar instead of being merged into a full window.
+    expect(result[0].count).toBe(0);
+    // The most recent bar sums the last two days (59 + 60).
+    expect(result[result.length - 1].count).toBe(59 + 60);
+  });
+
+  it('records each aggregated bucket span (startDate and days)', () => {
+    const data = generateData(61); // 3M -> step 2, remainder 1
+    const result = getFilteredData(data, '3M');
+    // The partial oldest bucket spans a single day.
+    expect(result[0].startDate).toBe('2024-01-01');
+    expect(result[0].days).toBe(1);
+    // The next bucket aggregates two days.
+    expect(result[1].startDate).toBe('2024-01-02');
+    expect(result[1].date).toBe('2024-01-03');
+    expect(result[1].days).toBe(2);
+
+    // Non-downsampled views keep raw single days without a span.
+    const small = getFilteredData(generateData(10), '1W');
+    expect(small[0].startDate).toBeUndefined();
   });
 
   it('applies downsampling when items exceed 60', () => {

--- a/components/dashboard/ActivityLandscape.test.tsx
+++ b/components/dashboard/ActivityLandscape.test.tsx
@@ -71,3 +71,10 @@ it('renders with empty data without crashing', () => {
 
   expect(screen.getByText('Activity Landscape')).toBeTruthy();
 });
+it('labels aggregated bars with a date range rather than a single day', () => {
+  // 100 days on the default 3M view downsample into 2-day buckets, so bars span a range.
+  render(<ActivityLandscape data={mockData} />);
+
+  const rangeBars = screen.getAllByLabelText(/contributions from .+ to .+/i);
+  expect(rangeBars.length).toBeGreaterThan(0);
+});

--- a/components/dashboard/ActivityLandscape.tsx
+++ b/components/dashboard/ActivityLandscape.tsx
@@ -4,11 +4,33 @@ import { useState, type SyntheticEvent } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import type { ActivityData } from '@/types/dashboard';
 import VisualizationTooltip from './VisualizationTooltip';
-import { formatTooltipDate, getActivityInsight, getContributionLabel } from './tooltipUtils';
+import {
+  formatTooltipDate,
+  formatTooltipRange,
+  getActivityInsight,
+  getContributionLabel,
+} from './tooltipUtils';
 
 const tabs = ['1W', '1M', '3M', '1Y'];
 
-export const getFilteredData = (data: ActivityData[], activeTab: string): ActivityData[] => {
+// One bar: a single day, or an aggregated bucket that also records its window span (startDate, days).
+export type ActivityBar = ActivityData & { startDate?: string; days?: number };
+
+// Sum a window of days into one bar; count and loc are window sums and the bar records the bucket's span.
+const aggregateBucket = (bucket: ActivityData[]): ActivityBar => {
+  const last = bucket[bucket.length - 1];
+  return {
+    date: last.date,
+    startDate: bucket[0].date,
+    days: bucket.length,
+    count: bucket.reduce((sum, d) => sum + d.count, 0),
+    intensity: Math.max(...bucket.map((d) => d.intensity)) as ActivityData['intensity'],
+    locAdditions: bucket.reduce((sum, d) => sum + (d.locAdditions || 0), 0),
+    locDeletions: bucket.reduce((sum, d) => sum + (d.locDeletions || 0), 0),
+  };
+};
+
+export const getFilteredData = (data: ActivityData[], activeTab: string): ActivityBar[] => {
   let days = 90;
   if (activeTab === '1W') days = 7;
   if (activeTab === '1M') days = 30;
@@ -16,10 +38,21 @@ export const getFilteredData = (data: ActivityData[], activeTab: string): Activi
 
   const recent = data.slice(-days);
 
-  // Downsample to max 60 bars to keep the visualization clean
+  // Aggregate into at most 60 bars, summing each window so no days are dropped.
   if (recent.length > 60) {
     const step = Math.ceil(recent.length / 60);
-    return recent.filter((_, i) => i % step === 0).slice(-60);
+    const remainder = recent.length % step;
+    const buckets: ActivityBar[] = [];
+
+    // Keep the partial bucket at the oldest edge so the most recent bars stay full windows.
+    if (remainder > 0) {
+      buckets.push(aggregateBucket(recent.slice(0, remainder)));
+    }
+    for (let i = remainder; i < recent.length; i += step) {
+      buckets.push(aggregateBucket(recent.slice(i, i + step)));
+    }
+
+    return buckets;
   }
 
   return recent;
@@ -46,18 +79,26 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
 
   const maxCount = Math.max(...displayData.map(getValue), 1);
 
-  const showTooltip = (e: SyntheticEvent<HTMLDivElement>, day: ActivityData, value: number) => {
+  const showTooltip = (e: SyntheticEvent<HTMLDivElement>, day: ActivityBar, value: number) => {
     const rect = e.currentTarget.getBoundingClientRect();
+    const isRange = !!day.startDate && day.startDate !== day.date;
 
     setTooltip({
-      title: formatTooltipDate(day.date),
+      title:
+        day.startDate && day.startDate !== day.date
+          ? formatTooltipRange(day.startDate, day.date)
+          : formatTooltipDate(day.date),
       metric: mode === 'loc' ? `${value} lines modified` : getContributionLabel(day.count),
       insight:
         mode === 'loc'
           ? value > 0
             ? 'Code activity recorded'
             : 'No code changes recorded'
-          : getActivityInsight(day.count, day.intensity),
+          : isRange
+            ? day.count === 0
+              ? 'No activity in this range'
+              : `Total across ${day.days} days`
+            : getActivityInsight(day.count, day.intensity),
       x: rect.left + rect.width / 2,
       y: rect.top - 10,
     });
@@ -148,7 +189,11 @@ export default function ActivityLandscape({ data }: { data: ActivityData[] }) {
                 className="group/bar relative flex h-full flex-1 cursor-pointer items-end outline-none"
                 aria-label={`${
                   mode === 'loc' ? `${val} lines modified` : getContributionLabel(day.count)
-                } on ${formatTooltipDate(day.date)}`}
+                } ${
+                  day.startDate && day.startDate !== day.date
+                    ? `from ${formatTooltipDate(day.startDate)} to ${formatTooltipDate(day.date)}`
+                    : `on ${formatTooltipDate(day.date)}`
+                }`}
                 tabIndex={0}
                 onMouseEnter={(e) => showTooltip(e, day, val)}
                 onFocus={(e) => showTooltip(e, day, val)}

--- a/components/dashboard/ActivityLandscape.type-compiler.test.tsx
+++ b/components/dashboard/ActivityLandscape.type-compiler.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expectTypeOf } from 'vitest';
 import type React from 'react';
 import type { ActivityData } from '@/types/dashboard';
-import ActivityLandscape, { getFilteredData } from './ActivityLandscape';
+import ActivityLandscape, { getFilteredData, type ActivityBar } from './ActivityLandscape';
 
 type ActivityLandscapeProps = React.ComponentProps<typeof ActivityLandscape>;
 
@@ -23,8 +23,8 @@ describe('ActivityLandscape Type Compiler Validation', () => {
     expectTypeOf<ActivityData['locDeletions']>().toEqualTypeOf<number | undefined>();
   });
 
-  it('getFilteredData returns ActivityData array', () => {
-    expectTypeOf<ReturnType<typeof getFilteredData>>().toEqualTypeOf<ActivityData[]>();
+  it('getFilteredData returns ActivityBar array (a day or an aggregated bucket span)', () => {
+    expectTypeOf<ReturnType<typeof getFilteredData>>().toEqualTypeOf<ActivityBar[]>();
   });
 
   it('exports ActivityLandscape as a React component type', () => {

--- a/components/dashboard/tooltipUtils.test.ts
+++ b/components/dashboard/tooltipUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { ActivityData } from '@/types/dashboard';
 import {
   formatTooltipDate,
+  formatTooltipRange,
   getActivityInsight,
   getContributionLabel,
   getLocalActiveStreak,
@@ -21,6 +22,10 @@ describe('tooltipUtils', () => {
 
   it('returns original value for invalid date strings', () => {
     expect(formatTooltipDate('invalid-date')).toBe('invalid-date');
+  });
+
+  it('formats a date range from a start and end date', () => {
+    expect(formatTooltipRange('2024-01-01', '2024-01-07')).toBe('Jan 1, 2024 - Jan 7, 2024');
   });
 
   it('returns activity insights based on count and intensity', () => {

--- a/components/dashboard/tooltipUtils.ts
+++ b/components/dashboard/tooltipUtils.ts
@@ -17,6 +17,10 @@ export function formatTooltipDate(date: string) {
   return tooltipDateFormatter.format(parsed);
 }
 
+export function formatTooltipRange(start: string, end: string) {
+  return `${formatTooltipDate(start)} - ${formatTooltipDate(end)}`;
+}
+
 export function getContributionLabel(count: number) {
   return `${count} contribution${count === 1 ? '' : 's'}`;
 }


### PR DESCRIPTION
## Description

Fixes #4759

`getFilteredData` in `components/dashboard/ActivityLandscape.tsx` downsampled the 3M and 1Y views with `recent.filter((_, i) => i % step === 0)`, which keeps only every Nth day and drops the rest (for 1Y the step is 7, so roughly six of every seven days were discarded). Each bar reflected one sampled day instead of the window it spans, biasing the relative bar heights for both commits and lines-of-code modes.

This change replaces the every-Nth-day sampling with bucket-and-sum aggregation:

- Days are grouped into buckets of `step = ceil(length / 60)`.
- Each bucket aggregates its window: `count`, `locAdditions`, and `locDeletions` are summed, `intensity` is the bucket maximum, and the bucket's date is its most recent day.
- When the window does not divide evenly, the partial bucket is placed at the oldest edge so the most recent bars stay full windows.

The number of bars is unchanged (`ceil(length / step)`, the same count the old sampling produced), so the views still cap at 60 bars; only the per-bar values now reflect the real totals over each window rather than a single sampled day. No days are dropped.

Because an aggregated bar now sums several days, each bucket also records its span (`startDate`, `days`) and the bar is presented as a date range rather than a single day: the tooltip title shows "start - end", the bar aria-label reads "N contributions from start to end", and the tooltip insight shows "Total across N days" instead of a single-day label. Single-day bars (the 1W and 1M views, and any window of 60 or fewer days) are unchanged.

Updated the affected tests to assert the new behavior: the 3M first-bar value now reflects the summed bucket, a new test asserts the bucketed total equals the full-window total (conservation), and the extreme-count scaling test asserts finite summed values plus total conservation instead of per-day equality. The length tests (3M, 1Y, 60, 61) are unchanged because the bucket count matches the previous output length.

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

No new UI element. On the 3M and 1Y ranges, each bar now represents the summed activity of its window, so bar heights reflect the real per-period totals instead of a single sampled day.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (all 11 ActivityLandscape test files pass, 62 tests; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Dashboard component, not the badge SVG output.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
