### PR TITLE
fix(a11y): make star ratings visible to screen readers

### DIFF
--- a/app/compare/CompareClient.accessibility.test.tsx
+++ b/app/compare/CompareClient.accessibility.test.tsx
@@ -20,8 +20,25 @@ vi.mock('framer-motion', () => ({
     {},
     {
       get: (_, tag) => {
-        return ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) =>
-          React.createElement(tag as string, props, children);
+        return ({
+          children,
+          animate,
+          initial,
+          exit,
+          transition,
+          variants,
+          whileHover,
+          whileTap,
+          whileFocus,
+          whileDrag,
+          whileInView,
+          layout,
+          layoutId,
+          ...props
+        }: {
+          children?: ReactNode;
+          [key: string]: unknown;
+        }) => React.createElement(tag as string, props, children);
       },
     }
   ),

--- a/app/compare/CompareClient.empty-fallback.test.tsx
+++ b/app/compare/CompareClient.empty-fallback.test.tsx
@@ -23,6 +23,8 @@ vi.mock('framer-motion', () => ({
       delete props.whileInView;
       delete props.whileHover;
       delete props.whileTap;
+      delete props.whileHover;
+      delete props.whileInView;
       delete props.viewport;
       delete props.transition;
       return <div className={className}>{children}</div>;
@@ -32,6 +34,8 @@ vi.mock('framer-motion', () => ({
       delete props.animate;
       delete props.whileHover;
       delete props.whileTap;
+      delete props.whileHover;
+      delete props.whileInView;
       delete props.transition;
       return (
         <button className={className} onClick={onClick} disabled={disabled}>

--- a/app/compare/CompareClient.mouse-interactivity.test.tsx
+++ b/app/compare/CompareClient.mouse-interactivity.test.tsx
@@ -20,8 +20,25 @@ vi.mock('framer-motion', () => ({
     {},
     {
       get: (_, tag) => {
-        return ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) =>
-          React.createElement(tag as string, props, children);
+        return ({
+          children,
+          animate,
+          initial,
+          exit,
+          transition,
+          variants,
+          whileHover,
+          whileTap,
+          whileFocus,
+          whileDrag,
+          whileInView,
+          layout,
+          layoutId,
+          ...props
+        }: {
+          children?: ReactNode;
+          [key: string]: unknown;
+        }) => React.createElement(tag as string, props, children);
       },
     }
   ),

--- a/app/compare/CompareClient.responsive-breakpoints.test.tsx
+++ b/app/compare/CompareClient.responsive-breakpoints.test.tsx
@@ -17,8 +17,25 @@ vi.mock('framer-motion', () => ({
     {},
     {
       get: (_, tag) => {
-        return ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) =>
-          React.createElement(tag as string, props, children);
+        return ({
+          children,
+          animate,
+          initial,
+          exit,
+          transition,
+          variants,
+          whileHover,
+          whileTap,
+          whileFocus,
+          whileDrag,
+          whileInView,
+          layout,
+          layoutId,
+          ...props
+        }: {
+          children?: ReactNode;
+          [key: string]: unknown;
+        }) => React.createElement(tag as string, props, children);
       },
     }
   ),

--- a/app/compare/CompareClient.test.tsx
+++ b/app/compare/CompareClient.test.tsx
@@ -20,8 +20,25 @@ vi.mock('framer-motion', () => ({
     {},
     {
       get: (_, tag) => {
-        return ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) =>
-          React.createElement(tag as string, props, children);
+        return ({
+          children,
+          animate,
+          initial,
+          exit,
+          transition,
+          variants,
+          whileHover,
+          whileTap,
+          whileFocus,
+          whileDrag,
+          whileInView,
+          layout,
+          layoutId,
+          ...props
+        }: {
+          children?: ReactNode;
+          [key: string]: unknown;
+        }) => React.createElement(tag as string, props, children);
       },
     }
   ),

--- a/app/compare/CompareClient.theme-contrast.test.tsx
+++ b/app/compare/CompareClient.theme-contrast.test.tsx
@@ -19,8 +19,25 @@ vi.mock('framer-motion', () => ({
     {},
     {
       get: (_, tag) => {
-        return ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) =>
-          React.createElement(tag as string, props, children);
+        return ({
+          children,
+          animate,
+          initial,
+          exit,
+          transition,
+          variants,
+          whileHover,
+          whileTap,
+          whileFocus,
+          whileDrag,
+          whileInView,
+          layout,
+          layoutId,
+          ...props
+        }: {
+          children?: ReactNode;
+          [key: string]: unknown;
+        }) => React.createElement(tag as string, props, children);
       },
     }
   ),

--- a/app/compare/page.mouse-interactivity.test.tsx
+++ b/app/compare/page.mouse-interactivity.test.tsx
@@ -20,8 +20,25 @@ vi.mock('framer-motion', () => ({
     {},
     {
       get: (_, tag) => {
-        return ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) =>
-          React.createElement(tag as string, props, children);
+        return ({
+          children,
+          animate,
+          initial,
+          exit,
+          transition,
+          variants,
+          whileHover,
+          whileTap,
+          whileFocus,
+          whileDrag,
+          whileInView,
+          layout,
+          layoutId,
+          ...props
+        }: {
+          children?: ReactNode;
+          [key: string]: unknown;
+        }) => React.createElement(tag as string, props, children);
       },
     }
   ),

--- a/app/compare/page.theme-contrast.test.tsx
+++ b/app/compare/page.theme-contrast.test.tsx
@@ -18,8 +18,25 @@ vi.mock('framer-motion', () => ({
     {},
     {
       get: (_, tag) => {
-        return ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) =>
-          React.createElement(tag as string, props, children);
+        return ({
+          children,
+          animate,
+          initial,
+          exit,
+          transition,
+          variants,
+          whileHover,
+          whileTap,
+          whileFocus,
+          whileDrag,
+          whileInView,
+          layout,
+          layoutId,
+          ...props
+        }: {
+          children?: ReactNode;
+          [key: string]: unknown;
+        }) => React.createElement(tag as string, props, children);
       },
     }
   ),

--- a/components/WallOfLove.accessibility.test.tsx
+++ b/components/WallOfLove.accessibility.test.tsx
@@ -45,7 +45,8 @@ describe('WallOfLove accessibility', () => {
     expect(images.length).toBeGreaterThan(0);
 
     images.forEach((image) => {
-      expect(image.getAttribute('alt')).toBeTruthy();
+      const alt = image.getAttribute('alt') || image.getAttribute('aria-label');
+      expect(alt).toBeTruthy();
     });
   });
 

--- a/components/WallOfLove.massive-scaling.test.tsx
+++ b/components/WallOfLove.massive-scaling.test.tsx
@@ -204,7 +204,7 @@ describe('WallOfLove — Massive Scaling', () => {
     // 6 cards in Row1 × 2 (duplicate) = 12 images
     // 6 cards in Row2 × 2 (duplicate) = 12 images
     // Total = 24
-    const avatars = screen.getAllByRole('img');
+    const avatars = screen.getAllByRole('img').filter((el) => el.tagName.toLowerCase() === 'img');
     expect(avatars.length).toBe(24);
 
     // Every image must have a non-empty src (no broken blank images)

--- a/components/WallOfLove.tsx
+++ b/components/WallOfLove.tsx
@@ -160,10 +160,11 @@ function GitHubIcon() {
 /* ─── Star Rating ─── */
 function StarRating() {
   return (
-    <div className="flex gap-0.5">
+    <div className="flex gap-0.5" role="img" aria-label="5 out of 5 stars">
       {[...Array(5)].map((_, i) => (
         <svg
           key={i}
+          aria-hidden="true"
           width="12"
           height="12"
           viewBox="0 0 24 24"

--- a/components/dashboard/Achievements.responsive-breakpoints.test.tsx
+++ b/components/dashboard/Achievements.responsive-breakpoints.test.tsx
@@ -21,6 +21,8 @@ vi.mock('framer-motion', () => ({
       delete safeProps.transition;
       delete safeProps.whileHover;
       delete safeProps.whileTap;
+      delete safeProps.whileHover;
+      delete safeProps.whileInView;
       return (
         <div className={className} {...safeProps}>
           {children}

--- a/components/dashboard/CommitClock.timezone-boundaries.test.tsx
+++ b/components/dashboard/CommitClock.timezone-boundaries.test.tsx
@@ -34,17 +34,33 @@ interface MotionGProps extends React.SVGProps<SVGGElement> {
 vi.mock('framer-motion', () => {
   const motion = {
     div: React.forwardRef<HTMLDivElement, MotionDivProps>(
-      ({ children, className, style, ...rest }, ref) => (
+      (
+        {
+          children,
+          className,
+          style,
+          initial,
+          animate,
+          whileInView,
+          viewport,
+          transition,
+          whileHover,
+          ...rest
+        },
+        ref
+      ) => (
         <div ref={ref} className={className} style={style} {...rest}>
           {children}
         </div>
       )
     ),
-    g: React.forwardRef<SVGGElement, MotionGProps>(({ children, className, ...rest }, ref) => (
-      <g ref={ref} className={className} {...rest}>
-        {children}
-      </g>
-    )),
+    g: React.forwardRef<SVGGElement, MotionGProps>(
+      ({ children, className, initial, animate, transition, ...rest }, ref) => (
+        <g ref={ref} className={className} {...rest}>
+          {children}
+        </g>
+      )
+    ),
   };
 
   motion.div.displayName = 'motion.div';

--- a/components/dashboard/ComparisonStatsCard.test.tsx
+++ b/components/dashboard/ComparisonStatsCard.test.tsx
@@ -21,7 +21,18 @@ import ComparisonStatsCard from './ComparisonStatsCard';
 // Strips motion-specific props so they don't leak into the DOM.
 vi.mock('framer-motion', () => ({
   motion: {
-    div: ({ children, className, style, ...rest }: any) => (
+    div: ({
+      children,
+      className,
+      style,
+      whileInView,
+      whileHover,
+      whileTap,
+      initial,
+      animate,
+      transition,
+      ...rest
+    }: any) => (
       <div className={className} style={style} {...rest}>
         {children}
       </div>

--- a/components/dashboard/ProfileCard.timezone-boundaries.test.tsx
+++ b/components/dashboard/ProfileCard.timezone-boundaries.test.tsx
@@ -10,6 +10,7 @@ interface MockMotionProps {
   transition?: unknown;
   whileHover?: unknown;
   whileTap?: unknown;
+  whileInView?: unknown;
 }
 
 type SafeDivProps = React.ComponentPropsWithoutRef<'div'> & MockMotionProps;

--- a/components/dashboard/ProfileCard.timezone-boundaries.test.tsx
+++ b/components/dashboard/ProfileCard.timezone-boundaries.test.tsx
@@ -24,6 +24,8 @@ vi.mock('framer-motion', () => {
       delete domProps.transition;
       delete domProps.whileHover;
       delete domProps.whileTap;
+      delete domProps.whileHover;
+      delete domProps.whileInView;
       return (
         <div ref={ref} {...domProps}>
           {children}
@@ -41,6 +43,8 @@ vi.mock('framer-motion', () => {
       delete domProps.transition;
       delete domProps.whileHover;
       delete domProps.whileTap;
+      delete domProps.whileHover;
+      delete domProps.whileInView;
       return (
         <button ref={ref} {...domProps}>
           {children}


### PR DESCRIPTION
## Description
Fixes #4175 

The `StarRating` component in WallOfLove rendered 5 SVG stars without any ARIA attributes or semantic roles, making the rating completely invisible to screen readers. Visually impaired users had no way to know the testimonial rating.

### Changes made

Added proper ARIA attributes to make the star rating accessible:

**Before:**
```tsx
<div className="flex gap-0.5">
  {[...Array(5)].map((_, i) => (
    <svg key={i} ...>
      <path ... />
    </svg>
  ))}
</div>
```

**After:**
```tsx
<div className="flex gap-0.5" role="img" aria-label="5 out of 5 stars">
  {[...Array(5)].map((_, i) => (
    <svg key={i} aria-hidden="true" ...>
      <path ... />
    </svg>
  ))}
</div>
```

### How it works

- **`role="img"`** on the container — Marks the entire rating as a meaningful image/icon
- **`aria-label="5 out of 5 stars"`** — Provides the text alternative that screen readers announce
- **`aria-hidden="true"` on individual SVGs** — Prevents each star from being announced separately, reducing noise

### User experience

- **Screen reader users** → Hear "5 out of 5 stars" when encountering the rating ✅
- **Sighted users** → See the visual 5-star display unchanged ✅
- **Keyboard users** → Unaffected ✅

### WCAG Compliance

Resolves:
- **SC 1.1.1 (Non-text Content):** Star rating now has a text alternative
- **SC 4.1.2 (Name, Role, Value):** Container role and label are properly semantically marked

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — accessibility improvement only, visual display unchanged.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.