### PR TITLE
fix(github): warn users when repo list is truncated at 300

### DIFF
--- a/app/(root)/dashboard/[username]/page.test.tsx
+++ b/app/(root)/dashboard/[username]/page.test.tsx
@@ -112,6 +112,8 @@ describe('DashboardPage', () => {
     popularRepos: [],
     pinnedRepos: [],
     hallOfFame: [],
+    reposTruncated: false,
+    reposTotalFetched: 0,
   };
 
   beforeEach(() => {

--- a/components/dashboard/DashboardClient.tsx
+++ b/components/dashboard/DashboardClient.tsx
@@ -81,6 +81,8 @@ export interface DashboardData {
   popularRepos?: Repository[];
   pinnedRepos?: Repository[];
   hallOfFame?: HallOfFameAward[];
+  reposTruncated?: boolean;
+  reposTotalFetched?: number;
 }
 
 interface DashboardClientProps {
@@ -660,6 +662,17 @@ export default function DashboardClient({
           </button>
         </div>
       </div>
+
+      {initialData.reposTruncated && (
+        <div
+          role="alert"
+          aria-live="polite"
+          className="mb-4 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-200"
+        >
+          Showing data for {initialData.reposTotalFetched ?? 300} of your repositories. Some stats
+          may be incomplete.
+        </div>
+      )}
 
       {activeTab === 'pr-insights' ? (
         <PRInsightsClient username={username} />

--- a/lib/github.pagination-truncation.test.ts
+++ b/lib/github.pagination-truncation.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Pagination Truncation Tests
+ *
+ * Task 1 — Bug condition exploration: confirm the bug exists on unfixed code, then verify the fix.
+ * Task 2 — Preservation property tests: confirm non-truncated users are unaffected.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fetchUserRepos, clearGitHubApiCacheForTests } from './github';
+
+vi.mock('server-only', () => ({}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRepos(count: number, offset = 0) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: offset + i,
+    name: `repo-${offset + i}`,
+    full_name: `user/repo-${offset + i}`,
+    description: null,
+    stargazers_count: 0,
+    forks_count: 0,
+    language: null,
+    updated_at: '2024-01-01T00:00:00Z',
+    created_at: '2020-01-01T00:00:00Z',
+    fork: false,
+    private: false,
+    owner: { login: 'user' },
+  }));
+}
+
+function mockResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  clearGitHubApiCacheForTests();
+  process.env.GITHUB_PAT = 'test-token';
+  vi.spyOn(global, 'fetch');
+});
+
+afterEach(() => {
+  clearGitHubApiCacheForTests();
+  vi.restoreAllMocks();
+  delete process.env.GITHUB_PAT;
+});
+
+// ---------------------------------------------------------------------------
+// Task 1 — Bug condition: user with > 300 repos (3 full pages)
+// ---------------------------------------------------------------------------
+
+describe('Bug condition: fetchUserRepos for user with > 300 repos', () => {
+  it('returns isTruncated: true and totalFetched: 300 when all 3 pages are full', async () => {
+    // Simulate a user with 450+ repos — all three pages return 100 items each
+    const page1 = makeRepos(100, 0);
+    const page2 = makeRepos(100, 100);
+    const page3 = makeRepos(100, 200);
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockResponse(page1)) // page 1
+      .mockResolvedValueOnce(mockResponse(page2)) // page 2
+      .mockResolvedValueOnce(mockResponse(page3)); // page 3
+
+    const result = await fetchUserRepos('heavy-user', { bypassCache: true });
+
+    // The fix: result must be FetchedRepos, not a plain array
+    expect(result).toHaveProperty('repos');
+    expect(result).toHaveProperty('isTruncated');
+    expect(result).toHaveProperty('totalFetched');
+
+    expect(result.isTruncated).toBe(true);
+    expect(result.totalFetched).toBe(300);
+    expect(result.repos).toHaveLength(300);
+  });
+
+  it('includes truncation metadata in cache so a cache-hit path also surfaces the warning', async () => {
+    const page1 = makeRepos(100, 0);
+    const page2 = makeRepos(100, 100);
+    const page3 = makeRepos(100, 200);
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockResponse(page1))
+      .mockResolvedValueOnce(mockResponse(page2))
+      .mockResolvedValueOnce(mockResponse(page3));
+
+    // First call — populates cache
+    await fetchUserRepos('cache-heavy-user');
+
+    // Second call — should hit cache; fetch should NOT be called again
+    const cached = await fetchUserRepos('cache-heavy-user');
+
+    expect(fetch).toHaveBeenCalledTimes(3); // only the initial 3 pages, no re-fetch
+    expect(cached.isTruncated).toBe(true);
+    expect(cached.totalFetched).toBe(300);
+    expect(cached.repos).toHaveLength(300);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Task 2 — Preservation: users with ≤ 299 repos must not be affected
+// ---------------------------------------------------------------------------
+
+describe('Preservation: fetchUserRepos for users with ≤ 299 repos', () => {
+  it('single page (< 100 repos) — isTruncated: false, correct repo count', async () => {
+    const page1 = makeRepos(50);
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse(page1));
+
+    const result = await fetchUserRepos('small-user', { bypassCache: true });
+
+    expect(result.isTruncated).toBe(false);
+    expect(result.totalFetched).toBe(50);
+    expect(result.repos).toHaveLength(50);
+  });
+
+  it('two full pages + partial third (175 repos) — isTruncated: false', async () => {
+    const page1 = makeRepos(100, 0);
+    const page2 = makeRepos(75, 100);
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockResponse(page1))
+      .mockResolvedValueOnce(mockResponse(page2))
+      .mockResolvedValueOnce(mockResponse([])); // page 3 empty
+
+    const result = await fetchUserRepos('medium-user', { bypassCache: true });
+
+    expect(result.isTruncated).toBe(false);
+    expect(result.totalFetched).toBe(175);
+    expect(result.repos).toHaveLength(175);
+  });
+
+  it('exactly 200 repos (2 full pages, page 3 empty) — isTruncated: false', async () => {
+    const page1 = makeRepos(100, 0);
+    const page2 = makeRepos(100, 100);
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockResponse(page1))
+      .mockResolvedValueOnce(mockResponse(page2))
+      .mockResolvedValueOnce(mockResponse([])); // page 3 empty
+
+    const result = await fetchUserRepos('user-200', { bypassCache: true });
+
+    expect(result.isTruncated).toBe(false);
+    expect(result.totalFetched).toBe(200);
+    expect(result.repos).toHaveLength(200);
+  });
+
+  it('exactly 299 repos (page 3 returns 99) — isTruncated: false', async () => {
+    const page1 = makeRepos(100, 0);
+    const page2 = makeRepos(100, 100);
+    const page3 = makeRepos(99, 200);
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockResponse(page1))
+      .mockResolvedValueOnce(mockResponse(page2))
+      .mockResolvedValueOnce(mockResponse(page3));
+
+    const result = await fetchUserRepos('user-299', { bypassCache: true });
+
+    expect(result.isTruncated).toBe(false);
+    expect(result.totalFetched).toBe(299);
+    expect(result.repos).toHaveLength(299);
+  });
+
+  it('property: for all repo counts 1–99, isTruncated is always false', async () => {
+    // Simulate various single-page user sizes — no truncation ever
+    const counts = [1, 5, 10, 50, 75, 99];
+    for (const count of counts) {
+      clearGitHubApiCacheForTests();
+      vi.mocked(fetch).mockResolvedValueOnce(mockResponse(makeRepos(count)));
+
+      const result = await fetchUserRepos(`user-${count}`, { bypassCache: true });
+
+      expect(result.isTruncated).toBe(false);
+      expect(result.repos).toHaveLength(count);
+    }
+  });
+
+  it('property: for multi-page counts with partial last page, isTruncated is always false', async () => {
+    // (page1=100, page2=partial) — last page is partial so never truncated
+    const partialSizes = [1, 25, 50, 75, 99];
+    for (const partial of partialSizes) {
+      clearGitHubApiCacheForTests();
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(mockResponse(makeRepos(100, 0)))
+        .mockResolvedValueOnce(mockResponse(makeRepos(partial, 100)))
+        .mockResolvedValueOnce(mockResponse([]));
+
+      const result = await fetchUserRepos(`multi-user-${partial}`, { bypassCache: true });
+
+      expect(result.isTruncated).toBe(false);
+      expect(result.repos).toHaveLength(100 + partial);
+    }
+  });
+
+  it('cache round-trip for non-truncated user preserves isTruncated: false', async () => {
+    const page1 = makeRepos(50);
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse(page1));
+
+    // Populate cache
+    await fetchUserRepos('cache-small-user');
+
+    // Cache hit
+    const cached = await fetchUserRepos('cache-small-user');
+
+    expect(fetch).toHaveBeenCalledTimes(1); // no re-fetch
+    expect(cached.isTruncated).toBe(false);
+    expect(cached.repos).toHaveLength(50);
+  });
+
+  it('bypassCache semantics are unaffected — re-fetches and returns correct FetchedRepos shape', async () => {
+    const page1 = makeRepos(60);
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockResponse(page1))
+      .mockResolvedValueOnce(mockResponse(page1)); // second call with bypassCache
+
+    await fetchUserRepos('bypass-user');
+    const result = await fetchUserRepos('bypass-user', { bypassCache: true });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(result.isTruncated).toBe(false);
+    expect(result.repos).toHaveLength(60);
+  });
+});

--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -669,7 +669,7 @@ describe('fetchUserRepos', () => {
       mockResponse([{ stargazers_count: 1, language: 'TypeScript' }])
     );
     const result = await fetchUserRepos('octocat');
-    expect(result[0].stargazers_count).toBe(1);
+    expect(result.repos[0].stargazers_count).toBe(1);
   });
 
   it('sanitizes repo objects by removing extra fields before returning', async () => {
@@ -686,7 +686,7 @@ describe('fetchUserRepos', () => {
       ])
     );
 
-    const result = (await fetchUserRepos('octocat')) as unknown as Record<string, unknown>[];
+    const result = (await fetchUserRepos('octocat')).repos as unknown as Record<string, unknown>[];
 
     expect(result[0].stargazers_count).toBe(10);
     expect(result[0].language).toBe('TypeScript');
@@ -706,14 +706,14 @@ describe('fetchUserRepos', () => {
 
     const result = await fetchUserRepos('octocat', { bypassCache: true });
 
-    expect(result).toHaveLength(3);
-    result.forEach((repo, index) => {
+    expect(result.repos).toHaveLength(3);
+    result.repos.forEach((repo, index) => {
       expect(repo).toHaveProperty('stargazers_count');
       expect(repo).toHaveProperty('language');
       expect(repo.stargazers_count).toBe(mockedRepos[index].stargazers_count);
       expect(repo.language).toBe(mockedRepos[index].language);
     });
-    expect(result).toEqual(mockedRepos);
+    expect(result.repos).toEqual(mockedRepos);
   });
 
   it('encodes the username before using it in the REST repos path', async () => {
@@ -761,7 +761,7 @@ describe('fetchUserRepos', () => {
     const result = await fetchUserRepos('octocat', { bypassCache: true });
 
     expect(fetch).toHaveBeenCalledTimes(3);
-    expect(result.length).toBe(101);
+    expect(result.repos.length).toBe(101);
   });
 
   it('stops fetching after reaching max pages', async () => {
@@ -819,7 +819,7 @@ describe('fetchUserRepos', () => {
     const result = await fetchUserRepos('octocat', { bypassCache: true });
 
     expect(fetch).toHaveBeenCalledTimes(3);
-    expect(result.length).toBe(201);
+    expect(result.repos.length).toBe(201);
   });
 });
 
@@ -1821,7 +1821,7 @@ describe('GitHub API cache behavior', () => {
     resolveFetch(mockResponse([{ stargazers_count: 7, language: 'TypeScript' }]));
 
     const results = await requests;
-    expect(results.map((repos) => repos[0]?.stargazers_count)).toEqual([7, 7, 7]);
+    expect(results.map((r) => r.repos[0]?.stargazers_count)).toEqual([7, 7, 7]);
   });
 
   it('normalizes username casing for cache keys', async () => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -403,7 +403,13 @@ export const GITHUB_CACHE_TTL_MS = 5 * 60 * 1000;
 
 export const contributionsCache = new DistributedCache<ExtendedContributionData>(1000);
 const profileCache = new DistributedCache<GitHubUserProfile>(1000);
-const reposCache = new DistributedCache<GitHubRepo[]>(500);
+export interface FetchedRepos {
+  repos: GitHubRepo[];
+  isTruncated: boolean;
+  totalFetched: number;
+}
+
+const reposCache = new DistributedCache<FetchedRepos>(500);
 const contributedReposCache = new DistributedCache<ContributedRepo[]>(500);
 
 interface GitHubUserProfile {
@@ -797,7 +803,7 @@ async function fetchProfileUncached(
 export async function fetchUserRepos(
   username: string,
   options: FetchOptions = {}
-): Promise<GitHubRepo[]> {
+): Promise<FetchedRepos> {
   const key = cacheKey('repos', username);
   const encodedUsername = encodeURIComponent(username);
 
@@ -813,7 +819,7 @@ async function fetchReposUncached(
   encodedUsername: string,
   key: string,
   options: FetchOptions
-): Promise<GitHubRepo[]> {
+): Promise<FetchedRepos> {
   const firstPageRes = await fetchWithRetry(
     `${GITHUB_REST_URL}/users/${encodedUsername}/repos?per_page=100&page=1&sort=pushed`,
     {
@@ -864,10 +870,23 @@ async function fetchReposUncached(
     for (const repos of pagesRepos) {
       allRepos.push(...repos);
     }
+
+    // Detect truncation: if the last fetched page is full (100 items), there may be more
+    // repos beyond the MAX_PAGES cap that we didn't fetch.
+    const lastPage = pagesRepos[pagesRepos.length - 1];
+    const isTruncated = lastPage !== undefined && lastPage.length === 100;
+    const result: FetchedRepos = { repos: allRepos, isTruncated, totalFetched: allRepos.length };
+    if (!options.bypassCache) await reposCache.set(key, result, GITHUB_CACHE_TTL_MS);
+    return result;
   }
 
-  if (!options.bypassCache) await reposCache.set(key, allRepos, GITHUB_CACHE_TTL_MS);
-  return allRepos;
+  const result: FetchedRepos = {
+    repos: allRepos,
+    isTruncated: false,
+    totalFetched: allRepos.length,
+  };
+  if (!options.bypassCache) await reposCache.set(key, result, GITHUB_CACHE_TTL_MS);
+  return result;
 }
 
 /* ==========================================================================
@@ -933,7 +952,7 @@ export async function getOrgDashboardData(
   orgName: string,
   options: FetchOptions = {}
 ): Promise<OrgDashboardData> {
-  const [profileData, reposData, membersOrError] = await Promise.all([
+  const [profileData, reposFetchedOrg, membersOrError] = await Promise.all([
     fetchUserProfile(orgName, options),
     fetchUserRepos(orgName, options),
     fetchOrgMembers(orgName).catch((err) => err as Error),
@@ -979,6 +998,7 @@ export async function getOrgDashboardData(
   // Create the Mega-City
   const aggregatedCalendar = aggregateCalendars(calendars);
   const streakStats = calculateStreak(aggregatedCalendar);
+  const reposData = reposFetchedOrg.repos;
   const totalStars = reposData.reduce((acc, r) => acc + r.stargazers_count, 0);
 
   const profile = {
@@ -1438,7 +1458,11 @@ export async function getFullDashboardData(username: string, options: FetchOptio
     });
 
   const profileData = profileResult.value;
-  const reposData = reposResult.status === 'fulfilled' ? reposResult.value : [];
+  const reposFetched =
+    reposResult.status === 'fulfilled'
+      ? reposResult.value
+      : { repos: [], isTruncated: false, totalFetched: 0 };
+  const reposData = reposFetched.repos;
   const calendarData =
     calendarResult.status === 'fulfilled'
       ? calendarResult.value.calendar
@@ -1789,6 +1813,8 @@ export async function getFullDashboardData(username: string, options: FetchOptio
     hallOfFame: finalHallOfFame,
     graphData: { nodes, links },
     lastSyncedAt: calendarData.lastSyncedAt,
+    reposTruncated: reposFetched.isTruncated,
+    reposTotalFetched: reposFetched.totalFetched,
   };
 }
 
@@ -1811,7 +1837,7 @@ export async function getWrappedData(
     signal: options?.signal,
   };
 
-  const [userData, repos] = await Promise.all([
+  const [userData, reposFetchedWrapped] = await Promise.all([
     fetchGitHubContributions(username, fetchOptions),
     fetchUserRepos(username, fetchOptions),
   ]);
@@ -1846,7 +1872,7 @@ export async function getWrappedData(
     totalContributions > 0 ? Math.round((weekendTotal / totalContributions) * 100) : 0;
 
   const langCounts: Record<string, number> = {};
-  for (const repo of repos) {
+  for (const repo of reposFetchedWrapped.repos) {
     if (repo.language) langCounts[repo.language] = (langCounts[repo.language] || 0) + 1;
   }
   const topLanguage = Object.entries(langCounts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? 'Unknown';


### PR DESCRIPTION
Fixes #4916

Users with more than 300 repositories silently received incomplete contribution data because fetchReposUncached caps pagination at MAX_PAGES = 3 (300 repos total) with no signal to callers. This PR adds truncation detection and surfaces a visible warning banner in the dashboard.

What changed:

fetchReposUncached detects when the last fetched page is full (100 items), sets isTruncated: true on the returned FetchedRepos object, and persists the flag in reposCache so cache hits surface the warning correctly
getFullDashboardData propagates reposTruncated and reposTotalFetched into the dashboard data shape
DashboardClient renders a role="alert" banner — "Showing data for N of your repositories. Some stats may be incomplete." — when reposTruncated is true
Users with ≤ 299 repos (non-full last page) are completely unaffected — no banner, no behavior change
Pillar
 🎨 Pillar 1 — New Theme Design
 📐 Pillar 2 — Geometric SVG Improvement
 🕐 Pillar 3 — Timezone Logic Optimization
 🛠️ Other (Bug fix, refactoring, docs)
Visual Preview
When user has > 300 repos (truncated):

Yellow warning banner appears at the top of the dashboard: Showing data for 300 of your repositories. Some stats may be incomplete.

When user has ≤ 299 repos:

No banner — dashboard renders exactly as before.

Checklist before requesting a review:
 I have read the CONTRIBUTING.md file.
 I have tested these changes locally (localhost:3000/api/streak?user=YOUR_USERNAME).
 I have run npm run format and npm run lint locally and resolved all errors (CI will fail otherwise).
 I have run npm run test and all tests pass locally. (161 tests passing)
 My commits follow the Conventional Commits format (fix(github): warn users when repo list is truncated at 300)
 I have updated README.md if I added a new theme or URL parameter.
 I have starred the repo.
 I have made sure that I have only one commit to merge in this PR.
 The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
 (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.