### PR TITLE
test(ApiPr-insightsRoute-theme-contrast): verify Dark and Light Prefers-Color-Scheme Visual Cohesion

### DIFF
--- a/app/api/pr-insights/route.theme-contrast.test.ts
+++ b/app/api/pr-insights/route.theme-contrast.test.ts
@@ -39,91 +39,81 @@ const mockInsights: PRInsightData = {
   },
 };
 
-function makeRequest(
-  params: Record<string, string> = {},
-  headers: Record<string, string> = {}
-): Request {
+function makeRequest(params: Record<string, string> = {}): Request {
   const url = new URL('http://localhost/api/pr-insights');
   for (const [key, value] of Object.entries(params)) {
     url.searchParams.set(key, value);
   }
-  return new Request(url.toString(), {
-    headers: new Headers(headers),
-  });
+  return new Request(url.toString());
 }
 
-describe('GET /api/pr-insights theme-contrast: Dark and Light Prefers-Color-Scheme Visual Cohesion', () => {
+describe('GET /api/pr-insights', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(fetchPRInsights).mockResolvedValue(mockInsights);
   });
 
-  it('returns identical data structure regardless of dark or light prefers-color-scheme header', async () => {
-    const darkResponse = await GET(
-      makeRequest({ username: 'testuser' }, { 'sec-ch-prefers-color-scheme': 'dark' })
-    );
-    const lightResponse = await GET(
-      makeRequest({ username: 'testuser' }, { 'sec-ch-prefers-color-scheme': 'light' })
-    );
+  it('returns 400 when the username parameter is missing', async () => {
+    const response = await GET(makeRequest());
 
-    const darkBody = await darkResponse.json();
-    const lightBody = await lightResponse.json();
-
-    // API is theme-agnostic — payload must be identical for both color schemes
-    expect(darkBody).toEqual(lightBody);
-    expect(darkResponse.status).toBe(200);
-    expect(lightResponse.status).toBe(200);
-  });
-
-  it('returns numeric stat fields suitable for color-coded badges in both themes', async () => {
-    const response = await GET(makeRequest({ username: 'testuser' }));
+    expect(response.status).toBe(400);
     const body = await response.json();
-
-    // mergeRate, totalPRs etc are rendered as colored stat cards in both light/dark UI
-    expect(typeof body.mergeRate).toBe('number');
-    expect(typeof body.totalPRs).toBe('number');
-    expect(typeof body.openPRs).toBe('number');
-    expect(typeof body.mergedPRs).toBe('number');
-    expect(typeof body.closedPRs).toBe('number');
+    expect(body.error).toBe('Username is required');
+    expect(fetchPRInsights).not.toHaveBeenCalled();
   });
 
-  it('returns highlight fields with title and url required for accessible link contrast styling', async () => {
-    const response = await GET(makeRequest({ username: 'testuser' }));
+  it('returns 400 when the username exceeds the 39 character GitHub limit', async () => {
+    const longUsername = 'a'.repeat(40);
+    const response = await GET(makeRequest({ username: longUsername }));
+
+    expect(response.status).toBe(400);
     const body = await response.json();
-
-    // Highlight cards need title/url text for theme-aware link styling
-    expect(body.highlights.mostDiscussed).toHaveProperty('title');
-    expect(body.highlights.mostDiscussed).toHaveProperty('url');
-    expect(body.highlights.fastestMerged).toHaveProperty('title');
-    expect(body.highlights.largest).toHaveProperty('title');
+    expect(body.error).toBe('Invalid GitHub username');
+    expect(fetchPRInsights).not.toHaveBeenCalled();
   });
 
-  it('returns consistent error response and Content-Type regardless of theme headers', async () => {
-    const darkResponse = await GET(makeRequest({}, { 'sec-ch-prefers-color-scheme': 'dark' }));
-    const lightResponse = await GET(makeRequest({}, { 'sec-ch-prefers-color-scheme': 'light' }));
+  it('returns 400 for a username containing invalid characters', async () => {
+    const response = await GET(makeRequest({ username: 'invalid_user!' }));
 
-    expect(darkResponse.status).toBe(400);
-    expect(lightResponse.status).toBe(400);
-
-    expect(darkResponse.headers.get('content-type')).toMatch(/application\/json/);
-    expect(lightResponse.headers.get('content-type')).toMatch(/application\/json/);
-
-    const darkBody = await darkResponse.json();
-    const lightBody = await lightResponse.json();
-    expect(darkBody.error).toBe(lightBody.error);
-  });
-
-  it('returns repoPerformance array with mergeRate values usable for progress bar contrast styling in both themes', async () => {
-    const response = await GET(makeRequest({ username: 'testuser' }));
+    expect(response.status).toBe(400);
     const body = await response.json();
+    expect(body.error).toBe('Invalid GitHub username');
+    expect(fetchPRInsights).not.toHaveBeenCalled();
+  });
 
-    expect(Array.isArray(body.repoPerformance)).toBe(true);
-    body.repoPerformance.forEach((repo: { mergeRate: number; name: string }) => {
-      // mergeRate drives progress bar fill color in both light/dark themes
-      expect(typeof repo.mergeRate).toBe('number');
-      expect(repo.mergeRate).toBeGreaterThanOrEqual(0);
-      expect(repo.mergeRate).toBeLessThanOrEqual(100);
-      expect(typeof repo.name).toBe('string');
-    });
+  it('trims whitespace from the username before validation and fetching', async () => {
+    const response = await GET(makeRequest({ username: '  octocat  ' }));
+
+    expect(response.status).toBe(200);
+    expect(fetchPRInsights).toHaveBeenCalledWith('octocat');
+  });
+
+  it('returns the full PR insights payload on a successful fetch', async () => {
+    const response = await GET(makeRequest({ username: 'octocat' }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual(mockInsights);
+    expect(fetchPRInsights).toHaveBeenCalledWith('octocat');
+  });
+
+  it('returns 500 with the error message when fetchPRInsights throws an Error', async () => {
+    vi.mocked(fetchPRInsights).mockRejectedValue(new Error('GitHub API error'));
+
+    const response = await GET(makeRequest({ username: 'octocat' }));
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toBe('GitHub API error');
+  });
+
+  it('returns 500 with a generic message when fetchPRInsights throws a non-Error value', async () => {
+    vi.mocked(fetchPRInsights).mockRejectedValue('unexpected failure');
+
+    const response = await GET(makeRequest({ username: 'octocat' }));
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toBe('Failed to fetch PR insights');
   });
 });

--- a/app/api/pr-insights/route.theme-contrast.test.ts
+++ b/app/api/pr-insights/route.theme-contrast.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from './route';
+
+vi.mock('@/services/github/pr-insights', () => ({
+  fetchPRInsights: vi.fn(),
+}));
+
+import { fetchPRInsights } from '@/services/github/pr-insights';
+import type { PRInsightData } from '@/services/github/pr-insights';
+
+const mockInsights: PRInsightData = {
+  totalPRs: 20,
+  openPRs: 5,
+  mergedPRs: 12,
+  closedPRs: 3,
+  mergeRate: 60,
+  avgReviewTime: 5,
+  avgTimeToFirstReview: 2,
+  avgCycleTime: 24,
+  weeklyActivity: [{ name: '2024-W01', prs: 3 }],
+  monthlyActivity: [{ name: '2024-01', prs: 8 }],
+  reviewsGiven: 7,
+  reviewsReceived: 9,
+  avgReviewResponseTime: 5,
+  fastestReview: 1,
+  slowestReview: 48,
+  repoPerformance: [
+    { name: 'org/repo', totalPRs: 10, mergeRate: 70, reviewCount: 4, avgReviewTime: 6 },
+  ],
+  highlights: {
+    mostDiscussed: { title: 'Big PR', url: 'https://github.com/org/repo/pull/1', comments: 12 },
+    fastestMerged: { title: 'Quick fix', url: 'https://github.com/org/repo/pull/2', time: 0.5 },
+    largest: {
+      title: 'Refactor',
+      url: 'https://github.com/org/repo/pull/3',
+      additions: 500,
+      deletions: 100,
+    },
+  },
+};
+
+function makeRequest(
+  params: Record<string, string> = {},
+  headers: Record<string, string> = {}
+): Request {
+  const url = new URL('http://localhost/api/pr-insights');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new Request(url.toString(), {
+    headers: new Headers(headers),
+  });
+}
+
+describe('GET /api/pr-insights theme-contrast: Dark and Light Prefers-Color-Scheme Visual Cohesion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchPRInsights).mockResolvedValue(mockInsights);
+  });
+
+  it('returns identical data structure regardless of dark or light prefers-color-scheme header', async () => {
+    const darkResponse = await GET(
+      makeRequest({ username: 'testuser' }, { 'sec-ch-prefers-color-scheme': 'dark' })
+    );
+    const lightResponse = await GET(
+      makeRequest({ username: 'testuser' }, { 'sec-ch-prefers-color-scheme': 'light' })
+    );
+
+    const darkBody = await darkResponse.json();
+    const lightBody = await lightResponse.json();
+
+    // API is theme-agnostic — payload must be identical for both color schemes
+    expect(darkBody).toEqual(lightBody);
+    expect(darkResponse.status).toBe(200);
+    expect(lightResponse.status).toBe(200);
+  });
+
+  it('returns numeric stat fields suitable for color-coded badges in both themes', async () => {
+    const response = await GET(makeRequest({ username: 'testuser' }));
+    const body = await response.json();
+
+    // mergeRate, totalPRs etc are rendered as colored stat cards in both light/dark UI
+    expect(typeof body.mergeRate).toBe('number');
+    expect(typeof body.totalPRs).toBe('number');
+    expect(typeof body.openPRs).toBe('number');
+    expect(typeof body.mergedPRs).toBe('number');
+    expect(typeof body.closedPRs).toBe('number');
+  });
+
+  it('returns highlight fields with title and url required for accessible link contrast styling', async () => {
+    const response = await GET(makeRequest({ username: 'testuser' }));
+    const body = await response.json();
+
+    // Highlight cards need title/url text for theme-aware link styling
+    expect(body.highlights.mostDiscussed).toHaveProperty('title');
+    expect(body.highlights.mostDiscussed).toHaveProperty('url');
+    expect(body.highlights.fastestMerged).toHaveProperty('title');
+    expect(body.highlights.largest).toHaveProperty('title');
+  });
+
+  it('returns consistent error response and Content-Type regardless of theme headers', async () => {
+    const darkResponse = await GET(makeRequest({}, { 'sec-ch-prefers-color-scheme': 'dark' }));
+    const lightResponse = await GET(makeRequest({}, { 'sec-ch-prefers-color-scheme': 'light' }));
+
+    expect(darkResponse.status).toBe(400);
+    expect(lightResponse.status).toBe(400);
+
+    expect(darkResponse.headers.get('content-type')).toMatch(/application\/json/);
+    expect(lightResponse.headers.get('content-type')).toMatch(/application\/json/);
+
+    const darkBody = await darkResponse.json();
+    const lightBody = await lightResponse.json();
+    expect(darkBody.error).toBe(lightBody.error);
+  });
+
+  it('returns repoPerformance array with mergeRate values usable for progress bar contrast styling in both themes', async () => {
+    const response = await GET(makeRequest({ username: 'testuser' }));
+    const body = await response.json();
+
+    expect(Array.isArray(body.repoPerformance)).toBe(true);
+    body.repoPerformance.forEach((repo: { mergeRate: number; name: string }) => {
+      // mergeRate drives progress bar fill color in both light/dark themes
+      expect(typeof repo.mergeRate).toBe('number');
+      expect(repo.mergeRate).toBeGreaterThanOrEqual(0);
+      expect(repo.mergeRate).toBeLessThanOrEqual(100);
+      expect(typeof repo.name).toBe('string');
+    });
+  });
+});


### PR DESCRIPTION
## Description

Closes #4435

## What changed
- Created new file `app/api/pr-insights/route.theme-contrast.test.ts` with 5 test cases

## Test cases
1. Returns identical data structure regardless of dark or light prefers-color-scheme header
2. Returns numeric stat fields suitable for color-coded badges in both themes
3. Returns highlight fields with title and url required for accessible link contrast styling
4. Returns consistent error response and Content-Type regardless of theme headers
5. Returns repoPerformance array with mergeRate values usable for progress bar contrast styling in both themes

## How it works
Since `route.ts` is a server-side API with no rendered UI, theme contrast is interpreted as the API being theme-agnostic: it must return identical, well-typed data regardless of the client's color scheme so the frontend can apply correct light/dark contrast styling.

- Mocks `fetchPRInsights` to return a deterministic PR insights payload
- Verifies dark vs light prefers-color-scheme headers produce identical JSON responses
- Confirms numeric stat fields (mergeRate, totalPRs, etc.) used for color-coded badges
- Checks highlight objects contain title/url needed for accessible link styling
- Validates error responses are consistent across themes
- Asserts repoPerformance mergeRate values stay within 0-100 for progress bar rendering

## Tests
All 5 new tests pass. All existing tests pass.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
