### PR TITLE
fix(achievements): replace local GITHUB_USERNAME_REGEX with shared validateGitHubUsername

### DIFF
--- a/app/api/achievements/route.ts
+++ b/app/api/achievements/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { validateGitHubUsername } from '@/lib/validations';
 import { getFullDashboardData } from '@/lib/github';
 import type {
   AchievementDef,
@@ -9,8 +10,6 @@ import type {
   AchievementData,
   AchievementsResponse,
 } from '@/types/achievements';
-
-const GITHUB_USERNAME_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;
 
 const ACHIEVEMENT_DEFS: AchievementDef[] = [
   // 🔥 Contribution
@@ -551,7 +550,7 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const username = searchParams.get('username');
 
-  if (!username || !GITHUB_USERNAME_REGEX.test(username)) {
+  if (!username || !validateGitHubUsername(username)) {
     return NextResponse.json({ error: 'Valid username parameter is required' }, { status: 400 });
   }
 


### PR DESCRIPTION
## Description
Fixes #5426

`app/api/achievements/route.ts` defined its own local `GITHUB_USERNAME_REGEX` instead of using the shared `validateGitHubUsername` utility from `@/lib/validations`:

```ts
// Before — local duplicate
const GITHUB_USERNAME_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;
if (!username || !GITHUB_USERNAME_REGEX.test(username)) { ... }

// After — shared utility (same as ci-analytics/route.ts)
import { validateGitHubUsername } from '@/lib/validations';
if (!username || !validateGitHubUsername(username)) { ... }
```

Duplicate validation logic means if the regex in `lib/validations` is ever updated, `achievements/route.ts` silently diverges and enforces different rules than the rest of the API.

Changes made:
- Removed local `GITHUB_USERNAME_REGEX` constant
- Added `import { validateGitHubUsername } from '@/lib/validations'`
- Replaced `GITHUB_USERNAME_REGEX.test(username)` with `validateGitHubUsername(username)`
- Verified zero new TypeScript errors introduced by this change

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — validation logic change with no visual output.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.