### PR TITLE
test: add accessibility coverage for CustomizeCTA

### DIFF
--- a/app/components/CustomizeCTA.accessibility.test.tsx
+++ b/app/components/CustomizeCTA.accessibility.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CustomizeCTA } from './CustomizeCTA';
+
+vi.mock('@/context/TranslationContext', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'customize_cta.studio_badge': 'Customization Studio',
+        'customize_cta.title': 'Create Your Perfect Profile',
+        'customize_cta.desc': 'Customize your profile with advanced options.',
+        'customize_cta.btn': 'Open Studio',
+      };
+
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+describe('CustomizeCTA Accessibility', () => {
+  it('renders the primary heading for screen readers', () => {
+    render(<CustomizeCTA />);
+
+    expect(
+      screen.getByRole('heading', {
+        name: /create your perfect profile/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('renders an accessible navigation link to customization studio', () => {
+    render(<CustomizeCTA />);
+
+    expect(
+      screen.getByRole('link', {
+        name: /open studio/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('preserves keyboard-focusable interactive elements', () => {
+    render(<CustomizeCTA />);
+
+    const link = screen.getByRole('link', {
+      name: /open studio/i,
+    });
+
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/customize');
+  });
+
+  it('renders descriptive content for assistive technologies', () => {
+    render(<CustomizeCTA />);
+
+    expect(screen.getByText(/customize your profile with advanced options/i)).toBeInTheDocument();
+  });
+
+  it('maintains logical heading hierarchy and decorative accessibility rules', () => {
+    render(<CustomizeCTA />);
+
+    const heading = screen.getByRole('heading', {
+      name: /create your perfect profile/i,
+    });
+
+    expect(heading.tagName).toBe('H2');
+
+    const decorativeSvgs = document.querySelectorAll('svg[aria-hidden="true"]');
+
+    expect(decorativeSvgs.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4560

Added `app/components/CustomizeCTA.accessibility.test.tsx` to verify Accessibility Standards & Screen Reader Aria Compliance for the CustomizeCTA component.

### Added Test Coverage

* Screen-reader accessible heading verification
* Accessible CTA link rendering and navigation validation
* Keyboard-focusable interactive element checks
* Descriptive content accessibility verification
* Heading hierarchy and decorative element accessibility validation

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable)
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
