### PR TITLE
test(recommendationEngine): add empty fallback coverage for invalid selections

### DIFF
--- a/lib/graph/recommendationEngine.empty-fallback.test.ts
+++ b/lib/graph/recommendationEngine.empty-fallback.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { getRecommendations } from './recommendationEngine';
+
+describe('Recommendation Engine Empty & Missing Input Fallbacks', () => {
+  it('returns an empty array when selectedIds is undefined', () => {
+    expect(getRecommendations(undefined as unknown as string[])).toEqual([]);
+  });
+
+  it('returns an empty array when selectedIds is null', () => {
+    expect(getRecommendations(null as unknown as string[])).toEqual([]);
+  });
+
+  it('returns an empty array when all selected technologies are unknown', () => {
+    const recommendations = getRecommendations(['unknown-tech', 'another-unknown-tech']);
+
+    expect(recommendations).toEqual([]);
+  });
+
+  it('ignores unknown technologies while still processing valid selections', () => {
+    const recommendations = getRecommendations(['react', 'unknown-tech']);
+
+    expect(recommendations.length).toBeGreaterThan(0);
+
+    expect(recommendations.some((rec) => rec.id === 'tailwindcss')).toBe(true);
+  });
+
+  it('returns stable recommendation objects when no candidate technologies remain', () => {
+    const recommendations = getRecommendations([
+      'react',
+      'nextjs',
+      'typescript',
+      'tailwindcss',
+      'nodejs',
+    ]);
+
+    recommendations.forEach((recommendation) => {
+      expect(recommendation.id).toBeTruthy();
+      expect(recommendation.score).toBeGreaterThanOrEqual(0);
+      expect(recommendation.score).toBeLessThanOrEqual(100);
+      expect(recommendation.reasons).toBeDefined();
+      expect(Array.isArray(recommendation.reasons)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4278 

Added a dedicated empty-fallback test suite for `lib/graph/recommendationEngine.ts`.

### Coverage Added

- Verifies the recommendation engine safely returns an empty array when provided with `undefined` input.
- Tests graceful handling of `null` selections without runtime failures.
- Confirms unknown technology identifiers produce a safe empty result instead of invalid recommendations.
- Validates that invalid technology IDs are ignored when mixed with valid selections.
- Ensures recommendation objects remain stable and correctly structured when edge-case selection sets are processed.

The test suite focuses on real fallback and defensive-code paths present in the recommendation engine implementation, specifically around missing selections, invalid identifiers, and mixed valid/invalid inputs. These scenarios help guarantee stable recommendation generation when upstream data is incomplete or malformed.

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

- N/A – Test-only changes.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
