### PR TITLE
fix: add keyboard focus-visible ring to dashboard buttons (#77)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -167,10 +167,16 @@ body {
 }
 
 /* Vercel-style focus ring */
+/* Keyboard focus ring — visible only for keyboard nav, not mouse clicks */
 @layer base {
   *:focus-visible {
-    outline: 2px solid rgba(99, 102, 241, 0.6);
-    outline-offset: 2px;
+    outline: 2px solid #34d399;
+    outline-offset: 3px;
+    border-radius: 6px;
+  }
+
+  *:focus:not(:focus-visible) {
+    outline: none;
   }
 
   /* Enhanced typography for better readability */

--- a/components/dashboard/DashboardClient.tsx
+++ b/components/dashboard/DashboardClient.tsx
@@ -566,7 +566,7 @@ export default function DashboardClient({
           {isCompareMode && secondUserData && (
             <button
               onClick={handleExitCompare}
-              className="flex items-center gap-2 rounded-xl border border-black/10 dark:border-[rgba(255,255,255,0.15)] bg-red-600 hover:bg-red-700 text-white px-4 py-2 text-sm font-semibold transition-all duration-200 active:scale-[0.98]"
+              className="flex items-center gap-2 rounded-xl border border-black/10 dark:border-[rgba(255,255,255,0.15)] bg-red-600 hover:bg-red-700 text-white px-4 py-2 text-sm font-semibold transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
             >
               Exit Compare Mode
             </button>
@@ -577,7 +577,7 @@ export default function DashboardClient({
             <>
               <button
                 onClick={() => setIsOptimizerOpen(true)}
-                className="flex items-center gap-2 rounded-xl border border-black/10 dark:border-[rgba(255,255,255,0.15)] bg-black dark:bg-[#111] hover:bg-zinc-800 dark:hover:bg-zinc-900 px-4 py-2 text-sm font-semibold text-white dark:text-white transition-all duration-200 active:scale-[0.98]"
+                className="flex items-center gap-2 rounded-xl border border-black/10 dark:border-[rgba(255,255,255,0.15)] bg-black dark:bg-[#111] hover:bg-zinc-800 dark:hover:bg-zinc-900 px-4 py-2 text-sm font-semibold text-white dark:text-white transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -598,7 +598,7 @@ export default function DashboardClient({
               <button
                 ref={triggerRef}
                 onClick={handleOpenModal}
-                className="flex items-center gap-2 rounded-xl border border-black/10 dark:border-[rgba(255,255,255,0.15)] bg-black dark:bg-[#111] hover:bg-zinc-800 dark:hover:bg-zinc-900 px-4 py-2 text-sm font-semibold text-white dark:text-white transition-all duration-200 active:scale-[0.98]"
+                className="flex items-center gap-2 rounded-xl border border-black/10 dark:border-[rgba(255,255,255,0.15)] bg-black dark:bg-[#111] hover:bg-zinc-800 dark:hover:bg-zinc-900 px-4 py-2 text-sm font-semibold text-white dark:text-white transition-all duration-200 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               >
                 Compare Profile
               </button>
@@ -617,7 +617,7 @@ export default function DashboardClient({
           <RefreshButton username={username} />
           <button
             onClick={handleShareDashboard}
-            className="flex items-center gap-2 rounded-xl border border-black/10 px-4 py-2 text-sm font-semibold hover:bg-gray-100 dark:hover:bg-zinc-800 transition"
+            className="flex items-center gap-2 rounded-xl border border-black/10 px-4 py-2 text-sm font-semibold hover:bg-gray-100 dark:hover:bg-zinc-800 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
           >
             <Share2 size={16} />
             Share
@@ -648,13 +648,13 @@ export default function DashboardClient({
         <div className="bg-white/50 dark:bg-zinc-900/50 p-1.5 rounded-2xl flex gap-2 w-fit border border-black/10 dark:border-white/10 shadow-sm backdrop-blur-sm">
           <button
             onClick={() => setActiveTab('overview')}
-            className={`px-6 py-2.5 rounded-xl text-sm font-bold transition-all ${activeTab === 'overview' ? 'bg-white dark:bg-zinc-800 text-gray-900 dark:text-white shadow-sm ring-1 ring-black/5 dark:ring-white/10' : 'text-gray-500 hover:text-gray-900 dark:hover:text-white'}`}
+            className={`px-6 py-2.5 rounded-xl text-sm font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-black ${activeTab === 'overview' ? 'bg-white dark:bg-zinc-800 text-gray-900 dark:text-white shadow-sm ring-1 ring-black/5 dark:ring-white/10' : 'text-gray-500 hover:text-gray-900 dark:hover:text-white'}`}
           >
             Overview
           </button>
           <button
             onClick={() => setActiveTab('pr-insights')}
-            className={`px-6 py-2.5 rounded-xl text-sm font-bold transition-all ${activeTab === 'pr-insights' ? 'bg-white dark:bg-zinc-800 text-gray-900 dark:text-white shadow-sm ring-1 ring-black/5 dark:ring-white/10' : 'text-gray-500 hover:text-gray-900 dark:hover:text-white'}`}
+            className={`px-6 py-2.5 rounded-xl text-sm font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-black ${activeTab === 'pr-insights' ? 'bg-white dark:bg-zinc-800 text-gray-900 dark:text-white shadow-sm ring-1 ring-black/5 dark:ring-white/10' : 'text-gray-500 hover:text-gray-900 dark:hover:text-white'}`}
           >
             PR Insights
           </button>

--- a/components/dashboard/RefreshButton.tsx
+++ b/components/dashboard/RefreshButton.tsx
@@ -45,8 +45,8 @@ export default function RefreshButton({ username }: RefreshButtonProps) {
       onClick={handleRefresh}
       aria-label="Refresh dashboard contribution data"
       title="Refresh dashboard contribution data"
-      className="flex items-center gap-2 rounded-xl border border-black/10 dark:border-[rgba(255,255,255,0.15)] bg-black dark:bg-black px-4 py-2 text-sm font-semibold text-white dark:text-white transition-all duration-200 hover:bg-gray-800 dark:hover:bg-white/10 active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed"
-    >
+      className="flex items-center gap-2 rounded-xl border border-black/10 dark:border-[rgba(255,255,255,0.15)] bg-black dark:bg-black px-4 py-2 text-sm font-semibold text-white dark:text-white transition-all duration-200 hover:bg-gray-800 dark:hover:bg-white/10 active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+      >
       <RefreshCw size={16} className={isPending ? 'animate-spin' : ''} />
 
       {isPending ? t('dashboard.refreshing') : t('dashboard.refresh_btn')}


### PR DESCRIPTION
Program: GSSoC'26

## Description

Fixes #5091 

## Summary

 Keyboard users could not identify which element was focused while tabbing through the dashboard because the default browser outline was suppressed with `outline-none` and no custom focus style was provided.

## Changes

### `app/globals.css`

* Updated the global `*:focus-visible` ring from low-contrast indigo (`rgba(99,102,241,0.6)`) to the site's emerald accent (`#34d399`).
* Added `*:focus:not(:focus-visible) { outline: none }` so the focus ring appears only during keyboard navigation and not for mouse or touch interactions.

### `components/dashboard/RefreshButton.tsx`

* Added:

  * `focus-visible:outline-none`
  * `focus-visible:ring-2`
  * `focus-visible:ring-emerald-400`
  * `focus-visible:ring-offset-2`
  * `focus-visible:ring-offset-black`

### `components/dashboard/DashboardClient.tsx`

Applied the same focus-visible ring classes to:

* Exit Compare Mode
* Profile Optimizer
* Compare Profile
* Share Comparison
* Overview tab
* PR Insights tab

## How to Test

1. Open `/dashboard/<any-username>`.
2. Press `Tab` repeatedly.
3. ✅ A green focus ring should appear around each focused button.
4. Click any button with the mouse.
5. ✅ No focus ring should appear, preserving the expected mouse interaction.

## Checklist

* [x] I have read the CONTRIBUTING.md file.
* [x] I have tested these changes locally.
* [x] I have run `npm run lint` with no errors.
* [x] My commit follows the Conventional Commits format.
* [x] I joined the CommitPulse Discord server.

