### PR TITLE
fix: Race Condition in DistributedCache.update() Affecting Rate Limiting Consistency

### DIFF
--- a/lib/cache.test.ts
+++ b/lib/cache.test.ts
@@ -868,6 +868,37 @@ describe('DistributedCache', () => {
     );
     cache.destroy();
   });
+
+  it('evicts stale local state when a Redis update loses an expiry race', async () => {
+    process.env.KV_REST_API_URL = 'https://mock-redis.upstash.io';
+    process.env.KV_REST_API_TOKEN = 'mock-token';
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ result: 'OK' }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ result: null }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ result: null }),
+      } as Response);
+
+    const cache = new DistributedCache<string>();
+    await cache.set('redis-key', 'old-value', 60000);
+
+    expect(await cache.update('redis-key', 'new-value')).toBe(false);
+    expect(await cache.get('redis-key')).toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(3);
+
+    cache.destroy();
+  });
 });
 
 describe('TTLCache with infinite TTL', () => {

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -350,10 +350,8 @@ export class DistributedCache<T> {
   }
 
   async update(key: string, value: T): Promise<boolean> {
-    this.localCache.update(key, value);
-
     if (!this.useRedis) {
-      return this.localCache.has(key);
+      return this.localCache.update(key, value);
     }
 
     try {
@@ -370,7 +368,16 @@ export class DistributedCache<T> {
         throw new Error(`Redis HTTP error: ${res.status}`);
       }
       const data = await res.json();
-      return data.result === 'OK';
+      const updated = data.result === 'OK';
+
+      if (updated) {
+        this.localCache.update(key, value);
+      } else {
+        // Redis no longer has the key, so the L1 value is stale.
+        this.localCache.delete(key);
+      }
+
+      return updated;
     } catch (err) {
       console.error(`[DistributedCache] UPDATE failed for key "${key}":`, err);
       return false;

--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DistributedCache } from './cache';
 import { rateLimit, RateLimiter } from './rate-limit';
 
 beforeEach(() => {
@@ -175,6 +176,34 @@ describe('rateLimit', () => {
       expect((await rateLimit('9.9.9.2', limit, 60000)).success).toBe(false);
     });
   });
+
+  it('starts a fresh window when an update loses an expiry race', async () => {
+    vi.setSystemTime(1000);
+    const getSpy = vi
+      .spyOn(DistributedCache.prototype, 'get')
+      .mockResolvedValueOnce({ count: 2, resetAt: 5000 });
+    const updateSpy = vi.spyOn(DistributedCache.prototype, 'update').mockResolvedValueOnce(false);
+    const setSpy = vi.spyOn(DistributedCache.prototype, 'set').mockResolvedValueOnce();
+
+    const result = await rateLimit('expiry-race-function', 5, 60000);
+
+    expect(result).toEqual({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      reset: 61000,
+    });
+    expect(updateSpy).toHaveBeenCalledWith('expiry-race-function', { count: 3, resetAt: 5000 });
+    expect(setSpy).toHaveBeenCalledWith(
+      'expiry-race-function',
+      { count: 1, resetAt: 61000 },
+      60000
+    );
+
+    getSpy.mockRestore();
+    updateSpy.mockRestore();
+    setSpy.mockRestore();
+  });
 });
 
 it('keys expire exactly at the window limit with sliding time advances', async () => {
@@ -295,6 +324,31 @@ describe('RateLimiter', () => {
 
     // Window should have expired — count resets, request is allowed
     expect(await limiter.check(ip)).toBe(true);
+  });
+
+  it('starts a fresh window when an update loses an expiry race', async () => {
+    vi.setSystemTime(1000);
+    const limiter = new RateLimiter(5, 60000);
+    const cache = (
+      limiter as unknown as {
+        cache: DistributedCache<{ count: number; resetAt: number }>;
+      }
+    ).cache;
+
+    vi.spyOn(cache, 'get').mockResolvedValueOnce({ count: 2, resetAt: 5000 });
+    const updateSpy = vi.spyOn(cache, 'update').mockResolvedValueOnce(false);
+    const setSpy = vi.spyOn(cache, 'set').mockResolvedValueOnce();
+
+    const result = await limiter.checkWithResult('expiry-race-class');
+
+    expect(result).toEqual({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      reset: 61000,
+    });
+    expect(updateSpy).toHaveBeenCalledWith('expiry-race-class', { count: 3, resetAt: 5000 });
+    expect(setSpy).toHaveBeenCalledWith('expiry-race-class', { count: 1, resetAt: 61000 }, 60000);
   });
 
   it('reset() clears the counter and restores the full request allowance', async () => {

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -119,7 +119,19 @@ export class RateLimiter {
       };
     } else {
       const resetAt = record.resetAt;
-      await this.cache.update(ip, { count: count + 1, resetAt });
+      const updated = await this.cache.update(ip, { count: count + 1, resetAt });
+
+      if (!updated) {
+        const freshResetAt = now + this.windowMs;
+        await this.cache.set(ip, { count: 1, resetAt: freshResetAt }, this.windowMs);
+        return {
+          success: true,
+          limit: this.limit,
+          remaining: this.limit - 1,
+          reset: freshResetAt,
+        };
+      }
+
       return {
         success: true,
         limit: this.limit,
@@ -285,7 +297,18 @@ export async function rateLimit(
   }
 
   const newCount = tracker.count + 1;
-  await trackers.update(ip, { count: newCount, resetAt: tracker.resetAt });
+  const updated = await trackers.update(ip, { count: newCount, resetAt: tracker.resetAt });
+
+  if (!updated) {
+    const resetAt = now + windowMs;
+    await trackers.set(ip, { count: 1, resetAt }, windowMs);
+    return {
+      success: true,
+      limit,
+      remaining: limit - 1,
+      reset: resetAt,
+    };
+  }
 
   if (newCount > limit) {
     return {


### PR DESCRIPTION


## Related Issue

Closes #4761 

## Description

This PR fixes a race condition between `DistributedCache` and `RateLimiter` that can cause inconsistent rate-limiting behavior across distributed application instances.

### Root Cause

`RateLimiter.checkWithResult()` currently performs the following sequence:

```text
cache.get()
   ↓
modify value
   ↓
cache.update()
```

In distributed cache mode, `DistributedCache.update()` relies on Redis/KV update semantics (`SET ... KEEPTTL XX`), which only succeed if the key still exists.

If the cache entry expires between the `get()` and `update()` operations:

1. `get()` returns a valid rate-limit record.
2. The key expires before `update()` executes.
3. `update()` returns `false`.
4. The return value is ignored by `RateLimiter.checkWithResult()`.
5. Rate-limit state becomes inconsistent across instances.

This can result in requests being incorrectly allowed or denied when multiple instances are processing traffic simultaneously.

## Changes Made

### Rate Limiter Improvements

* Added validation for the return value of `DistributedCache.update()`.
* Prevented silent failures when cache updates do not succeed.
* Added handling for expired records detected during update operations.

### Cache Consistency Improvements

* Ensured update failures are explicitly handled.
* Recreated or refreshed rate-limit records when necessary.
* Improved synchronization between local cache (L1) and distributed cache (Redis/KV).

### Error Handling

* Added safeguards for TTL-boundary edge cases.
* Prevented stale state propagation across distributed instances.

## Example Scenario Fixed

### Before

```text
Instance A:
get() → success

Key expires

update() → false

Result ignored

Rate limit state becomes inconsistent
```

### After

```text
Instance A:
get() → success

Key expires

update() → false

Failure detected

Record recreated/retried

State remains consistent
```

## Testing

### Reproduction Scenario

1. Configure Redis/KV as the distributed cache backend.
2. Deploy multiple application instances.
3. Create a rate-limit entry with a short TTL.
4. Generate requests close to expiration boundaries.
5. Force expiration between `get()` and `update()`.
6. Verify that update failures are handled correctly.

### Results

* Update failures no longer occur silently.
* Rate-limit records remain consistent across instances.
* No incorrect allow/deny decisions observed near TTL expiration boundaries.
* Distributed deployments behave predictably under concurrent load.

## Impact

**Severity:** Medium–High

This fix improves:

* Distributed cache consistency
* Rate-limiting accuracy
* Multi-instance reliability
* Production stability under concurrent traffic
* Resilience to TTL expiration edge cases

## Checklist

* [x] Issue reproduced
* [x] Root cause identified
* [x] Update failure handling implemented
* [x] Distributed cache behavior validated
* [x] Concurrent scenarios tested

---

## GSSoC 2026

**Contributor:** @Krishnx21

**Program:** GirlScript Summer of Code 2026 (GSSoC'26)
