### PR TITLE
test(technologies-section): add theme contrast coverage for dark and light modes

### DIFF
--- a/app/generator/components/sections/TechnologiesSection.theme-contrast.test.tsx
+++ b/app/generator/components/sections/TechnologiesSection.theme-contrast.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TechnologiesSection } from './TechnologiesSection';
+import React from 'react';
+
+describe('TechnologiesSection Theme Contrast & Visual Cohesion', () => {
+  const defaultProps = {
+    selected: ['react'],
+    onChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.documentElement.className = '';
+  });
+
+  afterEach(() => {
+    document.documentElement.className = '';
+  });
+
+  it('renders correctly in light theme with proper structure', () => {
+    document.documentElement.className = 'light';
+
+    render(<TechnologiesSection {...defaultProps} />);
+
+    expect(screen.getByText('Technologies')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search technologies...')).toBeInTheDocument();
+    expect(screen.getByText(/Select your tech stack/i)).toBeInTheDocument();
+  });
+
+  it('renders correctly in dark theme with proper structure', () => {
+    document.documentElement.className = 'dark';
+
+    render(<TechnologiesSection {...defaultProps} />);
+
+    expect(screen.getByText('Technologies')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search technologies...')).toBeInTheDocument();
+    expect(screen.getByText(/Select your tech stack/i)).toBeInTheDocument();
+  });
+
+  it('ensures text remains visible in light mode (contrast proxy check)', () => {
+    document.documentElement.className = 'light';
+
+    render(<TechnologiesSection {...defaultProps} />);
+
+    expect(screen.getByText('Technologies')).toBeVisible();
+    expect(screen.getByText(/Technology Dependency Graph/i)).toBeVisible();
+    expect(screen.getByText(/Selected \(1\)/i)).toBeVisible();
+  });
+
+  it('ensures text remains visible in dark mode (contrast proxy check)', () => {
+    document.documentElement.className = 'dark';
+
+    render(<TechnologiesSection {...defaultProps} />);
+
+    expect(screen.getByText('Technologies')).toBeVisible();
+    expect(screen.getByText(/Technology Dependency Graph/i)).toBeVisible();
+    expect(screen.getByText(/Selected \(1\)/i)).toBeVisible();
+  });
+
+  it('maintains UI stability when filtering technologies in dark mode', () => {
+    document.documentElement.className = 'dark';
+
+    render(<TechnologiesSection {...defaultProps} />);
+
+    const searchInput = screen.getByPlaceholderText('Search technologies...');
+
+    fireEvent.change(searchInput, {
+      target: { value: 'react' },
+    });
+
+    expect(searchInput).toBeInTheDocument();
+    expect(screen.getByText(/Technology Dependency Graph/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4469

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test coverage only)

## Changes

* Added `TechnologiesSection.theme-contrast.test.tsx`
* Added coverage for light theme rendering
* Added coverage for dark theme rendering
* Verified visibility of primary UI elements across themes
* Verified technology selection content remains visible
* Verified graph section remains visible in both themes
* Verified search/filter interactions maintain UI stability

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
