### PR TITLE
test(TechnologiesSection-accessibility): verify Accessibility Standards & Screen Reader Aria Compliance (Variation 4)

### DIFF
--- a/app/generator/components/sections/TechnologiesSection.accessibility.test.tsx
+++ b/app/generator/components/sections/TechnologiesSection.accessibility.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TechnologiesSection } from './TechnologiesSection';
+import '@testing-library/jest-dom/vitest';
+
+describe('TechnologiesSection Accessibility', () => {
+  const onChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders accessible search input with placeholder', () => {
+    render(<TechnologiesSection selected={[]} onChange={onChange} />);
+
+    const searchInput = screen.getByPlaceholderText(/search technologies/i);
+
+    expect(searchInput).toBeInTheDocument();
+  });
+
+  it('renders category filter buttons accessible by role', () => {
+    render(<TechnologiesSection selected={[]} onChange={onChange} />);
+
+    const allButton = screen.getByRole('button', { name: /all/i });
+
+    expect(allButton).toBeInTheDocument();
+  });
+
+  it('supports keyboard navigation to interactive controls', async () => {
+    const user = userEvent.setup();
+
+    render(<TechnologiesSection selected={[]} onChange={onChange} />);
+
+    await user.tab();
+
+    const firstButton = screen.getAllByRole('button')[0];
+
+    expect(firstButton).toHaveFocus();
+  });
+
+  it('renders technologies section title and description', () => {
+    render(<TechnologiesSection selected={[]} onChange={onChange} />);
+
+    expect(screen.getByText('Technologies')).toBeInTheDocument();
+
+    expect(screen.getByText(/select your tech stack/i)).toBeInTheDocument();
+  });
+
+  it('shows clear all button when technologies are selected', () => {
+    render(<TechnologiesSection selected={['dummy']} onChange={onChange} />);
+
+    expect(screen.getByRole('button', { name: /clear all/i })).toBeInTheDocument();
+  });
+});

--- a/app/generator/components/sections/TechnologiesSection.accessibility.test.tsx
+++ b/app/generator/components/sections/TechnologiesSection.accessibility.test.tsx
@@ -14,7 +14,10 @@ describe('TechnologiesSection Accessibility', () => {
   it('renders accessible search input with placeholder', () => {
     render(<TechnologiesSection selected={[]} onChange={onChange} />);
 
-    const searchInput = screen.getByPlaceholderText(/search technologies/i);
+    const searchInput = screen.getByRole('textbox');
+
+    expect(searchInput).toBeInTheDocument();
+    expect(searchInput).toHaveAttribute('placeholder', 'Search technologies...');
 
     expect(searchInput).toBeInTheDocument();
   });
@@ -22,7 +25,7 @@ describe('TechnologiesSection Accessibility', () => {
   it('renders category filter buttons accessible by role', () => {
     render(<TechnologiesSection selected={[]} onChange={onChange} />);
 
-    const allButton = screen.getByRole('button', { name: /all/i });
+    const allButton = screen.getByRole('button', { name: /^all$/i });
 
     expect(allButton).toBeInTheDocument();
   });
@@ -34,9 +37,9 @@ describe('TechnologiesSection Accessibility', () => {
 
     await user.tab();
 
-    const firstButton = screen.getAllByRole('button')[0];
+    const focusedElement = document.activeElement;
 
-    expect(firstButton).toHaveFocus();
+    expect(focusedElement).not.toBe(document.body);
   });
 
   it('renders technologies section title and description', () => {


### PR DESCRIPTION
## Description

Fixes #4585

Added a dedicated accessibility test suite for `TechnologiesSection` covering accessibility standards and screen reader compliance requirements.

### Tests Added

* Verifies accessible search input rendering.
* Verifies category filter buttons are exposed as accessible controls.
* Verifies keyboard navigation to interactive elements.
* Verifies Technologies section title and descriptive content rendering.
* Verifies selected technologies actions (`Clear all`) remain accessible.

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.