### PR TITLE
fix: validate GitHub username in PR Insights endpoint

### DIFF
--- a/app/api/pr-insights/route.ts
+++ b/app/api/pr-insights/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { fetchPRInsights } from '@/services/github/pr-insights';
+import { validateGitHubUsername } from '@/lib/validations';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -9,8 +10,13 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Username is required' }, { status: 400 });
   }
 
+  const trimmed = username.trim();
+  if (trimmed.length > 39 || !validateGitHubUsername(trimmed)) {
+    return NextResponse.json({ error: 'Invalid GitHub username' }, { status: 400 });
+  }
+
   try {
-    const data = await fetchPRInsights(username);
+    const data = await fetchPRInsights(trimmed);
     return NextResponse.json(data);
   } catch (error: unknown) {
     console.error('Error fetching PR insights:', error);


### PR DESCRIPTION
## Description

Fixes #5033

## Pillar

- [ ] Pillar 1 — New Theme Design
- [ ] Pillar 2 — Geometric SVG Improvement
- [ ] Pillar 3 — Timezone Logic Optimization
- [x] Other (Bug fix, refactoring, docs)

## Changes

- Added validateGitHubUsername import from lib/validations
- Added username trimming and length validation (max 39 chars)
- Added regex validation using existing validateGitHubUsername function
- Returns 400 with structured error for invalid usernames
- Prevents malformed usernames from reaching GitHub GraphQL API

## Verification

- GET /api/pr-insights?username=bad%20user returns 400
- GET /api/pr-insights?username=-octocat returns 400
- GET /api/pr-insights?username=octocat! returns 400
- GET /api/pr-insights?username=octocat returns 200 (valid)

## Checklist

- [x] I have read the CONTRIBUTING.md file.
- [x] I have tested these changes locally.
- [x] My commits follow the Conventional Commits format.