### PR TITLE
test(api-wrapped-route): verify accessibility standards and screen re…

### DIFF
--- a/app/api/wrapped/route.accessibility.test.ts
+++ b/app/api/wrapped/route.accessibility.test.ts
@@ -1,0 +1,135 @@
+// app/api/wrapped/route.accessibility.test.ts
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from './route';
+import { getWrappedData } from '../../../lib/github';
+import type { ContributionCalendar } from '../../../types';
+import type { WrappedStats } from '../../../types/dashboard';
+
+vi.mock('../../../lib/github', () => ({
+  getWrappedData: vi.fn(),
+  fetchGitHubContributions: vi.fn(),
+}));
+
+const mockCalendar: ContributionCalendar = {
+  totalContributions: 1420,
+  weeks: [
+    {
+      contributionDays: [
+        { contributionCount: 5, date: '2025-11-19' },
+        { contributionCount: 42, date: '2025-11-20' },
+        { contributionCount: 12, date: '2025-11-21' },
+      ],
+    },
+  ],
+};
+
+const mockWrappedStats: WrappedStats = {
+  totalContributions: 1420,
+  mostActiveDate: '2025-11-20',
+  highestDailyCount: 42,
+  busiestMonth: '2025-11',
+  weekendRatio: 24,
+  topLanguage: 'TypeScript',
+  calendar: mockCalendar,
+};
+
+function makeRequest(params: Record<string, string> = {}): Request {
+  const url = new URL('http://localhost/api/wrapped');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new Request(url.toString());
+}
+
+describe('ApiWrappedRoute Accessibility (WCAG / ARIA compliance)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getWrappedData).mockResolvedValue(mockWrappedStats);
+  });
+
+  // Test 1: Plain Language Validation Errors (WCAG 3.3.1 Error Identification)
+  it('1. returns descriptive plain-text JSON errors for invalid parameters without technical leaks', async () => {
+    const response = await GET(makeRequest({ user: 'invalid_user--' }));
+    expect(response.status).toBe(400);
+
+    const body = await response.json();
+    expect(typeof body.error).toBe('string');
+    expect(body.error.trim().length).toBeGreaterThan(0);
+    // Must not leak raw JavaScript/TypeScript system values to screen reader users
+    expect(body.error).not.toContain('undefined');
+    expect(body.error).not.toContain('null');
+  });
+
+  // Test 2: Descriptive plain-language SVG error messages (WCAG 3.3.1)
+  it('2. renders descriptive SVG text for rate-limit (429) and not-found (404) states', async () => {
+    // Rate limit SVG error
+    vi.mocked(getWrappedData).mockRejectedValueOnce(new Error('API Rate Limit Exceeded'));
+    const resRateLimit = await GET(makeRequest({ user: 'octocat' }));
+    expect(resRateLimit.status).toBe(429);
+
+    const rateLimitSvg = await resRateLimit.text();
+    expect(rateLimitSvg).toContain('<svg');
+    expect(rateLimitSvg).toContain('RATE LIMIT');
+
+    // User not found SVG error
+    vi.mocked(getWrappedData).mockRejectedValueOnce(new Error('User not found'));
+    const resNotFound = await GET(makeRequest({ user: 'nonexistent' }));
+    expect(resNotFound.status).toBe(404);
+
+    const notFoundSvg = await resNotFound.text();
+    expect(notFoundSvg).toContain('<svg');
+    expect(notFoundSvg).toContain('NOT FOUND');
+  });
+
+  // Test 3: SVG Semantic ARIA Landmarks & Accessible Tags
+  it('3. embeds role="img", aria-labelledby, and aria-describedby linked to matching title and desc tags in the SVG', async () => {
+    const response = await GET(makeRequest({ user: 'octocat', year: '2025' }));
+    expect(response.status).toBe(200);
+
+    const svg = await response.text();
+
+    // Find matching aria attributes and IDs
+    expect(svg).toContain('role="img"');
+    expect(svg).toContain('aria-labelledby="cp-title-octocat"');
+    expect(svg).toContain('aria-describedby="cp-desc-octocat"');
+
+    // Title tag verification
+    expect(svg).toContain('<title id="cp-title-octocat">octocat\'s GitHub Wrapped 2025</title>');
+
+    // Desc tag verification (contains stats summary for accessibility readers)
+    expect(svg).toContain('<desc id="cp-desc-octocat">');
+    expect(svg).toContain('1420 total contributions');
+    expect(svg).toContain('top language is TypeScript');
+  });
+
+  // Test 4: Parsing Correctness & Content Types (WCAG 4.1.1 Parsing)
+  it('4. returns correct content-type header format for valid SVGs and JSON errors', async () => {
+    // Valid SVG response
+    const resSuccess = await GET(makeRequest({ user: 'octocat' }));
+    expect(resSuccess.headers.get('Content-Type')).toContain('image/svg+xml');
+
+    // Validation JSON error
+    const resFail = await GET(makeRequest({ user: '' }));
+    expect(resFail.headers.get('Content-Type')).toContain('application/json');
+  });
+
+  // Test 5: Safe Character Escaping in Accessible Tags
+  it('5. sanitizes user inputs inside SVG accessibility tags to prevent malformed XML or script injections', async () => {
+    const maliciousStats = {
+      ...mockWrappedStats,
+      topLanguage: 'TypeScript<script>alert("xss")</script>',
+    };
+    vi.mocked(getWrappedData).mockResolvedValueOnce(maliciousStats);
+
+    const response = await GET(makeRequest({ user: 'octocat' }));
+    const svg = await response.text();
+
+    // Verify script tags are escaped/removed and don't render raw elements
+    expect(svg).not.toContain('<script>');
+    expect(svg).not.toContain('</script>');
+
+    // Verifying it escapes XML-breaking characters
+    expect(svg).toContain('TypeScript&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
+  });
+});

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -1288,7 +1288,7 @@ export function generateWrappedSVG(
         <circle cx="0" cy="0" r="14" stroke="${params.autoTheme ? 'var(--cp-accent)' : accent}" stroke-width="3" fill="none"
                 stroke-dasharray="${circ.toFixed(2)}" stroke-dashoffset="${strokeDashoffset.toFixed(2)}"
                 stroke-linecap="round" transform="rotate(-90)" />
-        <text x="0" y="3.5" text-anchor="middle" font-family="${statsFont}" font-size="9" font-weight="700" ${textClass}>${clampedRatio}%</text>
+        <text x="0" y="3.5" text-anchor="middle" font-family="${statsFont.replace(/"/g, "'")}" font-size="9" font-weight="700" ${textClass}>${clampedRatio}%</text>
       </g>
     </g>
   </g>


### PR DESCRIPTION
# test(ApiWrappedRoute-accessibility): verify Accessibility Standards & Screen Reader Aria Compliance (Variation 4)

## Description

Fixes #4559

## Pillar

- [🛠️] Other (Bug fix, refactoring, docs)

## Visual Preview

This PR adds a dedicated accessibility test suite under `app/api/wrapped/route.accessibility.test.ts` to verify `/api/wrapped` compliance with WCAG guidelines:
- **WCAG 3.3.1 (Error Identification)**: Descriptive error messaging for bad inputs and rate limits without system value leakages (e.g. `undefined`/`null`).
- **WCAG 4.1.1 (Parsing & Semantics)**: Correct media headers (`image/svg+xml` and `application/json`), semantic ARIA properties (`role="img"`, `aria-labelledby`, `aria-describedby`), and correct `<title>`/`<desc>` mappings.
- **Output Sanitization**: Escaping XML-breaking characters and preventing raw scripts from rendering in title/description blocks.

<img width="958" height="487" alt="image" src="https://github.com/user-attachments/assets/669874ac-c6ff-4ede-8457-4d606c3b013c" />

<img width="1326" height="516" alt="image" src="https://github.com/user-attachments/assets/0a6b5d33-54df-477d-adf0-d53718718c94" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1f162a24-c075-493a-b049-7b5ee3628114" />


All tests, formatting checks, lint rules, typecheck, and production build compilations pass with 0 errors.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
