### PR TITLE
fix: validate GitHub usernames in PR insights API

### DIFF
--- a/app/api/pr-insights/route.ts
+++ b/app/api/pr-insights/route.ts
@@ -1,13 +1,21 @@
 import { NextResponse } from 'next/server';
 import { fetchPRInsights } from '@/services/github/pr-insights';
+import { githubParamsSchema } from '@/lib/validations';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const username = searchParams.get('username');
+  const validation = githubParamsSchema.safeParse({
+  username: searchParams.get('username'),
+});
 
-  if (!username) {
-    return NextResponse.json({ error: 'Username is required' }, { status: 400 });
-  }
+if (!validation.success) {
+  return NextResponse.json(
+    { error: validation.error.issues[0]?.message || 'Invalid GitHub username' },
+    { status: 400 }
+  );
+}
+
+const username = validation.data.username;
 
   try {
     const data = await fetchPRInsights(username);


### PR DESCRIPTION
## Description

Fixes #5033

This PR adds GitHub username validation to the PR Insights API endpoint before making upstream GitHub requests.

### Changes

* Reused the existing `githubParamsSchema` validation from `lib/validations.ts`.
* Validated and sanitized the `username` query parameter in `app/api/pr-insights/route.ts`.
* Return `400 Bad Request` for invalid GitHub usernames instead of forwarding invalid input to GitHub and returning a `500` error.

### Examples

The following inputs now return `400 Bad Request`:

* `bad user`
* `-octocat`
* `octocat!`

Valid GitHub usernames continue to work as expected.

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (API validation fix)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
