### PR TITLE
test(not-found-empty-fallback): verify Edge Cases and Empty Fallbacks

### DIFF
--- a/app/not-found.empty-fallback.test.tsx
+++ b/app/not-found.empty-fallback.test.tsx
@@ -1,0 +1,126 @@
+// app/not-found.empty-fallback.test.tsx
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { toast } from 'sonner';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { children: React.ReactNode }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import NotFound from './not-found';
+
+describe('NotFound Component - Empty & Missing Input Fallbacks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default mock for navigator.clipboard
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('renders successfully with default empty layout state and correct header', () => {
+    expect(() => render(<NotFound />)).not.toThrow();
+
+    // Verify backdrop headers exist and standard styling markers are present
+    expect(screen.getAllByText('𝒐𝒐𝒑𝒔')).toHaveLength(2);
+    expect(
+      screen.getByRole('heading', {
+        name: /Looks like this commit got force-pushed to \/dev\/null/i,
+      })
+    ).toBeInTheDocument();
+
+    // Verify links exist
+    const gitCheckoutMainLink = screen.getByRole('link', { name: 'git checkout main' });
+    expect(gitCheckoutMainLink).toBeInTheDocument();
+    expect(gitCheckoutMainLink).toHaveAttribute(
+      'href',
+      'https://github.com/JhaSourav07/commitpulse'
+    );
+    expect(gitCheckoutMainLink).toHaveAttribute('target', '_blank');
+
+    const goBackHomeLink = screen.getByRole('link', { name: 'Go back home' });
+    expect(goBackHomeLink).toBeInTheDocument();
+    expect(goBackHomeLink).toHaveAttribute('href', '/');
+  });
+
+  it('verifies that the terminal mock exhibits the correct Git command string and hint text', () => {
+    render(<NotFound />);
+
+    // Check key DOM text structures in the bash emulation UI
+    expect(screen.getByText('commitpulse — bash')).toBeInTheDocument();
+    expect(screen.getByText('git checkout')).toBeInTheDocument();
+    expect(screen.getByText('this-page')).toBeInTheDocument();
+    expect(
+      screen.getByText(/The page you're looking for has been rebased out of existence/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText('hint: Did you mean some other username?')).toBeInTheDocument();
+  });
+
+  it('triggers clipboard copy successfully and calls toast.success', async () => {
+    render(<NotFound />);
+
+    const terminalContainer = screen.getByText('commitpulse — bash').closest('div');
+    expect(terminalContainer).toBeInTheDocument();
+
+    if (terminalContainer) {
+      await fireEvent.click(terminalContainer);
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        expect.stringContaining('git checkout this-page')
+      );
+      expect(vi.mocked(toast.success)).toHaveBeenCalledWith('Terminal output copied!');
+    }
+  });
+
+  it('handles clipboard writeText rejection gracefully and calls toast.error', async () => {
+    // Override writeText to reject
+    vi.mocked(navigator.clipboard.writeText).mockRejectedValueOnce(new Error('Clipboard error'));
+
+    render(<NotFound />);
+
+    const terminalContainer = screen.getByText('commitpulse — bash').closest('div');
+    expect(terminalContainer).toBeInTheDocument();
+
+    if (terminalContainer) {
+      await fireEvent.click(terminalContainer);
+      expect(navigator.clipboard.writeText).toHaveBeenCalled();
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Failed to copy terminal output');
+    }
+  });
+
+  it('handles missing navigator.clipboard gracefully and calls toast.error without crashing', async () => {
+    // Delete navigator.clipboard
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    render(<NotFound />);
+
+    const terminalContainer = screen.getByText('commitpulse — bash').closest('div');
+    expect(terminalContainer).toBeInTheDocument();
+
+    if (terminalContainer) {
+      await fireEvent.click(terminalContainer);
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Failed to copy terminal output');
+    }
+  });
+});


### PR DESCRIPTION
## Description
Fixes #4244

Added a dedicated testing and performance verification suite for the root `NotFound` page component to handle layout fallbacks, shell command copy triggers, and legacy browser environments.

## Coverage Added
* **Functional Integrity (type:feature)**: 
  * Asserts that `NotFound` mounts safely, displays custom backdrop `"𝒐𝒐𝒑𝒔"` styling components, and presents the force-pushed warning message without runtime issues.
  * Checks the key DOM structures and text strings inside the bash emulator block (e.g. `'commitpulse — bash'`, `'git checkout this-page'`, hint texts).
  * Simulates clicking the terminal card to copy its content when the Clipboard API succeeds, verifying that the dynamic clipboard write is triggered and `toast.success` displays `'Terminal output copied!'`.
* **Performance & Safety (type:performance)**: 
  * Asserts that when `navigator.clipboard.writeText` rejects/throws an exception, the component handles it gracefully without a runtime crash and displays `'Failed to copy terminal output'`.
  * Simulates connection/browser states where `navigator.clipboard` is completely missing (unsecure/legacy environments) to confirm the fallback path runs safely and triggers the error toast.
* **Robust Verification (type:testing)**: 
  * Introduces a brand new isolated unit testing suite in `app/not-found.empty-fallback.test.tsx` containing 5 critical boundary and action interaction scenarios.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A (Unit testing additions)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth curves, correct colors).
