### PR TITLE
fix: escape backticks in svg text

### DIFF
--- a/lib/svg/generator.escapeXML.test.ts
+++ b/lib/svg/generator.escapeXML.test.ts
@@ -16,6 +16,10 @@ describe('escapeXML', () => {
     expect(escapeXML('hello world')).toBe('hello world');
   });
 
+  it('should escape backticks to prevent attribute breakout', () => {
+    expect(escapeXML('label=`alert(1)`')).toBe('label=&#96;alert(1)&#96;');
+  });
+
   it('should return an empty string unchanged', () => {
     expect(escapeXML('')).toBe('');
   });

--- a/lib/svg/generator.test.ts
+++ b/lib/svg/generator.test.ts
@@ -1529,8 +1529,11 @@ describe('escapeXML', () => {
   });
 
   it('leaves a safe string unchanged', () => {
-    const safe = 'Hello World 123!@#%^*()_+-=[]{}|;:,./?`~';
+    const safe = 'Hello World 123!@#%^*()_+-=[]{}|;:,./?~';
     expect(escapeXML(safe)).toBe(safe);
+  });
+  it('escapes backticks in XML-sensitive strings', () => {
+    expect(escapeXML('onload=`alert(1)`')).toBe('onload=&#96;alert(1)&#96;');
   });
   it('escapes script injection characters <script>&" together', () => {
     expect(escapeXML('<script>&"')).toBe('&lt;script&gt;&amp;&quot;');

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -107,7 +107,8 @@ export function escapeXML(str: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+    .replace(/'/g, '&#39;')
+    .replace(/`/g, '&#96;');
 }
 
 export function particleCount(count?: number | null): number {


### PR DESCRIPTION
## Summary\n- escape backticks in SVG text generation\n- add regression coverage for XML escaping behavior\n\n## Validation\n- reviewed the svg helper diff\n- no runtime behavior outside escaping