### PR TITLE
Fix/loc deterministic random

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -12,6 +12,7 @@ import { DistributedCache } from '@/lib/cache';
 import { LANGUAGE_COLORS } from '@/lib/svg/languageColors';
 import { CONTRIBUTION_MILESTONES, STREAK_MILESTONES } from './svg/constants';
 import { quotaMonitor } from '@/services/github/quota-monitor';
+import { deterministicRandom } from '@/lib/svg/generator';
 
 interface GitHubRepo {
   name: string;
@@ -897,8 +898,13 @@ async function fetchContributionsUncached(
         }
         return {
           ...rawDay,
-          locAdditions: Math.max(1, Math.floor(Math.random() * (count * 10))),
-          locDeletions: Math.floor(Math.random() * (count * 5)),
+          locAdditions: Math.max(
+            1,
+            Math.floor(deterministicRandom(`${username}:${rawDay.date}:additions`) * (count * 10))
+          ),
+          locDeletions: Math.floor(
+            deterministicRandom(`${username}:${rawDay.date}:deletions`) * (count * 5)
+          ),
         };
       }),
     };


### PR DESCRIPTION
## Description
Fixes #5600

I'm a GSSoC'26 contributor working on this fix.

In `fetchContributionsUncached` (`lib/github.ts`), LOC values for `mode=loc` were generated using `Math.random()`, making them non-deterministic. Every cache miss produced completely different `locAdditions` and `locDeletions` values for the same user on the same date, breaking cache integrity and making the `mode=loc` badge visually unstable across requests.

This fix replaces `Math.random()` with the existing `deterministicRandom()` utility (already exported from `lib/svg/generator.ts` and used throughout the codebase), seeded with `username + date` to produce stable, consistent LOC estimates per user per day.

**Before:**
locAdditions: Math.max(1, Math.floor(Math.random() * (count * 10))),
locDeletions: Math.floor(Math.random() * (count * 5)),

**After:**
locAdditions: Math.max(1, Math.floor(deterministicRandom(`${username}:${rawDay.date}:additions`) * (count * 10))),
locDeletions: Math.floor(deterministicRandom(`${username}:${rawDay.date}:deletions`) * (count * 5)),

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — backend data processing fix. No visual change in SVG structure; LOC values are now stable and consistent across requests for the same user.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter. *(N/A — no new param added)*
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). *(N/A — no SVG change)*
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.