### PR TITLE
test(themes): add test-utils theme contrast coverage

### DIFF
--- a/lib/svg/themes/test-utils.theme-contrast.test.ts
+++ b/lib/svg/themes/test-utils.theme-contrast.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { contrastRatio, hexToRgb, relativeLuminance } from './test-utils';
+
+const WCAG_AA_TEXT_CONTRAST = 4.5;
+
+const themePairs = {
+  dark: {
+    background: '#0f172a',
+    foreground: '#f8fafc',
+    mutedForeground: '#cbd5e1',
+    overlay: '#1e293b',
+  },
+  light: {
+    background: '#ffffff',
+    foreground: '#0f172a',
+    mutedForeground: '#334155',
+    overlay: '#f1f5f9',
+  },
+};
+
+describe('test-utils theme contrast cohesion', () => {
+  it('converts dark and light theme hex colors into rgb channels', () => {
+    expect(hexToRgb(themePairs.dark.background)).toEqual({
+      r: 15,
+      g: 23,
+      b: 42,
+    });
+
+    expect(hexToRgb(themePairs.light.foreground)).toEqual({
+      r: 15,
+      g: 23,
+      b: 42,
+    });
+  });
+
+  it('computes lower luminance for dark backgrounds than light backgrounds', () => {
+    expect(relativeLuminance(themePairs.dark.background)).toBeLessThan(
+      relativeLuminance(themePairs.light.background)
+    );
+  });
+
+  it('keeps primary text readable in both dark and light theme presets', () => {
+    expect(
+      contrastRatio(themePairs.dark.background, themePairs.dark.foreground)
+    ).toBeGreaterThanOrEqual(WCAG_AA_TEXT_CONTRAST);
+
+    expect(
+      contrastRatio(themePairs.light.background, themePairs.light.foreground)
+    ).toBeGreaterThanOrEqual(WCAG_AA_TEXT_CONTRAST);
+  });
+
+  it('keeps muted text readable against background overlays', () => {
+    expect(
+      contrastRatio(themePairs.dark.overlay, themePairs.dark.mutedForeground)
+    ).toBeGreaterThanOrEqual(WCAG_AA_TEXT_CONTRAST);
+
+    expect(
+      contrastRatio(themePairs.light.overlay, themePairs.light.mutedForeground)
+    ).toBeGreaterThanOrEqual(WCAG_AA_TEXT_CONTRAST);
+  });
+
+  it('rejects invalid stylesheet color tokens before contrast checks run', () => {
+    expect(() => contrastRatio('bg-slate-900', themePairs.dark.foreground)).toThrow(
+      'Invalid hex color'
+    );
+
+    expect(() => hexToRgb('#fff')).toThrow('Invalid hex color');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4524

Added a dedicated test suite for `lib/svg/themes/test-utils.ts` to verify dark and light theme contrast behavior.

Coverage:

* Validates hex-to-RGB conversion for dark and light theme colors.
* Verifies luminance differences between dark and light backgrounds.
* Ensures primary text contrast satisfies WCAG AA standards.
* Ensures muted foreground colors remain readable on overlays.
* Confirms invalid stylesheet/Tailwind color tokens are rejected before contrast checks.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`npx vitest run lib/svg/themes/test-utils.theme-contrast.test.ts`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [x] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
