### PR TITLE
fix: prevent rate-limit bypass via spoofed IP headers

### DIFF
--- a/app/api/track-user/route.test.ts
+++ b/app/api/track-user/route.test.ts
@@ -176,6 +176,12 @@ describe('POST /api/track-user', () => {
     expect(response.headers.get('x-ratelimit-reset')).toBe(reset.toString());
   });
 
+  it('applies rate limiting to localhost requests', async () => {
+    await POST(makeRequest({ username: 'valid-user' }));
+
+    expect(trackUserRateLimiter.checkWithResult).toHaveBeenCalledWith('127.0.0.1');
+  });
+
   describe('Without MONGODB_URI (Local Development Bypass)', () => {
     it('returns 200 and bypassed flag when MONGODB_URI is undefined', async () => {
       delete process.env.MONGODB_URI;

--- a/app/api/track-user/route.ts
+++ b/app/api/track-user/route.ts
@@ -12,15 +12,13 @@ export async function POST(req: Request) {
 
   const rateLimitKey = ip === 'unknown' ? 'unknown-client' : ip;
 
-  if (ip !== '127.0.0.1') {
-    const rateLimitResult = await trackUserRateLimiter.checkWithResult(rateLimitKey);
+  const rateLimitResult = await trackUserRateLimiter.checkWithResult(rateLimitKey);
 
-    if (!rateLimitResult.success) {
-      return NextResponse.json(
-        { success: false, error: 'Too many requests, please try again later.' },
-        { status: 429, headers: getRateLimitHeaders(rateLimitResult) }
-      );
-    }
+  if (!rateLimitResult.success) {
+    return NextResponse.json(
+      { success: false, error: 'Too many requests, please try again later.' },
+      { status: 429, headers: getRateLimitHeaders(rateLimitResult) }
+    );
   }
 
   let body: unknown;

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -141,7 +141,7 @@ describe('middleware', () => {
     expect(response.headers.get('X-RateLimit-Reset')).toBe('123456789');
   });
 
-  it('uses first IP from x-forwarded-for when subsequent hops are trusted', async () => {
+  it('ignores x-forwarded-for when no authoritative request.ip is available', async () => {
     vi.mocked(rateLimit).mockResolvedValue({
       success: true,
       limit: 60,
@@ -157,7 +157,7 @@ describe('middleware', () => {
 
     await middleware(request);
 
-    expect(rateLimit).toHaveBeenCalledWith('1.2.3.4', 60, 60000);
+    expect(rateLimit).toHaveBeenCalledWith('127.0.0.1', 60, 60000);
   });
 
   it('ignores spoofed x-forwarded-for when subsequent hops are untrusted', async () => {
@@ -178,10 +178,10 @@ describe('middleware', () => {
 
     await middleware(request);
 
-    expect(rateLimit).toHaveBeenCalledWith('5.6.7.8', 60, 60000);
+    expect(rateLimit).toHaveBeenCalledWith('127.0.0.1', 60, 60000);
   });
 
-  it('uses x-real-ip if x-forwarded-for is missing', async () => {
+  it('ignores x-real-ip if no authoritative request.ip is available', async () => {
     vi.mocked(rateLimit).mockResolvedValue({
       success: true,
       limit: 60,
@@ -197,7 +197,7 @@ describe('middleware', () => {
 
     await middleware(request);
 
-    expect(rateLimit).toHaveBeenCalledWith('9.9.9.9', 60, 60000);
+    expect(rateLimit).toHaveBeenCalledWith('127.0.0.1', 60, 60000);
   });
 
   it('defaults to 127.0.0.1 when no IP headers', async () => {
@@ -215,7 +215,7 @@ describe('middleware', () => {
     expect(rateLimit).toHaveBeenCalledWith('127.0.0.1', 60, 60000);
   });
 
-  it('prefers x-real-ip over x-forwarded-for to prevent spoofing', async () => {
+  it('does not allow x-real-ip to override x-forwarded-for or the fallback bucket', async () => {
     vi.mocked(rateLimit).mockResolvedValue({
       success: true,
       limit: 60,
@@ -232,8 +232,7 @@ describe('middleware', () => {
 
     await middleware(request);
 
-    // Expect 9.9.9.9 instead of 1.2.3.4 because x-real-ip is more secure
-    expect(rateLimit).toHaveBeenCalledWith('9.9.9.9', 60, 60000);
+    expect(rateLimit).toHaveBeenCalledWith('127.0.0.1', 60, 60000);
   });
 
   it('handles multiple IPs with whitespace', async () => {
@@ -252,7 +251,28 @@ describe('middleware', () => {
 
     await middleware(request);
 
-    expect(rateLimit).toHaveBeenCalledWith('1.2.3.4', 60, 60000);
+    expect(rateLimit).toHaveBeenCalledWith('127.0.0.1', 60, 60000);
+  });
+
+  it('uses authoritative request.ip instead of spoofable forwarded headers', async () => {
+    vi.mocked(rateLimit).mockResolvedValue({
+      success: true,
+      limit: 60,
+      remaining: 59,
+      reset: 123456789,
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/streak?user=octocat', {
+      headers: {
+        'x-forwarded-for': '1.2.3.4',
+        'x-real-ip': '9.9.9.9',
+      },
+    });
+    Object.defineProperty(request, 'ip', { value: '203.0.113.20' });
+
+    await middleware(request);
+
+    expect(rateLimit).toHaveBeenCalledWith('203.0.113.20', 60, 60000);
   });
 
   it('includes compare API matcher in proxy config', () => {

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,10 +12,7 @@ import { getClientIp } from './utils/getClientIp';
  * @see https://nextjs.org/docs/app/building-your-application/routing/middleware
  */
 export async function middleware(request: NextRequest): Promise<NextResponse> {
-  // 1. Prioritize x-real-ip to prevent spoofing
-  // 2. Fallback to getClientIp which securely parses x-forwarded-for hops
-  // 3. Fallback to localhost
-  const ip = request.headers.get('x-real-ip') ?? getClientIp(request) ?? '127.0.0.1';
+  const ip = getClientIp(request);
 
   const isRefresh =
     request.nextUrl.searchParams.get('refresh') === 'true' ||

--- a/types/network.ts
+++ b/types/network.ts
@@ -23,4 +23,10 @@ export interface GetClientIpOptions {
    * E.g., ['x-vercel-forwarded-for', 'cf-connecting-ip', 'x-real-ip']
    */
   headersPriority?: string[];
+
+  /**
+   * IP address of the peer that connected directly to the application.
+   * Forwarded headers are trusted only when this peer is a configured proxy.
+   */
+  directIp?: string;
 }

--- a/utils/getClientIp.test.ts
+++ b/utils/getClientIp.test.ts
@@ -23,7 +23,7 @@ describe('getClientIp', () => {
     expect(ip).toBe('203.0.113.10');
   });
 
-  it('uses direct client-supplied custom priority headers if available', () => {
+  it('ignores direct client-supplied custom priority headers', () => {
     const req = new Request('http://localhost:3000/api/streak', {
       headers: {
         'cf-connecting-ip': '198.51.100.99',
@@ -31,7 +31,7 @@ describe('getClientIp', () => {
     });
 
     const ip = getClientIp(req);
-    expect(ip).toBe('198.51.100.99');
+    expect(ip).toBe('127.0.0.1');
   });
 
   it('ignores x-forwarded-for entirely when no trusted proxies are configured', () => {
@@ -44,7 +44,7 @@ describe('getClientIp', () => {
     const ip = getClientIp(req, {
       proxyConfig: { trustedProxies: [], trustPrivateRanges: false },
     });
-    expect(ip).toBe('127.0.0.1'); // Default fallback because x-real-ip and others are missing
+    expect(ip).toBe('127.0.0.1');
   });
 
   it('extracts correct IP through a trusted proxy chain', () => {
@@ -60,6 +60,7 @@ describe('getClientIp', () => {
         trustedProxies: ['127.0.0.1', '203.0.113.10'],
         trustPrivateRanges: true,
       },
+      directIp: '127.0.0.1',
     });
     expect(ip).toBe('198.51.100.5');
   });
@@ -77,6 +78,7 @@ describe('getClientIp', () => {
         trustedProxies: ['127.0.0.1'],
         trustPrivateRanges: true,
       },
+      directIp: '127.0.0.1',
     });
     expect(ip).toBe('8.8.8.8');
   });
@@ -93,6 +95,7 @@ describe('getClientIp', () => {
         trustedProxies: ['*'],
         trustPrivateRanges: false,
       },
+      directIp: '203.0.113.10',
     });
     expect(ip).toBe('198.51.100.5');
   });
@@ -108,8 +111,43 @@ describe('getClientIp', () => {
         trustedProxies: ['192.168.1.1'],
         trustPrivateRanges: false,
       },
+      directIp: '192.168.1.1',
     };
     expect(getClientIp(req, options)).toBe('198.51.100.10');
+  });
+
+  it('returns the direct peer and ignores spoofed headers when the peer is not trusted', () => {
+    const req = new Request('http://localhost:3000/api/streak', {
+      headers: {
+        'x-forwarded-for': '127.0.0.1',
+        'x-real-ip': '127.0.0.1',
+        'cf-connecting-ip': '127.0.0.1',
+      },
+    });
+
+    expect(
+      getClientIp(req, {
+        proxyConfig: { trustedProxies: ['10.0.0.1'], trustPrivateRanges: false },
+        directIp: '198.51.100.25',
+      })
+    ).toBe('198.51.100.25');
+  });
+
+  it('does not allow rotating forwarded headers to rotate the resolved IP', () => {
+    const options = {
+      proxyConfig: { trustedProxies: [], trustPrivateRanges: false },
+      directIp: '198.51.100.25',
+    };
+
+    const first = new Request('http://localhost/api/streak', {
+      headers: { 'x-real-ip': '1.1.1.1' },
+    });
+    const second = new Request('http://localhost/api/streak', {
+      headers: { 'x-real-ip': '8.8.8.8' },
+    });
+
+    expect(getClientIp(first, options)).toBe('198.51.100.25');
+    expect(getClientIp(second, options)).toBe('198.51.100.25');
   });
 
   it('falls back to 127.0.0.1 when headers are missing or malformed', () => {

--- a/utils/getClientIp.ts
+++ b/utils/getClientIp.ts
@@ -77,7 +77,34 @@ export function getClientIp(
     return requestIp;
   }
 
-  // 2. Process X-Forwarded-For securely if present
+  const directIp = options.directIp?.trim();
+  const forwardedHeaders = [
+    'x-forwarded-for',
+    ...(options.headersPriority || ['x-vercel-proxied-for', 'cf-connecting-ip', 'x-real-ip']),
+  ];
+
+  // Forwarded headers cannot establish their own trust boundary. Without a
+  // separately supplied direct peer IP, treat them as attacker-controlled.
+  if (!directIp) {
+    const spoofedHeader = forwardedHeaders.find((headerName) => headers.get(headerName));
+    if (spoofedHeader) {
+      logSecurityEvent('UNTRUSTED_FORWARDED_HEADER_IGNORED', {
+        resolvedIp: 'unknown',
+        header: spoofedHeader,
+      });
+    }
+
+    return process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'
+      ? '127.0.0.1'
+      : 'unknown';
+  }
+
+  // A direct, untrusted peer is the client. Never let it override its own IP.
+  if (!isTrustedProxy(directIp, config)) {
+    return directIp;
+  }
+
+  // 2. Process X-Forwarded-For only when the direct peer is trusted.
   const xff = headers.get('x-forwarded-for');
   if (xff) {
     const ips = xff
@@ -85,19 +112,6 @@ export function getClientIp(
       .map((ip: string) => ip.trim())
       .filter(Boolean);
     if (ips.length > 0) {
-      // If we don't trust any proxies, do NOT trust X-Forwarded-For values supplied by the client
-      if (config.trustedProxies.length === 0 && !config.trustPrivateRanges) {
-        const fallbackIp = headers.get('x-real-ip')?.trim() || '127.0.0.1';
-        if (ips[0] !== fallbackIp) {
-          logSecurityEvent('SPOOFED_HEADER_ATTEMPT', {
-            claimedIp: ips[0],
-            resolvedIp: fallbackIp,
-            header: 'x-forwarded-for',
-          });
-        }
-        return fallbackIp;
-      }
-
       // If all proxies are trusted via wildcard
       if (config.trustedProxies.includes('*')) {
         // When trusting ALL proxies via wildcard, the true client IP is the leftmost entry (ips[0])
@@ -114,7 +128,7 @@ export function getClientIp(
 
       // Traverse from right to left (most recent to oldest proxy hop)
       // The rightmost IP is the one that connected directly to our server/balancer
-      let clientIp = ips[ips.length - 1];
+      let clientIp = directIp;
 
       for (let i = ips.length - 1; i >= 0; i--) {
         const currentIp = ips[i];
@@ -144,7 +158,7 @@ export function getClientIp(
     }
   }
 
-  // 3. Custom/Platform priority headers (e.g. Cloudflare, Vercel)
+  // 3. Custom/platform headers are accepted only behind a trusted direct peer.
   const priorityHeaders = options.headersPriority || [
     'x-vercel-proxied-for',
     'cf-connecting-ip',
@@ -161,11 +175,5 @@ export function getClientIp(
     }
   }
 
-  // 4. Ultimate Fallback
-  // 4. Ultimate Fallback
-  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
-    return '127.0.0.1';
-  }
-
-  return 'unknown';
+  return directIp;
 }


### PR DESCRIPTION
## Summary

- remove middleware's direct trust of the client-controlled `x-real-ip` header
- treat forwarding headers as untrusted unless a separately supplied direct peer IP is a configured trusted proxy
- use authoritative `NextRequest.ip` when the platform provides it
- return the direct peer IP when it is not trusted instead of allowing forwarded-header overrides
- remove the `127.0.0.1` rate-limit exemption from `/api/track-user`
- add regression tests for rotating `x-real-ip`, spoofed localhost headers, authoritative request IPs, and localhost rate limiting

## Security impact

Previously, attackers could rotate `x-real-ip` or other forwarding headers to receive a fresh rate-limit bucket for every request. Some spoofed requests could also resolve to `127.0.0.1`, causing `/api/track-user` to skip its limiter entirely.

Forwarding headers can no longer establish their own trust boundary, and localhost requests now consume rate-limit capacity like every other request.

## Verification

- `npm run test -- middleware app/api/track-user utils services/security lib/rate-limit.test.ts` (42 files, 333 tests passed)
- `npm run test -- utils/getClientIp.test.ts utils/trustedProxy.test.ts middleware.test.ts middleware.accessibility.test.ts app/api/track-user/route.test.ts lib/rate-limit.test.ts` (6 files, 84 tests passed)
- `npm run typecheck`
- focused ESLint and `git diff --check`

`npm run build` could not start compilation because Windows/OneDrive denied Next.js permission to remove the pre-existing generated `.next/diagnostics` directory (`EPERM`).

Fixes #5196