### PR TITLE
test: add ThemeQuickPresets mouse interactivity coverage

### DIFF
--- a/app/customize/components/ThemeQuickPresets.mouse-interactivity.test.tsx
+++ b/app/customize/components/ThemeQuickPresets.mouse-interactivity.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ThemeQuickPresets } from './ThemeQuickPresets';
+
+describe('ThemeQuickPresets mouse interactivity', () => {
+  it('renders interactive theme buttons with tooltip titles', () => {
+    render(<ThemeQuickPresets theme="dark" onThemeChange={vi.fn()} />);
+
+    const darkButton = screen.getByRole('button', { name: /apply dark theme/i });
+
+    expect(darkButton).toHaveAttribute('title', 'Dark');
+    expect(darkButton).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('triggers theme change when a preset is clicked', () => {
+    const onThemeChange = vi.fn();
+
+    render(<ThemeQuickPresets theme="dark" onThemeChange={onThemeChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /apply light theme/i }));
+
+    expect(onThemeChange).toHaveBeenCalledTimes(1);
+    expect(onThemeChange).toHaveBeenCalledWith('light');
+  });
+
+  it('keeps hoverable preset buttons styled with pointer cursor class support', () => {
+    render(<ThemeQuickPresets theme="dark" onThemeChange={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: /apply dark theme/i });
+
+    fireEvent.mouseEnter(button);
+
+    expect(button).toHaveClass('tqp-btn');
+  });
+
+  it('preserves active overlay visuals while hovering the selected preset', () => {
+    render(<ThemeQuickPresets theme="dark" onThemeChange={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: /apply dark theme/i });
+
+    fireEvent.mouseEnter(button);
+
+    expect(button.querySelector('.tqp-ring')).not.toBeNull();
+    expect(button.querySelector('.tqp-dot')).not.toBeNull();
+  });
+
+  it('handles touch interactions and propagates theme selection', () => {
+    const onThemeChange = vi.fn();
+
+    render(<ThemeQuickPresets theme="dark" onThemeChange={onThemeChange} />);
+
+    const neonButton = screen.getByRole('button', { name: /apply neon theme/i });
+
+    fireEvent.touchStart(neonButton);
+    fireEvent.click(neonButton);
+
+    expect(onThemeChange).toHaveBeenCalledWith('neon');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4695

Added a dedicated mouse interactivity test suite for `ThemeQuickPresets`.

### Coverage

* Verifies interactive theme preset buttons expose tooltip titles.
* Ensures click interactions trigger the correct `onThemeChange` callback.
* Validates hoverable preset buttons remain interactive.
* Confirms active overlay visuals remain present for the selected theme.
* Tests touch interaction and click propagation behavior.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run the relevant tests locally.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if required.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The change is limited to test coverage and does not affect SVG output.
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
