### PR TITLE
test(dashboard): match empty-fallback streak assertion to the three-way label

### DIFF
--- a/components/dashboard/HistoricalTrendView.empty-fallback.test.tsx
+++ b/components/dashboard/HistoricalTrendView.empty-fallback.test.tsx
@@ -108,7 +108,8 @@ describe('HistoricalTrendView - Empty & Missing Input Fallbacks', () => {
 
     expect(screen.getByText('Contributions')).toBeInTheDocument();
     expect(screen.getByText('Active Days')).toBeInTheDocument();
-    expect(screen.getByText('Current Streak')).toBeInTheDocument();
+    // The streak card label is Current/Ending/Upcoming depending on where the window sits vs today.
+    expect(screen.getByText(/(Current|Ending|Upcoming) Streak/)).toBeInTheDocument();
     expect(screen.getByText('Longest Streak')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Description

Fixes #4837

`HistoricalTrendView.empty-fallback.test.tsx` ("maintains the standard empty layout styling and structure") asserted `getByText('Current Streak')`. The streak stat-card label is context-aware (`Current Streak` when the window includes today, `Ending Streak` for a past window, `Upcoming Streak` for a future window), and the test's `emptyPeriod` is January 2026. Once that window is in the past relative to the current date, the card renders `Ending Streak`, so the fixed-string assertion fails.

This change makes that one assertion label-agnostic, matching whichever of the three labels applies: `getByText(/(Current|Ending|Upcoming) Streak/)`. The test still verifies the streak stat card renders as part of the empty layout, and it no longer depends on the run date. No other assertions change.

## Pillar

- [ ] Pillar 1: New Theme Design
- [ ] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

Not applicable. Test-only change.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (all `HistoricalTrendView` test files pass; the previously failing empty-fallback case now passes).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Test-only change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
