### PR TITLE
test(DashboardError): add mouse interactivity tests

### DIFF
--- a/app/(root)/dashboard/error.mouse-interactivity.test.tsx
+++ b/app/(root)/dashboard/error.mouse-interactivity.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DashboardError from './error';
+
+import type { ReactNode } from 'react';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe('DashboardError Mouse Interactivity', () => {
+  const mockReset = vi.fn();
+
+  const renderComponent = (message = 'Something went wrong') => {
+    return render(<DashboardError error={new Error(message)} reset={mockReset} />);
+  };
+
+  it('triggers reset when Try again button is clicked', () => {
+    renderComponent();
+
+    const button = screen.getByRole('button', {
+      name: /try again/i,
+    });
+
+    fireEvent.click(button);
+
+    expect(mockReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles mouse enter and mouse leave on Try again button', () => {
+    renderComponent();
+
+    const button = screen.getByRole('button', {
+      name: /try again/i,
+    });
+
+    fireEvent.mouseEnter(button);
+    fireEvent.mouseLeave(button);
+
+    expect(button).toBeTruthy();
+  });
+
+  it('handles mouse enter and mouse leave on Go back home button', () => {
+    renderComponent();
+
+    const button = screen.getByRole('button', {
+      name: /go back home/i,
+    });
+
+    fireEvent.mouseEnter(button);
+    fireEvent.mouseLeave(button);
+
+    expect(button).toBeTruthy();
+  });
+
+  it('renders navigation link correctly', () => {
+    renderComponent();
+
+    const link = screen.getByRole('link');
+
+    expect(link.getAttribute('href')).toBe('/');
+  });
+
+  it('keeps interactive controls visible after mouse interactions', () => {
+    renderComponent();
+
+    const retryButton = screen.getByRole('button', {
+      name: /try again/i,
+    });
+
+    fireEvent.mouseEnter(retryButton);
+    fireEvent.mouseMove(retryButton);
+    fireEvent.mouseLeave(retryButton);
+
+    expect(
+      screen.getByRole('button', {
+        name: /try again/i,
+      })
+    ).toBeTruthy();
+
+    expect(
+      screen.getByRole('button', {
+        name: /go back home/i,
+      })
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4663

Added mouse interactivity tests for `app/(root)/dashboard/error.tsx`.

The test suite verifies:

- Try again button triggers reset callback
- Mouse enter and mouse leave interactions on Try again button
- Mouse enter and mouse leave interactions on Go back home button
- Navigation link renders correctly
- Interactive controls remain visible after mouse interactions

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)