### PR TITLE
[codex] fix strict GitHub username validation

### DIFF
--- a/lib/validations.accessibility.test.ts
+++ b/lib/validations.accessibility.test.ts
@@ -6,6 +6,8 @@ describe('validations.ts - Accessibility Standards & Screen Reader Aria Complian
     // Assert schema function returns expected output
     expect(validateGitHubUsername('octocat')).toBe(true);
     expect(validateGitHubUsername('invalid--user')).toBe(false);
+    expect(validateGitHubUsername('a'.repeat(39))).toBe(true);
+    expect(validateGitHubUsername('a'.repeat(40))).toBe(false);
 
     const validationAlert = {
       role: 'alert',

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -67,7 +67,7 @@ export function toDimensionValue(val?: string): number | undefined {
 }
 
 export function validateGitHubUsername(username: string): boolean {
-  return /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i.test(username);
+  return GITHUB_USERNAME_REGEX.test(username);
 }
 
 /**
@@ -141,7 +141,7 @@ const timeZoneParam = z
   .optional()
   .refine(isValidTimeZone, { message: 'Invalid timezone' });
 
-export const GITHUB_USERNAME_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9]))*$/;
+export const GITHUB_USERNAME_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;
 
 export const githubUsernameSchema = z
   .string({ error: 'Invalid GitHub username' })


### PR DESCRIPTION
## Description\n\nTighten GitHub username validation so it matches GitHub's 39-character limit and rejects invalid leading/trailing hyphen patterns.\n\n## Validation\n\n- npm test -- --run lib/validations.accessibility.test.ts lib/validations.githubParamsSchema.test.ts lib/validations.streakParamsSchema.test.ts lib/validations.massive-scaling.test.ts\n- git diff --check