### PR TITLE
test(DashboardSkeleton): add accessibility coverage

### DIFF
--- a/components/dashboard/DashboardSkeleton.accessibility.test.tsx
+++ b/components/dashboard/DashboardSkeleton.accessibility.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import DashboardSkeleton from './DashboardSkeleton';
+
+describe('DashboardSkeleton accessibility', () => {
+  it('renders the dashboard skeleton container without crashing', () => {
+    const { container } = render(<DashboardSkeleton />);
+
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('uses a responsive grid layout for logical dashboard regions', () => {
+    const { container } = render(<DashboardSkeleton />);
+
+    const root = container.firstChild;
+
+    expect(root).toHaveClass('grid');
+    expect(root).toHaveClass('grid-cols-1');
+    expect(root).toHaveClass('lg:grid-cols-[300px_1fr_320px]');
+  });
+
+  it('does not expose decorative loading placeholders as focusable controls', () => {
+    render(<DashboardSkeleton />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('does not create incorrect heading hierarchy during loading state', () => {
+    render(<DashboardSkeleton />);
+
+    expect(screen.queryAllByRole('heading')).toHaveLength(0);
+  });
+
+  it('renders shimmer placeholders as non-interactive loading visuals', () => {
+    const { container } = render(<DashboardSkeleton />);
+
+    const shimmerElements = container.querySelectorAll('.shimmer');
+
+    expect(shimmerElements.length).toBeGreaterThan(0);
+
+    shimmerElements.forEach((element) => {
+      expect(element).not.toHaveAttribute('tabindex');
+      expect(element).not.toHaveAttribute('role', 'button');
+      expect(element).not.toHaveAttribute('aria-label');
+    });
+  });
+});


### PR DESCRIPTION
## Description

Added accessibility-focused test coverage for `DashboardSkeleton`.

### Covered test cases

* Verifies the dashboard skeleton renders successfully.
* Validates responsive grid layout structure for logical content organization.
* Ensures loading placeholders are not exposed as focusable interactive elements.
* Confirms no incorrect heading hierarchy is introduced during loading states.
* Verifies shimmer placeholders remain decorative and non-interactive.

Fixes #4601

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse quality standards.
* [ ] (Recommended) I joined the CommitPulse Discord community.

## Test Evidence

```bash
npx vitest run components/dashboard/DashboardSkeleton.accessibility.test.tsx
```

All 5 accessibility-related test cases pass successfully.
