### PR TITLE
[codex] fix: centralize framer-motion test mock

### DIFF
--- a/app/components/CustomizeCTA.test.tsx
+++ b/app/components/CustomizeCTA.test.tsx
@@ -2,15 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { CustomizeCTA } from './CustomizeCTA';
 
-// framer-motion relies on browser animation APIs that jsdom doesn't implement.
-// Swapping motion.div for a plain div lets us test content without fighting the animation layer.
-vi.mock('framer-motion', () => ({
-  motion: {
-    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-      <div {...props}>{children}</div>
-    ),
-  },
-}));
+vi.mock('framer-motion', () => globalThis.__framerMotionMock);
 
 // next/link needs a real Next.js router to work. A plain <a> is a faithful enough
 // stand-in for everything these tests care about.

--- a/app/components/FeatureCard.test.tsx
+++ b/app/components/FeatureCard.test.tsx
@@ -2,15 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { FeatureCard } from './FeatureCard';
 
-// Same deal as the CTA test — framer-motion's whileHover and animation props
-// don't mean anything to jsdom, so we stub motion.div with a plain div.
-vi.mock('framer-motion', () => ({
-  motion: {
-    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-      <div {...props}>{children}</div>
-    ),
-  },
-}));
+vi.mock('framer-motion', () => globalThis.__framerMotionMock);
 
 const TestIcon = () => <svg data-testid="test-icon" aria-label="feature icon" />;
 

--- a/app/components/navbar.test.tsx
+++ b/app/components/navbar.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Navbar from './navbar';
-import type { ReactNode } from 'react';
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
@@ -17,11 +16,7 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
-vi.mock('framer-motion', () => ({
-  motion: {
-    div: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  },
-}));
+vi.mock('framer-motion', () => globalThis.__framerMotionMock);
 
 vi.mock('lucide-react', () => ({
   Menu: () => <div>MenuIcon</div>,

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -28,27 +28,7 @@ vi.mock('next/link', () => ({
   ),
 }));
 
-// Mock framer-motion
-vi.mock('framer-motion', () => ({
-  motion: {
-    div: ({ children, className, ...props }: any) => (
-      <div className={className} data-testid="motion-div" {...props}>
-        {children}
-      </div>
-    ),
-    p: ({ children, className, ...props }: any) => (
-      <p className={className} data-testid="motion-p" {...props}>
-        {children}
-      </p>
-    ),
-    a: ({ children, className, href, ...props }: any) => (
-      <a href={href} className={className} data-testid="motion-a" {...props}>
-        {children}
-      </a>
-    ),
-  },
-  AnimatePresence: ({ children }: any) => <>{children}</>,
-}));
+vi.mock('framer-motion', () => globalThis.__framerMotionMock);
 
 const mockRecentSearches = {
   searches: ['octocat', 'torvalds'] as string[],

--- a/components/dashboard/Achievements.test.tsx
+++ b/components/dashboard/Achievements.test.tsx
@@ -2,35 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import Achievements from './Achievements';
 
-// Mock framer-motion to avoid animation issues in tests
-vi.mock('framer-motion', () => ({
-  motion: {
-    div: ({
-      children,
-      className,
-      ...props
-    }: {
-      children: React.ReactNode;
-      className?: string;
-      [key: string]: unknown;
-    }) => {
-      const safeProps = { ...props };
-      delete safeProps.initial;
-      delete safeProps.whileInView;
-      delete safeProps.viewport;
-      delete safeProps.transition;
-      return (
-        <div
-          className={className}
-          data-testid={safeProps['data-testid'] || 'motion-div'}
-          {...safeProps}
-        >
-          {children}
-        </div>
-      );
-    },
-  },
-}));
+vi.mock('framer-motion', () => globalThis.__framerMotionMock);
 
 const mockAchievements = [
   {

--- a/components/dashboard/LanguageChart.test.tsx
+++ b/components/dashboard/LanguageChart.test.tsx
@@ -1,25 +1,8 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import LanguageChart, { buildGradientStops } from './LanguageChart';
 
-vi.mock('framer-motion', () => ({
-  motion: {
-    div: ({ children, className, style, ...props }: any) => {
-      delete props.initial;
-      delete props.animate;
-      delete props.whileInView;
-      delete props.viewport;
-      delete props.transition;
-
-      return (
-        <div className={className} style={style} {...props}>
-          {children}
-        </div>
-      );
-    },
-  },
-}));
+vi.mock('framer-motion', () => globalThis.__framerMotionMock);
 
 describe('LanguageChart', () => {
   it('renders an empty state when no language data is available', () => {

--- a/components/dashboard/ShareSheet.test.tsx
+++ b/components/dashboard/ShareSheet.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import ShareSheet from './ShareSheet';
@@ -8,28 +7,7 @@ vi.mock('html-to-image', () => ({
   toPng: vi.fn().mockResolvedValue('data:image/png;base64,mockdata'),
 }));
 
-// Mock framer-motion to avoid animation issues in tests
-vi.mock('framer-motion', () => ({
-  motion: {
-    div: ({ children, className, onClick, ...props }: any) => (
-      <div className={className} onClick={onClick} data-testid="motion-div" {...props}>
-        {children}
-      </div>
-    ),
-    button: ({ children, className, onClick, disabled, ...props }: any) => (
-      <button
-        className={className}
-        onClick={onClick}
-        disabled={disabled}
-        data-testid="motion-button"
-        {...props}
-      >
-        {children}
-      </button>
-    ),
-  },
-  AnimatePresence: ({ children }: any) => <>{children}</>,
-}));
+vi.mock('framer-motion', () => globalThis.__framerMotionMock);
 
 describe('ShareSheet', () => {
   const defaultProps = {
@@ -109,9 +87,11 @@ describe('ShareSheet', () => {
   });
 
   it('calls onClose when overlay is clicked', () => {
-    render(<ShareSheet {...defaultProps} />);
-    const overlay = screen.getAllByTestId('motion-div')[0];
-    fireEvent.click(overlay);
+    const { container } = render(<ShareSheet {...defaultProps} />);
+    const overlay = container.querySelector('#share-sheet-overlay');
+
+    expect(overlay).toBeTruthy();
+    fireEvent.click(overlay as Element);
     expect(defaultProps.onClose).toHaveBeenCalled();
   });
 

--- a/test/framer-motion.ts
+++ b/test/framer-motion.ts
@@ -1,0 +1,70 @@
+import { createElement, forwardRef, Fragment, type ReactNode } from 'react';
+
+const MOTION_PROP_KEYS = new Set([
+  'animate',
+  'initial',
+  'transition',
+  'viewport',
+  'whileHover',
+  'whileTap',
+  'whileInView',
+  'exit',
+  'layout',
+  'layoutId',
+  'drag',
+  'dragConstraints',
+  'dragElastic',
+  'dragMomentum',
+  'dragTransition',
+  'variants',
+  'custom',
+  'onAnimationComplete',
+  'onUpdate',
+]);
+
+function stripMotionProps(props: Record<string, unknown>) {
+  const safeProps: Record<string, unknown> = { ...props };
+
+  for (const key of MOTION_PROP_KEYS) {
+    delete safeProps[key];
+  }
+
+  return safeProps;
+}
+
+function createMotionComponent(tag: string) {
+  return forwardRef<unknown, { children?: ReactNode; [key: string]: unknown }>(
+    function MotionComponent({ children, ...props }, ref) {
+      return createElement(tag, { ...stripMotionProps(props), ref }, children);
+    }
+  );
+}
+
+export function createFramerMotionMock() {
+  const cache = new Map<string, ReturnType<typeof createMotionComponent>>();
+
+  const motion = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (typeof prop !== 'string') {
+          return undefined;
+        }
+
+        if (!cache.has(prop)) {
+          cache.set(prop, createMotionComponent(prop));
+        }
+
+        return cache.get(prop);
+      },
+    }
+  ) as Record<string, ReturnType<typeof createMotionComponent>>;
+
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children: ReactNode }) =>
+      createElement(Fragment, null, children),
+  };
+}
+
+export type FramerMotionMock = ReturnType<typeof createFramerMotionMock>;

--- a/test/globals.d.ts
+++ b/test/globals.d.ts
@@ -1,0 +1,7 @@
+import type { FramerMotionMock } from './framer-motion';
+
+declare global {
+  var __framerMotionMock: FramerMotionMock;
+}
+
+export {};

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeAll } from 'vitest';
+import { afterEach } from 'vitest';
 import { installTimezoneMock, resetMockTimezone } from './timezone';
+import { createFramerMotionMock } from './framer-motion';
 
 const localStorageMemory = (() => {
   const store: Record<string, string> = {};
@@ -22,15 +23,20 @@ const localStorageMemory = (() => {
   };
 })();
 
-beforeAll(() => {
-  installTimezoneMock();
+installTimezoneMock();
 
-  Object.defineProperty(globalThis, 'localStorage', {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    value: localStorageMemory,
-  });
+Object.defineProperty(globalThis, '__framerMotionMock', {
+  configurable: true,
+  enumerable: false,
+  writable: false,
+  value: createFramerMotionMock(),
+});
+
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  value: localStorageMemory,
 });
 
 afterEach(() => {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeAll } from 'vitest';
+import { installTimezoneMock, resetMockTimezone } from './timezone';
+
+const localStorageMemory = (() => {
+  const store: Record<string, string> = {};
+
+  return {
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = String(value);
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    clear() {
+      for (const key of Object.keys(store)) {
+        delete store[key];
+      }
+    },
+  };
+})();
+
+beforeAll(() => {
+  installTimezoneMock();
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: localStorageMemory,
+  });
+});
+
+afterEach(() => {
+  resetMockTimezone();
+  localStorageMemory.clear();
+});

--- a/test/timezone.test.ts
+++ b/test/timezone.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getMockTimezone, resetMockTimezone, setMockTimezone } from './timezone';
+
+afterEach(() => {
+  resetMockTimezone();
+});
+
+describe('timezone mock helper', () => {
+  it('defaults DateTimeFormat without an explicit timezone to UTC', () => {
+    const formatter = new Intl.DateTimeFormat('en-US');
+
+    expect(formatter.resolvedOptions().timeZone).toBe('UTC');
+    expect(getMockTimezone()).toBe('UTC');
+  });
+
+  it('lets tests switch the default timezone when needed', () => {
+    setMockTimezone('Etc/GMT+8');
+
+    const formatter = new Intl.DateTimeFormat('en-CA', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+    const parts = formatter.formatToParts(new Date('2024-06-16T07:00:00.000Z'));
+    const mapped = Object.fromEntries(
+      parts.filter((part) => part.type !== 'literal').map((part) => [part.type, part.value])
+    );
+
+    expect(formatter.resolvedOptions().timeZone).toBe('Etc/GMT+8');
+    expect(mapped).toMatchObject({
+      year: '2024',
+      month: '06',
+      day: '15',
+    });
+  });
+
+  it('keeps explicit timeZone options intact', () => {
+    setMockTimezone('Etc/GMT+8');
+
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'America/New_York',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+
+    expect(formatter.resolvedOptions().timeZone).toBe('America/New_York');
+  });
+});

--- a/test/timezone.ts
+++ b/test/timezone.ts
@@ -1,0 +1,45 @@
+import { vi } from 'vitest';
+
+const RealDateTimeFormat = Intl.DateTimeFormat;
+const DEFAULT_TIMEZONE = 'UTC';
+
+let activeTimezone = DEFAULT_TIMEZONE;
+let installed = false;
+
+type DateTimeFormatArgs = ConstructorParameters<typeof Intl.DateTimeFormat>;
+
+function createFormatter([locales, options]: DateTimeFormatArgs) {
+  return new RealDateTimeFormat(locales, {
+    ...options,
+    timeZone: options?.timeZone ?? activeTimezone,
+  });
+}
+
+export function installTimezoneMock(defaultTimezone: string = DEFAULT_TIMEZONE) {
+  activeTimezone = defaultTimezone;
+
+  if (installed) {
+    return;
+  }
+
+  installed = true;
+
+  vi.spyOn(Intl, 'DateTimeFormat').mockImplementation(function mockedDateTimeFormat(
+    this: unknown,
+    ...args: DateTimeFormatArgs
+  ) {
+    return createFormatter(args);
+  } as typeof Intl.DateTimeFormat);
+}
+
+export function setMockTimezone(timezone: string) {
+  activeTimezone = timezone;
+}
+
+export function resetMockTimezone() {
+  activeTimezone = DEFAULT_TIMEZONE;
+}
+
+export function getMockTimezone() {
+  return activeTimezone;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./test/setup.ts'],
     include: ['**/*.test.ts', '**/*.test.tsx'],
     exclude: ['node_modules', '.next'],
     coverage: {


### PR DESCRIPTION
Centralizes the framer-motion test mock in shared test setup, adds a typed global mock, and updates the affected suites to use stable selectors.\n\nValidation:\n- npm test -- --run app/components/FeatureCard.test.tsx app/components/CustomizeCTA.test.tsx app/components/navbar.test.tsx app/page.test.tsx components/dashboard/Achievements.test.tsx components/dashboard/LanguageChart.test.tsx components/dashboard/ShareSheet.test.tsx\n- npm test