### PR TITLE
test: add notify route delete coverage

### DIFF
--- a/app/api/notify/route.delete.test.ts
+++ b/app/api/notify/route.delete.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { DELETE } from './route';
+
+vi.mock('@/lib/mongodb', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('@/models/Notification', () => ({
+  Notification: {
+    findOne: vi.fn(),
+    deleteOne: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  notifyRateLimiter: {
+    check: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/github-owner-verification', () => ({
+  verifyGitHubOwner: vi.fn(),
+}));
+
+vi.mock('@/lib/notification-management-token', () => ({
+  createNotificationManagementToken: vi.fn(),
+  getNotificationManagementToken: vi.fn(() => null),
+  hashNotificationManagementToken: vi.fn(),
+  verifyNotificationManagementToken: vi.fn(() => false),
+}));
+
+import { Notification } from '@/models/Notification';
+import { notifyRateLimiter } from '@/lib/rate-limit';
+import { verifyGitHubOwner } from '@/lib/github-owner-verification';
+
+const makeRequest = (search = '') => {
+  return new NextRequest(`http://localhost:3000/api/notify${search ? `?${search}` : ''}`, {
+    method: 'DELETE',
+    headers: {
+      'x-forwarded-for': '127.0.0.1',
+    },
+  });
+};
+
+describe('DELETE /api/notify', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    process.env = {
+      ...originalEnv,
+      MONGODB_URI: 'mongodb://localhost/test',
+    };
+
+    vi.mocked(notifyRateLimiter.check).mockResolvedValue(true);
+
+    vi.mocked(verifyGitHubOwner).mockResolvedValue({
+      verified: true,
+      status: 200,
+      message: 'verified',
+    });
+
+    vi.mocked(Notification.findOne).mockReturnValue({
+      select: vi.fn().mockResolvedValue({
+        username: 'testuser',
+        managementTokenHash: 'hash',
+      }),
+    } as never);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns 400 when user parameter is missing', async () => {
+    const res = await DELETE(makeRequest());
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 429 when rate limited', async () => {
+    vi.mocked(notifyRateLimiter.check).mockResolvedValue(false);
+
+    const res = await DELETE(makeRequest('user=testuser'));
+
+    expect(res.status).toBe(429);
+  });
+
+  it('bypasses gracefully when MONGODB_URI is not set in development', async () => {
+    delete process.env.MONGODB_URI;
+
+    vi.stubEnv('NODE_ENV', 'development');
+
+    const res = await DELETE(makeRequest('user=testuser'));
+
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+
+    expect(data.success).toBe(true);
+    expect(data.message).toContain('bypassed');
+  });
+
+  it('returns 404 when notification preferences do not exist', async () => {
+    vi.mocked(Notification.deleteOne).mockResolvedValue({
+      deletedCount: 0,
+    } as never);
+
+    const res = await DELETE(makeRequest('user=testuser'));
+
+    expect(res.status).toBe(404);
+
+    const data = await res.json();
+
+    expect(data.message).toContain('No notification preferences found');
+  });
+
+  it('returns 200 when notification preferences are deleted successfully', async () => {
+    vi.mocked(Notification.deleteOne).mockResolvedValue({
+      deletedCount: 1,
+    } as never);
+
+    const res = await DELETE(makeRequest('user=testuser'));
+
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+
+    expect(data.success).toBe(true);
+    expect(data.message).toContain('deleted successfully');
+  });
+});

--- a/app/api/notify/route.delete.test.ts
+++ b/app/api/notify/route.delete.test.ts
@@ -58,8 +58,6 @@ describe('DELETE /api/notify', () => {
 
     vi.mocked(verifyGitHubOwner).mockResolvedValue({
       verified: true,
-      status: 200,
-      message: 'verified',
     });
 
     vi.mocked(Notification.findOne).mockReturnValue({


### PR DESCRIPTION
## Description

Fixes #4433

Added `app/api/notify/route.delete.test.ts` to provide isolated test coverage for the notify DELETE endpoint.

### Added Test Coverage

* Missing user parameter validation
* Rate limiting behavior
* Development-mode bypass when database configuration is unavailable
* Notification preference not found handling
* Successful notification preference deletion

### Validation

* Added 5 test cases
* Verified locally using Vitest
* All tests passing successfully

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if required. (Not applicable)
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable)
* [ ] (Recommended) I joined the CommitPulse Discord community.
