### PR TITLE
test: add accessibility coverage for ContributorsClient

### DIFF
--- a/app/contributors/ContributorsClient.accessibility.test.tsx
+++ b/app/contributors/ContributorsClient.accessibility.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ContributorsClient from './ContributorsClient';
+
+const mockContributors = [
+  {
+    id: 1,
+    login: 'alice',
+    avatar_url: 'https://example.com/alice.png',
+    contributions: 42,
+    html_url: 'https://github.com/alice',
+  },
+];
+
+vi.mock('./ContributorsSearch', () => ({
+  default: () => <div>Contributors Search</div>,
+}));
+
+vi.mock('@/components/Leaderboard', () => ({
+  default: () => <div>Leaderboard</div>,
+}));
+
+vi.mock('@/app/components/Footer', () => ({
+  Footer: () => <div>Footer</div>,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: React.PropsWithChildren<{ href: string }>) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+      <div {...props}>{children}</div>
+    ),
+
+    h1: ({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+      <h1 {...props}>{children}</h1>
+    ),
+
+    h2: ({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+      <h2 {...props}>{children}</h2>
+    ),
+
+    p: ({ children, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+      <p {...props}>{children}</p>
+    ),
+
+    span: ({ children, ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
+      <span {...props}>{children}</span>
+    ),
+  },
+  useMotionValue: () => ({ set: vi.fn() }),
+  useSpring: <T,>(v: T) => v,
+  useTransform: () => 0,
+}));
+
+vi.mock('gsap', () => ({
+  default: {
+    registerPlugin: vi.fn(),
+    fromTo: vi.fn(),
+    to: vi.fn(),
+  },
+}));
+
+vi.mock('gsap/ScrollTrigger', () => ({
+  ScrollTrigger: {
+    getAll: () => [],
+  },
+}));
+
+const renderClient = () =>
+  render(
+    <ContributorsClient
+      contributors={mockContributors}
+      totalContributions={42}
+      topContributors={mockContributors}
+    />
+  );
+
+describe('ContributorsClient Accessibility Standards & Screen Reader Aria Compliance', () => {
+  it('renders accessible heading content for screen readers', () => {
+    renderClient();
+
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
+  it('exposes semantic heading hierarchy', () => {
+    renderClient();
+
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+
+    expect(screen.getByRole('heading', { name: /the vanguard/i })).toBeInTheDocument();
+
+    expect(screen.getByRole('heading', { name: /the collective/i })).toBeInTheDocument();
+  });
+
+  it('does not expose unnecessary aria-label attributes', () => {
+    renderClient();
+
+    document.querySelectorAll('[aria-label]').forEach((element) => {
+      expect(element).toBeFalsy();
+    });
+  });
+
+  it('does not expose unnecessary aria-labelledby attributes', () => {
+    renderClient();
+
+    document.querySelectorAll('[aria-labelledby]').forEach((element) => {
+      expect(element).toBeFalsy();
+    });
+  });
+
+  it('does not expose unnecessary aria-describedby attributes', () => {
+    renderClient();
+
+    document.querySelectorAll('[aria-describedby]').forEach((element) => {
+      expect(element).toBeFalsy();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4566 

Added accessibility test coverage for ContributorsClient.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
