### PR TITLE
test(pr-insights): add empty input fallback coverage

### DIFF
--- a/app/api/pr-insights/route.empty-fallback.test.ts
+++ b/app/api/pr-insights/route.empty-fallback.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from './route';
+import { fetchPRInsights } from '@/services/github/pr-insights';
+import { RateLimiter } from '@/lib/rate-limit';
+
+vi.mock('@/services/github/pr-insights', () => ({
+  fetchPRInsights: vi.fn(),
+}));
+
+describe('PR Insights Route Empty/Missing Inputs Verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.spyOn(RateLimiter.prototype, 'checkWithResult').mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: 123456789,
+    });
+
+    vi.mocked(fetchPRInsights).mockResolvedValue([] as never);
+  });
+
+  it('returns username required when username query parameter is completely missing', async () => {
+    const request = new Request('http://localhost/api/pr-insights');
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      error: 'Username is required',
+    });
+
+    expect(fetchPRInsights).not.toHaveBeenCalled();
+  });
+
+  it('returns username required when username is provided as an empty string', async () => {
+    const request = new Request('http://localhost/api/pr-insights?username=');
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      error: 'Username is required',
+    });
+
+    expect(fetchPRInsights).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid username when username contains only whitespace characters', async () => {
+    const request = new Request('http://localhost/api/pr-insights?username=%20%20%20%20');
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      error: 'Invalid GitHub username',
+    });
+
+    expect(fetchPRInsights).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid username when username contains only tabs and newlines', async () => {
+    const request = new Request('http://localhost/api/pr-insights?username=%0A%09');
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      error: 'Invalid GitHub username',
+    });
+
+    expect(fetchPRInsights).not.toHaveBeenCalled();
+  });
+
+  it('trims excessive surrounding whitespace and successfully fetches insights', async () => {
+    const request = new Request(
+      'http://localhost/api/pr-insights?username=%20%20%20octocat%20%20%20'
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(fetchPRInsights).toHaveBeenCalledWith('octocat');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4202

Added `route.empty-fallback.test.ts` to verify edge-case handling and fallback behavior for the PR Insights API route when optional or missing inputs are provided.

### Test coverage includes:

* Empty or missing query parameter handling.
* Graceful fallback behavior for incomplete request inputs.
* Verification that the route returns a valid non-breaking response.
* Runtime stability when optional values are omitted.
* Consistent API behavior under empty-input scenarios.

The new tests focus on production-relevant edge cases to ensure the endpoint remains resilient when receiving incomplete or minimally configured requests.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A – Test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.