### PR TITLE
test(AdvancedSettingsPanel): verify accessibility standards and scree…

### DIFF
--- a/app/customize/components/AdvancedSettingsPanel.accessibility.test.tsx
+++ b/app/customize/components/AdvancedSettingsPanel.accessibility.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { AdvancedSettingsPanel } from './AdvancedSettingsPanel';
+import React from 'react';
+import type { ViewMode, DeltaFormat, Language, Timezone } from '../types';
+
+const defaultProps = {
+  hideTitle: false,
+  hideBackground: false,
+  hideStats: false,
+  viewMode: 'default' as ViewMode,
+  deltaFormat: 'percent' as DeltaFormat,
+  badgeWidth: '' as const,
+  badgeHeight: '' as const,
+  grace: 2,
+  language: 'en' as Language,
+  timezone: 'UTC' as Timezone,
+  onHideTitleChange: vi.fn(),
+  onHideBackgroundChange: vi.fn(),
+  onHideStatsChange: vi.fn(),
+  onViewModeChange: vi.fn(),
+  onDeltaFormatChange: vi.fn(),
+  onBadgeWidthChange: vi.fn(),
+  onBadgeHeightChange: vi.fn(),
+  onGraceChange: vi.fn(),
+  onLanguageChange: vi.fn(),
+  onTimezoneChange: vi.fn(),
+};
+
+describe('AdvancedSettingsPanel Accessibility Tests', () => {
+  // Test 1: Landmark and Section Landmark Roles
+  it('1. verifies that the root container has a region role with a descriptive accessibility label', () => {
+    render(<AdvancedSettingsPanel {...defaultProps} />);
+
+    const region = screen.getByRole('region', { name: /advanced settings configuration/i });
+    expect(region).toBeInTheDocument();
+
+    const titleText = screen.getByText('Advanced Settings');
+    expect(titleText).toBeInTheDocument();
+  });
+
+  // Test 2: Programmatic Label-to-Control Pairings via htmlFor
+  it('2. verifies that all form controls (selects, inputs, and sliders) are paired programmatically with semantic label elements', () => {
+    render(<AdvancedSettingsPanel {...defaultProps} />);
+
+    // View Layout selector and label
+    const viewSelect = screen.getByLabelText(/^view layout$/i);
+    expect(viewSelect).toBeInTheDocument();
+    expect(viewSelect).toHaveAttribute('id', 'view-select');
+
+    // Delta Format selector and label
+    const deltaSelect = screen.getByLabelText(/^delta format$/i);
+    expect(deltaSelect).toBeInTheDocument();
+    expect(deltaSelect).toHaveAttribute('id', 'delta-select');
+
+    // Width input and label
+    const widthInput = screen.getByLabelText(/^width$/i);
+    expect(widthInput).toBeInTheDocument();
+    expect(widthInput).toHaveAttribute('id', 'width-input');
+
+    // Height input and label
+    const heightInput = screen.getByLabelText(/^height$/i);
+    expect(heightInput).toBeInTheDocument();
+    expect(heightInput).toHaveAttribute('id', 'height-input');
+
+    // Grace Days range slider and label
+    const graceSlider = screen.getByLabelText(/^grace days$/i);
+    expect(graceSlider).toBeInTheDocument();
+    expect(graceSlider).toHaveAttribute('id', 'grace-input');
+
+    // Language selector and label
+    const langSelect = screen.getByLabelText(/^language$/i);
+    expect(langSelect).toBeInTheDocument();
+    expect(langSelect).toHaveAttribute('id', 'lang-select');
+
+    // Timezone selector and label
+    const timezoneSelect = screen.getByLabelText(/^timezone$/i);
+    expect(timezoneSelect).toBeInTheDocument();
+    expect(timezoneSelect).toHaveAttribute('id', 'timezone-select');
+  });
+
+  // Test 3: ARIA Accessibility State Properties
+  it('3. verifies that the grace days range slider reports correct ARIA bounds and values', () => {
+    render(<AdvancedSettingsPanel {...defaultProps} grace={4} />);
+
+    const graceSlider = screen.getByLabelText(/^grace days$/i);
+    expect(graceSlider).toHaveAttribute('aria-valuemin', '0');
+    expect(graceSlider).toHaveAttribute('aria-valuemax', '7');
+    expect(graceSlider).toHaveAttribute('aria-valuenow', '4');
+  });
+
+  // Test 4: Keyboard Accessibility (Focus Management)
+  it('4. verifies that interactive elements (checkboxes, inputs, selects, range controls) receive sequential focus', () => {
+    render(<AdvancedSettingsPanel {...defaultProps} />);
+
+    const titleCheckbox = screen.getByLabelText(/hide title/i);
+    const viewSelect = screen.getByLabelText(/^view layout$/i);
+    const widthInput = screen.getByLabelText(/^width$/i);
+    const graceSlider = screen.getByLabelText(/^grace days$/i);
+    const timezoneSelect = screen.getByLabelText(/^timezone$/i);
+
+    titleCheckbox.focus();
+    expect(document.activeElement).toBe(titleCheckbox);
+
+    viewSelect.focus();
+    expect(document.activeElement).toBe(viewSelect);
+
+    widthInput.focus();
+    expect(document.activeElement).toBe(widthInput);
+
+    graceSlider.focus();
+    expect(document.activeElement).toBe(graceSlider);
+
+    timezoneSelect.focus();
+    expect(document.activeElement).toBe(timezoneSelect);
+  });
+
+  // Test 5: Interactive Callback Propagation
+  it('5. verifies that changing control options triggers their respective callback handlers', () => {
+    const onHideTitleChange = vi.fn();
+    const onViewModeChange = vi.fn();
+    const onBadgeWidthChange = vi.fn();
+    const onGraceChange = vi.fn();
+
+    render(
+      <AdvancedSettingsPanel
+        {...defaultProps}
+        onHideTitleChange={onHideTitleChange}
+        onViewModeChange={onViewModeChange}
+        onBadgeWidthChange={onBadgeWidthChange}
+        onGraceChange={onGraceChange}
+      />
+    );
+
+    // Click checkbox
+    const titleCheckbox = screen.getByLabelText(/hide title/i);
+    fireEvent.click(titleCheckbox);
+    expect(onHideTitleChange).toHaveBeenCalledWith(true);
+
+    // Change Select value
+    const viewSelect = screen.getByLabelText(/^view layout$/i);
+    fireEvent.change(viewSelect, { target: { value: 'monthly' } });
+    expect(onViewModeChange).toHaveBeenCalledWith('monthly');
+
+    // Type in dimension input
+    const widthInput = screen.getByLabelText(/^width$/i);
+    fireEvent.change(widthInput, { target: { value: '450' } });
+    expect(onBadgeWidthChange).toHaveBeenCalledWith(450);
+
+    // Slide range slider
+    const graceSlider = screen.getByLabelText(/^grace days$/i);
+    fireEvent.change(graceSlider, { target: { value: '5' } });
+    expect(onGraceChange).toHaveBeenCalledWith(5);
+  });
+});

--- a/app/customize/components/AdvancedSettingsPanel.tsx
+++ b/app/customize/components/AdvancedSettingsPanel.tsx
@@ -9,19 +9,25 @@ import {
   type Language,
   type Timezone,
 } from '../types';
-import { SectionLabel } from './SectionLabel';
 import { StyledSelect } from './ThemeSelector';
 
 function ControlRow({
   label,
   children,
+  htmlFor,
 }: {
   label: string;
   children: React.ReactNode;
+  htmlFor?: string;
 }): ReactElement {
   return (
     <div className="flex flex-col gap-1.5">
-      <SectionLabel>{label}</SectionLabel>
+      <label
+        htmlFor={htmlFor}
+        className="block text-[10px] font-bold uppercase tracking-[0.22em] text-gray-600 dark:text-white/60 mb-2 cursor-pointer"
+      >
+        {label}
+      </label>
       {children}
     </div>
   );
@@ -71,7 +77,7 @@ export function AdvancedSettingsPanel({
   onTimezoneChange: (value: Timezone) => void;
 }): ReactElement {
   return (
-    <div>
+    <section role="region" aria-label="Advanced Settings Configuration">
       <p className="text-xs font-bold uppercase tracking-[0.22em] text-emerald-600 dark:text-emerald-400 mb-4">
         Advanced Settings
       </p>
@@ -80,8 +86,12 @@ export function AdvancedSettingsPanel({
         {/* Visibility Toggles */}
         <ControlRow label="Visibility Options">
           <div className="flex flex-col gap-2">
-            <label className="flex items-center gap-2 cursor-pointer text-sm text-gray-700 dark:text-white/70">
+            <label
+              htmlFor="hide-title-checkbox"
+              className="flex items-center gap-2 cursor-pointer text-sm text-gray-700 dark:text-white/70"
+            >
               <input
+                id="hide-title-checkbox"
                 type="checkbox"
                 checked={hideTitle}
                 onChange={(e) => onHideTitleChange(e.target.checked)}
@@ -89,8 +99,12 @@ export function AdvancedSettingsPanel({
               />
               Hide Title
             </label>
-            <label className="flex items-center gap-2 cursor-pointer text-sm text-gray-700 dark:text-white/70">
+            <label
+              htmlFor="hide-bg-checkbox"
+              className="flex items-center gap-2 cursor-pointer text-sm text-gray-700 dark:text-white/70"
+            >
               <input
+                id="hide-bg-checkbox"
                 type="checkbox"
                 checked={hideBackground}
                 onChange={(e) => onHideBackgroundChange(e.target.checked)}
@@ -98,8 +112,12 @@ export function AdvancedSettingsPanel({
               />
               Hide Background
             </label>
-            <label className="flex items-center gap-2 cursor-pointer text-sm text-gray-700 dark:text-white/70">
+            <label
+              htmlFor="hide-stats-checkbox"
+              className="flex items-center gap-2 cursor-pointer text-sm text-gray-700 dark:text-white/70"
+            >
               <input
+                id="hide-stats-checkbox"
                 type="checkbox"
                 checked={hideStats}
                 onChange={(e) => onHideStatsChange(e.target.checked)}
@@ -113,7 +131,7 @@ export function AdvancedSettingsPanel({
         <div className="h-px bg-black/5 dark:bg-white/5" />
 
         {/* Layout Options */}
-        <ControlRow label="View Layout">
+        <ControlRow label="View Layout" htmlFor="view-select">
           <div className="relative">
             <StyledSelect
               id="view-select"
@@ -129,7 +147,7 @@ export function AdvancedSettingsPanel({
           </div>
         </ControlRow>
 
-        <ControlRow label="Delta Format">
+        <ControlRow label="Delta Format" htmlFor="delta-select">
           <div className="relative">
             <StyledSelect
               id="delta-select"
@@ -149,8 +167,9 @@ export function AdvancedSettingsPanel({
 
         {/* Dimensions */}
         <div className="grid grid-cols-2 gap-4">
-          <ControlRow label="Width">
+          <ControlRow label="Width" htmlFor="width-input">
             <input
+              id="width-input"
               type="number"
               min="100"
               max="1200"
@@ -163,8 +182,9 @@ export function AdvancedSettingsPanel({
               className="w-full min-w-0 bg-white/60 backdrop-blur-md border border-black/10 dark:bg-black/40 dark:border-white/10 rounded-xl px-3 py-2 text-sm font-mono text-black dark:text-emerald-300 placeholder:text-gray-400 dark:placeholder:text-white/20 outline-none focus:border-emerald-500/50 transition-colors"
             />
           </ControlRow>
-          <ControlRow label="Height">
+          <ControlRow label="Height" htmlFor="height-input">
             <input
+              id="height-input"
               type="number"
               min="80"
               max="800"
@@ -182,15 +202,19 @@ export function AdvancedSettingsPanel({
         <div className="h-px bg-black/5 dark:bg-white/5" />
 
         {/* Grace and Localization */}
-        <ControlRow label="Grace Days">
+        <ControlRow label="Grace Days" htmlFor="grace-input">
           <div className="relative flex items-center">
             <div className="absolute inset-x-0 h-1 rounded-full bg-gray-300 dark:bg-white/6" />
             <input
+              id="grace-input"
               type="range"
               min="0"
               max="7"
               step="1"
               value={grace}
+              aria-valuemin={0}
+              aria-valuemax={7}
+              aria-valuenow={grace}
               onChange={(e) => onGraceChange(Number(e.target.value))}
               className="w-full relative bg-transparent appearance-none outline-none slider"
             />
@@ -204,7 +228,7 @@ export function AdvancedSettingsPanel({
           </div>
         </ControlRow>
 
-        <ControlRow label="Language">
+        <ControlRow label="Language" htmlFor="lang-select">
           <div className="relative">
             <StyledSelect
               id="lang-select"
@@ -220,7 +244,7 @@ export function AdvancedSettingsPanel({
           </div>
         </ControlRow>
 
-        <ControlRow label="Timezone">
+        <ControlRow label="Timezone" htmlFor="timezone-select">
           <div className="relative">
             <StyledSelect
               id="timezone-select"
@@ -237,6 +261,6 @@ export function AdvancedSettingsPanel({
           </div>
         </ControlRow>
       </div>
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
# test(AdvancedSettingsPanel-accessibility): verify Accessibility Standards & Screen Reader Aria Compliance (Variation 4)

## Description

Fixes #4568

## Pillar

- [🛠️] Other (Bug fix, refactoring, docs)

## Visual Preview

This PR adds screen reader accessibility support to the `AdvancedSettingsPanel` component by introducing:
- Landmark region wrapping (`<section role="region" aria-label="Advanced Settings Configuration">`).
- Semantic `<label>` elements with `htmlFor` explicitly associated with inputs, selects, and checkboxes (e.g. view layout select, delta format select, dimensions input, timezone, language, and visibility toggles).
- Complete ARIA range values on the grace days slider (`aria-valuemin`, `aria-valuemax`, `aria-valuenow`).

Additionally, a robust test suite is introduced to verify these accessibility attributes under `app/customize/components/AdvancedSettingsPanel.accessibility.test.tsx` (5/5 tests passed).
<img width="1292" height="407" alt="image" src="https://github.com/user-attachments/assets/b78d2eb0-250d-452d-9cbe-b72648b1ff5d" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
