### PR TITLE
test(Leaderboard): add empty fallback tests

### DIFF
--- a/components/Leaderboard.empty-fallback.test.tsx
+++ b/components/Leaderboard.empty-fallback.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps, ReactNode } from 'react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, vi } from 'vitest';
+import Leaderboard, { type Contributor } from './Leaderboard';
+
+// Mock next/image
+vi.mock('next/image', () => ({
+  default: ({ alt = '', src = '', fill, ...props }: ComponentProps<'img'> & { fill?: boolean }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} src={src} {...props} />
+  ),
+}));
+
+// Mock framer-motion
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    {
+      get:
+        () =>
+        ({ children, ...props }: { children?: ReactNode }) => <div {...props}>{children}</div>,
+    }
+  ),
+}));
+
+describe('Leaderboard Empty Fallback', () => {
+  const contributor: Contributor = {
+    id: 1,
+    login: 'testuser',
+    avatar_url: 'https://example.com/avatar.png',
+    contributions: 100,
+    html_url: 'https://github.com/testuser',
+  };
+
+  it('renders without crashing when contributors array is empty', () => {
+    const { container } = render(<Leaderboard contributors={[]} />);
+
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders no contributor names when contributors array is empty', () => {
+    render(<Leaderboard contributors={[]} />);
+
+    expect(screen.queryByText('testuser')).not.toBeInTheDocument();
+  });
+
+  it('renders a single contributor correctly', () => {
+    render(<Leaderboard contributors={[contributor]} />);
+
+    expect(screen.getByText('testuser')).toBeInTheDocument();
+    expect(screen.getByText('100')).toBeInTheDocument();
+  });
+
+  it('renders fallback avatar container when avatar_url is empty', () => {
+    const contributorWithoutAvatar: Contributor = {
+      ...contributor,
+      avatar_url: '',
+    };
+
+    render(<Leaderboard contributors={[contributorWithoutAvatar]} />);
+
+    expect(screen.getByText('testuser')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('does not render list entries when fewer than four contributors exist', () => {
+    render(<Leaderboard contributors={[contributor]} />);
+
+    expect(screen.queryByText('#4')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Adds empty fallback test coverage for the Leaderboard component.

### Changes

* Added `components/Leaderboard.empty-fallback.test.tsx`
* Verified rendering when the contributors array is empty
* Verified no contributor names are rendered for empty input
* Verified single contributor rendering
* Verified fallback avatar container rendering when `avatar_url` is empty
* Verified no list entries are rendered when fewer than four contributors exist

Fixes #2753

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

