### PR TITLE
test(readmeGenerator-theme-contrast): verify Dark and Light Prefers-Color-Scheme Visual Cohesion (#4474)

### DIFF
--- a/app/generator/utils/readmeGenerator.theme-contrast.test.ts
+++ b/app/generator/utils/readmeGenerator.theme-contrast.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { generateReadme } from './readmeGenerator';
+import { TECHNOLOGIES } from '../data/technologies';
+import { SOCIALS } from '../data/socials';
+import type { GeneratorState } from '../types';
+
+const baseState = (): GeneratorState => ({
+  name: 'Test User',
+  description: '',
+  selectedTechs: [],
+  selectedSocials: [],
+  socialLinks: {},
+  githubUsername: '',
+  showCommitPulse: false,
+  commitPulseAccent: '#ffffff',
+  showSnakeGraph: false,
+  showPacmanGraph: false,
+  graphPlacement: 'bottom',
+});
+
+// Dynamically retrieve the first simpleicon technology and social to maintain test resilience
+const simpleIconTech = TECHNOLOGIES.find((t) => t.type === 'simpleicon')!;
+const simpleIconSocial = SOCIALS.find((s) => s.type === 'simpleicon' && s.siSlug)!;
+
+describe('readmeGenerator theme-contrast', () => {
+  it('verifies dark-mode simpleicon tech icons use white (#ffffff) srcset', () => {
+    const state = {
+      ...baseState(),
+      selectedTechs: [simpleIconTech.id],
+    };
+    const md = generateReadme(state);
+
+    // Assert the prefers-color-scheme dark source is active and has the white variant
+    const slug = simpleIconTech.iconUrl.split('/').pop() || simpleIconTech.id;
+    expect(md).toContain('<picture>');
+    expect(md).toContain(
+      `<source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/${slug}/ffffff"`
+    );
+  });
+
+  it('verifies light-mode simpleicon tech icons use black (#000000) as the img fallback src', () => {
+    const state = {
+      ...baseState(),
+      selectedTechs: [simpleIconTech.id],
+    };
+    const md = generateReadme(state);
+
+    // Assert the img fallback uses the black variant for light backgrounds
+    const slug = simpleIconTech.iconUrl.split('/').pop() || simpleIconTech.id;
+    expect(md).toContain(`<img src="https://cdn.simpleicons.org/${slug}/000000"`);
+  });
+
+  it('verifies dark-mode simpleicon social icons use white (#ffffff) srcset', () => {
+    const state = {
+      ...baseState(),
+      selectedSocials: [simpleIconSocial.id],
+      socialLinks: { [simpleIconSocial.id]: 'https://example.com/social' },
+    };
+    const md = generateReadme(state);
+
+    // Assert the prefers-color-scheme dark source is active and has the white variant for socials
+    expect(md).toContain('<picture>');
+    expect(md).toContain(
+      `<source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/${simpleIconSocial.siSlug}/ffffff"`
+    );
+  });
+
+  it('verifies light-mode simpleicon social icons use black (#000000) as the img fallback src', () => {
+    const state = {
+      ...baseState(),
+      selectedSocials: [simpleIconSocial.id],
+      socialLinks: { [simpleIconSocial.id]: 'https://example.com/social' },
+    };
+    const md = generateReadme(state);
+
+    // Assert the img fallback uses the black variant for light backgrounds for socials
+    expect(md).toContain(
+      `<img src="https://cdn.simpleicons.org/${simpleIconSocial.siSlug}/000000"`
+    );
+  });
+
+  it('ensures background divs and other tags do not contain style attributes that could clip/override contrast', () => {
+    const state: GeneratorState = {
+      name: 'John Doe',
+      description: 'A passionate developer',
+      selectedTechs: [simpleIconTech.id],
+      selectedSocials: [simpleIconSocial.id],
+      socialLinks: { [simpleIconSocial.id]: 'https://example.com/social' },
+      githubUsername: 'johndoe',
+      showCommitPulse: true,
+      commitPulseAccent: '#ff0000',
+      showSnakeGraph: true,
+      showPacmanGraph: true,
+      graphPlacement: 'bottom',
+    };
+    const md = generateReadme(state);
+
+    // Assert that <div> elements in the output do not contain style= attributes with background, color, or opacity
+    const divRegex = /<div[^>]*>/g;
+    const matches = md.match(divRegex);
+    expect(matches).not.toBeNull();
+    matches?.forEach((divTag) => {
+      expect(divTag).not.toContain('style=');
+      expect(divTag).not.toContain('background');
+      expect(divTag).not.toContain('color');
+      expect(divTag).not.toContain('opacity');
+    });
+
+    // Ensure all other standard structural/textual HTML elements do not contain inline styles that override theme contrast
+    const allTagsRegex = /<(div|p|h1|h2|h3|a|img|picture|source)[^>]*>/g;
+    const allMatches = md.match(allTagsRegex);
+    allMatches?.forEach((tag) => {
+      expect(tag).not.toContain('style=');
+    });
+  });
+});

--- a/app/generator/utils/readmeGenerator.theme-contrast.test.ts
+++ b/app/generator/utils/readmeGenerator.theme-contrast.test.ts
@@ -18,12 +18,22 @@ const baseState = (): GeneratorState => ({
   graphPlacement: 'bottom',
 });
 
-// Dynamically retrieve the first simpleicon technology and social to maintain test resilience
-const simpleIconTech = TECHNOLOGIES.find((t) => t.type === 'simpleicon')!;
-const simpleIconSocial = SOCIALS.find((s) => s.type === 'simpleicon' && s.siSlug)!;
+// Dynamic helpers to safely retrieve simpleicon entries to prevent module-level execution errors
+const getSimpleIconTech = () => {
+  const tech = TECHNOLOGIES.find((t) => t.type === 'simpleicon');
+  expect(tech).toBeDefined();
+  return tech!;
+};
+
+const getSimpleIconSocial = () => {
+  const social = SOCIALS.find((s) => s.type === 'simpleicon' && s.siSlug);
+  expect(social).toBeDefined();
+  return social!;
+};
 
 describe('readmeGenerator theme-contrast', () => {
   it('verifies dark-mode simpleicon tech icons use white (#ffffff) srcset', () => {
+    const simpleIconTech = getSimpleIconTech();
     const state = {
       ...baseState(),
       selectedTechs: [simpleIconTech.id],
@@ -33,12 +43,24 @@ describe('readmeGenerator theme-contrast', () => {
     // Assert the prefers-color-scheme dark source is active and has the white variant
     const slug = simpleIconTech.iconUrl.split('/').pop() || simpleIconTech.id;
     expect(md).toContain('<picture>');
-    expect(md).toContain(
-      `<source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/${slug}/ffffff"`
-    );
+
+    // Parse source tags and verify the correct media and white icon srcset
+    const sourceRegex = /<source\b[^>]*>/gi;
+    const sources = md.match(sourceRegex) || [];
+    expect(sources.length).toBeGreaterThan(0);
+    const hasDarkSource = sources.some((source) => {
+      const hasDarkMedia = /media="\(prefers-color-scheme:\s*dark\)"/i.test(source);
+      const hasWhiteSrcset = new RegExp(
+        `srcset="https:\\/\\/cdn\\.simpleicons\\.org\\/${slug}\\/ffffff"`,
+        'i'
+      ).test(source);
+      return hasDarkMedia && hasWhiteSrcset;
+    });
+    expect(hasDarkSource).toBe(true);
   });
 
   it('verifies light-mode simpleicon tech icons use black (#000000) as the img fallback src', () => {
+    const simpleIconTech = getSimpleIconTech();
     const state = {
       ...baseState(),
       selectedTechs: [simpleIconTech.id],
@@ -51,6 +73,7 @@ describe('readmeGenerator theme-contrast', () => {
   });
 
   it('verifies dark-mode simpleicon social icons use white (#ffffff) srcset', () => {
+    const simpleIconSocial = getSimpleIconSocial();
     const state = {
       ...baseState(),
       selectedSocials: [simpleIconSocial.id],
@@ -60,12 +83,24 @@ describe('readmeGenerator theme-contrast', () => {
 
     // Assert the prefers-color-scheme dark source is active and has the white variant for socials
     expect(md).toContain('<picture>');
-    expect(md).toContain(
-      `<source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/${simpleIconSocial.siSlug}/ffffff"`
-    );
+
+    // Parse source tags and verify the correct media and white icon srcset for socials
+    const sourceRegex = /<source\b[^>]*>/gi;
+    const sources = md.match(sourceRegex) || [];
+    expect(sources.length).toBeGreaterThan(0);
+    const hasDarkSource = sources.some((source) => {
+      const hasDarkMedia = /media="\(prefers-color-scheme:\s*dark\)"/i.test(source);
+      const hasWhiteSrcset = new RegExp(
+        `srcset="https:\\/\\/cdn\\.simpleicons\\.org\\/${simpleIconSocial.siSlug}\\/ffffff"`,
+        'i'
+      ).test(source);
+      return hasDarkMedia && hasWhiteSrcset;
+    });
+    expect(hasDarkSource).toBe(true);
   });
 
   it('verifies light-mode simpleicon social icons use black (#000000) as the img fallback src', () => {
+    const simpleIconSocial = getSimpleIconSocial();
     const state = {
       ...baseState(),
       selectedSocials: [simpleIconSocial.id],
@@ -80,6 +115,8 @@ describe('readmeGenerator theme-contrast', () => {
   });
 
   it('ensures background divs and other tags do not contain style attributes that could clip/override contrast', () => {
+    const simpleIconTech = getSimpleIconTech();
+    const simpleIconSocial = getSimpleIconSocial();
     const state: GeneratorState = {
       name: 'John Doe',
       description: 'A passionate developer',
@@ -95,20 +132,20 @@ describe('readmeGenerator theme-contrast', () => {
     };
     const md = generateReadme(state);
 
-    // Assert that <div> elements in the output do not contain style= attributes with background, color, or opacity
+    // Assert that <div> elements in the output do not contain style= attributes
     const divRegex = /<div[^>]*>/g;
     const matches = md.match(divRegex);
     expect(matches).not.toBeNull();
+    expect(matches?.length).toBeGreaterThan(0);
     matches?.forEach((divTag) => {
       expect(divTag).not.toContain('style=');
-      expect(divTag).not.toContain('background');
-      expect(divTag).not.toContain('color');
-      expect(divTag).not.toContain('opacity');
     });
 
     // Ensure all other standard structural/textual HTML elements do not contain inline styles that override theme contrast
     const allTagsRegex = /<(div|p|h1|h2|h3|a|img|picture|source)[^>]*>/g;
     const allMatches = md.match(allTagsRegex);
+    expect(allMatches).not.toBeNull();
+    expect(allMatches?.length).toBeGreaterThan(0);
     allMatches?.forEach((tag) => {
       expect(tag).not.toContain('style=');
     });


### PR DESCRIPTION
Closes #4474


## Description

Introduces a comprehensive, isolated test suite for the `readmeGenerator` utility to guarantee dual-theme prefers-color-scheme contrast and cohesion in both light and dark modes. Specifically, the test coverage includes:
- Verifying dark-mode simpleicon tech icons use the white variant (`/ffffff` in `<source>`).
- Verifying light-mode simpleicon tech icons use the black variant (`/000000` in the fallback `<img>`).
- Verifying dark-mode simpleicon social icons use the white variant (`/ffffff` in `<source>`).
- Verifying light-mode simpleicon social icons use the black variant (`/000000` in the fallback `<img>`).
- Guaranteeing that structural and content containers (like `div`, `p`, headers, and anchors) do not inject inline style overrides (`style=`, background, color, opacity) that could clip layout elements or compromise text contrast.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs, testing)

## Visual Preview
N/A (Unit and integration testing suite for generated HTML/Markdown output)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
