### PR TITLE
Fix Recharts ResponsiveContainer Warnings in Tests

### DIFF
--- a/components/dashboard/PRInsights/PRInsightsClient.accessibility.test.tsx
+++ b/components/dashboard/PRInsights/PRInsightsClient.accessibility.test.tsx
@@ -16,6 +16,16 @@ vi.mock('framer-motion', () => ({
     }
   ),
 }));
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<typeof import('recharts')>('recharts');
+
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 800, height: 400 }}>{children}</div>
+    ),
+  };
+});
 
 class ResizeObserverMock {
   observe() {}


### PR DESCRIPTION
## Description

This PR removes Recharts width/height calculation warnings from accessibility tests by mocking ResponsiveContainer with fixed dimensions in the test environment.

## Changes

- Added a test-only mock for ResponsiveContainer.
- Provided fixed width and height values to avoid jsdom layout calculation issues.
- Prevented width(-1) and height(-1) warnings during test execution.

Fixes #5357 

## Pillar

- [x] 📐 Pillar 2 — Geometric SVG Improvement
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
