### PR TITLE
test(Footer-empty-fallback): verify Edge Cases and Empty Fallbacks

### DIFF
--- a/app/components/Footer.empty-fallback.test.tsx
+++ b/app/components/Footer.empty-fallback.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Footer } from './Footer';
+import { useTranslation } from '@/context/TranslationContext';
+import '@testing-library/jest-dom';
+
+vi.mock('@/context/TranslationContext', () => ({
+  useTranslation: vi.fn(),
+}));
+
+describe('Footer empty-fallback and edge-cases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders raw translation keys as fallback when t returns the path keys', () => {
+    vi.mocked(useTranslation).mockReturnValue({
+      language: 'en',
+      changeLanguage: vi.fn(),
+      t: (path: string) => path,
+      isPending: false,
+    });
+
+    render(<Footer />);
+
+    // Check that sections render raw keys
+    expect(screen.getByText('footer.tagline')).toBeInTheDocument();
+    expect(screen.getByText('footer.navigation')).toBeInTheDocument();
+    expect(screen.getByText('footer.resources')).toBeInTheDocument();
+    expect(screen.getByText('footer.connect')).toBeInTheDocument();
+
+    // Check navigation links contain path strings
+    expect(screen.getByRole('link', { name: 'footer.home' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'footer.contributors' })).toBeInTheDocument();
+  });
+
+  it('renders blank slots without crashing when translation strings are empty', () => {
+    vi.mocked(useTranslation).mockReturnValue({
+      language: 'en',
+      changeLanguage: vi.fn(),
+      t: () => '',
+      isPending: false,
+    });
+
+    const { container } = render(<Footer />);
+
+    // Verify it doesn't crash and layout spans/links are rendered but empty
+    const footer = screen.getByRole('contentinfo');
+    expect(footer).toBeInTheDocument();
+
+    const links = container.querySelectorAll('a');
+    expect(links.length).toBeGreaterThan(0);
+    links.forEach((link) => {
+      expect(link.textContent).toBe('');
+    });
+  });
+
+  it('handles copyright string safely when year parameter is missing or ignored by t', () => {
+    vi.mocked(useTranslation).mockReturnValue({
+      language: 'en',
+      changeLanguage: vi.fn(),
+      t: (path: string) => {
+        if (path === 'footer.copyright') {
+          return 'Copyright CommitPulse';
+        }
+        return path;
+      },
+      isPending: false,
+    });
+
+    render(<Footer />);
+
+    expect(screen.getByText('Copyright CommitPulse')).toBeInTheDocument();
+  });
+
+  it('handles custom LinkComponent renders safely with missing optional params', () => {
+    // Optional params like ariaLabel are undefined/missing for navigation links.
+    // We mock useTranslation to return specific values.
+    vi.mocked(useTranslation).mockReturnValue({
+      language: 'en',
+      changeLanguage: vi.fn(),
+      t: (path: string) => {
+        if (path === 'footer.home') return 'Home';
+        if (path === 'footer.github') return 'GitHub';
+        return '';
+      },
+      isPending: false,
+    });
+
+    render(<Footer />);
+
+    // Internal Link Component with missing parameters
+    const homeLink = screen.getByRole('link', { name: 'Home' });
+    expect(homeLink).toBeInTheDocument();
+    expect(homeLink).not.toHaveAttribute('aria-label'); // undefined ariaLabel
+    expect(homeLink).not.toHaveAttribute('target'); // not external
+
+    // External Link Component
+    const githubLink = screen.getByRole('link', { name: 'CommitPulse on GitHub' });
+    expect(githubLink).toBeInTheDocument();
+    expect(githubLink).toHaveAttribute('target', '_blank');
+    expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders correct current year when system date environment changes', () => {
+    const mockT = vi.fn().mockImplementation((path: string, params?: Record<string, string>) => {
+      if (path === 'footer.copyright' && params) {
+        return `© ${params.year} CommitPulse`;
+      }
+      return path;
+    });
+
+    vi.mocked(useTranslation).mockReturnValue({
+      language: 'en',
+      changeLanguage: vi.fn(),
+      t: mockT,
+      isPending: false,
+    });
+
+    const currentYear = new Date().getFullYear().toString();
+    render(<Footer />);
+
+    expect(screen.getByText(`© ${currentYear} CommitPulse`)).toBeInTheDocument();
+    expect(mockT).toHaveBeenCalledWith('footer.copyright', { year: currentYear });
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4213

This PR introduces comprehensive unit and integration test coverage for the `Footer` component to verify its behavior under edge cases and empty/missing inputs. Specifically, the tests assert:
* **Fallback Translation Keys**: Ensures that if the translation helper `t` returns raw path keys (like `footer.tagline`), the component falls back safely to displaying those keys without throwing errors.
* **Empty/Null Translation Strings**: Confirms that when translation values return empty strings, the layout spans and links render cleanly as blank slots rather than crashing the component.
* **Missing Copyright Params**: Validates that copyright translations still show static layout text gracefully if parameters (e.g., the dynamic calendar year) are missing or ignored.
* **Optional Link Parameters**: Tests custom internal links with missing parameters (such as `ariaLabel` or target attributes) to ensure they do not produce exceptions, while verifying that external links receive the correct fallback attributes (`target="_blank"`, `rel="noopener noreferrer"`, etc.).
* **Dynamic System Date**: Verifies that the copyright year is updated and localized dynamically using the current calendar year.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A (Unit testing additions)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth curves, correct colors).
