### PR TITLE
test(DashboardLayout-theme-contrast): verify Dark and Light Prefers-Color-Scheme Visual Cohesion

### DIFF
--- a/app/(root)/dashboard/layout.theme-contrast.test.tsx
+++ b/app/(root)/dashboard/layout.theme-contrast.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import DashboardLayout from './layout';
+
+vi.mock('sonner', () => ({
+  Toaster: () => <div data-testid="toaster" />,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('DashboardLayout theme-contrast: Dark and Light Prefers-Color-Scheme Visual Cohesion', () => {
+  it('applies light mode text color class for sufficient contrast on light backgrounds', () => {
+    const { container } = render(
+      <DashboardLayout>
+        <p>Dashboard content</p>
+      </DashboardLayout>
+    );
+
+    const root = container.firstChild as HTMLElement;
+
+    // text-gray-900 ensures sufficient contrast in light mode
+    expect(root.className).toContain('text-gray-900');
+  });
+
+  it('applies dark mode text color class for sufficient contrast on dark backgrounds', () => {
+    const { container } = render(
+      <DashboardLayout>
+        <p>Dashboard content</p>
+      </DashboardLayout>
+    );
+
+    const root = container.firstChild as HTMLElement;
+
+    // dark:text-white ensures sufficient contrast in dark mode
+    expect(root.className).toContain('dark:text-white');
+  });
+
+  it('uses a transparent background so it does not clip foreground content colors in either theme', () => {
+    const { container } = render(
+      <DashboardLayout>
+        <p>Dashboard content</p>
+      </DashboardLayout>
+    );
+
+    const root = container.firstChild as HTMLElement;
+
+    // bg-transparent allows parent theme background to show through without clipping content
+    expect(root.className).toContain('bg-transparent');
+  });
+
+  it('renders children content correctly within the themed main wrapper', () => {
+    render(
+      <DashboardLayout>
+        <p>Dashboard content</p>
+      </DashboardLayout>
+    );
+
+    // Children must render visibly regardless of theme
+    expect(screen.getByText('Dashboard content')).toBeDefined();
+  });
+
+  it('renders the Toaster component for theme-aware notification styling', () => {
+    render(
+      <DashboardLayout>
+        <p>Dashboard content</p>
+      </DashboardLayout>
+    );
+
+    // Toaster (sonner) must render so notifications adapt to both themes
+    expect(screen.getByTestId('toaster')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description

Closes #4430

## What changed
- Created new file `app/(root)/dashboard/layout.theme-contrast.test.tsx` with 5 test cases

## Test cases
1. Applies light mode text color class for sufficient contrast on light backgrounds
2. Applies dark mode text color class for sufficient contrast on dark backgrounds
3. Uses a transparent background so it does not clip foreground content colors in either theme
4. Renders children content correctly within the themed main wrapper
5. Renders the Toaster component for theme-aware notification styling

## How it works
- Mocks `sonner`'s Toaster to isolate the layout component
- Verifies `text-gray-900` and `dark:text-white` classes are present for light/dark contrast
- Confirms `bg-transparent` is applied so foreground content is never clipped by a background overlay
- Asserts children content renders correctly inside the `<main>` wrapper
- Checks the Toaster renders for theme-aware toast notifications

## Tests
All 5 new tests pass. All existing tests pass.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
