### PR TITLE
fix(ci-analytics): use per-IP rate limiting instead of shared global key

### DIFF
--- a/app/api/ci-analytics/route.test.ts
+++ b/app/api/ci-analytics/route.test.ts
@@ -22,15 +22,22 @@ describe('GET /api/ci-analytics', () => {
     expect(fetchCIAnalytics).not.toHaveBeenCalled();
   });
 
-  it('uses a fixed endpoint bucket that cannot be rotated with usernames', async () => {
+  it('uses per-IP rate limiting so different IPs get independent buckets', async () => {
     vi.mocked(fetchCIAnalytics).mockResolvedValue({} as never);
     const checkSpy = vi.spyOn(RateLimiter.prototype, 'check').mockResolvedValue(true);
 
-    await GET(new Request('http://localhost/api/ci-analytics?username=octocat'));
-    await GET(new Request('http://localhost/api/ci-analytics?username=torvalds'));
-
-    expect(checkSpy).toHaveBeenNthCalledWith(1, 'ci-analytics');
-    expect(checkSpy).toHaveBeenNthCalledWith(2, 'ci-analytics');
+    await GET(
+      new Request('http://localhost/api/ci-analytics?username=octocat', {
+        headers: { 'x-forwarded-for': '1.2.3.4' },
+      })
+    );
+    await GET(
+      new Request('http://localhost/api/ci-analytics?username=octocat', {
+        headers: { 'x-forwarded-for': '5.6.7.8' },
+      })
+    );
+    expect(checkSpy).toHaveBeenNthCalledWith(1, '1.2.3.4');
+    expect(checkSpy).toHaveBeenNthCalledWith(2, '5.6.7.8');
   });
 
   it('rejects invalid GitHub usernames before the service fan-out', async () => {

--- a/app/api/ci-analytics/route.ts
+++ b/app/api/ci-analytics/route.ts
@@ -6,13 +6,17 @@ import { RateLimiter } from '@/lib/rate-limit';
 const ciAnalyticsLimiter = new RateLimiter(10, 60_000, 1);
 
 export async function GET(request: Request) {
-  if (!(await ciAnalyticsLimiter.check('ci-analytics'))) {
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    request.headers.get('x-real-ip') ??
+    'unknown';
+
+  if (!(await ciAnalyticsLimiter.check(ip))) {
     return NextResponse.json(
       { error: 'Too many requests. Please try again later.' },
       { status: 429 }
     );
   }
-
   const { searchParams } = new URL(request.url);
   const username = searchParams.get('username')?.trim();
 


### PR DESCRIPTION
## Description

Fixes #5580 

## Problem
`app/api/ci-analytics/route.ts` used a hardcoded string `'ci-analytics'` 
as the rate limiter key, creating a single shared bucket for all users:

```if (!(await ciAnalyticsLimiter.check('ci-analytics'))) {```

This means all users share 10 requests per minute globally. A single user 
making 10 rapid requests exhausts the limit for every other user, effectively 
enabling a trivial DoS on the endpoint.

## Fix
Extract the client IP from request headers and use it as the rate limit key 
so each user gets their own independent bucket:

```const ip =
  request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
  request.headers.get('x-real-ip') ??
  'unknown';

if (!(await ciAnalyticsLimiter.check(ip))) {
```

This matches the pattern already used correctly in `/api/webhook` and 
`/api/reviews`.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [X] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [X] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [X] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [X] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

Suggested Lables: level:critical, bug, security
