### PR TITLE
feat: add structured logger and replace server-side console usage

### DIFF
--- a/app/(root)/dashboard/[username]/wrapped/page.tsx
+++ b/app/(root)/dashboard/[username]/wrapped/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from 'next/navigation';
+import { logger } from '@/lib/logger';
 import type { Metadata } from 'next';
 import GithubWrapped from '@/components/dashboard/GithubWrapped';
 import { getFullDashboardData, getWrappedData } from '@/lib/github';
@@ -37,7 +38,10 @@ export default async function WrappedPage({
       getWrappedData(username, targetYear),
     ]);
   } catch (error) {
-    console.error('[Wrapped] Failed to load wrapped data:', error);
+    logger.error('Failed to load wrapped data', {
+      source: 'Wrapped',
+      error,
+    });
     // If the user doesn't exist or API fails, trigger the 404 page
     return notFound();
   }

--- a/app/(root)/dashboard/error.tsx
+++ b/app/(root)/dashboard/error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import Link from 'next/link';
+import logger from '@/lib/logger';
 
 export default function DashboardError({
   error,
@@ -11,7 +12,9 @@ export default function DashboardError({
   reset: () => void;
 }) {
   useEffect(() => {
-    console.error(error);
+    logger.error('Dashboard error', {
+      error,
+    });
   }, [error]);
 
   const isRateLimit = error.message.includes('API limit') || error.message.includes('rate limit');

--- a/app/(root)/dashboard/org/[orgname]/page.tsx
+++ b/app/(root)/dashboard/org/[orgname]/page.tsx
@@ -12,6 +12,7 @@ import Heatmap from '@/components/dashboard/Heatmap';
 import AIInsights from '@/components/dashboard/AIInsights';
 import Achievements from '@/components/dashboard/Achievements';
 import { getOrgDashboardData, buildCommitClock, generateAchievements } from '@/lib/github';
+import logger from '@/lib/logger';
 
 export const revalidate = 3600; // Cache for 1 hour
 
@@ -59,7 +60,9 @@ export default async function OrgDashboardPage({
   try {
     data = await getOrgDashboardData(orgname, { bypassCache });
   } catch (error) {
-    console.error(error);
+    logger.error('Failed to load organization page', {
+      error,
+    });
     return notFound();
   }
 

--- a/app/api/github/route.ts
+++ b/app/api/github/route.ts
@@ -8,16 +8,14 @@ import { quotaMonitor } from '@/services/github/quota-monitor';
 import { refreshPolicy } from '@/services/github/refresh-policy';
 import { refreshRateLimiter } from '@/services/github/refresh-rate-limiter';
 import { backgroundRefresh } from '@/services/github/background-refresh';
+import { logger } from '@/lib/logger';
 
 function logSecurityEvent(event: string, details: Record<string, unknown>) {
-  console.warn(
-    JSON.stringify({
-      timestamp: new Date().toISOString(),
-      type: 'SECURITY_EVENT',
-      event,
-      ...details,
-    })
-  );
+  logger.warn('Security event', {
+    type: 'SECURITY_EVENT',
+    event,
+    ...details,
+  });
 }
 
 /**

--- a/app/api/notify/route.ts
+++ b/app/api/notify/route.ts
@@ -5,6 +5,7 @@ import { NotificationResponse } from '@/types/index';
 import { notifyPostSchema, notifyGetSchema } from '@/lib/validations';
 import { notifyRateLimiter } from '@/lib/rate-limit';
 import { getClientIp } from '@/utils/getClientIp';
+import logger from '@/lib/logger';
 
 /**
  * Masks an email address to prevent PII exposure in unauthenticated responses.
@@ -72,18 +73,18 @@ export async function POST(req: NextRequest): Promise<NextResponse<NotificationR
     // Graceful MONGODB_URI handling
     if (!process.env.MONGODB_URI) {
       if (process.env.NODE_ENV === 'production') {
-        console.error(
-          'CRITICAL: MONGODB_URI is not set in production environment. Notification registration is disabled.'
-        );
+        logger.error('Notification registration disabled: MONGODB_URI is not set', {
+          environment: process.env.NODE_ENV,
+        });
         return NextResponse.json(
           { success: false, message: 'Database configuration error.' },
           { status: 500 }
         );
       }
 
-      console.warn(
-        'MONGODB_URI is not set. Bypassing notification registration for local development.'
-      );
+      logger.warn('Notification registration bypassed: MONGODB_URI is not set', {
+        environment: process.env.NODE_ENV,
+      });
       return NextResponse.json({
         success: true,
         message: 'Notification registration bypassed (no database configured).',
@@ -125,7 +126,10 @@ export async function POST(req: NextRequest): Promise<NextResponse<NotificationR
       { status: 200 }
     );
   } catch (error) {
-    console.error('[/api/notify] Error saving notification preferences:', error);
+    logger.error('Failed to save notification preferences', {
+      route: '/api/notify',
+      error,
+    });
     return NextResponse.json(
       { success: false, message: 'Internal server error.' },
       { status: 500 }
@@ -167,16 +171,19 @@ export async function GET(req: NextRequest): Promise<NextResponse<NotificationRe
     // Graceful MONGODB_URI handling
     if (!process.env.MONGODB_URI) {
       if (process.env.NODE_ENV === 'production') {
-        console.error(
-          'CRITICAL: MONGODB_URI is not set in production environment. Notification lookup is disabled.'
-        );
+        logger.error('Notification lookup disabled: MONGODB_URI is not set', {
+          environment: process.env.NODE_ENV,
+        });
         return NextResponse.json(
           { success: false, message: 'Database configuration error.' },
           { status: 500 }
         );
       }
 
-      console.warn('MONGODB_URI is not set. Bypassing notification lookup for local development.');
+      logger.warn('Notification lookup bypassed: MONGODB_URI is not set', {
+        environment: process.env.NODE_ENV,
+      });
+
       return NextResponse.json({
         success: false,
         message: 'No notification preferences found (no database configured).',
@@ -216,7 +223,10 @@ export async function GET(req: NextRequest): Promise<NextResponse<NotificationRe
       { status: 200 }
     );
   } catch (error) {
-    console.error('[/api/notify] Error fetching notification preferences:', error);
+    logger.error('Failed to fetch notification preferences', {
+      route: '/api/notify',
+      error,
+    });
     return NextResponse.json(
       { success: false, message: 'Internal server error.' },
       { status: 500 }

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -6,6 +6,7 @@ import { ogParamsSchema } from '@/lib/validations';
 import { themes } from '@/lib/svg/themes';
 import { fetchGitHubContributions } from '@/lib/github';
 import { calculateStreak } from '@/lib/calculate';
+import { logger } from '@/lib/logger';
 
 const appUrl =
   process.env.NEXT_PUBLIC_SITE_URL ||
@@ -68,7 +69,10 @@ export async function GET(req: NextRequest) {
     longestStreak = stats.longestStreak;
     currentStreak = stats.currentStreak;
   } catch (err) {
-    console.error('[OG] stats fetch failed:', err);
+    logger.error('Stats fetch failed', {
+      source: 'OG',
+      error: err,
+    });
     // fallback to zeros if GitHub is unreachable
   }
 

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -17,6 +17,7 @@ import type { BadgeParams, ContributionCalendar } from '@/types';
 import { themes } from '@/lib/svg/themes';
 import { streakParamsSchema } from '@/lib/validations';
 import { sanitizeHexColor } from '@/lib/svg/sanitizer';
+import { logger } from '@/lib/logger';
 
 const SVG_CSP_HEADER =
   "default-src 'none'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src https://fonts.gstatic.com;";
@@ -438,7 +439,10 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
   }
 
   // 4. Return a 500 Internal Server Error for real crashes
-  console.error('[streak] Unhandled error:', message);
+  logger.error('Unhandled error', {
+    source: 'streak',
+    message,
+  });
 
   const errorSvg = `
       <svg xmlns="http://www.w3.org/2000/svg" width="400" height="150">

--- a/app/api/student/resume/confirm/route.ts
+++ b/app/api/student/resume/confirm/route.ts
@@ -4,6 +4,7 @@ import { StudentProfile } from '@/models/StudentProfile';
 import { RateLimiter } from '@/lib/rate-limit';
 import type { ParsedResume } from '@/types/student';
 import { getClientIp } from '@/utils/getClientIp';
+import { logger } from '@/lib/logger';
 
 const confirmLimiter = new RateLimiter(10, 60000);
 
@@ -58,7 +59,9 @@ export async function POST(req: Request) {
 
   try {
     if (!process.env.MONGODB_URI) {
-      console.warn('MONGODB_URI is not set. Bypassing student profile save.');
+      logger.warn('Student profile save bypassed: MONGODB_URI is not set', {
+        environment: process.env.NODE_ENV,
+      });
       return NextResponse.json({ success: true, bypassed: true });
     }
 
@@ -81,7 +84,9 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error('Error saving student profile:', error);
+    logger.error('Failed to save student profile', {
+      error,
+    });
     return NextResponse.json(
       { success: false, error: 'Failed to save profile data' },
       { status: 500 }

--- a/app/api/student/resume/upload/route.ts
+++ b/app/api/student/resume/upload/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { parseResume, ALLOWED_MIME_TYPES, MAX_FILE_SIZE } from '@/lib/resume-parser';
 import { RateLimiter } from '@/lib/rate-limit';
 import { getClientIp } from '@/utils/getClientIp';
+import logger from '@/lib/logger';
 
 const uploadLimiter = new RateLimiter(10, 60000);
 
@@ -59,7 +60,9 @@ export async function POST(req: Request) {
       fileName: file.name,
     });
   } catch (error) {
-    console.error('Error parsing resume:', error);
+    logger.error('Failed to parse resume', {
+      error,
+    });
     return NextResponse.json(
       { success: false, error: 'Failed to parse resume. Please enter your details manually.' },
       { status: 422 }

--- a/app/api/track-user/route.test.ts
+++ b/app/api/track-user/route.test.ts
@@ -159,9 +159,8 @@ describe('POST /api/track-user', () => {
       expect(data.success).toBe(true);
       expect(data.bypassed).toBe(true);
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'MONGODB_URI is not set. Bypassing user tracking for local development.'
-      );
+      expect(consoleSpy).toHaveBeenCalled();
+      expect(consoleSpy.mock.calls[0][0]).toContain('User tracking bypassed');
       expect(dbConnect).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();

--- a/app/api/track-user/route.ts
+++ b/app/api/track-user/route.ts
@@ -4,6 +4,7 @@ import { User } from '@/models/User';
 import { trackUserRateLimiter } from '@/lib/rate-limit';
 import { getClientIp } from '@/utils/getClientIp';
 import { trackUserProtection } from '@/services/security/track-user-protection';
+import logger from '@/lib/logger';
 
 export async function POST(req: Request) {
   // Get IP for rate limiting securely
@@ -60,9 +61,9 @@ export async function POST(req: Request) {
     if (!process.env.MONGODB_URI) {
       // In production, this is a critical configuration failure
       if (process.env.NODE_ENV === 'production') {
-        console.error(
-          'CRITICAL: MONGODB_URI is not set in production environment. User tracking is disabled.'
-        );
+        logger.error('User tracking disabled: MONGODB_URI is not set', {
+          environment: process.env.NODE_ENV,
+        });
         return NextResponse.json(
           { success: false, error: 'Database configuration error' },
           { status: 500 }
@@ -70,7 +71,9 @@ export async function POST(req: Request) {
       }
 
       // For development/non-production environments, bypass gracefully
-      console.warn('MONGODB_URI is not set. Bypassing user tracking for local development.');
+      logger.warn('User tracking bypassed: MONGODB_URI is not set', {
+        environment: process.env.NODE_ENV,
+      });
       trackUserProtection.recordWrite(trimmedUsername);
       return NextResponse.json({ success: true, bypassed: true });
     }
@@ -116,7 +119,10 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error('Error tracking user:', error);
+    logger.error('Failed to track user', {
+      route: '/api/track-user',
+      error,
+    });
 
     return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
   }

--- a/app/api/wrapped/route.ts
+++ b/app/api/wrapped/route.ts
@@ -6,6 +6,7 @@ import { generateWrappedSVG, generateNotFoundSVG, generateRateLimitSVG } from '@
 import { wrappedParamsSchema } from '@/lib/validations';
 import type { BadgeParams } from '@/types';
 import { themes } from '@/lib/svg/themes';
+import logger from '@/lib/logger';
 
 const SVG_CSP_HEADER =
   "default-src 'none'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src https://fonts.gstatic.com;";
@@ -199,7 +200,10 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
     });
   }
 
-  console.error('[wrapped] Unhandled error:', message);
+  logger.error('Unhandled error', {
+    source: 'wrapped',
+    message,
+  });
 
   const errorSvg = `
       <svg xmlns="http://www.w3.org/2000/svg" width="400" height="150">

--- a/app/contributors/page.tsx
+++ b/app/contributors/page.tsx
@@ -1,4 +1,5 @@
 import ContributorsClient from './ContributorsClient';
+import logger from '@/lib/logger';
 
 interface Contributor {
   id: number;
@@ -48,7 +49,9 @@ async function getContributors(): Promise<Contributor[]> {
 
     return res.json();
   } catch (error) {
-    console.error('Failed to fetch contributors:', error);
+    logger.error('Failed to fetch contributors', {
+      error,
+    });
     return [];
   }
 }

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,3 +1,5 @@
+import logger from '@/lib/logger';
+
 /**
  * Represents a cached item with its expiration timestamp.
  */
@@ -263,7 +265,11 @@ export class DistributedCache<T> {
       this.localCache.set(key, parsed, 5 * 60 * 1000);
       return parsed;
     } catch (err) {
-      console.error(`[DistributedCache] GET failed for key "${key}":`, err);
+      logger.error('Cache GET failed', {
+        component: 'DistributedCache',
+        key,
+        error: err,
+      });
       return this.localCache.get(key);
     }
   }
@@ -291,7 +297,11 @@ export class DistributedCache<T> {
         throw new Error(`Redis HTTP error: ${res.status}`);
       }
     } catch (err) {
-      console.error(`[DistributedCache] SET failed for key "${key}":`, err);
+      logger.error('Cache SET failed', {
+        component: 'DistributedCache',
+        key,
+        error: err,
+      });
     }
   }
 
@@ -318,7 +328,11 @@ export class DistributedCache<T> {
       const data = await res.json();
       return Boolean(data.result);
     } catch (err) {
-      console.error(`[DistributedCache] DELETE failed for key "${key}":`, err);
+      logger.error('Cache DELETE failed', {
+        component: 'DistributedCache',
+        key,
+        error: err,
+      });
       return localDeleted;
     }
   }
@@ -362,7 +376,11 @@ export class DistributedCache<T> {
       }
       return true;
     } catch (err) {
-      console.error(`[DistributedCache] UPDATE failed for key "${key}":`, err);
+      logger.error('Cache UPDATE failed', {
+        component: 'DistributedCache',
+        key,
+        error: err,
+      });
       return true;
     }
   }
@@ -420,7 +438,11 @@ return c`;
       this.localCache.set(key, count as unknown as T, ttlMs);
       return count;
     } catch (err) {
-      console.error(`[DistributedCache] INCR failed for key "${key}":`, err);
+      logger.error('Cache INCR failed', {
+        component: 'DistributedCache',
+        key,
+        error: err,
+      });
       const current = (this.localCache.get(key) as unknown as number) || 0;
       const next = current + 1;
       if (current === 0) {
@@ -523,7 +545,11 @@ return c`;
           }
         } catch (err) {
           // Redis network error during locking. Fallback to direct execution.
-          console.error(`[DistributedCache] Lock error for "${key}":`, err);
+          logger.error('Cache lock failed', {
+            component: 'DistributedCache',
+            key,
+            error: err,
+          });
           const fallbackData = await loadFn(cached);
           await this.set(key, fallbackData, ttlMs);
           return fallbackData;

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -12,6 +12,7 @@ import { DistributedCache } from '@/lib/cache';
 import { LANGUAGE_COLORS } from '@/lib/svg/languageColors';
 import { CONTRIBUTION_MILESTONES, STREAK_MILESTONES } from './svg/constants';
 import { quotaMonitor } from '@/services/github/quota-monitor';
+import logger from '@/lib/logger';
 
 interface GitHubRepo {
   name: string;
@@ -90,7 +91,10 @@ export async function fetchWithRetry(
   try {
     quotaMonitor.updateQuotaFromHeaders(res.headers);
   } catch (err) {
-    console.error('Failed to update quota monitor', err);
+    logger.error('Failed to update quota monitor', {
+      component: 'GitHub',
+      error: err,
+    });
   }
 
   // Check for rate limit headers
@@ -432,10 +436,11 @@ export async function fetchGitHubContributions(
     } catch (err: unknown) {
       const staleData = await contributionsCache.get(key);
       if (staleData) {
-        console.warn(
-          `[GitHub API] Fetch failed for "${username}", falling back to stale cache:`,
-          err
-        );
+        logger.warn('GitHub API fetch failed, falling back to stale cache', {
+          component: 'GitHub API',
+          username,
+          error: err,
+        });
         return {
           ...staleData,
           isOfflineFallback: true,
@@ -450,10 +455,11 @@ export async function fetchGitHubContributions(
   } catch (err: unknown) {
     const staleData = await contributionsCache.get(key);
     if (staleData) {
-      console.warn(
-        `[GitHub API] Fetch failed for "${username}", falling back to stale cache:`,
-        err
-      );
+      logger.warn('GitHub API fetch failed, falling back to stale cache', {
+        component: 'GitHub API',
+        username,
+        error: err,
+      });
       return {
         ...staleData,
         isOfflineFallback: true,

--- a/lib/logger.test.ts
+++ b/lib/logger.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('logger', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+
+    process.env = {
+      ...OLD_ENV,
+    };
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('debug is silent in production', async () => {
+    process.env = {
+      ...process.env,
+      NODE_ENV: 'production',
+    };
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const logger = (await import('./logger')).default;
+
+    logger.debug('debug message');
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('info is silent in production', async () => {
+    process.env = {
+      ...process.env,
+      NODE_ENV: 'production',
+    };
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const logger = (await import('./logger')).default;
+
+    logger.info('info message');
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('error always emits in production', async () => {
+    process.env = {
+      ...process.env,
+      NODE_ENV: 'production',
+    };
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const logger = (await import('./logger')).default;
+
+    logger.error('something failed');
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('production output is valid JSON', async () => {
+    process.env = {
+      ...process.env,
+      NODE_ENV: 'production',
+    };
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const logger = (await import('./logger')).default;
+
+    logger.error('json test', {
+      route: '/api/test',
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+
+    const output = logSpy.mock.calls[0][0] as string;
+
+    const parsed = JSON.parse(output);
+
+    expect(parsed.level).toBe('error');
+    expect(parsed.msg).toBe('json test');
+    expect(parsed.route).toBe('/api/test');
+    expect(parsed.timestamp).toBeDefined();
+  });
+});

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,77 @@
+type Context = Record<string, unknown>;
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+const COLORS = {
+  debug: '\x1b[36m', // Cyan
+  info: '\x1b[32m', // Green
+  warn: '\x1b[33m', // Yellow
+  error: '\x1b[31m', // Red
+  reset: '\x1b[0m',
+};
+
+function createTimestamp(): string {
+  return new Date().toISOString();
+}
+
+function logProduction(level: 'warn' | 'error', msg: string, ctx: Context = {}): void {
+  const payload = {
+    level,
+    msg,
+    timestamp: createTimestamp(),
+    ...ctx,
+  };
+
+  console.log(JSON.stringify(payload));
+}
+
+function logDevelopment(
+  level: 'debug' | 'info' | 'warn' | 'error',
+  msg: string,
+  ctx: Context = {}
+): void {
+  const color = COLORS[level];
+  const contextString = Object.keys(ctx).length > 0 ? ` ${JSON.stringify(ctx)}` : '';
+
+  const output = `${color}[${level.toUpperCase()}]${COLORS.reset} ${msg}${contextString}`;
+
+  if (level === 'error') {
+    console.error(output);
+  } else if (level === 'warn') {
+    console.warn(output);
+  } else {
+    console.log(output);
+  }
+}
+
+export const logger = {
+  debug(msg: string, ctx?: Context): void {
+    if (isProduction) return;
+    logDevelopment('debug', msg, ctx);
+  },
+
+  info(msg: string, ctx?: Context): void {
+    if (isProduction) return;
+    logDevelopment('info', msg, ctx);
+  },
+
+  warn(msg: string, ctx?: Context): void {
+    if (isProduction) {
+      logProduction('warn', msg, ctx);
+      return;
+    }
+
+    logDevelopment('warn', msg, ctx);
+  },
+
+  error(msg: string, ctx?: Context): void {
+    if (isProduction) {
+      logProduction('error', msg, ctx);
+      return;
+    }
+
+    logDevelopment('error', msg, ctx);
+  },
+};
+
+export default logger;


### PR DESCRIPTION
## Description

Fixes #4915

### Summary

Implemented a structured logging system for server-side runtime services.

### Changes Made

- Added `lib/logger.ts` with:
  - `debug()`
  - `info()`
  - `warn()`
  - `error()`

- Added environment-aware logging behavior:
  - Development: human-readable console output
  - Production: structured JSON logging

- Suppressed `debug` and `info` logs in production.

- Replaced server-side `console.warn()` and `console.error()` usages with structured logger methods across:
  - Dashboard pages
  - API routes
  - Cache utilities
  - GitHub integration utilities
  - Contributors page

- Added `lib/logger.test.ts` covering:
  - Debug logs are silent in production
  - Info logs are silent in production
  - Error logs are emitted in production
  - Production log output is valid JSON

- Updated affected tests to match the new logging implementation.

### Example Production Output

```json
{
  "level": "error",
  "msg": "Failed to fetch notification preferences",
  "route": "/api/notify",
  "timestamp": "2026-06-09T12:00:00.000Z"
}
```

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (logging infrastructure change)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.