### PR TITLE
test(generator-constants): add empty fallback coverage for invalid font inputs

### DIFF
--- a/lib/svg/generatorConstants.empty-fallback.test.ts
+++ b/lib/svg/generatorConstants.empty-fallback.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { SVG_WIDTH, SVG_HEIGHT, isFontKey } from './generatorConstants';
+import { FONT_MAP } from './fonts';
+
+describe('generatorConstants Empty & Missing Input Fallbacks', () => {
+  it('isFontKey safely rejects empty string input', () => {
+    expect(isFontKey('')).toBe(false);
+  });
+
+  it('isFontKey safely rejects whitespace-only values', () => {
+    expect(isFontKey(' ')).toBe(false);
+    expect(isFontKey('    ')).toBe(false);
+    expect(isFontKey('\t')).toBe(false);
+    expect(isFontKey('\n')).toBe(false);
+  });
+
+  it('isFontKey safely rejects undefined and null-like runtime values', () => {
+    expect(isFontKey(undefined as unknown as string)).toBe(false);
+    expect(isFontKey(null as unknown as string)).toBe(false);
+  });
+
+  it('isFontKey rejects malformed or unknown font identifiers', () => {
+    expect(isFontKey('unknown-font')).toBe(false);
+    expect(isFontKey('UNKNOWN-FONT')).toBe(false);
+    expect(isFontKey('<script>alert(1)</script>')).toBe(false);
+    expect(isFontKey('font-family:arial')).toBe(false);
+  });
+
+  it('exports stable fallback constants and a non-empty font map', () => {
+    expect(SVG_WIDTH).toBeGreaterThan(0);
+    expect(SVG_HEIGHT).toBeGreaterThan(0);
+
+    expect(Number.isFinite(SVG_WIDTH)).toBe(true);
+    expect(Number.isFinite(SVG_HEIGHT)).toBe(true);
+
+    expect(Object.keys(FONT_MAP).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4286 

Added a dedicated empty-fallback test suite for `lib/svg/generatorConstants.ts`.

### Coverage Added

- Verifies `isFontKey` safely rejects empty string inputs.
- Tests whitespace-only values and other missing input scenarios.
- Validates handling of `null` and `undefined`-like runtime values without runtime failures.
- Confirms malformed, unknown, and potentially unsafe font identifiers are rejected.
- Ensures exported SVG dimension constants and font mappings remain available as stable fallback configuration values.

The test suite focuses on edge cases and missing-input scenarios that align with the actual responsibilities of `generatorConstants.ts`, validating defensive behavior and preventing failures when invalid font configuration values are provided.

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

- N/A – Test-only changes.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
