### PR TITLE
fix(api): validate and clamp speed param to prevent broken SVG animation

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -208,6 +208,12 @@ export async function GET(request: Request) {
     const borderParam = searchParams.get('border');
     const sanitizedBorder = borderParam ? borderParam.replace(/[^a-fA-F0-9]/g, '') : undefined;
     const animate = searchParams.get('animate') !== 'false';
+    // Validate and clamp the speed param to prevent broken SVG animation
+    const rawSpeedNum = speed ? parseFloat(String(speed)) : NaN;
+    const validatedSpeed =
+      !isNaN(rawSpeedNum) && isFinite(rawSpeedNum) && rawSpeedNum >= 1 && rawSpeedNum <= 60
+        ? `${rawSpeedNum}s`
+        : '8s';
     const params: BadgeParams = {
       user: targetEntity,
       bg: isAutoTheme ? selectedTheme.bg : bg || selectedTheme.bg,
@@ -215,7 +221,7 @@ export async function GET(request: Request) {
       accent: isAutoTheme ? selectedTheme.accent : accent || selectedTheme.accent,
       border: sanitizedBorder,
       radius,
-      speed,
+      speed: validatedSpeed,
       scale,
       font,
       autoTheme: isAutoTheme,

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -210,10 +210,11 @@ export async function GET(request: Request) {
     const animate = searchParams.get('animate') !== 'false';
     // Validate and clamp the speed param to prevent broken SVG animation
     const rawSpeedNum = speed ? parseFloat(String(speed)) : NaN;
-    const validatedSpeed =
+    const validatedSpeed = (
       !isNaN(rawSpeedNum) && isFinite(rawSpeedNum) && rawSpeedNum >= 1 && rawSpeedNum <= 60
         ? `${rawSpeedNum}s`
-        : '8s';
+        : '8s'
+    ) as `${number}s`;
     const params: BadgeParams = {
       user: targetEntity,
       bg: isAutoTheme ? selectedTheme.bg : bg || selectedTheme.bg,


### PR DESCRIPTION
## Description

Adds validation for the `?speed=` URL parameter to prevent invalid values from breaking the SVG animation.

Fixes #5057

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] Other: API parameter validation / bug fix

## Visual Preview
  
<img width="951" height="852" alt="Screenshot 2026-06-09 181942" src="https://github.com/user-attachments/assets/60e140bc-3b31-4574-ab45-781ba20fc1e4" />
  

## Checklist before requesting a review:

- [x ] I have read the `CONTRIBUTING.md` file.
- [x ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [ x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ x] I have updated `README.md` if I added a new theme or URL parameter.
- [ x] I have started the repo.
- [ x] I have made sure that i have only one commit to merge in this PR.
- [ x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
