### PR TITLE
test(review-analytics): add empty fallback coverage

### DIFF
--- a/components/dashboard/PRInsights/ReviewAnalytics.empty-fallback.test.tsx
+++ b/components/dashboard/PRInsights/ReviewAnalytics.empty-fallback.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import ReviewAnalytics from './ReviewAnalytics';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+const emptyAnalytics = {
+  reviewsGiven: 0,
+  reviewsReceived: 0,
+  fastestReview: 0,
+  slowestReview: 0,
+} as never;
+
+const extremeAnalytics = {
+  reviewsGiven: 999999,
+  reviewsReceived: 888888,
+  fastestReview: 0.1,
+  slowestReview: 99999.9,
+} as never;
+
+describe('ReviewAnalytics Empty/Missing Inputs Verification', () => {
+  it('renders successfully with zero-value analytics without crashing', () => {
+    render(<ReviewAnalytics data={emptyAnalytics} />);
+
+    expect(screen.getByText('Review Analytics')).toBeInTheDocument();
+    expect(screen.getByText('Peer review participation and speed')).toBeInTheDocument();
+
+    expect(screen.getAllByText('0')).toHaveLength(2);
+    expect(screen.getAllByText('0.0')[0]).toBeInTheDocument();
+  });
+
+  it('renders all metric sections when analytics values are empty-like defaults', () => {
+    render(<ReviewAnalytics data={emptyAnalytics} />);
+
+    expect(screen.getByText('Reviews Given')).toBeInTheDocument();
+    expect(screen.getByText('Reviews Received')).toBeInTheDocument();
+    expect(screen.getByText('Fastest Review')).toBeInTheDocument();
+    expect(screen.getByText('Slowest Review')).toBeInTheDocument();
+  });
+
+  it('maintains layout structure when displaying default boundary values', () => {
+    const { container } = render(<ReviewAnalytics data={emptyAnalytics} />);
+
+    expect(container.querySelector('.grid.grid-cols-2')).toBeInTheDocument();
+
+    expect(container.querySelector('.rounded-3xl')).toBeInTheDocument();
+  });
+
+  it('formats decimal review timing values correctly for boundary inputs', () => {
+    render(
+      <ReviewAnalytics
+        data={
+          {
+            reviewsGiven: 0,
+            reviewsReceived: 0,
+            fastestReview: 1.23456,
+            slowestReview: 9.87654,
+          } as never
+        }
+      />
+    );
+
+    expect(screen.getByText('1.2')).toBeInTheDocument();
+    expect(screen.getByText('9.9')).toBeInTheDocument();
+
+    expect(screen.getAllByText('hrs')).toHaveLength(2);
+  });
+
+  it('renders extreme analytics values without breaking the DOM structure', () => {
+    render(<ReviewAnalytics data={extremeAnalytics} />);
+
+    expect(screen.getByText('999999')).toBeInTheDocument();
+    expect(screen.getByText('888888')).toBeInTheDocument();
+    expect(screen.getByText('0.1')).toBeInTheDocument();
+    expect(screen.getByText('99999.9')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4261

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Tests)

## Visual Preview

N/A (Test-only change)

## Summary

This PR adds dedicated empty-state and boundary-condition test coverage for the `ReviewAnalytics` component.

The new test suite verifies that the component remains stable and renders correctly when analytics values are empty-like defaults, boundary values, and unusually large values. It also validates metric formatting and ensures the expected layout structure is preserved during rendering.

## Changes Made

* Added new test file:

  `components/dashboard/PRInsights/ReviewAnalytics.empty-fallback.test.tsx`

* Added coverage for:

  * Rendering with zero-value analytics data
  * Presence of all review metric sections
  * Layout stability under empty/default values
  * Decimal formatting of review timing metrics
  * Rendering of extreme analytics values without DOM breakage

## Testing

Executed:

```bash
npm run test -- ReviewAnalytics.empty-fallback.test.tsx
npm run format:check
npm run typecheck
```

Results:

* All tests passed
* Formatting checks passed
* Type checking passed

## Coverage Added

* Verifies component stability with empty-like analytics values.
* Verifies expected metric sections remain visible.
* Verifies layout structure is preserved under boundary inputs.
* Verifies review timing values are formatted correctly.
* Verifies large analytics values render without breaking the UI.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and resolved formatting issues.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] This change is test-only and does not modify production functionality.