### PR TITLE
fix(resume): reject partial education/experience entries and enforce validators

### DIFF
--- a/app/api/student/resume/confirm/route.test.ts
+++ b/app/api/student/resume/confirm/route.test.ts
@@ -98,7 +98,7 @@ describe('POST /api/student/resume/confirm Extra Scenarios', () => {
     expect(StudentProfile.findOneAndUpdate).toHaveBeenCalledWith(
       { githubUsername: 'testuser' },
       expect.any(Object),
-      { upsert: true, new: true }
+      { upsert: true, new: true, runValidators: true }
     );
     expect(response.status).toBe(200);
   });

--- a/app/api/student/resume/confirm/route.ts
+++ b/app/api/student/resume/confirm/route.ts
@@ -90,7 +90,7 @@ export async function POST(req: Request) {
           updatedAt: new Date(),
         },
       },
-      { upsert: true, new: true }
+      { upsert: true, new: true, runValidators: true }
     );
 
     return NextResponse.json({ success: true });

--- a/app/api/student/resume/tests/confirm.test.ts
+++ b/app/api/student/resume/tests/confirm.test.ts
@@ -108,7 +108,7 @@ describe('POST /api/student/resume/confirm', () => {
     expect(StudentProfile.findOneAndUpdate).toHaveBeenCalledWith(
       { githubUsername: 'testuser' },
       expect.any(Object),
-      { upsert: true, new: true }
+      { upsert: true, new: true, runValidators: true }
     );
 
     expect(response.status).toBe(200);

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -642,7 +642,14 @@ export const resumeConfirmDataSchema = z.object({
     .max(50, { message: 'Too many education entries (max 50)' })
     .default([])
     .transform((items) =>
-      items.filter((e) => e.institution || e.degree || e.field || e.startDate || e.endDate)
+      items.filter(
+        (e) =>
+          e.institution.length > 0 &&
+          e.degree.length > 0 &&
+          e.field.length > 0 &&
+          e.startDate.length > 0 &&
+          e.endDate.length > 0
+      )
     ),
   experience: z
     .array(
@@ -657,7 +664,13 @@ export const resumeConfirmDataSchema = z.object({
     .max(50, { message: 'Too many experience entries (max 50)' })
     .default([])
     .transform((items) =>
-      items.filter((x) => x.company || x.role || x.startDate || x.endDate || x.description)
+      items.filter(
+        (x) =>
+          x.company.length > 0 &&
+          x.role.length > 0 &&
+          x.startDate.length > 0 &&
+          x.endDate.length > 0
+      )
     ),
 });
 


### PR DESCRIPTION
## Description

Fixes #5037

## Pillar

- [x] Other (Bug fix, refactoring, docs)

## Changes

- Updated education transform to require ALL fields (institution, degree, field, startDate, endDate)
- Updated experience transform to require ALL required fields (company, role, startDate, endDate)
- Partial entries with only some fields filled are now dropped
- Added runValidators: true to findOneAndUpdate call
- Ensures Mongoose schema constraints are enforced during updates

## Verification

- POST /api/student/resume/confirm with partial education entry (only institution) → entry is dropped
- POST /api/student/resume/confirm with complete education entry → entry is saved
- Database validators now run on update operations

## Checklist

- [x] I have read the CONTRIBUTING.md file.
- [x] I have tested these changes locally.
- [x] My commits follow the Conventional Commits format.
