### PR TITLE
fix: add safety array validation guard for empty profile contributions

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -709,8 +709,16 @@ async function fetchContributionsUncached(
   }
 
   let calendar = data.data.user.contributionsCollection?.contributionCalendar;
-  const repoContributions =
-    data.data.user.contributionsCollection?.commitContributionsByRepository || [];
+
+  // 🔽 CHANGE THIS SECTION 🔽
+  let repoContributions = data.data.user.contributionsCollection?.commitContributionsByRepository;
+  if (!repoContributions || !Array.isArray(repoContributions)) {
+    console.warn(
+      `[CommitPulse API] Empty profile or null repository nodes discovered for user "${username}". Falling back to baseline collection.`
+    );
+    repoContributions = [];
+  }
+  // 🔼 END OF CHANGE 🔼
 
   if (!calendar || !calendar.weeks) {
     calendar = {


### PR DESCRIPTION
## Description
Added a defensive structural check and array type validation guard in `lib/github.ts` to cleanly handle cases where a GitHub profile returns null or empty repository contribution nodes. This prevents unhandled TypeErrors from crashing the layout pipeline.

## Related Issue
Closes #5085