### PR TITLE
test(CommitPulseSection): verify accessibility standards and screen reader compliance

### DIFF
--- a/app/generator/components/sections/CommitPulseSection.accessibility.test.tsx
+++ b/app/generator/components/sections/CommitPulseSection.accessibility.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+import { CommitPulseSection } from './CommitPulseSection';
+
+// Mock debounce hook
+vi.mock('@/hooks/useDebounce', () => ({
+  useDebounce: (value: string) => value,
+}));
+
+// Mock username validation
+vi.mock('@/lib/validations', () => ({
+  validateGitHubUsername: () => true,
+}));
+
+// Mock next/image
+vi.mock('next/image', () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
+}));
+
+describe('CommitPulseSection Accessibility Standards & Screen Reader Compliance', () => {
+  const defaultProps = {
+    githubUsername: '',
+    showCommitPulse: true,
+    commitPulseAccent: '',
+    onGithubUsernameChange: vi.fn(),
+    onShowCommitPulseChange: vi.fn(),
+    onCommitPulseAccentChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Case 1
+  it('Case 1: exposes the CommitPulse toggle as an accessible switch', () => {
+    render(<CommitPulseSection {...defaultProps} />);
+
+    const toggle = screen.getByRole('switch', {
+      name: /toggle commitpulse badge/i,
+    });
+
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+
+  // Case 2
+  it('Case 2: GitHub username input remains keyboard accessible', () => {
+    render(<CommitPulseSection {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText(/omkarardekar12/i);
+
+    input.focus();
+
+    expect(input).toHaveFocus();
+  });
+
+  // Case 3
+  it('Case 3: clear username button exposes an accessible name', () => {
+    render(<CommitPulseSection {...defaultProps} githubUsername="octocat" />);
+
+    expect(
+      screen.getByRole('button', {
+        name: /clear username/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  // Case 4
+  it('Case 4: accent colour input remains keyboard accessible', () => {
+    render(<CommitPulseSection {...defaultProps} />);
+
+    const accentInput = screen.getByPlaceholderText('10b981');
+
+    accentInput.focus();
+
+    expect(accentInput).toHaveFocus();
+  });
+
+  // Case 5
+  it('Case 5: section heading hierarchy remains available to assistive technologies', () => {
+    render(<CommitPulseSection {...defaultProps} />);
+
+    expect(screen.getByText('CommitPulse Badge')).toBeInTheDocument();
+
+    expect(screen.getByText(/include badge in readme/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4581 

Adds accessibility-focused test coverage for `CommitPulseSection`.

### Covered scenarios

- Verifies the CommitPulse toggle is exposed as an accessible switch.
- Ensures the GitHub username input remains keyboard accessible.
- Confirms the clear username control exposes an accessible name.
- Verifies the accent colour input remains keyboard accessible.
- Confirms section heading content remains available to assistive technologies.

### Testing

- Added `app/generator/components/sections/CommitPulseSection.accessibility.test.tsx`
- Added 5 accessibility-focused test cases.
- All tests pass successfully with Vitest.

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

- N/A (test-only change)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] My commits follow the Conventional Commits format.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] This PR only adds automated test coverage and does not modify production functionality.
