### PR TITLE
test(time-accessibility): time utility accessibility and screen reader compliance boundaries

### DIFF
--- a/utils/time.accessibility.test.ts
+++ b/utils/time.accessibility.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getSecondsUntilUTCMidnight, getSecondsUntilMidnightInTimezone } from './time';
+
+describe('utils/time — Accessibility Standards & Screen Reader Aria Compliance', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('getSecondsUntilUTCMidnight returns a strictly positive number of seconds', () => {
+    vi.setSystemTime(new Date('2024-03-15T06:00:00.000Z'));
+    const result = getSecondsUntilUTCMidnight();
+    expect(result).toBeGreaterThan(0);
+    expect(Number.isFinite(result)).toBe(true);
+  });
+
+  it('getSecondsUntilUTCMidnight returns a value within the valid 1–86400 second range', () => {
+    vi.setSystemTime(new Date('2024-03-15T06:00:00.000Z'));
+    const result = getSecondsUntilUTCMidnight();
+    expect(result).toBe(64800);
+    expect(result).toBeLessThanOrEqual(86400);
+  });
+
+  it('getSecondsUntilMidnightInTimezone("UTC") matches getSecondsUntilUTCMidnight at the same moment', () => {
+    vi.setSystemTime(new Date('2024-03-15T06:00:00.000Z'));
+    const utcResult = getSecondsUntilUTCMidnight();
+    const tzResult = getSecondsUntilMidnightInTimezone('UTC');
+    expect(tzResult).toBe(utcResult);
+    expect(tzResult).toBe(64800);
+  });
+
+  it('getSecondsUntilMidnightInTimezone returns a positive value for America/New_York', () => {
+    vi.setSystemTime(new Date('2024-03-15T15:00:00.000Z'));
+    const result = getSecondsUntilMidnightInTimezone('America/New_York');
+    expect(result).toBe(46800);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThanOrEqual(86400);
+  });
+
+  it('getSecondsUntilMidnightInTimezone returns 86400 at exactly local midnight, correctly handling the hour-24 normalisation', () => {
+    vi.setSystemTime(new Date('2024-03-15T04:00:00.000Z'));
+    const result = getSecondsUntilMidnightInTimezone('America/New_York');
+    expect(result).toBe(86400);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4658 

- Added accessibility-framed boundary tests for `utils/time`. The functions drive `Cache-Control` TTLs that determine content freshness for screen readers and assistive technology clients — an invalid TTL (zero, negative, or out of range) causes stale or missing content. Covers: `getSecondsUntilUTCMidnight` returning strictly positive, `getSecondsUntilUTCMidnight` returning exactly 64800 at 06:00 UTC (within 1–86400 bounds), `getSecondsUntilMidnightInTimezone('UTC')` matching the UTC function at the same instant, `getSecondsUntilMidnightInTimezone('America/New_York')` returning 46800 at 11:00 AM EDT, and the midnight edge-case where `hour % 24` normalisation prevents a zero return at local midnight.

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.
