### PR TITLE
fix(dashboard): format ComparisonStatsCard values with thousands separators

### DIFF
--- a/components/dashboard/ComparisonStatsCard.massive-scaling.test.tsx
+++ b/components/dashboard/ComparisonStatsCard.massive-scaling.test.tsx
@@ -27,8 +27,8 @@ describe('ComparisonStatsCard — Massive Data Sets & Extreme High Bounds', () =
         icon="Flame"
       />
     );
-    expect(screen.getByText('999999999')).toBeInTheDocument();
-    expect(screen.getByText('888888888')).toBeInTheDocument();
+    expect(screen.getByText((999999999).toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText((888888888).toLocaleString())).toBeInTheDocument();
   });
 
   it('correctly identifies winner with extreme values', () => {
@@ -61,7 +61,7 @@ describe('ComparisonStatsCard — Massive Data Sets & Extreme High Bounds', () =
     const grid = container.querySelector('.grid.grid-cols-2');
     expect(grid).toBeInTheDocument();
 
-    expect(screen.getByText('1000000')).toBeInTheDocument();
+    expect(screen.getByText((1000000).toLocaleString())).toBeInTheDocument();
     expect(screen.getByText('1')).toBeInTheDocument();
 
     const progressBar = container.querySelector('.w-full.h-2');

--- a/components/dashboard/ComparisonStatsCard.responsive-breakpoints.test.tsx
+++ b/components/dashboard/ComparisonStatsCard.responsive-breakpoints.test.tsx
@@ -53,8 +53,8 @@ describe('ComparisonStatsCard Responsive Multi-device Layouts', () => {
     render(<ComparisonStatsCard {...defaultProps} />);
     expect(window.innerWidth).toBe(375);
     expect(screen.getByText('Total Commits')).toBeDefined();
-    expect(screen.getByText('1500')).toBeDefined();
-    expect(screen.getByText('1200')).toBeDefined();
+    expect(screen.getByText((1500).toLocaleString())).toBeDefined();
+    expect(screen.getByText((1200).toLocaleString())).toBeDefined();
   });
 
   it('asserts that grid columns and flex layouts are responsive', () => {

--- a/components/dashboard/ComparisonStatsCard.test.tsx
+++ b/components/dashboard/ComparisonStatsCard.test.tsx
@@ -313,9 +313,25 @@ describe('ComparisonStatsCard', () => {
         />
       );
 
-      expect(screen.getByText('9999')).toBeInTheDocument();
+      expect(screen.getByText((9999).toLocaleString())).toBeInTheDocument();
       expect(screen.getByText('1')).toBeInTheDocument();
       expect(screen.getByText('Winner')).toBeInTheDocument();
+    });
+
+    it('formats values with locale thousands separators (consistent with /compare)', () => {
+      render(
+        <ComparisonStatsCard
+          title="Total Contributions"
+          valueA={1234567}
+          valueB={89012}
+          labelA="Alice"
+          labelB="Bob"
+          icon="GitCommit"
+        />
+      );
+
+      expect(screen.getByText((1234567).toLocaleString())).toBeInTheDocument();
+      expect(screen.getByText((89012).toLocaleString())).toBeInTheDocument();
     });
   });
 

--- a/components/dashboard/ComparisonStatsCard.tsx
+++ b/components/dashboard/ComparisonStatsCard.tsx
@@ -92,7 +92,7 @@ export default function ComparisonStatsCard({
                   : 'text-gray-900 dark:text-white'
               }`}
             >
-              {valueA}
+              {valueA.toLocaleString()}
             </span>
             {isWinnerA && (
               <span
@@ -129,7 +129,7 @@ export default function ComparisonStatsCard({
                   : 'text-gray-900 dark:text-white'
               }`}
             >
-              {valueB}
+              {valueB.toLocaleString()}
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Description

Fixes #4954

`ComparisonStatsCard` rendered its two numeric values as bare text nodes (`{valueA}` / `{valueB}`), so large integers showed without thousands separators (for example `1234567`). This is inconsistent with the `/compare` view (`app/compare/CompareClient.tsx`), which renders the same values through `.toLocaleString()`, and with the rest of the dashboard (`GithubWrapped`, `GrowthTrendChart`).

This change formats both values with `.toLocaleString()`:

```
{valueA.toLocaleString()}
{valueB.toLocaleString()}
```

It uses no fixed locale argument, so it follows the viewer's locale exactly like `CompareClient` does. Values below 1000 render identically, so only large numbers change.

Updated the existing tests that asserted the unformatted strings (massive-scaling, responsive-breakpoints, and the main test file) to assert the locale-formatted output, and added a test that renders large values and checks they appear formatted. The assertions compute the expected text via `(value).toLocaleString()` so they stay correct under any runner locale (the default differs between environments) while still failing against the old unformatted render.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No layout change. Large comparison values now display with thousands separators (for example `1,234,567` instead of `1234567`), matching the `/compare` view.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (all 11 ComparisonStatsCard test files pass, 101 tests including the new one; `tsc --noEmit` clean; full suite clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). (Not an SVG change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
