### PR TITLE
test(generator-empty-fallback): add edge case coverage for empty and missing inputs

### DIFF
--- a/lib/svg/generator.empty-fallback.test.ts
+++ b/lib/svg/generator.empty-fallback.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveFont,
+  deterministicRandom,
+  particleCount,
+  escapeXML,
+  getSizeScale,
+} from './generator';
+
+describe('generator Edge Cases & Empty/Missing Inputs Verification', () => {
+  it('Case 1: resolves missing font input safely', () => {
+    expect(resolveFont(undefined)).toBeNull();
+    expect(resolveFont(null)).toBeNull();
+  });
+
+  it('Case 2: provides deterministic fallback behavior for empty seeds', () => {
+    const first = deterministicRandom('');
+    const second = deterministicRandom(undefined);
+
+    expect(first).toBeGreaterThanOrEqual(0);
+    expect(first).toBeLessThanOrEqual(1);
+    expect(first).toBe(second);
+  });
+
+  it('Case 3: handles null, undefined and invalid particle counts gracefully', () => {
+    expect(particleCount(undefined)).toBe(0);
+    expect(particleCount(null)).toBe(0);
+    expect(particleCount(NaN)).toBe(0);
+    expect(particleCount(-10)).toBe(0);
+  });
+
+  it('Case 4: maintains safe fallback output for empty strings and missing sizing inputs', () => {
+    expect(escapeXML('')).toBe('');
+    expect(getSizeScale(undefined)).toBe(1);
+    expect(getSizeScale('medium')).toBe(1);
+  });
+
+  it('Case 5: returns safe escaped output without runtime errors', () => {
+    expect(() => escapeXML('')).not.toThrow();
+
+    expect(escapeXML('<tag>&"\'')).toBe('&lt;tag&gt;&amp;&quot;&#39;');
+  });
+});


### PR DESCRIPTION
## Description
Added edge case and empty-input test coverage for `lib/svg/generator.ts`.

Fixes #4285 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
