### PR TITLE
fix(cache): pass caller ttlMs to L1 backfill instead of hardcoded 5-min

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -238,7 +238,7 @@ export class DistributedCache<T> {
     }
   }
 
-  async get(key: string): Promise<T | null> {
+  async get(key: string, localTtlMs: number = 5 * 60 * 1000): Promise<T | null> {
     if (!this.useRedis) {
       return this.localCache.get(key);
     }
@@ -270,7 +270,7 @@ export class DistributedCache<T> {
 
       const parsed = JSON.parse(data.result) as T;
       // Backfill local cache so subsequent requests in this instance are instant
-      this.localCache.set(key, parsed, 5 * 60 * 1000);
+      this.localCache.set(key, parsed, localTtlMs);
       return parsed;
     } catch (err) {
       console.error(`[DistributedCache] GET failed for key "${key}":`, err);
@@ -468,7 +468,7 @@ return c`;
     shouldFetch?: (cached: T) => boolean
   ): Promise<T> {
     // Attempt to retrieve an existing value before triggering a refresh.
-    const cached = await this.get(key);
+    const cached = await this.get(key, ttlMs);
 
     if (cached !== null && (!shouldFetch || !shouldFetch(cached))) {
       return cached;
@@ -562,7 +562,7 @@ return c`;
         const backoffMs = Math.min(BASE_POLL_MS * 2 ** attempt, MAX_POLL_MS);
         await new Promise((resolve) => setTimeout(resolve, backoffMs));
         attempt++;
-        const doubleCheck = await this.get(key);
+        const doubleCheck = await this.get(key, ttlMs);
 
         // Another instance may have already populated the cache while waiting.
         if (doubleCheck !== null && (!shouldFetch || !shouldFetch(doubleCheck))) {


### PR DESCRIPTION
## Description

Fixes #5141
`DistributedCache.get` was hardcoding a 5-minute TTL when backfilling the 
local L1 cache from Redis, ignoring the caller-specified TTL. This caused 
`shouldFetch` in `lib/github.ts` to fire on every cold L1 miss, triggering 
unnecessary GitHub API refetches every ~5 minutes instead of respecting the 
intended 7-day cache window.

Fix: added a `localTtlMs` parameter to `DistributedCache.get` (defaulting to 
5 min for backwards compatibility) and passed `ttlMs` through from `getOrSet` 
at both call sites.

Files changed: `lib/cache.ts`

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [X] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [X] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [X] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

 
