### PR TITLE
test(return-to-top): add empty input fallback coverage

### DIFF
--- a/components/ReturnToTop.empty-fallback.test.tsx
+++ b/components/ReturnToTop.empty-fallback.test.tsx
@@ -1,0 +1,153 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let reducedMotion = false;
+
+type ButtonMotionProps = {
+  children?: React.ReactNode;
+  whileHover?: unknown;
+  whileTap?: unknown;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: {
+      children?: React.ReactNode;
+    } & React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+
+    span: ({
+      children,
+      ...props
+    }: {
+      children?: React.ReactNode;
+    } & React.HTMLAttributes<HTMLSpanElement>) => <span {...props}>{children}</span>,
+
+    button: ({
+      children,
+      whileHover: _whileHover,
+      whileTap: _whileTap,
+      ...props
+    }: ButtonMotionProps) => {
+      void _whileHover;
+      void _whileTap;
+
+      return <button {...props}>{children}</button>;
+    },
+    circle: (props: React.SVGProps<SVGCircleElement>) => <circle {...props} />,
+  },
+
+  useReducedMotion: () => reducedMotion,
+  useScroll: () => ({ scrollYProgress: 0 }),
+  useSpring: (value: unknown) => value,
+  useTransform: () => 0,
+}));
+
+vi.mock('lucide-react', () => ({
+  ChevronUp: () => <svg data-testid="chevron-up-icon" />,
+}));
+
+import ReturnToTop from './ReturnToTop';
+
+describe('ReturnToTop Empty/Missing Inputs Verification', () => {
+  beforeEach(() => {
+    reducedMotion = false;
+
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    vi.restoreAllMocks();
+  });
+
+  it('renders safely without displaying the button when page is at the top', () => {
+    render(<ReturnToTop />);
+
+    expect(screen.queryByRole('button', { name: /back to top/i })).not.toBeInTheDocument();
+  });
+
+  it('remains hidden when scroll position stays below the visibility threshold', () => {
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 299,
+    });
+
+    render(<ReturnToTop />);
+
+    fireEvent.scroll(window);
+
+    expect(screen.queryByRole('button', { name: /back to top/i })).not.toBeInTheDocument();
+  });
+
+  it('becomes visible when scroll position exceeds the visibility threshold', () => {
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 301,
+    });
+
+    render(<ReturnToTop />);
+
+    fireEvent.scroll(window);
+
+    expect(screen.getByRole('button', { name: /back to top/i })).toBeInTheDocument();
+  });
+
+  it('uses auto scrolling behavior when reduced-motion mode is enabled', () => {
+    reducedMotion = true;
+
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 500,
+    });
+
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    render(<ReturnToTop />);
+
+    fireEvent.scroll(window);
+    fireEvent.click(screen.getByRole('button', { name: /back to top/i }));
+
+    expect(scrollToSpy).toHaveBeenCalledWith({
+      top: 0,
+      behavior: 'auto',
+    });
+  });
+
+  it('maintains stable visibility state across multiple scroll events', () => {
+    render(<ReturnToTop />);
+
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 350,
+    });
+
+    fireEvent.scroll(window);
+
+    expect(screen.getByRole('button', { name: /back to top/i })).toBeInTheDocument();
+
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 150,
+    });
+
+    fireEvent.scroll(window);
+
+    expect(screen.queryByRole('button', { name: /back to top/i })).not.toBeInTheDocument();
+
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 450,
+    });
+
+    fireEvent.scroll(window);
+
+    expect(screen.getByRole('button', { name: /back to top/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4249

Added `components/ReturnToTop.empty-fallback.test.tsx` to verify edge-case handling and fallback behavior for the ReturnToTop component when rendered under minimal or default conditions.

### What was tested

* Verifies the component renders safely without displaying the button when the page is initially at the top.
* Verifies the button remains hidden when scroll position stays below the visibility threshold.
* Verifies the button becomes visible once the scroll position exceeds the configured threshold.
* Verifies reduced-motion mode uses non-animated scrolling behavior when returning to the top.
* Verifies visibility state remains stable across multiple scroll position changes without runtime issues.

### Why

The ReturnToTop component relies on browser scroll state, visibility thresholds, and motion preferences. These tests ensure the component behaves predictably when no meaningful scroll state exists, when visibility conditions are not met, and when reduced-motion settings are enabled. This improves reliability and guards against regressions in default and edge-case scenarios.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.