### PR TITLE
[Bug] Isometric tile geometry mismatch — TILE_HEIGHT_HALF=9 vs tower tileHalfHeight=10

### DIFF
--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -1898,7 +1898,7 @@ function renderGhostTowers(
   let ghostTowers = '';
   for (const { col, row, h } of layout) {
     const tx = 300 + (col - row) * 16;
-    const ty = 120 + (col + row) * 9;
+    const ty = 120 + (col + row) * TILE_HEIGHT_HALF;
     ghostTowers += `
       <g transform="translate(${tx}, ${ty - h})">
         <path d="M0 10 L0 ${10 + h} L-16 ${h} L-16 0 Z"

--- a/lib/svg/layoutConstants.ts
+++ b/lib/svg/layoutConstants.ts
@@ -5,6 +5,6 @@ export const MAX_LOG_HEIGHT = 80;
 export const MAX_LINEAR_HEIGHT = 50;
 
 export const TILE_WIDTH_HALF = 16;
-export const TILE_HEIGHT_HALF = 9;
+export const TILE_HEIGHT_HALF = 10;
 export const GRID_ORIGIN_X = 300;
 export const GRID_ORIGIN_Y = 120;


### PR DESCRIPTION
## Issue
#4929 — The isometric tile grid uses \TILE_HEIGHT_HALF = 9\ while the tower geometry uses \	ileHalfHeight = 10\, causing adjacent towers to overlap.

## Cause
- \layoutConstants.ts\: \TILE_HEIGHT_HALF = 9\ → grid vertical step is 18px (9+9)
- \uildTowerPaths\ (generator.ts:132): \	ileHalfHeight = 10\ → tower is 20px tall
- \enderGhostTowers\ (generator.ts:1873): hardcoded \* 9\ vertical multiplier

The 2px discrepancy accumulates across 14 weeks to 14px of vertical distortion.

## Fix
1. Changed \TILE_HEIGHT_HALF\ from \9\ to \10\ in \layoutConstants.ts\
2. Changed \enderGhostTowers\ multiplier from \9\ to \TILE_HEIGHT_HALF\ (\10\) in \generator.ts:1873\

Closes #4929