### PR TITLE
test(useLocalStorage-accessibility): verify persistence and error handling behavior (Variation 4)

### DIFF
--- a/hooks/useLocalStorage.accessibility.test.ts
+++ b/hooks/useLocalStorage.accessibility.test.ts
@@ -1,0 +1,65 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { useLocalStorage } from './useLocalStorage';
+
+describe('useLocalStorage', () => {
+  const TEST_KEY = 'custom_settings_token';
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('initializes seamlessly with the provided default value on initial render', () => {
+    const { result } = renderHook(() => useLocalStorage(TEST_KEY, { theme: 'dark' }));
+
+    expect(result.current[0]).toEqual({ theme: 'dark' });
+  });
+
+  it('updates state and serializes data changes out to localStorage correctly', () => {
+    const { result } = renderHook(() => useLocalStorage(TEST_KEY, 'initial_state'));
+
+    act(() => {
+      const setValue = result.current[1];
+      setValue('mutated_state');
+    });
+
+    expect(result.current[0]).toBe('mutated_state');
+    expect(window.localStorage.getItem(TEST_KEY)).toBe(JSON.stringify('mutated_state'));
+  });
+
+  it('hydrates state directly from pre-existing localStorage entries inside browser lifecycle', async () => {
+    window.localStorage.setItem(TEST_KEY, JSON.stringify('cached_payload'));
+
+    const { result } = renderHook(() => useLocalStorage(TEST_KEY, 'fallback_default'));
+
+    await waitFor(() => {
+      expect(result.current[0]).toBe('cached_payload');
+    });
+  });
+
+  it('recovers gracefully and defaults to initial parameters when parsing corrupted JSON strings', () => {
+    window.localStorage.setItem(TEST_KEY, '{invalid_json_payload:');
+
+    const { result } = renderHook(() => useLocalStorage(TEST_KEY, 'safe_fallback'));
+
+    expect(result.current[0]).toBe('safe_fallback');
+  });
+
+  it('safely updates internal state even when localStorage.setItem throws an error', () => {
+    const storageSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+
+    const { result } = renderHook(() => useLocalStorage(TEST_KEY, 'baseline_value'));
+
+    act(() => {
+      const setValue = result.current[1];
+      setValue('exception_resilient_value');
+    });
+
+    expect(result.current[0]).toBe('exception_resilient_value');
+
+    storageSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Description

Closes #4619

Introduces an isolated, high-value unit test module for the `useLocalStorage.ts` utility hook. Since custom hooks do not manage persistent DOM elements, visual accessibility markup coordinates (like ARIA attributes, focus outlines, or tab indexing) are inherently the responsibility of consuming parent wrapper layouts rather than the hook logic itself.

To ensure pristine branch coverage and code resilience, this test module targets the hook's exact data-handling vectors:
- Baseline initialization fallback values when `localStorage` is empty.
- Multi-type object serialization out to `window.localStorage`.
- Asynchronous hydration from pre-existing browser storage records, safely isolated inside an asynchronous `waitFor` loop to prevent flake or race conditions during post-mount useEffect cycles.
- **Exception Resilience (Read):** Cleanly catching malformed JSON strings inside storage to prevent application crashes during state parsing.
- **Exception Resilience (Write):** Mocking a `QuotaExceededError` exception via a `Storage.prototype.setItem` spy to guarantee internal state updates still fall back gracefully under strict private browsing modes or disk quota ceilings.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs, hooks logic unit testing)

## Visual Preview
*(N/A: Introduction of automated testing assets to reinforce data-handling and initialization safety gates).*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format`, `npm run lint`, and `npm run typecheck` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format (`test(useLocalStorage-accessibility): ...`).
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] My branch passes all local integration tests (`npm run test`) smoothly.