### PR TITLE
[Bug] Race condition in DistributedCache.getOrSet — concurrent calls both execute loadFn

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -467,6 +467,11 @@ return c`;
     ttlMs: number,
     shouldFetch?: (cached: T) => boolean
   ): Promise<T> {
+    // Join an existing in-flight request before any async operation to avoid
+    // concurrent loadFn execution for the same key.
+    const existing = this.localLocks.get(key);
+    if (existing) return existing;
+
     // Attempt to retrieve an existing value before triggering a refresh.
     const cached = await this.get(key);
 
@@ -474,8 +479,7 @@ return c`;
       return cached;
     }
 
-    // Join an existing in-flight request instead of creating duplicate fetches
-    // within the same runtime instance.
+    // Double-check local locks after the await in case another call interleaved.
     const pendingLocal = this.localLocks.get(key);
     if (pendingLocal) return pendingLocal;
 


### PR DESCRIPTION
## Issue
#4928 — Race condition in \DistributedCache.getOrSet\ where concurrent calls for the same cache key both execute \loadFn\ instead of sharing the result.

## Cause
\wait this.get(key)\ at line 468 yields the event loop. Between this await completing and \	his.localLocks.set(key, promise)\ at line 568, a second concurrent call can interleave and also miss the local lock check, resulting in both calls executing \loadFn\ independently.

## Fix
1. **Pre-await check**: Check \	his.localLocks.get(key)\ synchronously before the first \wait\, so a call that arrives while another is mid-flight returns the existing promise immediately.
2. **Post-await double-check**: Re-check \	his.localLocks\ after the \wait this.get(key)\, catching the window where a second call entered before the promise was stored.

Since all operations between a resumed await and the next yield are synchronous (block the event loop), the promise creation and lock storage are atomic from the perspective of other callers.

## Additional Context
In serverless environments with concurrent instances, a cache expiry for a popular user triggers N simultaneous fetches instead of 1, multiplying API/database load.

Closes #4928