### PR TITLE
Test/use debounce accessibility

### DIFF
--- a/hooks/useDebounce.accessibility.test.ts
+++ b/hooks/useDebounce.accessibility.test.ts
@@ -1,0 +1,89 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useDebounce } from './useDebounce';
+
+describe('useDebounce accessibility behavior', () => {
+  it('returns the initial value immediately for accessible input text', () => {
+    const { result } = renderHook(() => useDebounce('screen reader query', 300));
+
+    expect(result.current).toBe('screen reader query');
+  });
+
+  it('keeps the previous value before the debounce delay completes', () => {
+    vi.useFakeTimers();
+
+    const { result, rerender } = renderHook(({ value, delay }) => useDebounce(value, delay), {
+      initialProps: { value: 'aria label', delay: 300 },
+    });
+
+    rerender({ value: 'aria description', delay: 300 });
+
+    expect(result.current).toBe('aria label');
+
+    vi.useRealTimers();
+  });
+
+  it('updates the value after the debounce delay completes', () => {
+    vi.useFakeTimers();
+
+    const { result, rerender } = renderHook(({ value, delay }) => useDebounce(value, delay), {
+      initialProps: { value: 'keyboard focus', delay: 300 },
+    });
+
+    rerender({ value: 'screen reader announcement', delay: 300 });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe('screen reader announcement');
+
+    vi.useRealTimers();
+  });
+
+  it('clears the previous timer when value changes quickly', () => {
+    vi.useFakeTimers();
+
+    const { result, rerender } = renderHook(({ value, delay }) => useDebounce(value, delay), {
+      initialProps: { value: 'heading level', delay: 300 },
+    });
+
+    rerender({ value: 'tooltip label', delay: 300 });
+    rerender({ value: 'visible focus outline', delay: 300 });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe('visible focus outline');
+
+    vi.useRealTimers();
+  });
+
+  it('supports debouncing non-string accessibility state values', () => {
+    vi.useFakeTimers();
+
+    const { result, rerender } = renderHook(({ value, delay }) => useDebounce(value, delay), {
+      initialProps: {
+        value: { expanded: false, selectedIndex: 0 },
+        delay: 200,
+      },
+    });
+
+    rerender({
+      value: { expanded: true, selectedIndex: 1 },
+      delay: 200,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toEqual({
+      expanded: true,
+      selectedIndex: 1,
+    });
+
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Description

Added accessibility-focused test coverage for the `useDebounce` hook.

### Covered test cases

* Verifies the initial value is returned immediately.
* Ensures the previous value is preserved before debounce completion.
* Confirms value updates after the configured delay.
* Validates timer cleanup when values change rapidly.
* Tests debounce behavior with non-string accessibility-related state values.

Fixes #4617

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

## Test Evidence

```bash
npx vitest run hooks/useDebounce.accessibility.test.ts
```

All 5 accessibility-related test cases pass successfully.
