### PR TITLE
feat: add Share Battle, Twitter/X and LinkedIn share buttons to compa…

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -969,7 +969,31 @@ export default function CompareClient() {
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<CompareResponse | null>(null);
   const [isExporting, setIsExporting] = useState(false);
+  const [copied, setCopied] = useState(false);
   const [monolithKey, setMonolithKey] = useState(0);
+
+  const handleShareBattle = () => {
+    const url = window.location.href;
+    navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  const handleTwitterShare = () => {
+    if (!d1 || !d2) return;
+    const text = encodeURIComponent(
+      `🔥 GitHub Battle: @${d1.profile.username} vs @${d2.profile.username}\n` +
+        `${winner === 'tie' ? "It's a tie! 🤝" : `🏆 @${winner} wins the showdown!`}\n\n` +
+        `Check it out 👇\n${window.location.href}\n\n#GitHub #CommitPulse #GSSoC`
+    );
+    window.open(`https://twitter.com/intent/tweet?text=${text}`, '_blank');
+  };
+
+  const handleLinkedInShare = () => {
+    const url = encodeURIComponent(window.location.href);
+    window.open(`https://www.linkedin.com/sharing/share-offsite/?url=${url}`, '_blank');
+  };
 
   const captureRef = useRef<HTMLDivElement>(null);
 
@@ -1447,14 +1471,105 @@ export default function CompareClient() {
                   </div>
                 </div>
 
-                {/* Floating Share Button */}
+                {/* Floating Action Buttons */}
+                {/* Floating Action Buttons */}
                 <motion.div
                   id="compare-share-button"
                   initial={{ opacity: 0, y: 50 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ type: 'spring', bounce: 0.5, delay: 1 }}
-                  className="fixed bottom-8 left-1/2 -translate-x-1/2 z-50"
+                  className="fixed bottom-8 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3"
                 >
+                  {/* Share Battle — copy link */}
+                  <motion.button
+                    whileHover={{ scale: 1.05 }}
+                    whileTap={{ scale: 0.95 }}
+                    onClick={handleShareBattle}
+                    title="Copy battle link"
+                    className="flex items-center gap-2 px-5 py-4 rounded-full bg-white/10 hover:bg-white/20 backdrop-blur-md border border-white/20 text-white font-bold shadow-[0_0_20px_rgba(255,255,255,0.1)] transition-colors"
+                  >
+                    {copied ? (
+                      <>
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="18"
+                          height="18"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <polyline points="20 6 9 17 4 12" />
+                        </svg>
+                        <span>Copied!</span>
+                      </>
+                    ) : (
+                      <>
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="18"
+                          height="18"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+                          <polyline points="16 6 12 2 8 6" />
+                          <line x1="12" y1="2" x2="12" y2="15" />
+                        </svg>
+                        <span>Share Battle</span>
+                      </>
+                    )}
+                  </motion.button>
+
+                  {/* Twitter / X share */}
+                  <motion.button
+                    whileHover={{ scale: 1.05 }}
+                    whileTap={{ scale: 0.95 }}
+                    onClick={handleTwitterShare}
+                    title="Share on X (Twitter)"
+                    className="flex items-center gap-2 px-5 py-4 rounded-full bg-black hover:bg-zinc-800 backdrop-blur-md border border-white/20 text-white font-bold shadow-[0_0_20px_rgba(0,0,0,0.4)] transition-colors"
+                  >
+                    {/* X logo */}
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="18"
+                      height="18"
+                      viewBox="0 0 24 24"
+                      fill="currentColor"
+                    >
+                      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.737-8.835L1.254 2.25H8.08l4.261 5.632 5.903-5.632Zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                    </svg>
+                    <span>Post on X</span>
+                  </motion.button>
+
+                  {/* LinkedIn share */}
+                  <motion.button
+                    whileHover={{ scale: 1.05 }}
+                    whileTap={{ scale: 0.95 }}
+                    onClick={handleLinkedInShare}
+                    title="Share on LinkedIn"
+                    className="flex items-center gap-2 px-5 py-4 rounded-full bg-[#0A66C2] hover:bg-[#0958a8] backdrop-blur-md border border-[#0A66C2]/50 text-white font-bold shadow-[0_0_20px_rgba(10,102,194,0.4)] transition-colors"
+                  >
+                    {/* LinkedIn logo */}
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="18"
+                      height="18"
+                      viewBox="0 0 24 24"
+                      fill="currentColor"
+                    >
+                      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+                    </svg>
+                    <span>Share on LinkedIn</span>
+                  </motion.button>
+
+                  {/* Export Wrapped Card */}
                   <motion.button
                     whileHover={{ scale: 1.05 }}
                     whileTap={{ scale: 0.95 }}
@@ -1469,8 +1584,6 @@ export default function CompareClient() {
                       {isExporting ? <Loader2 size={20} /> : <Camera size={20} />}
                     </motion.div>
                     <span>{isExporting ? 'Generating Epic Card...' : 'Export Wrapped Card'}</span>
-
-                    {/* Subtle glare effect on hover */}
                     <div className="absolute top-0 -inset-full h-full w-1/2 z-5 block transform -skew-x-12 bg-gradient-to-r from-transparent to-white opacity-20 group-hover:animate-shine" />
                   </motion.button>
                 </motion.div>


### PR DESCRIPTION
## What does this PR do?

Adds three new sharing buttons to the `/compare` page floating 
action bar, alongside the existing "Export Wrapped Card" button.

## Changes made

- **Share Battle** — copies the current comparison URL to clipboard
  with a 2-second "✓ Copied!" confirmation state
- **Post on X (Twitter)** — opens Twitter with a pre-filled tweet
  showing both usernames, the winner, and the battle link
- **Share on LinkedIn** — opens LinkedIn share dialog with the 
  battle URL

## File changed
- `app/compare/CompareClient.tsx`

## Screenshots
<img width="1856" height="885" alt="image" src="https://github.com/user-attachments/assets/e07fc724-317f-4bcb-888e-eaf40ef949ca" />
[a screenshot of the 4 buttons visible at the bottom]

## Related Issue
Closes #5047