### PR TITLE
fix(github): replace fabricated Math.random() LOC data with null values

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -897,8 +897,8 @@ async function fetchContributionsUncached(
         }
         return {
           ...rawDay,
-          locAdditions: Math.max(1, Math.floor(Math.random() * (count * 10))),
-          locDeletions: Math.floor(Math.random() * (count * 5)),
+          locAdditions: null, // GitHub API does not expose per-day LOC data
+          locDeletions: null, // GitHub API does not expose per-day LOC data
         };
       }),
     };


### PR DESCRIPTION
## Description
Fixes #5567 

`lib/github.ts` was generating fake Lines of Code (LOC) data using `Math.random()` 
and serving it as real GitHub stats. Every request returned different random numbers 
for the same user, making the data unreliable and misleading. GitHub's GraphQL API 
does not expose per-day LOC addition/deletion data, so these fields are now set to 
`null` with a clear comment explaining why.

## Changes
- `lib/github.ts` — replaced `Math.random()` LOC values with `null` on lines 900-901
- Added inline comments clarifying GitHub API does not expose this data

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — data layer fix, no visual output change.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `fix(github): replace fabricated Math.random() LOC data with null values`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.