### PR TITLE
fix(timezone): resolve fractional timezone boundary offset shifts

### DIFF
--- a/lib/calculate.fractional-tz.test.ts
+++ b/lib/calculate.fractional-tz.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { calculateStreak } from './calculate';
+import type { ContributionCalendar } from '../types';
+
+describe('calculateStreak — fractional timezone alignments (Issue #5257)', () => {
+  it('maps contributions pushed at 23:45 IST to the correct local calendar day in Asia/Kolkata', () => {
+    const calendar: ContributionCalendar = {
+      totalContributions: 1,
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 0, date: '2026-06-10' },
+            { contributionCount: 1, date: '2026-06-11' },
+            { contributionCount: 0, date: '2026-06-12' },
+          ],
+        },
+      ],
+    };
+
+    // 23:45 IST on June 11th, 2026 is 18:15 UTC on June 11th, 2026
+    const pushedTimeUtc = new Date('2026-06-11T18:15:00.000Z');
+
+    const result = calculateStreak(calendar, 'Asia/Kolkata', pushedTimeUtc);
+
+    expect(result.todayDate).toBe('2026-06-11');
+    expect(result.currentStreak).toBe(1);
+  });
+
+  it('maps contributions pushed at 23:45 NST to the correct local calendar day in Asia/Kathmandu', () => {
+    const calendar: ContributionCalendar = {
+      totalContributions: 1,
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 0, date: '2026-06-10' },
+            { contributionCount: 1, date: '2026-06-11' },
+            { contributionCount: 0, date: '2026-06-12' },
+          ],
+        },
+      ],
+    };
+
+    // 23:45 NST (Nepal Standard Time, UTC+5:45) on June 11th, 2026 is 18:00 UTC on June 11th, 2026
+    const pushedTimeUtc = new Date('2026-06-11T18:00:00.000Z');
+
+    const result = calculateStreak(calendar, 'Asia/Kathmandu', pushedTimeUtc);
+
+    expect(result.todayDate).toBe('2026-06-11');
+    expect(result.currentStreak).toBe(1);
+  });
+});

--- a/lib/calculate.ts
+++ b/lib/calculate.ts
@@ -25,6 +25,7 @@ export function convertLocalToUtc(
       minute: 'numeric',
       second: 'numeric',
       hour12: false,
+      hourCycle: 'h23',
     });
     const parts = formatter.formatToParts(utcDate);
     const partMap = Object.fromEntries(parts.map((p) => [p.type, p.value]));

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -50,6 +50,7 @@ export function getSecondsUntilMidnightInTimezone(tz?: string | null): number {
     minute: 'numeric',
     second: 'numeric',
     hour12: false,
+    hourCycle: 'h23',
   }).formatToParts(now);
 
   const get = (type: string) => parseInt(parts.find((p) => p.type === type)?.value ?? '0', 10);


### PR DESCRIPTION
Resolves #5257.

### Summary
This PR fixes fractional timezone alignments and midnight calculations by adding the `hourCycle: 'h23'` option to `Intl.DateTimeFormat` configurations inside `lib/calculate.ts` and `utils/time.ts`. This guarantees consistent 24-hour time formatting across various Node.js and browser environments, resolving system-specific midnight boundary shifts.