### PR TITLE
Resolves Issue-#4343

### DIFF
--- a/app/customize/utils.massive-scaling.test.ts
+++ b/app/customize/utils.massive-scaling.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+import { buildQueryParams, getExportSnippet, getBadgeUrl } from './utils';
+import type { CustomizeOptions, ExportFormat } from './types';
+
+describe('utils - Massive Data Sets and Extreme High Bounds Scaling', () => {
+  it('1. should populate mock objects with extreme metrics without overflow', () => {
+    const extremeOptions: CustomizeOptions = {
+      username: 'a'.repeat(255),
+      theme: 'dark',
+      bgHex: '#ffffff',
+      bgType: 'solid',
+      bgStart: '',
+      bgEnd: '',
+      bgAngle: 90,
+      accentHex: '#000000',
+      textHex: '#111111',
+      scale: 'log',
+      speed: '20s',
+      font: 'jetbrains',
+      year: '2099',
+      radius: 999999,
+      size: 'large',
+      hideTitle: true,
+      hideBackground: true,
+      hideStats: true,
+      viewMode: 'pulse',
+      deltaFormat: 'both',
+      badgeWidth: 999999,
+      badgeHeight: 999999,
+      grace: 999999,
+      language: 'es',
+      timezone: 'Asia/Kolkata',
+    };
+
+    const start = performance.now();
+    const result = buildQueryParams(extremeOptions);
+    const elapsed = performance.now() - start;
+
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeLessThan(8000);
+    expect(result).toContain('radius=999999');
+    expect(result).toContain('grace=999999');
+    expect(result).toContain('width=999999');
+    expect(result).toContain('height=999999');
+    expect(result).toContain('scale=log');
+    expect(result).toContain('speed=20s');
+    expect(result).toContain('font=jetbrains');
+    expect(result).toContain('year=2099');
+    expect(result).toContain('size=large');
+    expect(result).toContain('hide_title=true');
+    expect(result).toContain('hide_background=true');
+    expect(result).toContain('hide_stats=true');
+    expect(result).toContain('view=pulse');
+    expect(result).toContain('delta_format=both');
+    expect(result).toContain('lang=es');
+    expect(result).toContain('tz=Asia%2FKolkata');
+    expect(elapsed).toBeLessThan(50);
+  });
+
+  it('2. should render the module under highly loaded configuration without crashing', () => {
+    const baseParam = 'user=' + 'a'.repeat(1000);
+    const params = Array.from({ length: 5 }, (_, i) => `param${i}=` + 'b'.repeat(1000)).join('&');
+    const massiveQueryString = `${baseParam}&${params}&theme=dark`;
+
+    const formats: ExportFormat[] = ['markdown', 'html', 'action', 'tsx'];
+
+    formats.forEach((format) => {
+      const start = performance.now();
+      const snippet = getExportSnippet(format, massiveQueryString);
+      const elapsed = performance.now() - start;
+
+      expect(typeof snippet).toBe('string');
+      expect(snippet.length).toBeGreaterThan(0);
+      expect(snippet).toContain(massiveQueryString);
+      if (format === 'tsx') {
+        expect(snippet).toContain("'use client';");
+        expect(snippet).toContain('export function CommitPulse');
+      }
+      expect(elapsed).toBeLessThan(50);
+    });
+  });
+
+  it('3. should produce valid SVG coordinate params under extreme display bounds', () => {
+    const extremeOptions: CustomizeOptions = {
+      username: 'testuser',
+      theme: 'dark',
+      bgHex: '',
+      bgType: 'linear',
+      bgStart: '#ff0000',
+      bgEnd: '#0000ff',
+      bgAngle: 359,
+      accentHex: '',
+      textHex: '',
+      scale: 'linear',
+      speed: '8s',
+      font: 'Inter',
+      year: '',
+      radius: 8,
+      size: 'medium',
+      hideTitle: false,
+      hideBackground: false,
+      hideStats: false,
+      viewMode: 'default',
+      deltaFormat: 'percent',
+      badgeWidth: 99999,
+      badgeHeight: 99999,
+      grace: 1,
+      language: 'en',
+      timezone: 'UTC',
+    };
+
+    const query = buildQueryParams(extremeOptions);
+    const parsed = new URLSearchParams(query);
+
+    const angle = parsed.get('bgAngle');
+    expect(angle).toBe('359');
+    const angleNum = Number(angle);
+    expect(angleNum).toBeGreaterThanOrEqual(0);
+    expect(angleNum).toBeLessThanOrEqual(360);
+
+    const width = parsed.get('width');
+    const height = parsed.get('height');
+    expect(width).toBe('99999');
+    expect(height).toBe('99999');
+    expect(Number.isFinite(Number(width))).toBe(true);
+    expect(Number.isFinite(Number(height))).toBe(true);
+
+    const bgStart = parsed.get('bgStart');
+    const bgEnd = parsed.get('bgEnd');
+    expect(bgStart).toBe('ff0000');
+    expect(bgEnd).toBe('0000ff');
+    expect(bgStart).not.toContain('#');
+    expect(bgEnd).not.toContain('#');
+  });
+
+  it('4. should complete 1000 buildQueryParams calls within performance margin', () => {
+    const testOptions: CustomizeOptions = {
+      username: 'heavyuser',
+      theme: 'light',
+      bgHex: '#ffffff',
+      bgType: 'radial',
+      bgStart: '#111111',
+      bgEnd: '#222222',
+      bgAngle: 45,
+      accentHex: '#333333',
+      textHex: '#444444',
+      scale: 'log',
+      speed: '12s',
+      font: 'roboto',
+      year: '2025',
+      radius: 15,
+      size: 'small',
+      hideTitle: true,
+      hideBackground: true,
+      hideStats: true,
+      viewMode: 'skyline',
+      deltaFormat: 'absolute',
+      badgeWidth: 800,
+      badgeHeight: 600,
+      grace: 5,
+      language: 'fr',
+      timezone: 'Europe/Berlin',
+    };
+
+    const start = performance.now();
+    const firstResult = buildQueryParams(testOptions);
+
+    for (let i = 0; i < 1000; i++) {
+      const result = buildQueryParams(testOptions);
+      expect(result).toBe(firstResult);
+    }
+
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it('5. should generate 500 batch snippets without layout-breaking output', () => {
+    const start = performance.now();
+
+    for (let i = 0; i < 500; i++) {
+      const query = `user=user${i}&theme=theme${i}&radius=${i % 20}&width=${200 + i}`;
+      const htmlSnippet = getExportSnippet('html', query);
+      const markdownSnippet = getExportSnippet('markdown', query);
+
+      expect(htmlSnippet).toBeTruthy();
+      expect(markdownSnippet).toBeTruthy();
+
+      expect(htmlSnippet.startsWith('<img ')).toBe(true);
+      expect(htmlSnippet.endsWith(' />')).toBe(true);
+      expect(htmlSnippet).toContain(`user=user${i}`);
+      expect(htmlSnippet).toContain(`width=${200 + i}`);
+
+      expect(markdownSnippet.startsWith('![')).toBe(true);
+      expect(markdownSnippet).toContain(`](${getBadgeUrl(query)})`);
+    }
+
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
Closes #4343


## Description

Adds the new test file `app/customize/utils.massive-scaling.test.ts` to perform isolated scaling and performance verification on the customization utility functions (`app/customize/utils.ts`).

The tests assert:
1. **Extreme Option Metrics**: Confirms `buildQueryParams` handles extreme values (e.g., 255-char username, `999999` numeric values) cleanly.
2. **Large Query String Interpolation**: Validates snippet generation format safety under a highly loaded query string (thousands of characters).
3. **SVG/Gradient Coordinate Bounds**: Ensures extreme gradient angles (`359`) and display bounds (`99999`) serialize correctly into hash-stripped parameters.
4. **Volume Performance**: Benchmarks 1,000 runs of `buildQueryParams` to guarantee execution completes in `< 500ms`.
5. **Batch Snippet Layout Safety**: Generates 500 HTML/Markdown snippets to verify layout tag integrity under high volume.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A (Pure unit tests for utility functions)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
