### PR TITLE
fix(streak): re-chunk ?days output into real weekday-aligned weeks

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -126,6 +126,19 @@ describe('GET /api/streak', () => {
       expect(response.status).toBe(400);
     });
 
+    it('re-chunks ?days filtered days into real weeks instead of one overflowing week', async () => {
+      const response = await GET(makeRequest({ user: 'octocat', days: '10', format: 'json' }));
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      const weeks = body.calendar.weeks as { contributionDays: unknown[] }[];
+
+      // Before the fix all filtered days were crammed into a single week.
+      expect(weeks.length).toBeGreaterThan(1);
+      // No week exceeds 7 days, so isometric towers do not collapse and heatmap cells
+      // do not overflow the canvas below row 6.
+      expect(weeks.every((w) => w.contributionDays.length <= 7)).toBe(true);
+    });
+
     it('returns 400 Bad Request when ?layout= is set to an unsupported format', async () => {
       const response = await GET(makeRequest({ user: 'octocat', layout: 'unsupported_layout' }));
       expect(response.status).toBe(400);

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -3,7 +3,12 @@
 import crypto from 'crypto';
 import { NextResponse } from 'next/server';
 import { fetchGitHubContributions, getOrgDashboardData } from '@/lib/github';
-import { calculateStreak, calculateMonthlyStats, aggregateCalendars } from '@/lib/calculate';
+import {
+  calculateStreak,
+  calculateMonthlyStats,
+  aggregateCalendars,
+  chunkDaysIntoWeeks,
+} from '@/lib/calculate';
 import {
   generateNotFoundSVG,
   generateRateLimitSVG,
@@ -349,11 +354,7 @@ export async function GET(request: Request) {
 
       calendar = {
         totalContributions: filteredDays.reduce((sum, d) => sum + d.contributionCount, 0),
-        weeks: [
-          {
-            contributionDays: filteredDays,
-          },
-        ],
+        weeks: chunkDaysIntoWeeks(filteredDays),
       };
     }
 

--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -5,8 +5,9 @@ import {
   calculateWrappedStats,
   aggregateCalendars,
   isStreakAlive,
+  chunkDaysIntoWeeks,
 } from './calculate';
-import type { ContributionCalendar } from '../types';
+import type { ContributionCalendar, ContributionDay } from '../types';
 
 // Turns a flat array of daily counts into the ContributionCalendar shape,
 // grouping every 7 values into a "week" — the same way GitHub's API returns data.
@@ -2466,5 +2467,37 @@ describe('aggregateCalendars — missing days chronological order', () => {
     expect(jun1?.contributionCount).toBe(5);
     expect(jun3?.contributionCount).toBe(3);
     expect(result.totalContributions).toBe(8);
+  });
+});
+
+describe('chunkDaysIntoWeeks', () => {
+  // 30 consecutive days starting Mon 2024-01-01.
+  const days: ContributionDay[] = Array.from({ length: 30 }, (_, i) => ({
+    date: new Date(Date.UTC(2024, 0, 1 + i)).toISOString().slice(0, 10),
+    contributionCount: i,
+  }));
+
+  it('splits consecutive days into multiple weekday-aligned weeks (no single-column collapse)', () => {
+    const weeks = chunkDaysIntoWeeks(days);
+
+    // More than one week, so towers/heatmap are not all crammed into a single column.
+    expect(weeks.length).toBeGreaterThan(1);
+    // No week exceeds 7 days, so heatmap rows never overflow the canvas.
+    expect(weeks.every((w) => w.contributionDays.length <= 7)).toBe(true);
+    // Every day is preserved exactly once, in order.
+    const flattened = weeks.flatMap((w) => w.contributionDays);
+    expect(flattened).toHaveLength(30);
+    expect(flattened.map((d) => d.date)).toEqual(days.map((d) => d.date));
+  });
+
+  it('starts every week after the first on a Sunday', () => {
+    const weeks = chunkDaysIntoWeeks(days);
+    weeks.slice(1).forEach((week) => {
+      expect(new Date(week.contributionDays[0].date).getUTCDay()).toBe(0);
+    });
+  });
+
+  it('returns an empty array when given no days', () => {
+    expect(chunkDaysIntoWeeks([])).toEqual([]);
   });
 });

--- a/lib/calculate.ts
+++ b/lib/calculate.ts
@@ -275,6 +275,32 @@ export function aggregateCalendars(calendars: ContributionCalendar[]): Contribut
   }
   return aggregatedBase;
 }
+
+/**
+ * Chunks a flat, date-ordered list of contribution days into weekday-aligned weeks,
+ * starting a new week on each Sunday. This mirrors GitHub's calendar layout so the
+ * renderers keep their week (column) and weekday (row) grid instead of collapsing
+ * every day into a single week.
+ */
+export function chunkDaysIntoWeeks(days: ContributionDay[]): ContributionCalendar['weeks'] {
+  const weeks: ContributionCalendar['weeks'] = [];
+  let currentWeek: ContributionDay[] = [];
+
+  for (const day of days) {
+    if (currentWeek.length > 0 && new Date(day.date).getUTCDay() === 0) {
+      weeks.push({ contributionDays: currentWeek });
+      currentWeek = [];
+    }
+    currentWeek.push(day);
+  }
+
+  if (currentWeek.length > 0) {
+    weeks.push({ contributionDays: currentWeek });
+  }
+
+  return weeks;
+}
+
 /**
  * Processes a calendar to generate deep insights for "GitHub Wrapped"
  */


### PR DESCRIPTION
## Description

Fixes #4943

When `?days=N` was used on `/api/streak` (any view except `monthly`), the route put all of the last N filtered days into a single week (`weeks: [{ contributionDays: filteredDays }]`). The renderers assume a week (column) by weekday (row) grid, so this broke two views:

- Isometric towers position each tower by its week index and real weekday; with every day in week 0 they collapsed into one row at only seven weekday columns (days sharing a weekday overlapped).
- The heatmap positions each cell's `y` by its index within the week (`originY + row * step`); with N days in one week the rows ran 0..N-1 and the cells overflowed below the fixed canvas/viewBox.

This change re-chunks the filtered days into real, weekday-aligned weeks before rendering. A new pure helper `chunkDaysIntoWeeks(days)` in `lib/calculate.ts` starts a new week on each Sunday (matching GitHub's calendar layout), and the route uses it instead of building a single week. Towers now spread across the correct week and weekday positions, and each week has at most seven days so the heatmap never overflows.

Added unit tests for `chunkDaysIntoWeeks` (multiple weeks, at most seven days per week, Sunday-aligned, no days dropped) and a route test asserting that `?days=10` produces more than one week with at most seven days each.

## Pillar

- [ ] Pillar 1: New Theme Design
- [x] Pillar 2: Geometric SVG Improvement
- [ ] Pillar 3: Timezone Logic Optimization
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

No new UI element. With `?days=N`, isometric towers are now distinct (one per day) across real weeks instead of at most seven overlapping towers, and the `view=heatmap` cells stay within the canvas instead of overflowing below it.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`lib/calculate.test.ts` and `app/api/streak/route.test.ts` pass, including the new tests; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Restores correct geometry for the `days` parameter.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
