### PR TITLE
test: add accessibility tests for dashboard layout

### DIFF
--- a/app/(root)/dashboard/layout.accessibility.test.tsx
+++ b/app/(root)/dashboard/layout.accessibility.test.tsx
@@ -1,0 +1,62 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import DashboardLayout from './layout';
+
+vi.mock('sonner', () => ({
+  Toaster: () => <div data-testid="toaster" />,
+}));
+
+describe('DashboardLayout Accessibility', () => {
+  it('renders the main landmark element', () => {
+    render(
+      <DashboardLayout>
+        <div>Dashboard Content</div>
+      </DashboardLayout>
+    );
+
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  it('renders children inside the main landmark', () => {
+    render(
+      <DashboardLayout>
+        <div>Dashboard Content</div>
+      </DashboardLayout>
+    );
+
+    expect(screen.getByText('Dashboard Content')).toBeInTheDocument();
+  });
+
+  it('contains exactly one main landmark', () => {
+    render(
+      <DashboardLayout>
+        <div>Dashboard Content</div>
+      </DashboardLayout>
+    );
+
+    expect(screen.getAllByRole('main')).toHaveLength(1);
+  });
+
+  it('renders the toaster component for accessible notifications', () => {
+    render(
+      <DashboardLayout>
+        <div>Dashboard Content</div>
+      </DashboardLayout>
+    );
+
+    expect(screen.getByTestId('toaster')).toBeInTheDocument();
+  });
+
+  it('keeps the main landmark available for screen readers', () => {
+    render(
+      <DashboardLayout>
+        <button>Focusable Button</button>
+      </DashboardLayout>
+    );
+
+    expect(screen.getByRole('main')).toContainElement(
+      screen.getByRole('button', { name: 'Focusable Button' })
+    );
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4546 

Added accessibility-focused tests for `app/(root)/dashboard/layout.tsx`.

Coverage includes:
- Main landmark rendering
- Child content rendering inside the main landmark
- Toaster component rendering for accessible notifications
- Main landmark availability for screen readers

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
