### PR TITLE
fix: apply grace period to longest streak calculation

### DIFF
--- a/lib/calculate.ts
+++ b/lib/calculate.ts
@@ -46,12 +46,20 @@ export function calculateStreak(
   let tempStreak = 0;
 
   // 1. Calculate Longest Streak (Standard loop)
+  let gapCount = 0;
   for (const day of days) {
     if (day.contributionCount > 0) {
       tempStreak++;
+      gapCount = 0; // reset gap count on active day
       if (tempStreak > longestStreak) longestStreak = tempStreak;
     } else {
-      tempStreak = 0;
+      gapCount++;
+      if (gapCount <= grace) {
+        tempStreak++;
+      } else {
+        tempStreak = 0;
+        gapCount = 0;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

The longest streak calculation in `lib/calculate.ts` was ignoring the 
`grace` parameter entirely — any zero-contribution day would reset 
`tempStreak` to 0, while the current streak loop correctly respected 
grace. This caused `currentStreak` to exceed `longestStreak` in some 
cases, which is logically impossible.

Applied the same grace period logic to the longest streak loop using 
a `gapCount` tracker that only resets the streak after consecutive 
zero days exceed the grace threshold.

Fixes #5446 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
