### PR TITLE
feat(inactive-repo): add Inactive Repository Reminder component

### DIFF
--- a/app/(root)/dashboard/[username]/page.tsx
+++ b/app/(root)/dashboard/[username]/page.tsx
@@ -125,7 +125,6 @@ export default async function DashboardPage({
       name: r.name,
       url: `https://github.com/${username}/${r.name}`,
       pushedAt: r.pushed_at ?? r.updated_at ?? null,
-      isPrivate: r.private ?? false,
     }));
   } catch {
     allRepos = [];

--- a/app/(root)/dashboard/[username]/page.tsx
+++ b/app/(root)/dashboard/[username]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import DashboardClient from '@/components/dashboard/DashboardClient';
-import { getFullDashboardData, fetchUserProfile } from '@/lib/github';
+import { getFullDashboardData, fetchUserProfile, fetchUserRepos } from '@/lib/github';
+import type { RepoActivityInfo } from '@/types/dashboard';
 import { notFound, redirect } from 'next/navigation';
 import { resolveDashboardPeriod } from '@/utils/dashboardPeriod';
 import DashboardPageWrapper from '../DashboardPageWrapper';
@@ -117,6 +118,19 @@ export default async function DashboardPage({
     throw error;
   }
 
+  let allRepos: RepoActivityInfo[] = [];
+  try {
+    const reposData = await fetchUserRepos(username, { bypassCache });
+    allRepos = reposData.map((r) => ({
+      name: r.name,
+      url: `https://github.com/${username}/${r.name}`,
+      pushedAt: r.pushed_at ?? r.updated_at ?? null,
+      isPrivate: r.private ?? false,
+    }));
+  } catch {
+    allRepos = [];
+  }
+
   let compareData = null;
 
   if (compareUsername && compareUsername.toLowerCase() !== username.toLowerCase()) {
@@ -133,6 +147,7 @@ export default async function DashboardPage({
     <DashboardPageWrapper>
       <DashboardClient
         initialData={data}
+        allRepoActivity={allRepos}
         username={username}
         compareData={compareData}
         period={period}

--- a/components/dashboard/DashboardClient.tsx
+++ b/components/dashboard/DashboardClient.tsx
@@ -6,7 +6,7 @@ import DashboardSkeleton from './DashboardSkeleton';
 import { X, RefreshCw, Share2 } from 'lucide-react';
 import Link from 'next/link';
 import { toast } from 'sonner';
-import type { Achievement, Repository, HallOfFameAward } from '@/types/dashboard';
+import type { Achievement, Repository, HallOfFameAward, RepoActivityInfo } from '@/types/dashboard';
 import type { GraphNode, GraphLink } from '@/types';
 
 import RefreshButton from './RefreshButton';
@@ -29,6 +29,7 @@ import ProfileOptimizerModal from './ProfileOptimizerModal';
 import ResumeProfileSection from './ResumeProfileSection';
 import type { DashboardPeriod } from '@/utils/dashboardPeriod';
 import { PopularRepos } from './PopularPinnnedRepos';
+import InactiveRepoReminder from './InactiveRepoReminder';
 import PRInsightsClient from './PRInsights/PRInsightsClient';
 
 // Define the dashboard data structure
@@ -81,6 +82,7 @@ export interface DashboardData {
   popularRepos?: Repository[];
   pinnedRepos?: Repository[];
   hallOfFame?: HallOfFameAward[];
+  allRepos?: RepoActivityInfo[];
 }
 
 interface DashboardClientProps {
@@ -729,6 +731,8 @@ export default function DashboardClient({
               popularRepos={initialData.popularRepos || []}
               pinnedRepos={initialData.pinnedRepos || []}
             />
+
+            <InactiveRepoReminder repos={initialData.allRepos || []} />
           </aside>
 
           <div className="col-span-1 lg:col-span-3">

--- a/components/dashboard/DashboardClient.tsx
+++ b/components/dashboard/DashboardClient.tsx
@@ -82,11 +82,11 @@ export interface DashboardData {
   popularRepos?: Repository[];
   pinnedRepos?: Repository[];
   hallOfFame?: HallOfFameAward[];
-  allRepos?: RepoActivityInfo[];
 }
 
 interface DashboardClientProps {
   initialData: DashboardData;
+  allRepoActivity?: RepoActivityInfo[];
   username: string;
   compareData?: DashboardData | null;
   period: DashboardPeriod;
@@ -321,6 +321,7 @@ function getPersonalityTags(
 
 export default function DashboardClient({
   initialData,
+  allRepoActivity = [],
   username,
   compareData = null,
   period,
@@ -732,7 +733,7 @@ export default function DashboardClient({
               pinnedRepos={initialData.pinnedRepos || []}
             />
 
-            <InactiveRepoReminder repos={initialData.allRepos || []} />
+            <InactiveRepoReminder repos={allRepoActivity} />
           </aside>
 
           <div className="col-span-1 lg:col-span-3">

--- a/components/dashboard/InactiveRepoReminder.tsx
+++ b/components/dashboard/InactiveRepoReminder.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState, useMemo, useCallback } from 'react';
+import { RefreshCw, ArrowUpRight } from 'lucide-react';
+import type { RepoActivityInfo } from '@/types/dashboard';
+
+type InactivityFilter = 30 | 60 | 90 | 180 | 365;
+
+const FILTER_OPTIONS: { label: string; value: InactivityFilter }[] = [
+  { label: '30 Days', value: 30 },
+  { label: '60 Days', value: 60 },
+  { label: '90 Days', value: 90 },
+  { label: '180 Days', value: 180 },
+  { label: '1 Year', value: 365 },
+];
+
+function getInactiveDays(pushedAt: string | null): number | null {
+  if (!pushedAt) return null;
+  const diff = Date.now() - new Date(pushedAt).getTime();
+  return Math.floor(diff / (1000 * 60 * 60 * 24));
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return 'Unknown';
+  const d = new Date(dateStr);
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+interface InactiveRepoReminderProps {
+  repos: RepoActivityInfo[];
+}
+
+export default function InactiveRepoReminder({ repos }: InactiveRepoReminderProps) {
+  const [filter, setFilter] = useState<InactivityFilter>(90);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleRefresh = useCallback(() => {
+    setRefreshing(true);
+    setTimeout(() => setRefreshing(false), 600);
+  }, []);
+
+  const inactiveRepos = useMemo(() => {
+    return repos
+      .map((r) => ({ ...r, inactiveDays: getInactiveDays(r.pushedAt) }))
+      .filter(
+        (r): r is typeof r & { inactiveDays: number } =>
+          r.inactiveDays !== null && r.inactiveDays >= filter
+      )
+      .sort((a, b) => b.inactiveDays - a.inactiveDays);
+  }, [repos, filter]);
+
+  return (
+    <div className="w-full mx-auto">
+      <div className="p-5 rounded-xl border border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 shadow-sm">
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex items-center gap-2.5">
+            <span className="text-base opacity-80">💤</span>
+            <div>
+              <h3 className="text-sm font-bold text-gray-900 dark:text-white">
+                Inactive Repository Reminder
+              </h3>
+              <p className="text-[11px] text-gray-500 dark:text-zinc-400 leading-tight mt-0.5">
+                Repositories without recent pushes in your selected window
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 shrink-0">
+            <select
+              value={filter}
+              onChange={(e) => setFilter(Number(e.target.value) as InactivityFilter)}
+              className="text-xs font-semibold px-2.5 py-1.5 rounded-lg border border-gray-200 dark:border-neutral-700 bg-gray-50 hover:bg-gray-100 dark:bg-neutral-900 dark:hover:bg-neutral-800 text-gray-600 dark:text-zinc-400 transition-colors outline-none cursor-pointer"
+              aria-label="Inactivity filter"
+            >
+              {FILTER_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+
+            <button
+              onClick={handleRefresh}
+              className="flex items-center gap-1.5 text-xs font-semibold px-2.5 py-1.5 rounded-lg border border-gray-200 dark:border-neutral-700 bg-gray-50 hover:bg-gray-100 dark:bg-neutral-900 dark:hover:bg-neutral-800 text-gray-600 dark:text-zinc-400 transition-colors"
+              aria-label="Refresh"
+            >
+              <RefreshCw size={12} className={refreshing ? 'animate-spin' : ''} />
+            </button>
+          </div>
+        </div>
+
+        {inactiveRepos.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-10 text-center">
+            <span className="text-2xl mb-3">🎉</span>
+            <p className="text-sm text-gray-500 dark:text-zinc-400">
+              No inactive repositories found for the selected time range.
+            </p>
+          </div>
+        ) : (
+          <div className="max-h-[360px] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-neutral-700 scrollbar-track-transparent pr-1 space-y-2">
+            {inactiveRepos.map((repo) => (
+              <div
+                key={repo.name}
+                className="flex items-center gap-3 p-3 rounded-xl border border-gray-200/60 dark:border-neutral-800/60 bg-gray-50/40 dark:bg-neutral-900/40 hover:bg-gray-100/70 dark:hover:bg-neutral-800/50 transition-all duration-200 group"
+              >
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  <a
+                    href={repo.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-semibold text-sm text-gray-900 dark:text-white truncate group-hover:text-purple-600 dark:group-hover:text-purple-400 transition-colors"
+                  >
+                    {repo.name}
+                  </a>
+                  {repo.isPrivate && (
+                    <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full border text-amber-600 dark:text-amber-500 bg-amber-500/10 border-amber-500/20 shrink-0">
+                      Private
+                    </span>
+                  )}
+                </div>
+
+                <span className="text-xs text-gray-500 dark:text-zinc-400 shrink-0 min-w-[90px] text-right">
+                  {formatDate(repo.pushedAt)}
+                </span>
+
+                <span className="text-xs font-semibold text-gray-700 dark:text-zinc-300 shrink-0 min-w-[48px] text-right tabular-nums">
+                  {repo.inactiveDays !== null ? `${repo.inactiveDays}d` : '-'}
+                </span>
+
+                <a
+                  href={repo.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-gray-400 dark:text-zinc-500 hover:text-purple-600 dark:hover:text-purple-400 transition-colors shrink-0 p-0.5"
+                  aria-label="Open on GitHub"
+                >
+                  <ArrowUpRight size={14} />
+                </a>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/InactiveRepoReminder.tsx
+++ b/components/dashboard/InactiveRepoReminder.tsx
@@ -112,11 +112,6 @@ export default function InactiveRepoReminder({ repos }: InactiveRepoReminderProp
                   >
                     {repo.name}
                   </a>
-                  {repo.isPrivate && (
-                    <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full border text-amber-600 dark:text-amber-500 bg-amber-500/10 border-amber-500/20 shrink-0">
-                      Private
-                    </span>
-                  )}
                 </div>
 
                 <span className="text-xs text-gray-500 dark:text-zinc-400 shrink-0 min-w-[90px] text-right">

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -20,6 +20,8 @@ interface GitHubRepo {
   fork?: boolean;
   forks_count?: number;
   updated_at?: string;
+  pushed_at?: string;
+  private?: boolean;
   owner?: { login: string };
   created_at?: string;
 }
@@ -479,6 +481,8 @@ function sanitizeRepo(repo: GitHubRepo): GitHubRepo {
     fork: repo.fork,
     forks_count: repo.forks_count,
     updated_at: repo.updated_at,
+    pushed_at: repo.pushed_at,
+    private: repo.private,
     created_at: repo.created_at,
   };
 }
@@ -1789,6 +1793,12 @@ export async function getFullDashboardData(username: string, options: FetchOptio
     hallOfFame: finalHallOfFame,
     graphData: { nodes, links },
     lastSyncedAt: calendarData.lastSyncedAt,
+    allRepos: reposData.map((r) => ({
+      name: r.name,
+      url: `https://github.com/${r.owner?.login || profileData.login}/${r.name}`,
+      pushedAt: r.pushed_at ?? r.updated_at ?? null,
+      isPrivate: r.private ?? false,
+    })),
   };
 }
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -21,7 +21,6 @@ interface GitHubRepo {
   forks_count?: number;
   updated_at?: string;
   pushed_at?: string;
-  private?: boolean;
   owner?: { login: string };
   created_at?: string;
 }
@@ -482,7 +481,6 @@ function sanitizeRepo(repo: GitHubRepo): GitHubRepo {
     forks_count: repo.forks_count,
     updated_at: repo.updated_at,
     pushed_at: repo.pushed_at,
-    private: repo.private,
     created_at: repo.created_at,
   };
 }

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1793,12 +1793,6 @@ export async function getFullDashboardData(username: string, options: FetchOptio
     hallOfFame: finalHallOfFame,
     graphData: { nodes, links },
     lastSyncedAt: calendarData.lastSyncedAt,
-    allRepos: reposData.map((r) => ({
-      name: r.name,
-      url: `https://github.com/${r.owner?.login || profileData.login}/${r.name}`,
-      pushedAt: r.pushed_at ?? r.updated_at ?? null,
-      isPrivate: r.private ?? false,
-    })),
   };
 }
 

--- a/types/dashboard.ts
+++ b/types/dashboard.ts
@@ -119,3 +119,10 @@ export interface Repository {
     color: string;
   } | null;
 }
+
+export interface RepoActivityInfo {
+  name: string;
+  url: string;
+  pushedAt: string | null;
+  isPrivate: boolean;
+}

--- a/types/dashboard.ts
+++ b/types/dashboard.ts
@@ -124,5 +124,4 @@ export interface RepoActivityInfo {
   name: string;
   url: string;
   pushedAt: string | null;
-  isPrivate: boolean;
 }


### PR DESCRIPTION
## Description

Added a inactive repository feature so that users can know on which repo they have to look after now.

Fixes #5159 

## Pillar

- [x] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

<img width="484" height="699" alt="Screenshot 2026-06-11 001054" src="https://github.com/user-attachments/assets/157c4d9f-27dd-43cf-b28c-78525b89475f" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
