### PR TITLE
fix: prevent unauthenticated student profile upserts

### DIFF
--- a/app/api/student/resume/confirm/route.test.ts
+++ b/app/api/student/resume/confirm/route.test.ts
@@ -23,11 +23,18 @@ vi.mock('@/lib/rate-limit', () => {
   };
 });
 
+vi.mock('@/lib/github-owner-verification', () => ({
+  verifyGitHubOwner: vi.fn().mockResolvedValue({ verified: true }),
+}));
+
+import { verifyGitHubOwner } from '@/lib/github-owner-verification';
+
 function makeRequest(body: string | Record<string, unknown>): Request {
   return new Request('http://localhost/api/student/resume/confirm', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: 'Bearer test-owner-token',
     },
     body: typeof body === 'string' ? body : JSON.stringify(body),
   });
@@ -37,6 +44,7 @@ describe('POST /api/student/resume/confirm Extra Scenarios', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     delete process.env.MONGODB_URI;
+    vi.mocked(verifyGitHubOwner).mockResolvedValue({ verified: true });
   });
 
   afterEach(() => {
@@ -80,6 +88,45 @@ describe('POST /api/student/resume/confirm Extra Scenarios', () => {
     const body = await response.json();
     expect(body.success).toBe(true);
     expect(body.bypassed).toBe(true);
+    expect(StudentProfile.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 and does not write when GitHub authentication is missing', async () => {
+    process.env.MONGODB_URI = 'mongodb://localhost:27017/test';
+    vi.mocked(verifyGitHubOwner).mockResolvedValueOnce({
+      verified: false,
+      status: 401,
+      message: 'GitHub authentication is required.',
+    });
+
+    const response = await POST(
+      makeRequest({
+        githubUsername: 'victim',
+        data: { name: 'Attacker', email: 'attacker@example.com' },
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(StudentProfile.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 and does not write when the authenticated account is not the owner', async () => {
+    process.env.MONGODB_URI = 'mongodb://localhost:27017/test';
+    vi.mocked(verifyGitHubOwner).mockResolvedValueOnce({
+      verified: false,
+      status: 403,
+      message: 'The authenticated GitHub account does not own this username.',
+    });
+
+    const response = await POST(
+      makeRequest({
+        githubUsername: 'victim',
+        data: { name: 'Attacker', email: 'attacker@example.com' },
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(verifyGitHubOwner).toHaveBeenCalledWith(expect.any(Request), 'victim');
     expect(StudentProfile.findOneAndUpdate).not.toHaveBeenCalled();
   });
 

--- a/app/api/student/resume/confirm/route.ts
+++ b/app/api/student/resume/confirm/route.ts
@@ -4,6 +4,7 @@ import { StudentProfile } from '@/models/StudentProfile';
 import { RateLimiter } from '@/lib/rate-limit';
 import { getClientIp } from '@/utils/getClientIp';
 import { resumeConfirmDataSchema, GITHUB_USERNAME_REGEX } from '@/lib/validations';
+import { verifyGitHubOwner } from '@/lib/github-owner-verification';
 
 const confirmLimiter = new RateLimiter(10, 60000);
 
@@ -68,6 +69,15 @@ export async function POST(req: Request) {
     );
   }
   const profile = parsed.data;
+  const normalizedUsername = githubUsername.trim().toLowerCase();
+
+  const ownership = await verifyGitHubOwner(req, normalizedUsername);
+  if (!ownership.verified) {
+    return NextResponse.json(
+      { success: false, error: ownership.message },
+      { status: ownership.status }
+    );
+  }
 
   try {
     if (!process.env.MONGODB_URI) {
@@ -78,7 +88,7 @@ export async function POST(req: Request) {
     await dbConnect();
 
     await StudentProfile.findOneAndUpdate(
-      { githubUsername: githubUsername.trim().toLowerCase() },
+      { githubUsername: normalizedUsername },
       {
         $set: {
           name: profile.name,

--- a/app/api/student/resume/tests/confirm.test.ts
+++ b/app/api/student/resume/tests/confirm.test.ts
@@ -22,11 +22,18 @@ vi.mock('@/lib/rate-limit', () => {
   };
 });
 
+vi.mock('@/lib/github-owner-verification', () => ({
+  verifyGitHubOwner: vi.fn().mockResolvedValue({ verified: true }),
+}));
+
+import { verifyGitHubOwner } from '@/lib/github-owner-verification';
+
 function makeRequest(body: Record<string, unknown>): Request {
   return new Request('http://localhost/api/student/resume/confirm', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: 'Bearer test-owner-token',
     },
     body: JSON.stringify(body),
   });
@@ -35,6 +42,7 @@ function makeRequest(body: Record<string, unknown>): Request {
 describe('POST /api/student/resume/confirm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(verifyGitHubOwner).mockResolvedValue({ verified: true });
   });
 
   afterEach(() => {
@@ -113,6 +121,28 @@ describe('POST /api/student/resume/confirm', () => {
 
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
+  });
+
+  it('blocks profile takeover when the authenticated GitHub account does not match', async () => {
+    process.env.MONGODB_URI = 'mongodb://localhost:27017/test';
+    vi.mocked(verifyGitHubOwner).mockResolvedValueOnce({
+      verified: false,
+      status: 403,
+      message: 'The authenticated GitHub account does not own this username.',
+    });
+
+    const response = await POST(
+      makeRequest({
+        githubUsername: 'victim',
+        data: {
+          name: 'Attacker',
+          email: 'attacker@example.com',
+        },
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(StudentProfile.findOneAndUpdate).not.toHaveBeenCalled();
   });
 
   it('returns 500 when database update fails', async () => {

--- a/lib/github-owner-verification.test.ts
+++ b/lib/github-owner-verification.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { verifyGitHubOwner } from './github-owner-verification';
+
+describe('verifyGitHubOwner', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects requests without a bearer token', async () => {
+    const result = await verifyGitHubOwner(new Request('http://localhost/api/profile'), 'octocat');
+
+    expect(result).toEqual({
+      verified: false,
+      status: 401,
+      message: 'GitHub authentication is required.',
+    });
+  });
+
+  it('verifies a matching GitHub account', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({ login: 'OctoCat' }), { status: 200 }));
+    const request = new Request('http://localhost/api/profile', {
+      headers: { Authorization: 'Bearer caller-token' },
+    });
+
+    await expect(verifyGitHubOwner(request, 'octocat')).resolves.toEqual({ verified: true });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.github.com/user',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer caller-token' }),
+        cache: 'no-store',
+      })
+    );
+  });
+
+  it('rejects a token belonging to a different GitHub account', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ login: 'attacker' }), { status: 200 })
+    );
+    const request = new Request('http://localhost/api/profile', {
+      headers: { Authorization: 'Bearer attacker-token' },
+    });
+
+    const result = await verifyGitHubOwner(request, 'victim');
+
+    expect(result).toMatchObject({ verified: false, status: 403 });
+  });
+
+  it('rejects invalid tokens without exposing them', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 401 }));
+    const request = new Request('http://localhost/api/profile', {
+      headers: { Authorization: 'Bearer expired-token' },
+    });
+
+    const result = await verifyGitHubOwner(request, 'octocat');
+
+    expect(result).toMatchObject({ verified: false, status: 401 });
+    expect(JSON.stringify(result)).not.toContain('expired-token');
+  });
+
+  it('fails closed when GitHub ownership verification is unavailable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network failure'));
+    const request = new Request('http://localhost/api/profile', {
+      headers: { Authorization: 'Bearer caller-token' },
+    });
+
+    await expect(verifyGitHubOwner(request, 'octocat')).resolves.toMatchObject({
+      verified: false,
+      status: 502,
+    });
+  });
+});

--- a/lib/github-owner-verification.ts
+++ b/lib/github-owner-verification.ts
@@ -1,0 +1,90 @@
+const GITHUB_USER_API_URL = 'https://api.github.com/user';
+const VERIFY_TIMEOUT_MS = 5000;
+
+export type GitHubOwnerVerificationResult =
+  | { verified: true }
+  | {
+      verified: false;
+      status: 401 | 403 | 502;
+      message: string;
+    };
+
+function getBearerToken(request: Request): string | null {
+  const authorization = request.headers.get('authorization');
+  const match = authorization?.match(/^Bearer\s+(\S+)$/i);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Verifies that the caller's GitHub access token belongs to the requested username.
+ *
+ * Tokens are used only for the GitHub `/user` verification request and are never
+ * stored, logged, or included in error responses.
+ */
+export async function verifyGitHubOwner(
+  request: Request,
+  requestedUsername: string
+): Promise<GitHubOwnerVerificationResult> {
+  const token = getBearerToken(request);
+  if (!token) {
+    return {
+      verified: false,
+      status: 401,
+      message: 'GitHub authentication is required.',
+    };
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(GITHUB_USER_API_URL, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'CommitPulse',
+      },
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+
+    if (response.status === 401) {
+      return {
+        verified: false,
+        status: 401,
+        message: 'Invalid or expired GitHub access token.',
+      };
+    }
+
+    if (!response.ok) {
+      return {
+        verified: false,
+        status: 502,
+        message: 'Unable to verify GitHub account ownership.',
+      };
+    }
+
+    const profile = (await response.json()) as { login?: unknown };
+    if (
+      typeof profile.login !== 'string' ||
+      profile.login.toLowerCase() !== requestedUsername.trim().toLowerCase()
+    ) {
+      return {
+        verified: false,
+        status: 403,
+        message: 'The authenticated GitHub account does not own this username.',
+      };
+    }
+
+    return { verified: true };
+  } catch {
+    return {
+      verified: false,
+      status: 502,
+      message: 'Unable to verify GitHub account ownership.',
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}


### PR DESCRIPTION
## Summary

- require a caller-provided GitHub bearer token before creating or updating a student profile
- verify the authenticated GitHub `/user` identity matches the requested `githubUsername`
- fail closed on missing/invalid tokens, account mismatches, and upstream verification failures
- normalize the verified username once and use it for the MongoDB upsert
- add regression coverage proving unauthorized callers cannot reach `StudentProfile.findOneAndUpdate`

## Security impact

Previously, any caller could submit another GitHub user's username and overwrite that user's stored name, email, phone number, skills, education, and experience. Mutating requests now require proof of GitHub account ownership before any bypass or database write path is reached.

Tokens are used only for the GitHub ownership verification request and are never stored, logged, or returned in errors.

## Verification

- `npm run test -- app/api/student components/dashboard/ResumePreviewForm lib/resume-parser models/StudentProfile` (34 files, 189 tests passed)
- `npm run test -- lib/github-owner-verification.test.ts app/api/student/resume/confirm/route.test.ts app/api/student/resume/tests/confirm.test.ts lib/resume-parser.test.ts models/StudentProfile.test.ts` (5 files, 39 tests passed)
- `npm run typecheck`
- focused ESLint and `git diff --check`

`npm run build` could not start compilation because Windows/OneDrive denied Next.js permission to remove the pre-existing generated `.next/diagnostics` directory (`EPERM`).

Fixes #5194