### PR TITLE
fix(streak): trust the sanitized speed so in-range decimals are preserved

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -481,11 +481,10 @@ describe('GET /api/streak', () => {
       expect(body).toContain('20s');
     });
 
-    it('falls back to 8s when speed is a non-integer decimal like "2.0s"', async () => {
-      const response = await GET(makeRequest({ user: 'octocat', speed: '2.0s' }));
+    it('preserves an in-range decimal speed like "8.5s" instead of forcing it to an integer', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', speed: '8.5s' }));
       const body = await response.text();
-      expect(body).toContain('8s');
-      expect(body).not.toContain('2.0s');
+      expect(body).toContain('8.5s');
     });
   });
 

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -202,7 +202,7 @@ export async function GET(request: Request) {
       accent: isAutoTheme ? selectedTheme.accent : accent || selectedTheme.accent,
       border: sanitizedBorder,
       radius,
-      speed: speed && /^(?:[2-9]|1\d|20)s$/.test(speed) ? speed : '8s',
+      speed,
       scale,
       font,
       autoTheme: isAutoTheme,


### PR DESCRIPTION
## Description

Fixes #4775

The `/api/streak` route validated the `speed` parameter twice. `streakParamsSchema` already sanitizes it through `sanitizeSpeed`, which accepts `\d+(\.\d+)?s` in the 2s to 20s range, so `?speed=8.5s` produces the valid value `8.5s`. The route then re-checked that value while building `BadgeParams` with an integer-only regex `/^(?:[2-9]|1\d|20)s$/`, which does not match decimals, so a valid `8.5s` was discarded and reset to `8s`.

This change trusts the value already sanitized by the schema and assigns `speed` directly. `SpeedString` is `` `${number}s` `` and `sanitizeSpeed` guarantees a value in range (or the `8s` default), so the result is still a safe CSS duration with no second validation needed.

Updated the test that asserted the old behavior (a decimal was forced to `8s`) to instead assert that an in-range decimal like `8.5s` is preserved. The existing fallback tests (invalid format, missing unit, below or above bounds, and decimals below the minimum) are unchanged and still pass, because `sanitizeSpeed` already rejects those.

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

No new UI. A badge requested with an in-range decimal speed (for example `?speed=8.5s`) now animates at that speed instead of being reset to `8s`.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (all `app/api/streak/route.test.ts` tests pass, 182 tests; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Server-side parameter fix, no SVG layout change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
