### PR TITLE
test(PopularPinnnedRepos-accessibility): add accessibility tests

### DIFF
--- a/components/dashboard/PopularPinnnedRepos.accessibility.test.tsx
+++ b/components/dashboard/PopularPinnnedRepos.accessibility.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+
+import { PopularRepos } from './PopularPinnnedRepos';
+
+const mockRepo = {
+  name: 'commitpulse',
+  description: 'Repository description',
+  stargazerCount: 100,
+  forkCount: 20,
+  url: 'https://github.com/test/repo',
+  primaryLanguage: {
+    name: 'TypeScript',
+    color: '#3178c6',
+  },
+};
+
+describe('PopularRepos Accessibility', () => {
+  it('renders repository section heading for screen readers', () => {
+    render(<PopularRepos popularRepos={[mockRepo]} />);
+
+    expect(
+      screen.getByRole('heading', {
+        name: /popular repositories/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('renders dropdown trigger with correct accessibility attributes', () => {
+    render(<PopularRepos popularRepos={[mockRepo]} pinnedRepos={[mockRepo]} />);
+
+    const trigger = screen.getByRole('button', {
+      name: /popular/i,
+    });
+
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('opens accessible listbox when activated', async () => {
+    const user = userEvent.setup();
+
+    render(<PopularRepos popularRepos={[mockRepo]} pinnedRepos={[mockRepo]} />);
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /popular/i,
+      })
+    );
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('renders selectable repository views as accessible options', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PopularRepos popularRepos={[mockRepo]} pinnedRepos={[mockRepo]} starredRepos={[mockRepo]} />
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: /popular/i,
+      })
+    );
+
+    const popularOption = screen.getByRole('option', {
+      name: /popular/i,
+    });
+
+    expect(popularOption).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('repository links provide accessible names for screen readers', () => {
+    render(<PopularRepos popularRepos={[mockRepo]} />);
+
+    expect(
+      screen.getByRole('link', {
+        name: /commitpulse/i,
+      })
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4609

### Summary

Added a dedicated accessibility test suite for `PopularPinnnedRepos` by creating:

`components/dashboard/PopularPinnnedRepos.accessibility.test.tsx`

### Changes Made

* Added 5 accessibility-focused test cases.
* Verified repository section headings are exposed correctly to screen readers.
* Tested dropdown trigger accessibility attributes (`aria-haspopup` and `aria-expanded`).
* Verified accessible listbox behavior when repository view selection is opened.
* Validated selectable repository view options and ARIA selection states.
* Confirmed repository links expose accessible names for assistive technologies.

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run formatting/linting checks where applicable.
* [x] My commits follow the Conventional Commits format.
* [x] No README changes were required.
* [x] I have starred the repository.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] This PR only adds tests and does not modify production functionality.
