### PR TITLE
test(dashboard): add loading component coverage

### DIFF
--- a/app/(root)/dashboard/[username]/loading.mouse-interactivity.test.tsx
+++ b/app/(root)/dashboard/[username]/loading.mouse-interactivity.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+import DashboardUserLoading from './loading';
+
+vi.mock('@/components/dashboard/DashboardSkeleton', () => ({
+  default: () => <div data-testid="dashboard-skeleton">Dashboard Skeleton</div>,
+}));
+
+describe('DashboardUserLoading', () => {
+  it('renders the dashboard skeleton component', () => {
+    const { getByTestId } = render(<DashboardUserLoading />);
+
+    expect(getByTestId('dashboard-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders a single dashboard skeleton instance', () => {
+    const { getAllByTestId } = render(<DashboardUserLoading />);
+
+    expect(getAllByTestId('dashboard-skeleton')).toHaveLength(1);
+  });
+
+  it('applies the loading page background and text color classes', () => {
+    const { container } = render(<DashboardUserLoading />);
+
+    const wrapper = container.firstElementChild;
+
+    expect(wrapper?.className).toContain('bg-black');
+    expect(wrapper?.className).toContain('text-white');
+  });
+
+  it('applies responsive spacing and screen height classes', () => {
+    const { container } = render(<DashboardUserLoading />);
+
+    const wrapper = container.firstElementChild;
+
+    expect(wrapper?.className).toContain('min-h-screen');
+    expect(wrapper?.className).toContain('p-4');
+    expect(wrapper?.className).toContain('md:p-6');
+    expect(wrapper?.className).toContain('lg:p-8');
+  });
+
+  it('renders consistently across repeated mounts', () => {
+    const { unmount } = render(<DashboardUserLoading />);
+
+    unmount();
+
+    const secondRender = render(<DashboardUserLoading />);
+
+    expect(secondRender.container.querySelector('[data-testid="dashboard-skeleton"]')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4662

Added `app/(root)/dashboard/[username]/loading.mouse-interactivity.test.tsx` to provide isolated test coverage for the dashboard user loading page.

The loading component is a static loading-state wrapper that renders `DashboardSkeleton` and does not implement hover handlers, click handlers, tooltips, touch interactions, or cursor-state changes. The test suite therefore focuses on the actual runtime behavior present in the component.

### Added Test Coverage

* Dashboard skeleton rendering
* Single skeleton instance rendering
* Background and text styling classes
* Responsive spacing and minimum-height layout classes
* Consistent rendering across repeated mounts

### Validation

* Added 5 test cases
* Verified locally using Vitest
* `npm run typecheck` passes successfully

### Pillar

🛠️ Other (Testing)

### Visual Preview

N/A (test-only change)

### Checklist before requesting a review:

* [x] I have read the CONTRIBUTING.md file.
* [x] I have tested these changes locally.
* [x] I have run npm run typecheck locally.
* [x] My commits follow the Conventional Commits format.
* [x] I have updated README.md if required. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse premium quality standard. (Not applicable)
