### PR TITLE
fix: gracefully fallback on invalid color overrides to prevent malformed CSS injection

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -810,32 +810,32 @@ describe('GET /api/streak', () => {
       expect(body).toContain('#ff0000');
     });
 
-    it('does not crash when an invalid text color is provided', async () => {
+    it('does not crash when an invalid text color is provided and falls back gracefully', async () => {
       const response = await GET(makeRequest({ user: 'octocat', text: 'notacolor' }));
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(200);
     });
 
-    it('returns 400 when an invalid hex color is passed as accent', async () => {
+    it('falls back gracefully when an invalid hex color is passed as accent', async () => {
       const response = await GET(makeRequest({ user: 'octocat', accent: '#ZZZZZZZ' }));
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(200);
     });
 
-    it('returns 400 Bad Request for invalid color hex syntax targeting the ?accent= parameter', async () => {
+    it('strips invalid color hex syntax targeting the ?accent= parameter and returns 200', async () => {
       const response = await GET(makeRequest({ user: 'octocat', accent: '#ZZZZZZ' }));
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(200);
 
       const body = await response.text();
       expect(body).toContain('<svg');
       expect(response.headers.get('Content-Type')).toContain('image/svg+xml');
     });
   });
-  it('returns 400 when an invalid hex color is passed as bg', async () => {
+  it('falls back gracefully when an invalid hex color is passed as bg', async () => {
     const response = await GET(makeRequest({ user: 'octocat', bg: '#ZZZZZZ' }));
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(200);
   });
   describe('hide parameters', () => {
     it('removes the username title when hide_title=true', async () => {

--- a/lib/validations.streakParamsSchema.test.ts
+++ b/lib/validations.streakParamsSchema.test.ts
@@ -91,9 +91,12 @@ describe('streakParamsSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('fails for invalid bg hex color', () => {
+  it('strips an invalid hex color like "zzzzzz" for bg and falls back gracefully', () => {
     const result = streakParamsSchema.safeParse({ user: 'octocat', bg: 'zzzzzz' });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.bg).toBeUndefined();
+    }
   });
 
   it('clamps grace to 7 when out of range (> 7)', () => {

--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -1112,52 +1112,16 @@ describe('streakParamsSchema — view fallback behavior', () => {
 });
 
 describe('streakParamsSchema — accent parameter HEX color validation', () => {
-  it('rejects an invalid hex color like "#ZZZZZZ" for accent', () => {
-    // #ZZZZZZ contains non-hex characters — must fail schema validation
+  it('strips an invalid hex color like "#ZZZZZZ" for accent and falls back gracefully', () => {
+    // #ZZZZZZ contains non-hex characters — must be stripped to prevent CSS injection
     const result = streakParamsSchema.safeParse({
       user: 'octocat',
       accent: '#ZZZZZZ',
     });
 
-    expect(result.success).toBe(false);
-  });
-
-  it('rejects an invalid hex color like "#ZZZZZZ" for accent (Variation 4)', () => {
-    const result = streakParamsSchema.safeParse({
-      user: 'octocat',
-      accent: '#ZZZZZZ',
-    });
-
-    expect(result.success).toBe(false);
-  });
-
-  it('rejects an invalid hex color like "#ZZZZZZ" for accent (Variation 5)', () => {
-    const result = streakParamsSchema.safeParse({
-      user: 'octocat',
-      accent: '#ZZZZZZ',
-    });
-
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      // This extra check ensures Variation 5 isn't just a duplicate,
-      // but a stricter validation check!
-      expect(result.error.issues[0]?.message).toContain(
-        'accent must be a valid hex color (with or without #)'
-      );
-    }
-  });
-
-  it('rejects the invalid boundary hex color "#ZZZZZZ" for accent', () => {
-    const result = streakParamsSchema.safeParse({
-      user: 'octocat',
-      accent: '#ZZZZZZ',
-    });
-
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues[0]?.message).toContain(
-        'accent must be a valid hex color (with or without #)'
-      );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.accent).toBeUndefined();
     }
   });
 

--- a/lib/validations.theme-contrast.test.ts
+++ b/lib/validations.theme-contrast.test.ts
@@ -62,6 +62,9 @@ describe('Validations color and theme consistency', () => {
       user: 'octocat',
       bg: 'not-a-color',
     });
-    expect(invalid.success).toBe(false);
+    expect(invalid.success).toBe(true);
+    if (invalid.success) {
+      expect(invalid.data.bg).toBeUndefined();
+    }
   });
 });

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -10,6 +10,7 @@ import {
   sanitizeFont,
 } from './svg/sanitizer';
 import { themes } from './svg/themes';
+import type { HexColor } from '../types';
 
 export function toBooleanFlag(val?: string): boolean {
   return val === 'true' || val === '1';
@@ -226,7 +227,7 @@ const baseStreakParamsSchema = z.object({
       if (!val) return undefined;
       const cleanVal = val.trim().replace(/^#+/, '');
       if (/^([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(cleanVal)) {
-        return cleanVal;
+        return cleanVal as HexColor;
       }
       return undefined;
     }),
@@ -264,7 +265,7 @@ const baseStreakParamsSchema = z.object({
       if (!val) return undefined;
       const cleanVal = val.trim().replace(/^#+/, '');
       if (/^([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(cleanVal)) {
-        return cleanVal;
+        return cleanVal as HexColor;
       }
       return undefined;
     }),
@@ -279,12 +280,13 @@ const baseStreakParamsSchema = z.object({
           .map((c) => c.trim().replace(/^#+/, ''))
           .filter((c) => c.length > 0)
           .filter((c) => /^([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(c))
+          .map((c) => c as HexColor)
           .slice(0, 4);
         return parts.length > 0 ? parts : undefined;
       }
       const cleanVal = val.trim().replace(/^#+/, '');
       if (/^([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(cleanVal)) {
-        return cleanVal;
+        return cleanVal as HexColor;
       }
       return undefined;
     }),

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -10,7 +10,6 @@ import {
   sanitizeFont,
 } from './svg/sanitizer';
 import { themes } from './svg/themes';
-import type { HexColor } from '../types';
 
 export function toBooleanFlag(val?: string): boolean {
   return val === 'true' || val === '1';

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -222,10 +222,14 @@ const baseStreakParamsSchema = z.object({
   bg: z
     .string()
     .optional()
-    .refine((val) => !val || /^[0-9a-fA-F]{3,4}$|^[0-9a-fA-F]{6,8}$/.test(val.replace('#', '')), {
-      message: 'bg must be a valid hex color (with or without #)',
-    })
-    .transform((val) => (val ? sanitizeHexColor(val, '0d1117') : undefined)),
+    .transform((val) => {
+      if (!val) return undefined;
+      const cleanVal = val.trim().replace(/^#+/, '');
+      if (/^([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(cleanVal)) {
+        return cleanVal;
+      }
+      return undefined;
+    }),
   bgType: z.enum(['solid', 'linear', 'radial']).catch('solid').default('solid'),
   bgStart: z
     .string()
@@ -256,37 +260,33 @@ const baseStreakParamsSchema = z.object({
   text: z
     .string()
     .optional()
-    .refine((val) => !val || /^[0-9a-fA-F]{3,4}$|^[0-9a-fA-F]{6,8}$/.test(val.replace('#', '')), {
-      message: 'text must be a valid hex color (with or without #)',
-    })
-    .transform((val) => (val ? sanitizeHexColor(val, 'ffffff') : undefined)),
+    .transform((val) => {
+      if (!val) return undefined;
+      const cleanVal = val.trim().replace(/^#+/, '');
+      if (/^([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(cleanVal)) {
+        return cleanVal;
+      }
+      return undefined;
+    }),
   accent: z
     .string()
     .optional()
-    .refine(
-      (val) => {
-        if (!val) return true;
-        const parts = val.includes(',') ? val.split(',') : [val];
-        return parts.every((p) =>
-          /^[0-9a-fA-F]{3,4}$|^[0-9a-fA-F]{6,8}$/.test(p.trim().replace('#', ''))
-        );
-      },
-      {
-        message:
-          'accent must be a valid hex color (with or without #), or a comma-separated list of them',
-      }
-    )
     .transform((val) => {
       if (!val) return undefined;
       if (val.includes(',')) {
-        return val
+        const parts = val
           .split(',')
-          .map((c) => c.trim())
+          .map((c) => c.trim().replace(/^#+/, ''))
           .filter((c) => c.length > 0)
-          .slice(0, 4)
-          .map((c) => sanitizeHexColor(c, '00ffaa'));
+          .filter((c) => /^([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(c))
+          .slice(0, 4);
+        return parts.length > 0 ? parts : undefined;
       }
-      return sanitizeHexColor(val, '00ffaa');
+      const cleanVal = val.trim().replace(/^#+/, '');
+      if (/^([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(cleanVal)) {
+        return cleanVal;
+      }
+      return undefined;
     }),
 
   // Silently fall back to 'linear' for unknown values (matches old behavior)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
       '.next',
       ...(process.argv.some((arg) => arg.includes('massive-scaling'))
         ? []
-        : ['**/*.massive-scaling.test.ts']),
+        : ['**/*.massive-scaling.test.ts', '**/*.massive-scaling.test.tsx']),
     ],
     maxWorkers: process.env.CI ? 2 : 15,
     testTimeout: 30000,


### PR DESCRIPTION
## Description

Fixes #4996

This PR fixes an issue where invalid custom color override parameters (`bg`, `accent`, and `text`) could result in malformed CSS being generated inside SVG templates.

### Changes

* Added validation and transformation logic for custom color parameters.
* Invalid color values are now safely ignored and converted to `undefined`.
* Ensures the renderer falls back to default theme colors instead of generating malformed CSS.
* Updated validation tests to verify graceful fallback behavior.
* Updated route tests to verify invalid color overrides return a successful response and use defaults.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Validation and SVG rendering fix)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [x] I have updated `README.md` if required (not applicable).
* [x] I have starred the repo.
* [ ] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse quality standard.
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
