### PR TITLE
test(useDebounce): add massive scaling coverage

### DIFF
--- a/hooks/useDebounce.massive-scaling.test.ts
+++ b/hooks/useDebounce.massive-scaling.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDebounce } from './useDebounce';
+
+describe('useDebounce massive scaling behavior', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('handles extremely large string payloads without truncation', () => {
+    vi.useFakeTimers();
+
+    const largeValue = 'x'.repeat(100_000);
+
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 100), {
+      initialProps: { value: 'initial' },
+    });
+
+    rerender({ value: largeValue });
+
+    expect(result.current).toBe('initial');
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toBe(largeValue);
+    expect(result.current.length).toBe(100_000);
+  });
+
+  it('handles thousands of rapid updates and resolves to the latest value', () => {
+    vi.useFakeTimers();
+
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 50), {
+      initialProps: { value: 0 },
+    });
+
+    for (let i = 1; i <= 5000; i++) {
+      rerender({ value: i });
+    }
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(result.current).toBe(5000);
+  });
+
+  it('cancels previous timers during heavy update bursts', () => {
+    vi.useFakeTimers();
+
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 200), {
+      initialProps: { value: 0 },
+    });
+
+    for (let i = 1; i <= 1000; i++) {
+      rerender({ value: i });
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+    }
+
+    expect(result.current).toBe(0);
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe(1000);
+  });
+
+  it('supports large object payloads without mutation', () => {
+    vi.useFakeTimers();
+
+    const hugeObject = {
+      id: 'large',
+      values: Array.from({ length: 10000 }, (_, i) => ({
+        index: i,
+        value: `item-${i}`,
+      })),
+    };
+
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 100), {
+      initialProps: { value: {} },
+    });
+
+    rerender({ value: hugeObject });
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toEqual(hugeObject);
+    expect((result.current as typeof hugeObject).values).toHaveLength(10000);
+  });
+
+  it('remains stable under repeated debounce cycles', () => {
+    vi.useFakeTimers();
+
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 10), {
+      initialProps: { value: 0 },
+    });
+
+    for (let cycle = 1; cycle <= 100; cycle++) {
+      rerender({ value: cycle });
+
+      act(() => {
+        vi.advanceTimersByTime(10);
+      });
+
+      expect(result.current).toBe(cycle);
+    }
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4384

Adds massive scaling test coverage for `hooks/useDebounce.ts`.

### What was added

- Tests extremely large string payloads.
- Verifies thousands of rapid updates resolve to the latest debounced value.
- Confirms previous timers are properly cancelled during heavy update bursts.
- Tests large object payload handling without mutation.
- Validates stability across repeated debounce cycles.

### Validation

- ✅ `npx vitest run hooks/useDebounce.massive-scaling.test.ts`
- ✅ `npx eslint hooks/useDebounce.massive-scaling.test.ts`

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Test Coverage)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run the relevant tests and lint checks locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` if required.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable for test-only changes).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.