### PR TITLE
test(generator): add empty fallback coverage

### DIFF
--- a/app/generator/GeneratorClient.tsx
+++ b/app/generator/GeneratorClient.tsx
@@ -12,6 +12,11 @@ const INITIAL_STATE: GeneratorState = {
   selectedTechs: [],
   selectedSocials: [],
   socialLinks: {},
+
+  githubUsername: '',
+  showCommitPulse: false,
+  commitPulseAccent: '',
+  showSnakeGraph: false,
 };
 
 export function GeneratorClient() {

--- a/app/generator/types.empty-fallback.test.ts
+++ b/app/generator/types.empty-fallback.test.ts
@@ -9,6 +9,11 @@ describe('GeneratorState empty fallback verification', () => {
     selectedTechs: [],
     selectedSocials: [],
     socialLinks: {},
+
+    githubUsername: '',
+    showCommitPulse: false,
+    commitPulseAccent: '',
+    showSnakeGraph: false,
   };
 
   it('handles empty generator state without crashing', () => {

--- a/app/generator/types.empty-fallback.test.ts
+++ b/app/generator/types.empty-fallback.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { generateReadme, getEmptyReadme } from './utils/readmeGenerator';
+import type { GeneratorState } from './types';
+
+describe('GeneratorState empty fallback verification', () => {
+  const emptyState: GeneratorState = {
+    name: '',
+    description: '',
+    selectedTechs: [],
+    selectedSocials: [],
+    socialLinks: {},
+  };
+
+  it('handles empty generator state without crashing', () => {
+    expect(() => generateReadme(emptyState)).not.toThrow();
+  });
+
+  it('returns empty output for missing name and description', () => {
+    expect(generateReadme(emptyState)).toBe('');
+  });
+
+  it('handles empty tech and social selections', () => {
+    const result = generateReadme({
+      ...emptyState,
+      selectedTechs: [],
+      selectedSocials: [],
+    });
+
+    expect(result).not.toContain('Tech Stack');
+    expect(result).not.toContain('Connect With Me');
+  });
+
+  it('ignores social links when no social is selected', () => {
+    const result = generateReadme({
+      ...emptyState,
+      socialLinks: {
+        github: 'https://github.com/test',
+      },
+    });
+
+    expect(result).not.toContain('github');
+    expect(result).not.toThrow;
+  });
+
+  it('provides default empty README fallback', () => {
+    const result = getEmptyReadme();
+
+    expect(result).toContain("Hi, I'm Your Name");
+    expect(result).toContain('Your description goes here...');
+  });
+});

--- a/app/generator/types.ts
+++ b/app/generator/types.ts
@@ -50,4 +50,9 @@ export interface GeneratorState {
   selectedTechs: string[];
   selectedSocials: string[];
   socialLinks: Record<string, string>;
+
+  githubUsername: string;
+  showCommitPulse: boolean;
+  commitPulseAccent: string;
+  showSnakeGraph: boolean;
 }

--- a/services/github/background-refresh.massive-scaling.test.ts
+++ b/services/github/background-refresh.massive-scaling.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BackgroundRefresh } from './background-refresh';
 import { getFullDashboardData } from '../../lib/github';
 
@@ -13,6 +13,10 @@ describe('BackgroundRefresh - Massive Data Sets and Extreme High Bounds Scaling 
     service = BackgroundRefresh.getInstance();
     service.reset();
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('processes 100,000 isStale calls with diverse timestamps and measures sub-2000ms execution', () => {
@@ -35,6 +39,8 @@ describe('BackgroundRefresh - Massive Data Sets and Extreme High Bounds Scaling 
   });
 
   it('validates isStale boundary at exact 10-minute threshold crossing', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
     const boundaryExceeded = new Date(Date.now() - 600001).toISOString();
     expect(service.isStale(boundaryExceeded)).toBe(true);
 


### PR DESCRIPTION
## Description

Fixes #4241 

Added empty/missing input coverage for generator README generation.

Covered:
- empty generator state
- empty tech/social selections
- missing social links
- default empty README fallback
- no runtime errors on empty inputs

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x ] I have read the `CONTRIBUTING.md` file.
- [ x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [ x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [ x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
