### PR TITLE
\test(cacheControl): add empty-fallback test and robust options param…

### DIFF
--- a/utils/cacheControl.empty-fallback.test.ts
+++ b/utils/cacheControl.empty-fallback.test.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it } from 'vitest';
+import { buildCacheControlHeader } from './cacheControl';
+
+describe('buildCacheControlHeader - Edge Cases & Empty/Missing Inputs Verification', () => {
+  it('1. falls back to default cache control when options object is completely omitted', () => {
+    // Calling the function with no arguments should fallback gracefully without throwing
+    expect(buildCacheControlHeader()).toBe('s-maxage=3600, stale-while-revalidate=86400');
+  });
+
+  it('2. falls back to default cache control when options is an empty object', () => {
+    expect(buildCacheControlHeader({})).toBe('s-maxage=3600, stale-while-revalidate=86400');
+  });
+
+  it('3. falls back to default cache control when options object is null', () => {
+    // Casting to any to test JavaScript-level null input resilience
+    expect(buildCacheControlHeader(null as any)).toBe(
+      's-maxage=3600, stale-while-revalidate=86400'
+    );
+  });
+
+  it('4. falls back to default cache control when options contain only undefined or null values', () => {
+    expect(
+      buildCacheControlHeader({
+        bypass: undefined,
+        secondsToMidnight: undefined,
+        isHistoricalYear: undefined,
+      })
+    ).toBe('s-maxage=3600, stale-while-revalidate=86400');
+
+    expect(
+      buildCacheControlHeader({
+        bypass: null as any,
+        secondsToMidnight: null as any,
+        isHistoricalYear: null as any,
+      })
+    ).toBe('s-maxage=3600, stale-while-revalidate=86400');
+  });
+
+  it('5. prioritizes bypass=true even if other options are invalid/null/undefined', () => {
+    expect(
+      buildCacheControlHeader({
+        bypass: true,
+        secondsToMidnight: null as any,
+        isHistoricalYear: undefined,
+      })
+    ).toBe('no-cache, no-store, must-revalidate');
+  });
+
+  it('6. prioritizes isHistoricalYear=true when bypass is falsy and secondsToMidnight is null/undefined', () => {
+    expect(
+      buildCacheControlHeader({
+        bypass: false,
+        secondsToMidnight: undefined,
+        isHistoricalYear: true,
+      })
+    ).toBe('public, s-maxage=31536000, immutable');
+  });
+});

--- a/utils/cacheControl.ts
+++ b/utils/cacheControl.ts
@@ -4,11 +4,8 @@ interface CacheControlOptions {
   isHistoricalYear?: boolean;
 }
 
-export function buildCacheControlHeader({
-  bypass,
-  secondsToMidnight,
-  isHistoricalYear,
-}: CacheControlOptions): string {
+export function buildCacheControlHeader(options: CacheControlOptions = {}): string {
+  const { bypass, secondsToMidnight, isHistoricalYear } = options || {};
   if (bypass) {
     return 'no-cache, no-store, must-revalidate';
   }
@@ -17,7 +14,7 @@ export function buildCacheControlHeader({
     return 'public, s-maxage=31536000, immutable';
   }
 
-  if (secondsToMidnight !== undefined) {
+  if (secondsToMidnight !== undefined && secondsToMidnight !== null) {
     return `public, s-maxage=${secondsToMidnight}, stale-while-revalidate=86400`;
   }
 


### PR DESCRIPTION
## Description

Adds a robust empty-fallback test suite for `utils/cacheControl.ts` and refactors the `buildCacheControlHeader` function to safely handle missing or `null`/`undefined` option parameters without crashing.

Fixes #4304

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs) - *Adding fallback/unit test coverage*

## Visual Preview

*N/A — Purely a logic / unit testing update. No visual changes.*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
