### PR TITLE
test(dependencyGraph): add empty fallback coverage for missing node access

### DIFF
--- a/lib/graph/dependencyGraph.empty-fallback.test.ts
+++ b/lib/graph/dependencyGraph.empty-fallback.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { DEPENDENCY_GRAPH } from './dependencyGraph';
+
+describe('DEPENDENCY_GRAPH Empty & Missing Input Fallbacks', () => {
+  it('returns undefined for null-like key access', () => {
+    expect(DEPENDENCY_GRAPH[null as unknown as string]).toBeUndefined();
+  });
+
+  it('returns undefined for undefined-like key access', () => {
+    expect(DEPENDENCY_GRAPH[undefined as unknown as string]).toBeUndefined();
+  });
+
+  it('returns undefined for whitespace-only key lookups', () => {
+    expect(DEPENDENCY_GRAPH[' ']).toBeUndefined();
+    expect(DEPENDENCY_GRAPH['   ']).toBeUndefined();
+    expect(DEPENDENCY_GRAPH['\t']).toBeUndefined();
+    expect(DEPENDENCY_GRAPH['\n']).toBeUndefined();
+  });
+
+  it('safely handles access to missing graph nodes without runtime failures', () => {
+    const missingNode = DEPENDENCY_GRAPH['technology-that-does-not-exist'];
+
+    expect(missingNode).toBeUndefined();
+
+    const edges = missingNode?.edges ?? [];
+
+    expect(edges).toEqual([]);
+  });
+
+  it('maintains valid fallback graph structure when traversing unknown nodes', () => {
+    const requestedNodes = ['', 'unknown-tech', 'missing-node', '   '];
+
+    const resolvedNodes = requestedNodes.map((id) => DEPENDENCY_GRAPH[id]).filter(Boolean);
+
+    expect(resolvedNodes).toEqual([]);
+
+    expect(Object.keys(DEPENDENCY_GRAPH).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4277 

Added a dedicated empty-fallback test suite for `lib/graph/dependencyGraph.ts`.

### Coverage Added

- Verifies null-like key access safely returns undefined.
- Tests undefined-like key access without triggering runtime failures.
- Validates whitespace-only graph node lookups return safe fallback results.
- Confirms missing node traversal patterns gracefully resolve to empty collections.
- Ensures the exported dependency graph remains structurally valid while handling invalid and unknown node identifiers.

The test suite focuses on real edge cases that can occur when consumers access the dependency graph with invalid, missing, or malformed identifiers. These tests exercise defensive access patterns and verify that graph consumers can safely handle fallback scenarios without introducing runtime exceptions.

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

- N/A – Test-only changes.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
