### PR TITLE
fix: fail closed and harden GitHub webhook authentication

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -13,6 +13,10 @@ MONGODB_URI=mongodb+srv://<username>:<password>@cluster0.mongodb.net/commitpulse
 # Generate at: https://github.com/settings/tokens (No scopes required)
 GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# Required to authenticate GitHub webhook deliveries.
+# Use a long random value and configure the same secret in the GitHub webhook settings.
+GITHUB_WEBHOOK_SECRET=
+
 # Vercel KV / Upstash Redis URL for distributed rate limiting.
 # Leave blank to operate with degraded local-memory rate limits.
 KV_REST_API_URL=

--- a/app/api/webhook/route.test.ts
+++ b/app/api/webhook/route.test.ts
@@ -1,0 +1,88 @@
+import crypto from 'crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { POST } from './route';
+import { RateLimiter } from '@/lib/rate-limit';
+
+function signedRequest(body: string, secret: string, signature?: string): Request {
+  const digest =
+    signature ?? `sha256=${crypto.createHmac('sha256', secret).update(body).digest('hex')}`;
+
+  return new Request('http://localhost/api/webhook', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-hub-signature-256': digest,
+    },
+    body,
+  });
+}
+
+describe('POST /api/webhook', () => {
+  beforeEach(() => {
+    vi.spyOn(RateLimiter.prototype, 'check').mockResolvedValue(true);
+    process.env.GITHUB_WEBHOOK_SECRET = 'configured-test-secret';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.GITHUB_WEBHOOK_SECRET;
+  });
+
+  it('fails closed when the webhook secret is not configured', async () => {
+    delete process.env.GITHUB_WEBHOOK_SECRET;
+    const publicFallbackSignature = `sha256=${crypto
+      .createHmac('sha256', 'development_secret')
+      .update('{}')
+      .digest('hex')}`;
+
+    const response = await POST(signedRequest('{}', 'unused', publicFallbackSignature));
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: 'Webhook is not configured' });
+  });
+
+  it('accepts a payload signed with the configured secret', async () => {
+    const response = await POST(signedRequest('{"action":"opened"}', 'configured-test-secret'));
+
+    expect(response.status).toBe(200);
+  });
+
+  it('rejects signatures generated with the old public fallback secret', async () => {
+    const response = await POST(signedRequest('{}', 'development_secret'));
+
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects malformed signatures before comparison', async () => {
+    const response = await POST(signedRequest('{}', 'unused', 'sha256=not-hex'));
+
+    expect(response.status).toBe(401);
+  });
+
+  it('uses a fixed route bucket instead of attacker-controlled forwarding headers', async () => {
+    const checkSpy = vi.spyOn(RateLimiter.prototype, 'check').mockResolvedValue(true);
+    const request = new Request('http://localhost/api/webhook', {
+      method: 'POST',
+      headers: {
+        'x-forwarded-for': '198.51.100.10',
+        'x-hub-signature-256': `sha256=${crypto
+          .createHmac('sha256', 'configured-test-secret')
+          .update('{}')
+          .digest('hex')}`,
+      },
+      body: '{}',
+    });
+
+    await POST(request);
+
+    expect(checkSpy).toHaveBeenCalledWith('github-webhook');
+  });
+
+  it('returns 429 when the bounded webhook limiter rejects the request', async () => {
+    vi.spyOn(RateLimiter.prototype, 'check').mockResolvedValueOnce(false);
+
+    const response = await POST(signedRequest('{}', 'configured-test-secret'));
+
+    expect(response.status).toBe(429);
+  });
+});

--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -1,33 +1,31 @@
 import { NextResponse } from 'next/server';
 import crypto from 'crypto';
+import { RateLimiter } from '@/lib/rate-limit';
 
-const WEBHOOK_SECRET = process.env.GITHUB_WEBHOOK_SECRET || 'development_secret';
 const MAX_PAYLOAD_SIZE = 1024 * 1024; // 1MB
+const webhookRateLimiter = new RateLimiter(60, 60_000, 1);
 
-// In-memory rate limiting map: ip -> { count, resetTime }
-const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
-const RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
-const MAX_REQUESTS_PER_WINDOW = 10;
+function verifySignature(body: string, signature: string, secret: string): boolean {
+  if (!/^sha256=[0-9a-f]{64}$/i.test(signature)) return false;
 
-function checkRateLimit(ip: string): boolean {
-  const now = Date.now();
-  let record = rateLimitMap.get(ip);
-  if (!record || now > record.resetTime) {
-    record = { count: 1, resetTime: now + RATE_LIMIT_WINDOW };
-    rateLimitMap.set(ip, record);
-    return true;
-  }
-  record.count++;
-  if (record.count > MAX_REQUESTS_PER_WINDOW) {
-    return false;
-  }
-  return true;
+  const expected = Buffer.from(
+    `sha256=${crypto.createHmac('sha256', secret).update(body).digest('hex')}`,
+    'utf8'
+  );
+  const received = Buffer.from(signature, 'utf8');
+
+  return expected.length === received.length && crypto.timingSafeEqual(expected, received);
 }
 
 export async function POST(req: Request) {
+  const webhookSecret = process.env.GITHUB_WEBHOOK_SECRET?.trim();
+  if (!webhookSecret) {
+    console.error('CRITICAL: GITHUB_WEBHOOK_SECRET is not configured. Webhook endpoint disabled.');
+    return NextResponse.json({ error: 'Webhook is not configured' }, { status: 503 });
+  }
+
   // 1. Rate Limiting
-  const ip = req.headers.get('x-forwarded-for') || 'unknown_ip';
-  if (!checkRateLimit(ip)) {
+  if (!(await webhookRateLimiter.check('github-webhook'))) {
     return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
   }
 
@@ -40,7 +38,7 @@ export async function POST(req: Request) {
   let bodyText: string;
   try {
     bodyText = await req.text();
-  } catch (error) {
+  } catch {
     return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
   }
 
@@ -55,18 +53,14 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Missing signature' }, { status: 401 });
   }
 
-  const hmac = crypto.createHmac('sha256', WEBHOOK_SECRET);
-  const digest = 'sha256=' + hmac.update(bodyText).digest('hex');
-
-  if (signature !== digest) {
+  if (!verifySignature(bodyText, signature, webhookSecret)) {
     return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
   }
 
   // Valid payload, proceed...
-  let payload;
   try {
-    payload = JSON.parse(bodyText);
-  } catch (error) {
+    JSON.parse(bodyText);
+  } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 

--- a/env.local.example
+++ b/env.local.example
@@ -13,6 +13,10 @@ MONGODB_URI=mongodb+srv://<username>:<password>@cluster0.mongodb.net/commitpulse
 # Generate at: https://github.com/settings/tokens (No scopes required)
 GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# Required to authenticate GitHub webhook deliveries.
+# Use a long random value and configure the same secret in the GitHub webhook settings.
+GITHUB_WEBHOOK_SECRET=
+
 # Vercel KV / Upstash Redis URL for distributed rate limiting.
 # Leave blank to operate with degraded local-memory rate limits.
 KV_REST_API_URL=


### PR DESCRIPTION
## Summary

- remove the public `development_secret` webhook fallback
- disable the webhook endpoint when `GITHUB_WEBHOOK_SECRET` is missing
- validate SHA-256 signature shape and compare signatures with `timingSafeEqual`
- replace the spoofable, unbounded `x-forwarded-for` rate-limit map with the bounded shared rate limiter
- document the required webhook secret in environment examples
- add regression tests for fallback-secret forgery, malformed signatures, missing configuration, and spoofed forwarding headers

## Security impact

Previously, deployments missing `GITHUB_WEBHOOK_SECRET` accepted webhook payloads signed with the publicly known string `development_secret`. The route also used attacker-controlled `x-forwarded-for` values as keys in an unbounded map.

The endpoint now fails closed without configuration, authenticates signatures in constant time, and uses a bounded non-client-controlled rate-limit bucket.

## Verification

- `npm run test -- app/api/webhook lib/rate-limit.test.ts middleware.test.ts` (3 files, 55 tests passed)
- `npm run test -- app/api/webhook/route.test.ts lib/rate-limit.test.ts` (2 files, 28 tests passed)
- `npm run typecheck`
- focused ESLint and `git diff --check`

`npm run build` could not start compilation because Windows/OneDrive denied Next.js permission to remove the pre-existing generated `.next/diagnostics` directory (`EPERM`).