### PR TITLE
ci: Implement Next.js bundle size monitoring

### DIFF
--- a/.github/workflows/bundle-size-monitor.yml
+++ b/.github/workflows/bundle-size-monitor.yml
@@ -1,0 +1,115 @@
+name: Bundle Size Monitor
+
+on:
+  workflow_run:
+    workflows: ['CI Pipeline']
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  compare-sizes:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Base Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.pull_requests[0].base.ref || 'main' }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Base Branch
+        run: npm run build
+        env:
+          CI: false
+
+      - name: Download PR Bundle Sizes and Scripts
+        uses: actions/download-artifact@v4
+        with:
+          name: bundle-sizes
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Measure Base Bundle Size
+        run: node scripts/measure-bundle-size.js base-sizes.json
+
+      - name: Compare Sizes
+        run: node scripts/compare-bundle-sizes.js bundle-sizes.json base-sizes.json > size-report.md
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const reportPath = 'size-report.md';
+
+            if (!fs.existsSync(reportPath)) {
+              core.warning('No size report file found. Skipping comment.');
+              return;
+            }
+
+            const report = fs.readFileSync(reportPath, 'utf8');
+            const run = context.payload.workflow_run;
+            let prNumber = null;
+
+            if (run.pull_requests && run.pull_requests.length > 0) {
+              prNumber = run.pull_requests[0].number;
+            } else {
+              // Fallback: search open PRs for matching head SHA or branch
+              const { data: openPRs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100
+              });
+              const pr = openPRs.find(p => p.head.sha === run.head_sha) || openPRs.find(p => p.head.ref === run.head_branch);
+              if (pr) {
+                prNumber = pr.number;
+              }
+            }
+
+            if (!prNumber) {
+              core.warning('Could not resolve PR number for this run. Skipping comment.');
+              return;
+            }
+
+            const sentinel = '<!-- next-bundle-size-report -->';
+            const body = `${sentinel}\n${report}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            const botComment = comments.find(c => c.body && c.body.includes(sentinel));
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body
+              });
+              console.log(`Updated existing PR comment on PR #${prNumber}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body
+              });
+              console.log(`Created new PR comment on PR #${prNumber}`);
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,15 @@ jobs:
         run: npm run build
         env:
           CI: false
+
+      - name: Measure Bundle Size
+        run: node scripts/measure-bundle-size.js bundle-sizes.json
+
+      - name: Upload Bundle Sizes
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundle-sizes
+          path: |
+            bundle-sizes.json
+            scripts/measure-bundle-size.js
+            scripts/compare-bundle-sizes.js

--- a/scripts/compare-bundle-sizes.js
+++ b/scripts/compare-bundle-sizes.js
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const fs = require('fs');
+
+function formatSize(bytes) {
+  const absBytes = Math.abs(bytes);
+  const val = (absBytes / 1024).toFixed(2) + ' KB';
+  return bytes < 0 ? `-${val}` : val;
+}
+
+function formatDiff(bytes, baseBytes) {
+  if (bytes === 0) return '0 B';
+  const val = formatSize(bytes);
+  const pct = baseBytes > 0 ? ((bytes / baseBytes) * 100).toFixed(2) + '%' : '+100%';
+  const sign = bytes > 0 ? '+' : '';
+  return `${sign}${val} (${sign}${pct})`;
+}
+
+function main() {
+  const prPath = process.argv[2];
+  const basePath = process.argv[3];
+
+  if (!prPath || !basePath) {
+    console.error('Usage: node compare-bundle-sizes.js <pr-sizes.json> <base-sizes.json>');
+    process.exit(1);
+  }
+
+  const prData = JSON.parse(fs.readFileSync(prPath, 'utf8'));
+  const baseData = JSON.parse(fs.readFileSync(basePath, 'utf8'));
+
+  const allKeys = Array.from(new Set([...Object.keys(prData), ...Object.keys(baseData)])).sort();
+
+  const rows = [];
+  let prTotalJS = 0;
+  let baseTotalJS = 0;
+  let prTotalCSS = 0;
+  let baseTotalCSS = 0;
+
+  for (const key of allKeys) {
+    const pr = prData[key] || { size: 0, gzipped: 0 };
+    const base = baseData[key] || { size: 0, gzipped: 0 };
+
+    const sizeDiff = pr.size - base.size;
+    const gzipDiff = pr.gzipped - base.gzipped;
+
+    if (key.endsWith('.js')) {
+      prTotalJS += pr.size;
+      baseTotalJS += base.size;
+    } else if (key.endsWith('.css')) {
+      prTotalCSS += pr.size;
+      baseTotalCSS += base.size;
+    }
+
+    // Only show individual files with a difference > 100 bytes to keep the table clean
+    if (Math.abs(sizeDiff) > 100 || Math.abs(gzipDiff) > 100) {
+      let status = '⚪';
+      if (!baseData[key]) status = '🆕 New';
+      else if (!prData[key]) status = '🗑️ Deleted';
+      else if (gzipDiff > 0) status = '🔴 Regression';
+      else if (gzipDiff < 0) status = '🟢 Improvement';
+
+      rows.push({
+        asset: `\`${key}\``,
+        prSize: pr.gzipped > 0 ? formatSize(pr.gzipped) : '-',
+        baseSize: base.gzipped > 0 ? formatSize(base.gzipped) : '-',
+        diff: formatDiff(gzipDiff, base.gzipped),
+        status,
+      });
+    }
+  }
+
+  console.log('### 📦 Next.js Bundle Size Report (Gzipped Sizes)\n');
+  if (rows.length === 0) {
+    console.log('✨ No significant bundle size changes detected.');
+  } else {
+    console.log('| Asset | PR Size | Base Size | Difference | Status |');
+    console.log('| :--- | :--- | :--- | :--- | :--- |');
+    for (const r of rows) {
+      console.log(`| ${r.asset} | ${r.prSize} | ${r.baseSize} | ${r.diff} | ${r.status} |`);
+    }
+  }
+
+  console.log('\n### 📊 Summary of Totals\n');
+  console.log('| Category | PR Size | Base Size | Difference |');
+  console.log('| :--- | :--- | :--- | :--- |');
+
+  const jsDiff = prTotalJS - baseTotalJS;
+  console.log(
+    `| **Total JS** | ${formatSize(prTotalJS)} | ${formatSize(baseTotalJS)} | ${formatDiff(jsDiff, baseTotalJS)} |`
+  );
+
+  const cssDiff = prTotalCSS - baseTotalCSS;
+  console.log(
+    `| **Total CSS** | ${formatSize(prTotalCSS)} | ${formatSize(baseTotalCSS)} | ${formatDiff(cssDiff, baseTotalCSS)} |`
+  );
+}
+
+main();

--- a/scripts/measure-bundle-size.js
+++ b/scripts/measure-bundle-size.js
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+
+function normalizePath(filePath) {
+  // Replace build ID folder (e.g. static/oRr73JL35eL4J_9y-Ef4Q/_buildManifest.js -> static/[build-id]/_buildManifest.js)
+  let normalized = filePath.replace(
+    /static\/[^/]+\/(_buildManifest|_ssgManifest)\.js$/,
+    'static/[build-id]/$1.js'
+  );
+
+  // Replace hex hashes preceded by dash or dot (e.g. -711ef29bc66f648c or .dac65e4204a83905)
+  normalized = normalized.replace(/[-.][a-f0-9]{8,24}(?=\.js|\.css)/gi, '-[hash]');
+
+  // Replace pure hex filenames (e.g. static/css/9186d3cc0904cc35.css -> static/css/[hash].css)
+  normalized = normalized.replace(/\/([a-f0-9]{8,24})\.(js|css)$/gi, '/[hash].$2');
+
+  return normalized;
+}
+
+function walkDir(dir, fileList = []) {
+  if (!fs.existsSync(dir)) return fileList;
+  const files = fs.readdirSync(dir);
+  for (const file of files) {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
+    if (stat.isDirectory()) {
+      walkDir(filePath, fileList);
+    } else {
+      if (file.endsWith('.js') || file.endsWith('.css')) {
+        fileList.push(filePath);
+      }
+    }
+  }
+  return fileList;
+}
+
+function measureBundle() {
+  const staticDir = path.join(process.cwd(), '.next', 'static');
+  if (!fs.existsSync(staticDir)) {
+    console.error('No .next/static directory found. Make sure to run npm run build first.');
+    process.exit(1);
+  }
+  const files = walkDir(staticDir);
+  const results = {};
+
+  for (const file of files) {
+    const relativePath = path.relative(path.join(process.cwd(), '.next'), file).replace(/\\/g, '/');
+    const content = fs.readFileSync(file);
+    const size = content.length;
+    const gzipped = zlib.gzipSync(content).length;
+
+    const norm = normalizePath(relativePath);
+    if (!results[norm]) {
+      results[norm] = { size: 0, gzipped: 0, filesCount: 0 };
+    }
+    results[norm].size += size;
+    results[norm].gzipped += gzipped;
+    results[norm].filesCount += 1;
+  }
+
+  const outputJson = JSON.stringify(results, null, 2);
+  const outputPath = process.argv[2];
+
+  if (outputPath) {
+    fs.writeFileSync(outputPath, outputJson, 'utf8');
+    console.log(`Saved bundle size measurements to ${outputPath}`);
+  } else {
+    console.log(outputJson);
+  }
+}
+
+measureBundle();


### PR DESCRIPTION
Resolves #5279.

### Summary
This PR implements a Next.js bundle size monitoring pipeline. It recursively scans and calculates raw and gzipped sizes of all client-side static assets (JS and CSS) under `.next/static`, normalizing filenames to strip dynamic hashes. The PR sizes and measurement scripts are uploaded as artifacts. Finally, a `workflow_run` action downloads the artifacts, builds the base branch (`main`), compares the sizes, and comments a detailed markdown report on the pull request.