### PR TITLE
test(export3d-empty-fallback): verify Edge Cases and Empty Fallbacks

### DIFF
--- a/lib/export3d.empty-fallback.test.ts
+++ b/lib/export3d.empty-fallback.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { generateMonolithSTL, activityToTowers } from './export3d';
+import type { ActivityData } from '@/types/dashboard';
+
+describe('export3d empty-fallback and edge-cases', () => {
+  describe('activityToTowers', () => {
+    it('should return an empty array when activity is empty', () => {
+      expect(activityToTowers([])).toEqual([]);
+    });
+
+    it('should return an empty array when activity is null or undefined safely at runtime', () => {
+      expect(activityToTowers(null as unknown as ActivityData[])).toEqual([]);
+      expect(activityToTowers(undefined as unknown as ActivityData[])).toEqual([]);
+    });
+
+    it('should handle zero contribution count arrays without causing division-by-zero or NaN heights', () => {
+      const emptyActivity = [
+        { date: '2024-01-01', count: 0 },
+        { date: '2024-01-02', count: 0 },
+        { date: '2024-01-03', count: 0 },
+      ] as unknown as ActivityData[];
+
+      const towers = activityToTowers(emptyActivity);
+      expect(towers).toHaveLength(3);
+
+      towers.forEach((tower) => {
+        expect(tower.h).toBe(0);
+        expect(tower.intensityLevel).toBe(0);
+        expect(tower.hasCommits).toBe(false);
+        expect(tower.isGhost).toBe(false);
+      });
+    });
+
+    it('should fall back to calculated intensity when intensity is missing/undefined on non-empty activity', () => {
+      const activityWithoutIntensity = [
+        { date: '2024-01-01', count: 5 },
+        { date: '2024-01-02', count: 10 },
+      ] as unknown as ActivityData[];
+
+      const towers = activityToTowers(activityWithoutIntensity);
+      expect(towers).toHaveLength(2);
+      expect(towers[0].intensityLevel).toBe(2); // Math.ceil((5 / 10) * 4) = 2
+      expect(towers[1].intensityLevel).toBe(4); // Math.ceil((10 / 10) * 4) = 4
+
+      towers.forEach((tower) => {
+        expect(Number.isNaN(tower.intensityLevel)).toBe(false);
+      });
+    });
+  });
+
+  describe('generateMonolithSTL', () => {
+    it('should generate a valid default STL for empty tower arrays', () => {
+      const stl = generateMonolithSTL([]);
+      expect(stl).toContain('solid commitpulse_monolith');
+      expect(stl).toContain('endsolid commitpulse_monolith');
+      expect(stl).not.toContain('NaN');
+
+      const facets = (stl.match(/facet normal/g) ?? []).length;
+      expect(facets).toBe(12); // Exactly 12 facets for the base plate rectangular box
+    });
+
+    it('should ignore ghost or zero-height towers, rendering only the base plate', () => {
+      const zeroHeightTowers = [
+        {
+          x: 0,
+          y: 0,
+          h: 0,
+          hasCommits: false,
+          isGhost: false,
+          isToday: false,
+          isTodayWithCommits: false,
+          tooltip: '2024-01-01: 0 contributions',
+          date: '2024-01-01',
+          contributionCount: 0,
+          faceOpacity: { left: 1, right: 1, top: 1 },
+          strokeOpacity: 1,
+          strokeWidth: 1,
+          row: 0,
+          col: 0,
+          intensityLevel: 0,
+        },
+      ];
+
+      const stl = generateMonolithSTL(zeroHeightTowers);
+      expect(stl).toContain('solid commitpulse_monolith');
+      expect(stl).toContain('endsolid commitpulse_monolith');
+      expect(stl).not.toContain('NaN');
+
+      const facets = (stl.match(/facet normal/g) ?? []).length;
+      expect(facets).toBe(12); // Only base plate facets
+    });
+
+    it('should prevent NaN in vertex positions with custom coordinates', () => {
+      const stl = generateMonolithSTL([]);
+      const lines = stl.split('\n');
+      lines.forEach((line) => {
+        if (line.trim().startsWith('vertex')) {
+          expect(line).not.toContain('NaN');
+          const parts = line.trim().split(/\s+/);
+          expect(parts).toHaveLength(4); // "vertex", "x", "y", "z"
+          expect(Number.isNaN(parseFloat(parts[1]))).toBe(false);
+          expect(Number.isNaN(parseFloat(parts[2]))).toBe(false);
+          expect(Number.isNaN(parseFloat(parts[3]))).toBe(false);
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Closes #4275

Introduces a high-coverage, robust unit and integration test suite for `lib/export3d.ts`. Since this module handles 3D isometric city layouts and produces StereoLithography (STL) model outputs for 3D printer slicing, testing for edge cases and fallback values is critical to ensure it never outputs coordinate systems with `NaN` parameters.

This PR adds coverage for:
- **`activityToTowers` boundary safety**:
  - Handles empty contribution arrays, returning a clean `[]`.
  - Safely handles runtime null/undefined inputs using double-casting through `unknown` to respect strict ESLint constraints.
  - Prevents division-by-zero or `NaN` coordinate propagation when all daily contributions are `0`.
  - Ensures missing or undefined daily intensities fall back safely to logical scaling thresholds.

- **`generateMonolithSTL` ASCII output safety**:
  - Returns a valid base plate STL layout (exactly 12 facets) when tower data is empty.
  - Skips generating additional facets for zero-height/ghost towers.
  - Formats vertex coordinate lines to ensure zero occurrences of `NaN` outputs, which would otherwise crash 3D printer slicers.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Unit / integration tests for 3D Export)

## Visual Preview
Not applicable. This PR adds unit/integration tests and does not alter the visual layout or user interface.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions.
