### PR TITLE
test: add accessibility tests for StatsCardSkeleton

### DIFF
--- a/components/dashboard/StatsCardSkeleton.accessibility.test.tsx
+++ b/components/dashboard/StatsCardSkeleton.accessibility.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import StatsCardSkeleton from './StatsCardSkeleton';
+
+describe('StatsCardSkeleton Accessibility', () => {
+  it('renders without exposing any ARIA roles on the outer container', () => {
+    const { container } = render(<StatsCardSkeleton />);
+
+    // The outermost element is a plain div with no semantic role assigned.
+    // Skeleton loaders are presentational, so no role should be present.
+    const outerDiv = container.firstElementChild as HTMLElement;
+    expect(outerDiv).toBeInTheDocument();
+    expect(outerDiv).not.toHaveAttribute('role');
+  });
+
+  it('has no invalid or broken aria-labelledby references', () => {
+    render(<StatsCardSkeleton />);
+
+    // No element in this component uses aria-labelledby.
+    const elementsWithLabelledby = screen
+      .queryAllByRole('generic')
+      .filter((el) => el.hasAttribute('aria-labelledby'));
+    expect(elementsWithLabelledby).toHaveLength(0);
+  });
+
+  it('has no invalid or broken aria-describedby references', () => {
+    render(<StatsCardSkeleton />);
+
+    // No element in this component uses aria-describedby.
+    const allElements = document.querySelectorAll('[aria-describedby]');
+    expect(allElements).toHaveLength(0);
+  });
+
+  it('does not expose any interactive elements (buttons, links, inputs, etc.)', () => {
+    render(<StatsCardSkeleton />);
+
+    // Skeleton loaders should not expose interactive controls.
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.queryByRole('combobox')).toBeNull();
+    expect(screen.queryByRole('slider')).toBeNull();
+    expect(screen.queryByRole('tab')).toBeNull();
+    expect(screen.queryByRole('menuitem')).toBeNull();
+  });
+
+  it('does not incorrectly expose headings, status regions, or progress indicators', () => {
+    render(<StatsCardSkeleton />);
+
+    // The component is purely visual shimmer placeholders — no headings or semantic regions.
+    expect(screen.queryByRole('heading')).toBeNull();
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(screen.queryByRole('progressbar')).toBeNull();
+    expect(screen.queryByRole('region')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description

Adds a dedicated accessibility-focused test suite for StatsCardSkeleton.

Changes
1. Added components/dashboard/StatsCardSkeleton.accessibility.test.tsx
2. Added accessibility validation for screen-reader semantics
3. Verified ARIA label relationships where applicable
4. Validated accessibility description references
5. Ensured loading placeholders do not expose unintended interactive controls
6. Verified accessibility behavior of rendered loading state
7. Added coverage for accessibility-related DOM structure

Fixes #4613 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [ ] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
