### PR TITLE
fix(config): add HTTP security headers to next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,25 @@
 import type { NextConfig } from 'next';
-
 const nextConfig: NextConfig = {
-  // Prevent Turbopack from bundling next/og through its shared module context,
-  // which causes the "Next.js package not found" HMR panic on dynamic routes.
   serverExternalPackages: ['next/og', '@resvg/resvg-js'],
-  // Allow the local network IP to access dev resources without cross-origin warnings
   allowedDevOrigins: ['172.31.128.1'],
   devIndicators: false,
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+        ],
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {
@@ -20,5 +33,4 @@ const nextConfig: NextConfig = {
     ],
   },
 };
-
 export default nextConfig;


### PR DESCRIPTION
## Description
Fixes #5568 

The application had no HTTP security headers configured, leaving it exposed 
to clickjacking, MIME-type sniffing, and referrer data leakage. This PR adds 
a `headers()` function to `next.config.ts` that applies security headers to 
all routes.

## Changes
- `next.config.ts` — added `headers()` config with the following headers:
  - `X-Frame-Options: DENY` — prevents clickjacking
  - `X-Content-Type-Options: nosniff` — prevents MIME sniffing
  - `Referrer-Policy: strict-origin-when-cross-origin` — controls referrer leakage
  - `Permissions-Policy` — disables camera, microphone, geolocation
  - `Strict-Transport-Security` — enforces HTTPS with 2 year max-age

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — config change, no visual output.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `fix(config): add HTTP security headers to next.config.ts`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.