### PR TITLE
ci: Normalize stale assignment calculations to absolute hours

### DIFF
--- a/.github/scripts/issue-management/stale-assignment.js
+++ b/.github/scripts/issue-management/stale-assignment.js
@@ -1,6 +1,6 @@
 async function handleStaleAssignments({ github, context, core }) {
   const { owner, repo } = context.repo;
-  const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000;
+  const STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000; // 48 absolute hours
   const now = new Date();
 
   console.log(`Starting stale assignment check for ${owner}/${repo}`);
@@ -27,7 +27,7 @@ async function handleStaleAssignments({ github, context, core }) {
       const updatedAt = new Date(issue.updated_at);
       const timeSinceUpdate = now.getTime() - updatedAt.getTime();
 
-      if (timeSinceUpdate > TWO_DAYS_MS) {
+      if (timeSinceUpdate > STALE_THRESHOLD_MS) {
         const currentAssignees = issue.assignees.map((a) => a.login);
         if (currentAssignees.length === 0) continue;
 

--- a/.github/workflows/stale-assignments.yml
+++ b/.github/workflows/stale-assignments.yml
@@ -2,7 +2,7 @@ name: Stale Assignment Expiry
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Runs daily at midnight UTC
+    - cron: '0 * * * *' # Runs hourly
   workflow_dispatch: # Allows manual triggering from the Actions tab
 
 permissions:


### PR DESCRIPTION
Resolves #5281. Updates the stale assignment workflow schedule to run hourly (instead of daily) and changes the unassignment check to run against absolute elapsed hours (48 absolute hours) timezone-independently, preventing timezone bias for contributors.