### PR TITLE
test(i18n): add accessibility tests for badge labelsTest notification mouse interactivity

### DIFF
--- a/lib/i18n/badgeLabels.accessibility.test.ts
+++ b/lib/i18n/badgeLabels.accessibility.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { getLabels, labels, supportedLanguages } from './badgeLabels';
+
+describe('badgeLabels accessibility compliance', () => {
+  it('should provide all required label keys for every supported language', () => {
+    const requiredKeys = [
+      'CURRENT_STREAK',
+      'ANNUAL_SYNC_TOTAL',
+      'PEAK_STREAK',
+      'COMMITS_THIS_MONTH',
+      'VS_LAST_MONTH',
+    ];
+
+    supportedLanguages.forEach((lang) => {
+      const languageLabels = labels[lang];
+
+      requiredKeys.forEach((key) => {
+        expect(languageLabels).toHaveProperty(key);
+      });
+    });
+  });
+
+  it('should provide non-empty accessible text for every label', () => {
+    supportedLanguages.forEach((lang) => {
+      const languageLabels = labels[lang];
+
+      Object.values(languageLabels).forEach((value) => {
+        expect(typeof value).toBe('string');
+        expect(value.trim().length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  it('should return localized labels for supported languages', () => {
+    expect(getLabels('hi').CURRENT_STREAK).toBe('वर्तमान_स्ट्रीक');
+    expect(getLabels('zh').CURRENT_STREAK).toBe('当前连续记录');
+    expect(getLabels('ja').CURRENT_STREAK).toBe('現在のストリーク');
+  });
+
+  it('should support case-insensitive language lookup', () => {
+    expect(getLabels('EN')).toEqual(labels.en);
+    expect(getLabels('Hi')).toEqual(labels.hi);
+    expect(getLabels('ZH')).toEqual(labels.zh);
+  });
+
+  it('should fall back to english when language is unsupported', () => {
+    expect(getLabels('unknown')).toEqual(labels.en);
+    expect(getLabels('xyz')).toEqual(labels.en);
+  });
+
+  it('should ensure every language contains meaningful screen-reader text', () => {
+    supportedLanguages.forEach((lang) => {
+      const languageLabels = getLabels(lang);
+
+      Object.entries(languageLabels).forEach(([key, value]) => {
+        expect(value).toBeTruthy();
+        expect(value.trim()).not.toHaveLength(0);
+
+        if (key === 'COMMITS_THIS_MONTH') {
+          expect(value.length).toBeGreaterThan(2);
+        }
+      });
+    });
+  });
+
+  it('should expose supported languages that map to existing translations', () => {
+    supportedLanguages.forEach((lang) => {
+      expect(labels[lang]).toBeDefined();
+    });
+  });
+});

--- a/models/StudentProfile.error-resilience.test.ts
+++ b/models/StudentProfile.error-resilience.test.ts
@@ -1,0 +1,95 @@
+import mongoose from 'mongoose';
+import { describe, expect, it, vi } from 'vitest';
+import { StudentProfile } from './StudentProfile';
+
+describe('StudentProfile Error Resilience', () => {
+  it('handles invalid graduation year validation safely', () => {
+    const doc = new StudentProfile({
+      githubUsername: 'testuser',
+      name: 'Test User',
+      email: 'test@example.com',
+      graduationYear: 1900,
+    });
+
+    const error = doc.validateSync();
+
+    expect(error).toBeDefined();
+    expect(error?.errors.graduationYear).toBeDefined();
+  });
+
+  it('handles missing required fields without crashing', () => {
+    const doc = new StudentProfile({});
+
+    const error = doc.validateSync();
+
+    expect(error).toBeDefined();
+    expect(error?.errors.githubUsername).toBeDefined();
+    expect(error?.errors.name).toBeDefined();
+    expect(error?.errors.email).toBeDefined();
+  });
+
+  it('continues functioning when validation throws unexpectedly', () => {
+    const path = StudentProfile.schema.path('graduationYear') as mongoose.SchemaType & {
+      validators: Array<{ validator: (val: unknown) => boolean }>;
+    };
+
+    const originalValidator = path.validators[0].validator;
+
+    path.validators[0].validator = vi.fn(() => {
+      throw new Error('Unexpected validation failure');
+    });
+
+    const doc = new StudentProfile({
+      githubUsername: 'user',
+      name: 'User',
+      email: 'user@example.com',
+      graduationYear: 2025,
+    });
+
+    expect(() => doc.validateSync()).not.toThrow();
+
+    path.validators[0].validator = originalValidator;
+  });
+
+  it('preserves schema integrity after validation failures', () => {
+    const doc = new StudentProfile({
+      githubUsername: 'user',
+      name: 'User',
+      email: 'user@example.com',
+      graduationYear: 9999,
+    });
+
+    doc.validateSync();
+
+    expect(StudentProfile.schema.path('githubUsername')).toBeDefined();
+    expect(StudentProfile.schema.path('name')).toBeDefined();
+    expect(StudentProfile.schema.path('email')).toBeDefined();
+  });
+
+  it('updates updatedAt safely through pre-save hook execution', () => {
+    const schemaInternal = StudentProfile.schema as unknown as {
+      s?: {
+        hooks?: {
+          _pres?: Map<string, Array<{ fn: (this: mongoose.Document) => unknown }>>;
+        };
+      };
+    };
+
+    const saveHooks = schemaInternal.s?.hooks?._pres?.get('save') || [];
+
+    const doc = new StudentProfile({
+      githubUsername: 'safeuser',
+      name: 'Safe User',
+      email: 'safe@example.com',
+      updatedAt: new Date(0),
+    });
+
+    expect(() => {
+      saveHooks.forEach((hook) => {
+        hook.fn.call(doc);
+      });
+    }).not.toThrow();
+
+    expect(doc.updatedAt).toBeInstanceOf(Date);
+  });
+});


### PR DESCRIPTION
## Description

Fixes # (4629)

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Summary

Adds accessibility-focused tests for badge label translations.

## Changes

* Added `lib/i18n/badgeLabels.accessibility.test.ts`
* Verified all required translation keys exist across supported languages
* Verified labels contain non-empty accessible text
* Tested case-insensitive language lookup
* Tested fallback to English for unsupported languages
* Verified supported language mappings

## Testing

* All tests pass locally
* Repository test suite passes successfully


## Checklist before requesting a review:

- [ X] I have read the `CONTRIBUTING.md` file.
- [ X] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [X ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X ] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [X ] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
