### PR TITLE
[codex] test: add timezone mock helper

### DIFF
--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeAll } from 'vitest';
+import { installTimezoneMock, resetMockTimezone } from './timezone';
+
+const localStorageMemory = (() => {
+  const store: Record<string, string> = {};
+
+  return {
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = String(value);
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    clear() {
+      for (const key of Object.keys(store)) {
+        delete store[key];
+      }
+    },
+  };
+})();
+
+beforeAll(() => {
+  installTimezoneMock();
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: localStorageMemory,
+  });
+});
+
+afterEach(() => {
+  resetMockTimezone();
+  localStorageMemory.clear();
+});

--- a/test/timezone.test.ts
+++ b/test/timezone.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getMockTimezone, resetMockTimezone, setMockTimezone } from './timezone';
+
+afterEach(() => {
+  resetMockTimezone();
+});
+
+describe('timezone mock helper', () => {
+  it('defaults DateTimeFormat without an explicit timezone to UTC', () => {
+    const formatter = new Intl.DateTimeFormat('en-US');
+
+    expect(formatter.resolvedOptions().timeZone).toBe('UTC');
+    expect(getMockTimezone()).toBe('UTC');
+  });
+
+  it('lets tests switch the default timezone when needed', () => {
+    setMockTimezone('Etc/GMT+8');
+
+    const formatter = new Intl.DateTimeFormat('en-CA', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+    const parts = formatter.formatToParts(new Date('2024-06-16T07:00:00.000Z'));
+    const mapped = Object.fromEntries(
+      parts.filter((part) => part.type !== 'literal').map((part) => [part.type, part.value])
+    );
+
+    expect(formatter.resolvedOptions().timeZone).toBe('Etc/GMT+8');
+    expect(mapped).toMatchObject({
+      year: '2024',
+      month: '06',
+      day: '15',
+    });
+  });
+
+  it('keeps explicit timeZone options intact', () => {
+    setMockTimezone('Etc/GMT+8');
+
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'America/New_York',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+
+    expect(formatter.resolvedOptions().timeZone).toBe('America/New_York');
+  });
+});

--- a/test/timezone.ts
+++ b/test/timezone.ts
@@ -1,0 +1,45 @@
+import { vi } from 'vitest';
+
+const RealDateTimeFormat = Intl.DateTimeFormat;
+const DEFAULT_TIMEZONE = 'UTC';
+
+let activeTimezone = DEFAULT_TIMEZONE;
+let installed = false;
+
+type DateTimeFormatArgs = ConstructorParameters<typeof Intl.DateTimeFormat>;
+
+function createFormatter([locales, options]: DateTimeFormatArgs) {
+  return new RealDateTimeFormat(locales, {
+    ...options,
+    timeZone: options?.timeZone ?? activeTimezone,
+  });
+}
+
+export function installTimezoneMock(defaultTimezone: string = DEFAULT_TIMEZONE) {
+  activeTimezone = defaultTimezone;
+
+  if (installed) {
+    return;
+  }
+
+  installed = true;
+
+  vi.spyOn(Intl, 'DateTimeFormat').mockImplementation(function mockedDateTimeFormat(
+    this: unknown,
+    ...args: DateTimeFormatArgs
+  ) {
+    return createFormatter(args);
+  } as typeof Intl.DateTimeFormat);
+}
+
+export function setMockTimezone(timezone: string) {
+  activeTimezone = timezone;
+}
+
+export function resetMockTimezone() {
+  activeTimezone = DEFAULT_TIMEZONE;
+}
+
+export function getMockTimezone() {
+  return activeTimezone;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./test/setup.ts'],
     include: ['**/*.test.ts', '**/*.test.tsx'],
     exclude: ['node_modules', '.next'],
     coverage: {


### PR DESCRIPTION
Closes #5274.

Adds a Vitest setup hook that installs a reusable Intl.DateTimeFormat timezone mock with a stable UTC default, plus a helper for switching the mocked timezone per spec.

Also adds a lightweight in-memory localStorage stub so the shared jsdom test environment stays predictable for the existing component tests.

Validation:
- npm test -- --run test/timezone.test.ts

- npm test -- --run lib/calculate.test.ts

- npm test -- --run app/api/stats/route.test.ts app/api/streak/route.test.ts lib/github.test.ts

- npm test