### PR TITLE
test(socials): verify accessibility standards and screen reader compliance

### DIFF
--- a/app/generator/data/socials.accessibility.test.tsx
+++ b/app/generator/data/socials.accessibility.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { SocialsSection } from '../components/sections/SocialsSection';
+
+vi.mock('./socials', () => ({
+  SOCIALS: [
+    {
+      id: 'github',
+      name: 'GitHub',
+      type: 'simpleicon',
+      iconUrl: '/github.svg',
+      category: 'Development',
+      placeholder: 'https://github.com/yourusername',
+    },
+    {
+      id: 'linkedin',
+      name: 'LinkedIn',
+      type: 'simpleicon',
+      iconUrl: '/linkedin.svg',
+      category: 'Professional',
+      placeholder: 'https://linkedin.com/in/yourname',
+    },
+  ],
+  SOCIAL_CATEGORIES: ['Development', 'Professional'],
+}));
+
+describe('SocialsSection Accessibility Standards & Screen Reader Compliance', () => {
+  const defaultProps = {
+    selected: ['github'],
+    socialLinks: {
+      github: 'https://github.com/testuser',
+    },
+    onSelectedChange: vi.fn(),
+    onLinkChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Case 1: search field remains keyboard accessible', () => {
+    render(<SocialsSection {...defaultProps} />);
+
+    const searchInput = screen.getByPlaceholderText('Search platforms...');
+
+    searchInput.focus();
+
+    expect(searchInput).toHaveFocus();
+  });
+
+  it('Case 2: exposes navigation tabs as accessible buttons', () => {
+    render(<SocialsSection {...defaultProps} />);
+
+    expect(
+      screen.getByRole('button', {
+        name: /pick platforms/i,
+      })
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(/② Add Links/i)).toBeInTheDocument();
+  });
+
+  it('Case 3: exposes category filters as keyboard reachable controls', () => {
+    render(<SocialsSection {...defaultProps} />);
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Development',
+      })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Professional',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('Case 4: platform selectors expose readable accessible names', () => {
+    render(<SocialsSection {...defaultProps} />);
+
+    expect(
+      screen.getByRole('button', {
+        name: /github/i,
+      })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {
+        name: /linkedin/i,
+      })
+    ).toBeInTheDocument();
+    expect(screen.getByAltText('GitHub')).toBeInTheDocument();
+    expect(screen.getByAltText('LinkedIn')).toBeInTheDocument();
+  });
+
+  it('Case 5: selected platforms provide keyboard accessible URL fields', () => {
+    render(<SocialsSection {...defaultProps} />);
+
+    const linksTab = screen
+      .getAllByRole('button')
+      .find((btn) => btn.textContent?.includes('Add Links'));
+
+    expect(linksTab).toBeDefined();
+
+    fireEvent.click(linksTab!);
+
+    const urlInput = screen.getByDisplayValue('https://github.com/testuser');
+
+    urlInput.focus();
+
+    expect(urlInput).toHaveFocus();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4587 

Adds accessibility-focused test coverage for the Socials section.

The new test suite validates:

- Keyboard accessibility of the platform search input.
- Accessibility of navigation tabs used to switch between platform selection and link management.
- Keyboard reachability of social category filters.
- Readable accessible names for social platform selectors.
- Keyboard accessibility of URL input fields for selected platforms.

All tests pass successfully with Vitest.

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

- N/A (test-only change)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally (if required by the repository).
- [x] My commits follow the Conventional Commits format.
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] This PR only adds automated test coverage and does not modify production functionality.
