### PR TITLE
test(svg): add language colors massive scaling coverage

### DIFF
--- a/lib/svg/languageColors.massive-scaling.test.ts
+++ b/lib/svg/languageColors.massive-scaling.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { LANGUAGE_COLORS } from './languageColors';
+
+describe('LANGUAGE_COLORS Massive Data Sets and Extreme High Bounds Scaling', () => {
+  it('supports thousands of repeated language lookups without data corruption', () => {
+    const lookups = Array.from({ length: 10000 }, () => LANGUAGE_COLORS.TypeScript);
+
+    expect(lookups).toHaveLength(10000);
+    expect(lookups.every((color) => color === '#3178c6')).toBe(true);
+  });
+
+  it('preserves valid hexadecimal color values during massive iteration', () => {
+    const colors = Array.from({ length: 1000 }, () => Object.values(LANGUAGE_COLORS)).flat();
+
+    colors.forEach((color) => {
+      expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    });
+  });
+
+  it('maintains consistent language mappings across high-volume access', () => {
+    for (let i = 0; i < 5000; i++) {
+      expect(LANGUAGE_COLORS.JavaScript).toBe('#f1e05a');
+      expect(LANGUAGE_COLORS.TypeScript).toBe('#3178c6');
+    }
+  });
+
+  it('handles large derived language collections without losing entries', () => {
+    const languages = Array.from({ length: 1000 }, () => Object.keys(LANGUAGE_COLORS)).flat();
+
+    expect(languages.length).toBe(Object.keys(LANGUAGE_COLORS).length * 1000);
+    expect(languages).toContain('TypeScript');
+    expect(languages).toContain('Python');
+  });
+
+  it('preserves unique language identifiers under massive scaling scenarios', () => {
+    const uniqueLanguages = new Set(Object.keys(LANGUAGE_COLORS));
+
+    expect(uniqueLanguages.size).toBe(Object.keys(LANGUAGE_COLORS).length);
+    expect(uniqueLanguages.size).toBeGreaterThanOrEqual(20);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4403

Adds `lib/svg/languageColors.massive-scaling.test.ts` to verify LANGUAGE_COLORS behavior under massive data access patterns and extreme scaling scenarios.

### Added test coverage

* Verifies thousands of repeated language color lookups remain consistent without data corruption.
* Validates hexadecimal color values during large-scale iteration.
* Confirms language-to-color mappings remain stable under high-volume access.
* Ensures large derived language collections preserve all expected entries.
* Verifies unique language identifiers remain intact under massive scaling scenarios.

### Validation

* `languageColors.massive-scaling.test.ts` → 5/5 tests passing
* `npx eslint lib/svg/languageColors.massive-scaling.test.ts` ✅
* `npm run format:check` ✅
* Prettier formatting applied successfully

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.