### PR TITLE
\test(dateRange): add empty-fallback test and robust parsing"

### DIFF
--- a/utils/dateRange.empty-fallback.test.ts
+++ b/utils/dateRange.empty-fallback.test.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it } from 'vitest';
+import { formatDateRange, DEFAULT_DATE_RANGE } from './dateRange';
+
+describe('formatDateRange - Edge Cases & Empty/Missing Inputs Verification', () => {
+  it('1. falls back to default date range when year is completely omitted', () => {
+    expect(formatDateRange()).toEqual(DEFAULT_DATE_RANGE);
+  });
+
+  it('2. falls back to default date range when year is undefined', () => {
+    expect(formatDateRange(undefined)).toEqual(DEFAULT_DATE_RANGE);
+  });
+
+  it('3. falls back to default date range when year is null', () => {
+    expect(formatDateRange(null as any)).toEqual(DEFAULT_DATE_RANGE);
+  });
+
+  it('4. falls back to default date range when year is an empty or whitespace string', () => {
+    expect(formatDateRange('')).toEqual(DEFAULT_DATE_RANGE);
+    expect(formatDateRange('   ')).toEqual(DEFAULT_DATE_RANGE);
+  });
+
+  it('5. processes numerical years correctly without throwing', () => {
+    expect(formatDateRange(2024)).toEqual({
+      from: '2024-01-01T00:00:00Z',
+      to: '2024-12-31T23:59:59Z',
+    });
+
+    expect(formatDateRange(24)).toEqual({
+      from: '2024-01-01T00:00:00Z',
+      to: '2024-12-31T23:59:59Z',
+    });
+  });
+
+  it('6. falls back to default date range when year resolves to invalid numeric bounds or NaN', () => {
+    expect(formatDateRange(NaN as any)).toEqual(DEFAULT_DATE_RANGE);
+    expect(formatDateRange(false as any)).toEqual(DEFAULT_DATE_RANGE);
+    expect(formatDateRange({} as any)).toEqual(DEFAULT_DATE_RANGE);
+  });
+});

--- a/utils/dateRange.ts
+++ b/utils/dateRange.ts
@@ -28,12 +28,15 @@ export interface DateRange {
  * formatDateRange("") // returns DEFAULT_DATE_RANGE
  * formatDateRange(undefined) // returns DEFAULT_DATE_RANGE
  */
-export function formatDateRange(year?: string): DateRange {
-  if (!year || year.trim() === '') {
+export function formatDateRange(year?: string | number | null): DateRange {
+  if (year === undefined || year === null) {
     return { ...DEFAULT_DATE_RANGE };
   }
 
-  const trimmedYear = year.trim();
+  const trimmedYear = String(year).trim();
+  if (trimmedYear === '') {
+    return { ...DEFAULT_DATE_RANGE };
+  }
 
   // Handle partial years (1 or 2 digits): assume 20xx
   // For 2-digit: '24' -> 2024


### PR DESCRIPTION
## Description

Adds a robust empty-fallback test suite for `utils/dateRange.ts` and refactors the `formatDateRange` function to safely handle missing, null, undefined, empty/whitespace, or invalid year parameters without throwing exceptions or crashing.

Fixes #4306

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `test(dateRange): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
