### PR TITLE
fix(resume): return 500 when MongoDB missing in production

### DIFF
--- a/app/api/student/resume/confirm/route.ts
+++ b/app/api/student/resume/confirm/route.ts
@@ -81,7 +81,17 @@ export async function POST(req: Request) {
 
   try {
     if (!process.env.MONGODB_URI) {
-      console.warn('MONGODB_URI is not set. Bypassing student profile save.');
+      const isProduction =
+        process.env.NODE_ENV === 'production' ||
+        process.env.VERCEL_ENV === 'production' ||
+        process.env.VERCEL_ENV === 'preview';
+      if (isProduction) {
+        return NextResponse.json(
+          { success: false, error: 'Server configuration error: Database not configured' },
+          { status: 500 }
+        );
+      }
+      console.warn('MONGODB_URI is not set. Bypassing student profile save (local dev).');
       return NextResponse.json({ success: true, bypassed: true });
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes resume confirmation endpoint to return a 500 error in production/preview when MONGODB_URI is not configured, instead of silently returning success and dropping the profile save.

## Related issue

Fixes #5505

## Changes Made

- Only bypass persistence in local development (when NODE_ENV is not production and VERCEL_ENV is not production/preview)
- In production/preview deployments, return 500 with "Server configuration error: Database not configured"

## Checklist

- [x] My PR has a linked issue (Fixes #5505)
- [x] I have pulled the latest `main` and resolved any conflicts