### PR TITLE
test(StatsCardSkeleton-massive-scaling): verify Massive Data Sets and Extreme High Bounds Scaling (Variation 2)

### DIFF
--- a/components/dashboard/StatsCardSkeleton.massive-scaling.test.tsx
+++ b/components/dashboard/StatsCardSkeleton.massive-scaling.test.tsx
@@ -1,0 +1,96 @@
+import { describe, test, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import StatsCardSkeleton from './StatsCardSkeleton';
+
+describe('StatsCardSkeleton - Massive Data Scaling', () => {
+  test('should preserve structure across 1000 parallel instances', () => {
+    const count = 1000;
+    const { container } = render(
+      <div>
+        {Array.from({ length: count }).map((_, i) => (
+          <StatsCardSkeleton key={i} />
+        ))}
+      </div>
+    );
+
+    expect(container.querySelectorAll('.overflow-hidden')).toHaveLength(count);
+    expect(container.querySelectorAll('.space-y-3')).toHaveLength(count);
+  });
+
+  test('should render correct shimmer node counts under massive grid load', () => {
+    const cardsCount = 500;
+    const { container } = render(
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)' }}>
+        {Array.from({ length: cardsCount }).map((_, i) => (
+          <StatsCardSkeleton key={i} />
+        ))}
+      </div>
+    );
+
+    // 3 text placeholders + 1 icon placeholder + 12 chart bars = 16 shimmer nodes per card
+    // 500 cards * 16 shimmers = 8000 total nodes
+    expect(container.querySelectorAll('.shimmer')).toHaveLength(cardsCount * 16);
+  });
+
+  test('should scale micro-chart elements linearly with dataset size', () => {
+    const count = 1000;
+    const { container } = render(
+      <div>
+        {Array.from({ length: count }).map((_, i) => (
+          <StatsCardSkeleton key={i} />
+        ))}
+      </div>
+    );
+
+    // 1000 cards * 12 chart bars = 12000 total column nodes
+    expect(container.querySelectorAll('.flex-1.shimmer')).toHaveLength(count * 12);
+  });
+
+  test('should render exact deterministic chart heights matching specifications', () => {
+    const { container } = render(<StatsCardSkeleton />);
+
+    const expectedHeights = [
+      '24%',
+      '32%',
+      '18%',
+      '45%',
+      '38%',
+      '52%',
+      '28%',
+      '42%',
+      '35%',
+      '48%',
+      '30%',
+      '22%',
+    ];
+    const chartBars = container.querySelectorAll('.flex-1.shimmer');
+
+    expect(chartBars).toHaveLength(expectedHeights.length);
+
+    chartBars.forEach((bar, index) => {
+      const htmlElement = bar as HTMLElement;
+      expect(htmlElement.style.height).toBe(expectedHeights[index]);
+    });
+  });
+
+  test('should maintain node tree integrity when deeply nested', () => {
+    const nestedCount = 10;
+
+    const { container } = render(
+      <div className="super-wrapper-grid">
+        <div className="sub-wrapper-flex">
+          <section className="inner-dashboard-panel">
+            {Array.from({ length: nestedCount }).map((_, i) => (
+              <StatsCardSkeleton key={i} />
+            ))}
+          </section>
+        </div>
+      </div>
+    );
+
+    const parentContainer = container.querySelector('.inner-dashboard-panel');
+    expect(parentContainer).not.toBeNull();
+    expect(parentContainer?.querySelectorAll('.overflow-hidden')).toHaveLength(nestedCount);
+  });
+});


### PR DESCRIPTION
## Description

This PR introduces a brand-new, isolated massive scaling test suite for the `StatsCardSkeleton` dashboard component, fulfilling the requirements specified in the issue tracking card. 

Because virtual DOM environments (JSDOM) do not process real pixel dimensions, layout trees, or SVG graphics on unrendered canvas frames, this test suite bypasses fragile viewport mocking and flakey timing assertions (`performance.now()`). Instead, it anchors its verification on rigid, deterministic structural constraints, absolute array indexes, and DOM node count tracking under intense data scaling bounds.

**Key Assertions Verified:**
* **Structural Preservation:** Asserts tree node stability and layout integrity when mounting `1,000` concurrent instances simultaneously.
* **Shimmer Density:** Confirms exact DOM element totals (`8,000` nodes) scale flawlessly across complex flex-grid matrix groupings of `500` components.
* **Micro-Chart Linearity:** Validates that nested dashboard mini-charts generate exactly `12,000` distinct columns matching high data limits.
* **Deterministic Metrics:** Maps internal component styling records against the explicit, exact percentages set by the design architecture (`24%` to `22%`).
* **Deep Nesting Hierarchy:** Guarantees deep hierarchy wrappers process layout trees cleanly without dropping node frames.

Closes #4380

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs / Testing Integration)

## Visual Preview
All 5 isolated scaling test criteria pass successfully under Vitest local validation.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`npm run test`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format (e.g., `test(dashboard): add massive scaling verification suite for statscardskeleton`).
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.