### PR TITLE
test(AchievementsSkeleton): add accessibility coverage

### DIFF
--- a/components/dashboard/AchievementsSkeleton.accessibility.test.tsx
+++ b/components/dashboard/AchievementsSkeleton.accessibility.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import AchievementsSkeleton from './AchievementsSkeleton';
+
+describe('AchievementsSkeleton accessibility', () => {
+  it('renders the achievements skeleton container', () => {
+    const { container } = render(<AchievementsSkeleton />);
+
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('renders four decorative loading cells', () => {
+    render(<AchievementsSkeleton />);
+
+    expect(screen.getAllByTestId('skeleton-cell')).toHaveLength(4);
+  });
+
+  it('keeps skeleton cells non-focusable for keyboard users', () => {
+    render(<AchievementsSkeleton />);
+
+    screen.getAllByTestId('skeleton-cell').forEach((cell) => {
+      expect(cell).not.toHaveAttribute('tabindex');
+    });
+  });
+
+  it('does not expose decorative cells as interactive controls', () => {
+    render(<AchievementsSkeleton />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('does not create incorrect heading hierarchy during loading state', () => {
+    render(<AchievementsSkeleton />);
+
+    expect(screen.queryAllByRole('heading')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Description

Added accessibility-focused test coverage for `AchievementsSkeleton`.

### Covered test cases

* Verifies the skeleton component renders successfully.
* Ensures exactly four loading placeholder cells are displayed.
* Confirms skeleton cells are not keyboard-focusable.
* Verifies decorative placeholders are not exposed as interactive controls.
* Ensures no incorrect heading hierarchy is introduced during loading states.

Fixes #4600

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse quality standards.
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions and mentorship.

## Test Evidence

```bash
npx vitest run components/dashboard/AchievementsSkeleton.accessibility.test.tsx
```

All 5 accessibility-related test cases pass successfully.
