### PR TITLE
test(pr-insights): add TopMetricsRow empty fallback coverage

### DIFF
--- a/components/dashboard/PRInsights/TopMetricsRow.empty-fallback.test.tsx
+++ b/components/dashboard/PRInsights/TopMetricsRow.empty-fallback.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import TopMetricsRow from './TopMetricsRow';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+describe('TopMetricsRow Empty/Missing Inputs Verification', () => {
+  it('renders successfully with zero-value metrics without crashing', () => {
+    render(
+      <TopMetricsRow
+        data={
+          {
+            totalPRs: 0,
+            mergeRate: 0,
+            avgCycleTime: 0,
+            avgTimeToFirstReview: 0,
+            weeklyActivity: [],
+          } as never
+        }
+      />
+    );
+
+    expect(screen.getByText('Total PRs')).toBeInTheDocument();
+    expect(screen.getByText('Merge Rate')).toBeInTheDocument();
+    expect(screen.getByText('Avg Cycle Time')).toBeInTheDocument();
+    expect(screen.getByText('First Review')).toBeInTheDocument();
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.getAllByText('0.0')).toHaveLength(3);
+  });
+
+  it('renders normally when weeklyActivity is empty and does not show a trend badge', () => {
+    render(
+      <TopMetricsRow
+        data={
+          {
+            totalPRs: 42,
+            mergeRate: 75,
+            avgCycleTime: 12,
+            avgTimeToFirstReview: 3,
+            weeklyActivity: [],
+          } as never
+        }
+      />
+    );
+
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.queryByText(/this week/i)).not.toBeInTheDocument();
+  });
+
+  it('renders a trend badge using the latest weekly activity entry', () => {
+    render(
+      <TopMetricsRow
+        data={
+          {
+            totalPRs: 120,
+            mergeRate: 81.2,
+            avgCycleTime: 6.4,
+            avgTimeToFirstReview: 1.8,
+            weeklyActivity: [{ prs: 4 }, { prs: 7 }, { prs: 13 }],
+          } as never
+        }
+      />
+    );
+
+    expect(screen.getByText('+13 this week')).toBeInTheDocument();
+  });
+
+  it('formats decimal metrics to one decimal place', () => {
+    render(
+      <TopMetricsRow
+        data={
+          {
+            totalPRs: 250,
+            mergeRate: 98.765,
+            avgCycleTime: 12.349,
+            avgTimeToFirstReview: 1.256,
+            weeklyActivity: [],
+          } as never
+        }
+      />
+    );
+
+    expect(screen.getByText('98.8')).toBeInTheDocument();
+    expect(screen.getByText('12.3')).toBeInTheDocument();
+    expect(screen.getByText('1.3')).toBeInTheDocument();
+
+    expect(screen.getByText('%')).toBeInTheDocument();
+    expect(screen.getAllByText('hrs')).toHaveLength(2);
+  });
+
+  it('renders extreme metric values while preserving the metric card layout', () => {
+    const { container } = render(
+      <TopMetricsRow
+        data={
+          {
+            totalPRs: 999999,
+            mergeRate: 100,
+            avgCycleTime: 99999.9,
+            avgTimeToFirstReview: 88888.8,
+            weeklyActivity: [{ prs: 50000 }],
+          } as never
+        }
+      />
+    );
+
+    expect(screen.getByText('999999')).toBeInTheDocument();
+    expect(screen.getByText('100.0')).toBeInTheDocument();
+    expect(screen.getByText('99999.9')).toBeInTheDocument();
+    expect(screen.getByText('88888.8')).toBeInTheDocument();
+    expect(screen.getByText('+50000 this week')).toBeInTheDocument();
+
+    expect(
+      container.querySelector('.grid.grid-cols-1.md\\:grid-cols-2.lg\\:grid-cols-4')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4262

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Tests)

## Summary

This PR adds dedicated empty-state and boundary-condition test coverage for the `TopMetricsRow` component.

The new test suite verifies that the component remains stable and renders correctly when analytics data contains empty-like values, zero metrics, missing weekly activity information, and extreme metric values.

## Changes Made

Added a new test file:

* `components/dashboard/PRInsights/TopMetricsRow.empty-fallback.test.tsx`

Test coverage includes:

* Rendering with zero-value analytics data.
* Handling an empty `weeklyActivity` array without displaying a trend badge.
* Displaying the correct trend badge when weekly activity data is present.
* Verifying decimal formatting using the component's `.toFixed(1)` behavior.
* Rendering large metric values without breaking layout structure.

## Testing

Executed locally:

```bash
npm run test -- TopMetricsRow.empty-fallback.test.tsx
npm run typecheck
npm run format:check
npm run lint
```

Results:

* 5/5 tests passing
* TypeScript checks passed
* Formatting checks passed
* No new lint errors introduced

## Coverage Added

* Verifies stable rendering with empty/default metric values.
* Verifies fallback behavior when weekly activity data is unavailable.
* Verifies trend badge generation from valid activity data.
* Verifies numeric formatting consistency.
* Verifies layout stability under high-value metric inputs.

## Visual Preview

N/A (Test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run lint` locally.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if required. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] This change adds isolated test coverage without affecting production functionality.
