### PR TITLE
bug: escape backticks in svg text

### DIFF
--- a/lib/svg/generator.escapeXML.test.ts
+++ b/lib/svg/generator.escapeXML.test.ts
@@ -16,6 +16,10 @@ describe('escapeXML', () => {
     expect(escapeXML('hello world')).toBe('hello world');
   });
 
+  it('should escape backticks to prevent attribute breakout', () => {
+    expect(escapeXML('label=`alert(1)`')).toBe('label=&#96;alert(1)&#96;');
+  });
+
   it('should return an empty string unchanged', () => {
     expect(escapeXML('')).toBe('');
   });

--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -1529,8 +1529,11 @@ describe('escapeXML', () => {
   });
 
   it('leaves a safe string unchanged', () => {
-    const safe = 'Hello World 123!@#%^*()_+-=[]{}|;:,./?`~';
+    const safe = 'Hello World 123!@#%^*()_+-=[]{}|;:,./?~';
     expect(escapeXML(safe)).toBe(safe);
+  });
+  it('escapes backticks in XML-sensitive strings', () => {
+    expect(escapeXML('onload=`alert(1)`')).toBe('onload=&#96;alert(1)&#96;');
   });
   it('escapes script injection characters <script>&" together', () => {
     expect(escapeXML('<script>&"')).toBe('&lt;script&gt;&amp;&quot;');

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -107,7 +107,8 @@ export function escapeXML(str: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+    .replace(/'/g, '&#39;')
+    .replace(/`/g, '&#96;');
 }
 
 export function particleCount(count?: number | null): number {


### PR DESCRIPTION
Escapes backticks in SVG/XML text output so user-controlled strings cannot break out of attributes.\n\nValidation:\n- npm test -- --run lib/svg/generator.escapeXML.test.ts lib/svg/generator.test.ts\n\nCloses #5264