### PR TITLE
fix: return 400 for invalid tz param instead of silent UTC fallback

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -129,6 +129,7 @@ export async function GET(request: Request) {
         if (error instanceof Error && error.name === 'ValidationError') {
           return NextResponse.json({ error: error.message }, { status: 400 });
         }
+        return NextResponse.json({ error: `Invalid timezone: ${tzParam}` }, { status: 400 });
       }
     }
 


### PR DESCRIPTION
Before: returns `200` with SVG, silently defaults to UTC.
After: returns `400` with `{ "error": "Invalid timezone: NotATimezone" }`.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter. *(N/A — no new param added)*
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). *(N/A — no SVG change)*
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.