### PR TITLE
test(getClientIp-accessibility): verify Data Accessibility & Header R…

### DIFF
--- a/utils/getClientIp.accessibility.test.ts
+++ b/utils/getClientIp.accessibility.test.ts
@@ -2,11 +2,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getClientIp } from './getClientIp';
 
 describe('getClientIp Data Accessibility & Header Resolution Tests', () => {
+  const originalEnv = process.env.NODE_ENV;
+
   beforeEach(() => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.useFakeTimers();
+    process.env.NODE_ENV = 'development';
   });
 
   afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    vi.runAllTimers();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 

--- a/utils/getClientIp.accessibility.test.ts
+++ b/utils/getClientIp.accessibility.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getClientIp } from './getClientIp';
+
+describe('getClientIp Data Accessibility & Header Resolution Tests', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('1. reliably accesses the leftmost client IP in an X-Forwarded-For proxy chain when proxies are universally trusted', () => {
+    const request = new Request('https://commitpulse.com', {
+      headers: new Headers({
+        'x-forwarded-for': '203.0.113.1, 198.51.100.1, 192.0.2.1',
+      }),
+    });
+
+    const ip = getClientIp(request, {
+      proxyConfig: { trustedProxies: ['*'], trustPrivateRanges: true },
+    });
+
+    expect(ip).toBe('203.0.113.1');
+  });
+
+  it('2. accesses secure fallback priority headers (cf-connecting-ip) when primary forwarding headers are missing', () => {
+    const request = new Request('https://commitpulse.com', {
+      headers: new Headers({
+        'cf-connecting-ip': '198.51.100.5',
+        'x-real-ip': '198.51.100.2',
+      }),
+    });
+
+    const ip = getClientIp(request, {
+      proxyConfig: { trustedProxies: [], trustPrivateRanges: false },
+    });
+
+    expect(ip).toBe('198.51.100.5');
+  });
+
+  it('3. identifies spoofing attempts by verifying that claimed IPs match the securely accessed resolution', () => {
+    const request = new Request('https://commitpulse.com', {
+      headers: new Headers({
+        'x-forwarded-for': '9.9.9.9', // Claimed spoofed IP
+        'x-real-ip': '1.1.1.1', // Actual accessed IP
+      }),
+    });
+
+    const ip = getClientIp(request, {
+      proxyConfig: { trustedProxies: [], trustPrivateRanges: false },
+    });
+
+    expect(ip).toBe('1.1.1.1');
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('SPOOFED_HEADER_ATTEMPT'));
+  });
+
+  it('4. securely defaults to local loopback accessibility when no valid network headers are present', () => {
+    const request = new Request('https://commitpulse.com', {
+      headers: new Headers(), // Empty headers
+    });
+
+    const ip = getClientIp(request);
+    expect(ip).toBe('127.0.0.1');
+  });
+
+  it('5. resolves the correct client IP by traversing backwards through explicitly trusted proxy boundaries', () => {
+    const request = new Request('https://commitpulse.com', {
+      headers: new Headers({
+        // Client -> Untrusted -> Trusted -> Trusted
+        'x-forwarded-for': '203.0.113.1, 100.0.0.1, 192.168.1.100, 192.168.1.200',
+      }),
+    });
+
+    const ip = getClientIp(request, {
+      proxyConfig: {
+        trustedProxies: ['192.168.1.100', '192.168.1.200'],
+        trustPrivateRanges: false,
+      },
+    });
+
+    expect(ip).toBe('100.0.0.1');
+  });
+});

--- a/utils/getClientIp.accessibility.test.ts
+++ b/utils/getClientIp.accessibility.test.ts
@@ -18,6 +18,7 @@ describe('getClientIp Data Accessibility & Header Resolution Tests', () => {
     });
 
     const ip = getClientIp(request, {
+      directIp: '192.168.1.1',
       proxyConfig: { trustedProxies: ['*'], trustPrivateRanges: true },
     });
 
@@ -33,7 +34,8 @@ describe('getClientIp Data Accessibility & Header Resolution Tests', () => {
     });
 
     const ip = getClientIp(request, {
-      proxyConfig: { trustedProxies: [], trustPrivateRanges: false },
+      directIp: '192.168.1.1',
+      proxyConfig: { trustedProxies: ['192.168.1.1'], trustPrivateRanges: false },
     });
 
     expect(ip).toBe('198.51.100.5');
@@ -42,13 +44,13 @@ describe('getClientIp Data Accessibility & Header Resolution Tests', () => {
   it('3. identifies spoofing attempts by verifying that claimed IPs match the securely accessed resolution', () => {
     const request = new Request('https://commitpulse.com', {
       headers: new Headers({
-        'x-forwarded-for': '9.9.9.9', // Claimed spoofed IP
-        'x-real-ip': '1.1.1.1', // Actual accessed IP
+        'x-forwarded-for': '9.9.9.9, 1.1.1.1', // 9.9.9.9 is a spoofed injected IP, 1.1.1.1 is the real client
       }),
     });
 
     const ip = getClientIp(request, {
-      proxyConfig: { trustedProxies: [], trustPrivateRanges: false },
+      directIp: '192.168.1.1',
+      proxyConfig: { trustedProxies: ['192.168.1.1'], trustPrivateRanges: false },
     });
 
     expect(ip).toBe('1.1.1.1');
@@ -68,11 +70,12 @@ describe('getClientIp Data Accessibility & Header Resolution Tests', () => {
     const request = new Request('https://commitpulse.com', {
       headers: new Headers({
         // Client -> Untrusted -> Trusted -> Trusted
-        'x-forwarded-for': '203.0.113.1, 100.0.0.1, 192.168.1.100, 192.168.1.200',
+        'x-forwarded-for': '203.0.113.1, 100.0.0.1, 192.168.1.100',
       }),
     });
 
     const ip = getClientIp(request, {
+      directIp: '192.168.1.200',
       proxyConfig: {
         trustedProxies: ['192.168.1.100', '192.168.1.200'],
         trustPrivateRanges: false,


### PR DESCRIPTION
## Description
This PR Adds header resolution and IP access tests for utils/getClientIp.

Fixes #4657 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
