### PR TITLE
\test(getClientIp): add empty-fallback test and robust request handling"

### DIFF
--- a/utils/getClientIp.empty-fallback.test.ts
+++ b/utils/getClientIp.empty-fallback.test.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it } from 'vitest';
+import { getClientIp } from './getClientIp';
+
+describe('getClientIp - Edge Cases & Empty/Missing Inputs Verification', () => {
+  it('1. returns fallback IP when request object is null or undefined', () => {
+    expect(getClientIp(null as any)).toBe('127.0.0.1');
+    expect(getClientIp(undefined as any)).toBe('127.0.0.1');
+  });
+
+  it('2. returns fallback IP when request has no headers property or headers is malformed', () => {
+    expect(getClientIp({} as any)).toBe('127.0.0.1');
+    expect(getClientIp({ headers: null } as any)).toBe('127.0.0.1');
+    expect(getClientIp({ headers: {} } as any)).toBe('127.0.0.1');
+    expect(getClientIp({ headers: { get: 'not-a-function' } } as any)).toBe('127.0.0.1');
+  });
+
+  it('3. returns fallback IP when options object is null or undefined', () => {
+    const req = new Request('http://localhost:3000/api/streak');
+    expect(getClientIp(req, null as any)).toBe('127.0.0.1');
+    expect(getClientIp(req, undefined as any)).toBe('127.0.0.1');
+  });
+
+  it('4. behaves normally when options is empty object', () => {
+    const req = new Request('http://localhost:3000/api/streak');
+    expect(getClientIp(req, {})).toBe('127.0.0.1');
+  });
+
+  it('5. changes fallback behavior based on NODE_ENV (development/test vs production)', () => {
+    const originalEnv = process.env.NODE_ENV;
+    try {
+      (process.env as any).NODE_ENV = 'production';
+      expect(getClientIp(null as any)).toBe('unknown');
+      expect(getClientIp({} as any)).toBe('unknown');
+    } finally {
+      (process.env as any).NODE_ENV = originalEnv;
+    }
+  });
+
+  it('6. handles malformed request and headers without throwing even if headersPriority is custom', () => {
+    expect(
+      getClientIp(null as any, {
+        headersPriority: ['x-custom-ip'],
+      })
+    ).toBe('127.0.0.1');
+  });
+});

--- a/utils/getClientIp.ts
+++ b/utils/getClientIp.ts
@@ -57,8 +57,20 @@ export function getClientIp(
   request: Request | NextRequest,
   options: GetClientIpOptions = {}
 ): string {
-  const config = options.proxyConfig || loadTrustedProxyConfig();
+  const opt = options || {};
+  const isDevOrTest = process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
+  const defaultIp = isDevOrTest ? '127.0.0.1' : 'unknown';
+
+  if (!request) {
+    return defaultIp;
+  }
+
   const headers = request.headers;
+  if (!headers || typeof headers.get !== 'function') {
+    return defaultIp;
+  }
+
+  const config = opt.proxyConfig || loadTrustedProxyConfig();
 
   // 1. NextRequest has a secure, platform-populated request.ip property on Vercel/Next.js
   const requestIp = (request as unknown as { ip?: string }).ip;
@@ -77,10 +89,10 @@ export function getClientIp(
     return requestIp;
   }
 
-  const directIp = options.directIp?.trim();
+  const directIp = opt.directIp?.trim();
   const forwardedHeaders = [
     'x-forwarded-for',
-    ...(options.headersPriority || ['x-vercel-proxied-for', 'cf-connecting-ip', 'x-real-ip']),
+    ...(opt.headersPriority || ['x-vercel-proxied-for', 'cf-connecting-ip', 'x-real-ip']),
   ];
 
   // Forwarded headers cannot establish their own trust boundary. Without a
@@ -159,7 +171,7 @@ export function getClientIp(
   }
 
   // 3. Custom/platform headers are accepted only behind a trusted direct peer.
-  const priorityHeaders = options.headersPriority || [
+  const priorityHeaders = opt.headersPriority || [
     'x-vercel-proxied-for',
     'cf-connecting-ip',
     'x-real-ip',


### PR DESCRIPTION
## Description

Adds a robust empty-fallback test suite for `utils/getClientIp.ts` and refactors the `getClientIp` function to safely handle missing, malformed, or `null`/`undefined` request, request headers, and options parameters without crashing.

Fixes #4307

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs) - *Adding fallback/unit test coverage*

## Visual Preview

*N/A — Purely a logic / unit testing update. No visual changes.*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
