### PR TITLE
fix(achievements): compute AI Explorer from repos instead of languages

### DIFF
--- a/app/api/achievements/route.ts
+++ b/app/api/achievements/route.ts
@@ -585,11 +585,18 @@ export async function GET(request: Request) {
     const frontendCount = languageNames.filter((l) => FRONTEND_LANGUAGES.has(l)).length;
     const backendCount = languageNames.filter((l) => BACKEND_LANGUAGES.has(l)).length;
 
-    const aiRepoCount = languageNames.filter((l) =>
-      AI_KEYWORDS.some((kw) => l.toLowerCase().includes(kw))
+    const popularRepos = (dashboardData.popularRepos ?? []) as Array<{
+      name: string;
+      description: string | null;
+      stargazerCount: number;
+    }>;
+    const aiRepoCount = popularRepos.filter((repo) =>
+      AI_KEYWORDS.some(
+        (kw) =>
+          repo.name.toLowerCase().includes(kw) ||
+          (repo.description && repo.description.toLowerCase().includes(kw))
+      )
     ).length;
-
-    const popularRepos = (dashboardData.popularRepos ?? []) as Array<{ stargazerCount: number }>;
     let topStarDensity = 0;
     for (const repo of popularRepos) {
       const density = repo.stargazerCount / 6;


### PR DESCRIPTION
## Changes

- Removed AI keyword matching against language names
- Added AI keyword matching against repository names and descriptions
- `popularRepos` type widened to include `name` and `description` fields

## Context

Previously, AI Explorer achievement checked programming language names against AI keywords. Since language names like `Python` or `JavaScript` never match AI keywords, this achievement was effectively never earned.

Now it checks repository names and descriptions, which is the intended behavior — repos about AI/ML topics will have matching names and descriptions.

Fixes #5501