### PR TITLE
fix(svg): give the static-theme footer scan line an explicit accent fill

### DIFF
--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -67,6 +67,26 @@ describe('generateSVG', () => {
     expect(svg).not.toContain('PEAK_STREAK');
   });
 
+  it('gives the scan line an explicit fill on static themes so it stays visible', () => {
+    const svg = generateSVG(
+      mockStats,
+      {
+        user: 'avi',
+        bg: hexColor('0d1117'),
+        text: hexColor('c9d1d9'),
+        accent: hexColor('58a6ff'),
+        speed: '8s',
+        scale: 'linear',
+      },
+      mockCalendar
+    );
+
+    assertValidSVG(svg);
+    // Static themes do not define the .cp-accent-fill CSS rule, so the scan line must
+    // carry an explicit hex fill or it inherits fill="none" and disappears.
+    expect(svg).toMatch(/fill="#[0-9a-fA-F]{3,8}"\s+class="cp-accent-fill scan-line"/);
+  });
+
   it('renders stats labels when hide_stats is false', () => {
     const svg = generateSVG(
       mockStats,

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -582,6 +582,12 @@ function renderFooter(
   const s = createScaler(sf);
   const statsOffset = params.label === false ? -40 : 0;
 
+  // Static themes do not define the .cp-accent-fill CSS rule, so the scan line needs an
+  // explicit fill or it inherits the SVG default fill="none" and becomes invisible.
+  const scanLineFill = params.autoTheme
+    ? 'class="cp-accent-fill scan-line"'
+    : `fill="${accent}" class="cp-accent-fill scan-line"`;
+
   const titleText = `${truncateUsername(safeUser).toUpperCase()}${isWinner ? ' 👑' : ''}${
     params.isOfflineFallback
       ? '<tspan fill="#ff9f43" font-size="10px" font-weight="bold"> [STALE CACHE]</tspan>'
@@ -601,7 +607,7 @@ function renderFooter(
     y="${s(80 + statsOffset)}"
     width="${s(400)}"
     height="${s(1)}"
-    class="cp-accent-fill scan-line"
+    ${scanLineFill}
     fill-opacity="0.3"
     style="--scan-speed: ${params.speed || '8s'}; --scan-start: ${s(0)}px; --scan-end: ${s(240)}px;"
   />`;


### PR DESCRIPTION
## Description

Fixes #4946

The default badge footer's animated scan line (`renderFooter` in `lib/svg/generator.ts`) rendered the rect with only `class="cp-accent-fill scan-line"` and no `fill`. The `.cp-accent-fill` CSS rule is defined only for `auto` themes; static (non-auto) themes use inline `fill` attributes and never emit that rule, so on a static theme the scan line had no fill, inherited the SVG default `fill="none"`, and was invisible.

This change gives the footer scan line an explicit `fill` for non-auto themes, mirroring the existing `renderRadarScan` helper:

```ts
const scanLineFill = params.autoTheme
  ? 'class="cp-accent-fill scan-line"'
  : `fill="${accent}" class="cp-accent-fill scan-line"`;
```

For `auto` themes it keeps using the class (so the `prefers-color-scheme` variables still drive the color); for static themes it emits `fill="${accent}"` (the same `#`-prefixed accent the footer already receives). This also makes use of the `accent` parameter, which `renderFooter` previously received but never used. The auto-theme main and versus paths are unaffected (they key off `params.autoTheme`).

Added a test asserting the static-theme scan-line rect carries an explicit hex `fill` rather than relying on the undefined `.cp-accent-fill` rule.

## Pillar

- [ ] Pillar 1: New Theme Design
- [x] Pillar 2: Geometric SVG Improvement
- [x] Other (bug fix, refactoring, docs)

## Visual Preview

No new UI element. On static themes (for example the default `dark`), the footer scan line is now visible instead of being rendered with `fill="none"`.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`lib/svg/generator.test.ts` passes, 158 tests including the new scan-line test; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Restores the intended scan-line animation on static themes.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
