### PR TITLE
test(AnimatedCursor-theme-contrast): verify Dark and Light Prefers-Color-Scheme Visual Cohesion (Variation 3)  #4477

### DIFF
--- a/components/AnimatedCursor.theme-contrast.test.tsx
+++ b/components/AnimatedCursor.theme-contrast.test.tsx
@@ -1,0 +1,127 @@
+import { render, fireEvent } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AnimatedCursor from './AnimatedCursor';
+
+type Scheme = 'light' | 'dark';
+
+function mockThemeEnvironment(scheme: Scheme) {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: query === '(pointer: fine)' || query === `(prefers-color-scheme: ${scheme})`,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+  document.documentElement.classList.toggle('dark', scheme === 'dark');
+  document.documentElement.style.colorScheme = scheme;
+}
+
+function getCursorParts(container: HTMLElement) {
+  const [dot, ring] = Array.from(container.querySelectorAll('div'));
+
+  expect(dot).toBeInstanceOf(HTMLDivElement);
+  expect(ring).toBeInstanceOf(HTMLDivElement);
+
+  return { dot: dot as HTMLDivElement, ring: ring as HTMLDivElement };
+}
+
+describe('AnimatedCursor dark/light visual cohesion', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    document.documentElement.classList.remove('dark');
+    document.documentElement.style.colorScheme = '';
+  });
+
+  it('maintains static premium styling across light and dark color-scheme environments', () => {
+    for (const scheme of ['light', 'dark'] as const) {
+      mockThemeEnvironment(scheme);
+      const { container, unmount } = render(<AnimatedCursor />);
+      const { dot, ring } = getCursorParts(container);
+
+      expect(window.matchMedia(`(prefers-color-scheme: ${scheme})`).matches).toBe(true);
+      expect(document.documentElement.style.colorScheme).toBe(scheme);
+      expect(dot.style.background).toBe('rgb(88, 166, 255)');
+      expect(ring.style.border).toContain('rgba(88, 166, 255, 0.5)');
+
+      unmount();
+    }
+  });
+
+  it('keeps cursor layers theme-safe and restores the native cursor on unmount', () => {
+    mockThemeEnvironment('dark');
+    const { container, unmount } = render(<AnimatedCursor />);
+    const { dot, ring } = getCursorParts(container);
+
+    expect(document.body.style.cursor).toBe('none');
+    expect(dot.style.position).toBe('fixed');
+    expect(ring.style.position).toBe('fixed');
+    expect(dot.style.pointerEvents).toBe('none');
+    expect(ring.style.pointerEvents).toBe('none');
+    expect(Number(dot.style.zIndex)).toBeGreaterThan(Number(ring.style.zIndex));
+
+    unmount();
+    expect(document.body.style.cursor).toBe('');
+  });
+
+  it('has no textual cursor content that can fail foreground contrast in either theme', () => {
+    for (const scheme of ['light', 'dark'] as const) {
+      mockThemeEnvironment(scheme);
+      const { container, unmount } = render(<AnimatedCursor />);
+
+      const textContent = container.textContent?.trim() ?? '';
+      const textBearingElements = Array.from(container.querySelectorAll('*')).filter(
+        (element) => (element.textContent?.trim() ?? '').length > 0
+      );
+
+      expect(textContent).toBe('');
+      expect(textBearingElements).toHaveLength(0);
+
+      unmount();
+    }
+  });
+
+  it('keeps custom inline visual properties active for the dot and ring markup', () => {
+    mockThemeEnvironment('light');
+    const { container, unmount } = render(<AnimatedCursor />);
+    const { dot, ring } = getCursorParts(container);
+
+    expect(dot.style.width).toBe('8px');
+    expect(dot.style.height).toBe('8px');
+    expect(dot.style.borderRadius).toBe('50%');
+    expect(dot.style.transition).toBe('opacity 0.2s');
+    expect(ring.style.borderRadius).toBe('50%');
+    expect(ring.style.transition).toBe(
+      'width 0.2s, height 0.2s, border-color 0.2s, background 0.2s'
+    );
+
+    unmount();
+  });
+
+  it('keeps the hover overlay translucent so foreground cursor color is not clipped', () => {
+    mockThemeEnvironment('dark');
+    const { container, unmount } = render(<AnimatedCursor />);
+    const { dot, ring } = getCursorParts(container);
+
+    const target = document.createElement('button');
+    document.body.appendChild(target);
+    fireEvent.mouseOver(target);
+
+    expect(dot.style.background).toBe('rgb(88, 166, 255)');
+    expect(ring.style.border).toContain('rgb(88, 166, 255)');
+    expect(ring.style.background).toBe('rgba(88, 166, 255, 0.08)');
+    expect(ring.style.background).not.toBe('transparent');
+    expect(ring.style.pointerEvents).toBe('none');
+
+    target.remove();
+    unmount();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4477

Added isolated Dark and Light Prefers-Color-Scheme Visual Cohesion test coverage for `components/AnimatedCursor.tsx`.

The new test file (`components/AnimatedCursor.theme-contrast.test.tsx`) verifies all 5 requested implementation steps:
- Emulates both light and dark `prefers-color-scheme` environments.
- Confirms the cursor maintains its static premium styling consistently across both theme presets.
- Verifies there is no textual cursor content that could fail foreground contrast requirements.
- Checks the component’s custom inline visual properties are active on the rendered dot and ring elements.
- Ensures translucent hover overlay styling and `pointer-events: none` prevent foreground clipping or layout interference.

All 5 test cases pass cleanly via `vitest`.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Not applicable. This PR adds isolated testing coverage only and does not alter the production UI.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`). *(N/A for this PR; no API or UI behavior changed)*
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. *(N/A for this PR)*
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.