### PR TITLE
fix: use github API endpoint for OG image stats

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -14,20 +14,22 @@ export async function GET(req: NextRequest) {
   try {
     const baseUrl = req.nextUrl.origin;
 
-    const res = await fetch(`${baseUrl}/api/streak?user=${user}&refresh=true`, {
+    const res = await fetch(`${baseUrl}/api/github?username=${user}&refresh=true`, {
       cache: 'no-store',
     });
 
     if (res.ok) {
       const data = (await res.json()) as {
-        totalContributions?: number;
-        longestStreak?: number;
-        currentStreak?: number;
+        stats?: {
+          totalContributions?: number;
+          peakStreak?: number;
+          currentStreak?: number;
+        };
       };
 
-      totalCommits = data.totalContributions ?? 0;
-      longestStreak = data.longestStreak ?? 0;
-      currentStreak = data.currentStreak ?? 0;
+      totalCommits = data.stats?.totalContributions ?? 0;
+      longestStreak = data.stats?.peakStreak ?? 0;
+      currentStreak = data.stats?.currentStreak ?? 0;
     }
   } catch {
     // fallback


### PR DESCRIPTION
## Description

Fixes #4881

The Open Graph image route (`app/api/og/route.tsx`) was fetching data from `/api/streak` and attempting to parse the response using `res.json()`.

Since `/api/streak` returns SVG content (`image/svg+xml`) rather than JSON, this creates a response contract mismatch and prevents the OG route from retrieving actual statistics.

This PR updates the route to fetch data from `/api/github`, which returns structured JSON containing the required statistics (`totalContributions`, `peakStreak`, and `currentStreak`) used by the Open Graph image generator.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A – backend/API fix. No visual changes introduced.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable for this API fix).
* [x ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

## Suggested Labels:
gssoc:approved , gssoc'26 , enhancement , type:fix , level:beginner 