### PR TITLE
test(section-label): add massive scaling coverage

### DIFF
--- a/app/customize/components/SectionLabel.massive-scaling.test.tsx
+++ b/app/customize/components/SectionLabel.massive-scaling.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { SectionLabel } from './SectionLabel';
+
+describe('SectionLabel Massive Data Sets and Extreme High Bounds Scaling', () => {
+  it('renders labels containing thousands of characters without truncation or crashes', () => {
+    const largeLabel = 'A'.repeat(10000);
+
+    render(<SectionLabel>{largeLabel}</SectionLabel>);
+
+    expect(screen.getByText(largeLabel)).toBeInTheDocument();
+  });
+
+  it('renders extremely long unbroken strings while preserving content integrity', () => {
+    const longToken = 'CommitPulse'.repeat(2000);
+
+    render(<SectionLabel>{longToken}</SectionLabel>);
+
+    expect(screen.getByText(longToken)).toBeInTheDocument();
+  });
+
+  it('renders a large number of SectionLabel instances simultaneously', () => {
+    const labels = Array.from({ length: 1000 }, (_, index) => (
+      <SectionLabel key={index}>{`Label ${index}`}</SectionLabel>
+    ));
+
+    render(<>{labels}</>);
+
+    expect(screen.getByText('Label 0')).toBeInTheDocument();
+    expect(screen.getByText('Label 500')).toBeInTheDocument();
+    expect(screen.getByText('Label 999')).toBeInTheDocument();
+
+    expect(screen.getAllByText(/^Label \d+$/)).toHaveLength(1000);
+  });
+
+  it('preserves styling classes when rendering massive content payloads', () => {
+    const largeLabel = 'Scale'.repeat(3000);
+
+    render(<SectionLabel>{largeLabel}</SectionLabel>);
+
+    const label = screen.getByText(largeLabel);
+
+    expect(label.tagName).toBe('P');
+    expect(label).toHaveClass(
+      'text-[10px]',
+      'font-bold',
+      'uppercase',
+      'tracking-[0.22em]',
+      'text-gray-600',
+      'dark:text-white/60',
+      'mb-2'
+    );
+  });
+
+  it('supports repeated rerenders with large content without DOM corruption', () => {
+    const { rerender } = render(<SectionLabel>{'First'.repeat(2000)}</SectionLabel>);
+
+    rerender(<SectionLabel>{'Second'.repeat(2000)}</SectionLabel>);
+    rerender(<SectionLabel>{'Third'.repeat(2000)}</SectionLabel>);
+
+    expect(screen.getByText('Third'.repeat(2000))).toBeInTheDocument();
+    expect(screen.queryByText('First'.repeat(2000))).not.toBeInTheDocument();
+    expect(screen.queryByText('Second'.repeat(2000))).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4339

Added massive-scaling test coverage for `SectionLabel` by creating:

`app/customize/components/SectionLabel.massive-scaling.test.tsx`

### What was tested

* Rendering labels containing thousands of characters.
* Rendering extremely long unbroken strings without crashes.
* Rendering a large number of `SectionLabel` instances simultaneously.
* Preserving styling classes under large content payloads.
* Supporting repeated rerenders with large content while maintaining DOM integrity.

### Validation

* Verified successful rendering under extreme content sizes.
* Confirmed component styling remains intact during large-scale rendering.
* Ensured rerenders do not leave stale content in the DOM.
* Confirmed all tests pass locally.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Tests)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
