### PR TITLE
test(useRecentSearches): add empty fallback coverage for storage edge cases

### DIFF
--- a/hooks/useRecentSearches.empty-fallback.test.ts
+++ b/hooks/useRecentSearches.empty-fallback.test.ts
@@ -1,0 +1,58 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { useRecentSearches, STORAGE_KEY } from './useRecentSearches';
+
+describe('useRecentSearches Empty & Missing Input Fallbacks', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('returns an empty search list when storage is completely empty', () => {
+    const { result } = renderHook(() => useRecentSearches());
+
+    expect(result.current.searches).toEqual([]);
+  });
+
+  it('falls back to an empty list when localStorage contains malformed JSON', () => {
+    window.localStorage.setItem(STORAGE_KEY, '{invalid-json');
+
+    const { result } = renderHook(() => useRecentSearches());
+
+    expect(result.current.searches).toEqual([]);
+  });
+
+  it('falls back to an empty list when localStorage contains null', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'null');
+
+    const { result } = renderHook(() => useRecentSearches());
+
+    expect(result.current.searches).toEqual([]);
+  });
+
+  it('ignores removeSearch calls when the target item does not exist', () => {
+    const { result } = renderHook(() => useRecentSearches());
+
+    act(() => {
+      result.current.addSearch('octocat');
+    });
+
+    act(() => {
+      result.current.removeSearch('missing-user');
+    });
+
+    expect(result.current.searches).toEqual(['octocat']);
+  });
+
+  it('remains stable when localStorage access throws unexpectedly', () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage unavailable');
+    });
+
+    const { result } = renderHook(() => useRecentSearches());
+
+    expect(result.current.searches).toEqual([]);
+
+    getItemSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4271 

Added a dedicated empty-fallback test suite for `hooks/useRecentSearches.ts`.

### Coverage Added

- Verifies the hook initializes correctly when localStorage is empty.
- Tests fallback behavior when localStorage contains malformed JSON.
- Validates handling of `null` values stored in localStorage.
- Confirms removal operations are safely ignored when the requested search entry does not exist.
- Ensures the hook remains stable when localStorage access unexpectedly throws errors.

The test suite focuses on real edge cases present in the hook implementation, specifically around storage hydration, malformed persistence data, missing values, and storage access failures. These scenarios help ensure the hook remains resilient and does not introduce runtime errors when persistence data is unavailable or invalid.

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

- N/A – Test-only changes.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
