### PR TITLE
test(types): add dashboard empty fallback coverage

### DIFF
--- a/types/dashboard.empty-fallback.test.ts
+++ b/types/dashboard.empty-fallback.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  UserProfile,
+  ActivityData,
+  UserStats,
+  DashboardExportData,
+  WrappedStats,
+} from './dashboard';
+
+describe('types/dashboard - Edge Cases & Empty/Missing Inputs Verification', () => {
+  it('constructs UserProfile with empty strings and omitted optional type safely', () => {
+    const profile: UserProfile = {
+      username: '',
+      name: '',
+      avatarUrl: '',
+      isPro: false,
+      bio: '',
+      location: '',
+      joinedDate: '',
+      developerScore: 0,
+      stats: {
+        repositories: 0,
+        followers: 0,
+        following: 0,
+        stars: 0,
+      },
+    };
+
+    expect(profile.username).toBe('');
+    expect(profile.type).toBeUndefined();
+    expect(profile.stats.repositories).toBe(0);
+  });
+
+  it('constructs ActivityData with minimum valid values and missing LoC fields', () => {
+    const activity: ActivityData = {
+      date: '',
+      count: 0,
+      intensity: 0,
+    };
+
+    expect(activity.date).toBe('');
+    expect(activity.locAdditions).toBeUndefined();
+    expect(activity.locDeletions).toBeUndefined();
+  });
+
+  it('constructs UserStats with zero-value metrics without runtime issues', () => {
+    const stats: UserStats = {
+      currentStreak: 0,
+      peakStreak: 0,
+      totalContributions: 0,
+    };
+
+    expect(stats.currentStreak).toBe(0);
+    expect(stats.peakStreak).toBe(0);
+    expect(stats.totalContributions).toBe(0);
+  });
+
+  it('constructs DashboardExportData with empty arrays safely', () => {
+    const exportData: DashboardExportData = {
+      stats: {
+        currentStreak: 0,
+        peakStreak: 0,
+        totalContributions: 0,
+      },
+      languages: [],
+      activity: [],
+    };
+
+    expect(exportData.languages).toHaveLength(0);
+    expect(exportData.activity).toHaveLength(0);
+  });
+
+  it('constructs WrappedStats with empty calendar weeks and default-like values', () => {
+    const wrapped: WrappedStats = {
+      totalContributions: 0,
+      mostActiveDate: '',
+      highestDailyCount: 0,
+      busiestMonth: '',
+      weekendRatio: 0,
+      topLanguage: '',
+      calendar: {
+        totalContributions: 0,
+        weeks: [],
+      },
+    };
+
+    expect(wrapped.calendar.weeks).toHaveLength(0);
+    expect(wrapped.totalContributions).toBe(0);
+    expect(wrapped.topLanguage).toBe('');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4300

Adds `types/dashboard.empty-fallback.test.ts` to verify edge cases and empty/missing input handling for dashboard-related type definitions.

### Added test coverage

* Verifies `UserProfile` supports empty strings and omitted optional fields
* Verifies `ActivityData` handles missing optional LoC fields safely
* Verifies `UserStats` supports zero-value metrics
* Verifies `DashboardExportData` supports empty arrays without issues
* Verifies `WrappedStats` supports empty calendar data and default-like values

### Validation

* `dashboard.empty-fallback.test.ts` → 5/5 tests passing
* ESLint validation completed successfully

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and/or `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] This change only adds automated test coverage and does not modify runtime behavior.
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.