### PR TITLE
test: verify edge cases and missing inputs for resume confirm route

### DIFF
--- a/app/api/student/resume/confirm/route.empty-fallback.test.ts
+++ b/app/api/student/resume/confirm/route.empty-fallback.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { POST } from './route';
+import { StudentProfile } from '@/models/StudentProfile';
+
+vi.mock('@/lib/mongodb', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('@/models/StudentProfile', () => ({
+  StudentProfile: {
+    findOneAndUpdate: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/rate-limit', () => {
+  return {
+    RateLimiter: class {
+      check() {
+        return Promise.resolve(true);
+      }
+    },
+  };
+});
+
+vi.mock('@/lib/github-owner-verification', () => ({
+  verifyGitHubOwner: vi.fn().mockResolvedValue({ verified: true }),
+}));
+
+import { verifyGitHubOwner } from '@/lib/github-owner-verification';
+
+function makeRequest(body: string | Record<string, unknown>): Request {
+  return new Request('http://localhost/api/student/resume/confirm', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-owner-token',
+    },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+describe('POST /api/student/resume/confirm Edge Cases & Empty/Missing Inputs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.MONGODB_URI = 'mongodb://localhost:27017/test';
+    vi.mocked(verifyGitHubOwner).mockResolvedValue({ verified: true });
+  });
+
+  afterEach(() => {
+    delete process.env.MONGODB_URI;
+  });
+
+  it('returns 200 when optional arrays are provided but empty', async () => {
+    vi.mocked(StudentProfile.findOneAndUpdate).mockResolvedValueOnce({} as never);
+
+    const response = await POST(
+      makeRequest({
+        githubUsername: 'testuser',
+        data: {
+          name: 'John Doe',
+          email: 'john@example.com',
+          skills: [],
+          education: [],
+          experience: [],
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+
+    expect(StudentProfile.findOneAndUpdate).toHaveBeenCalledWith(
+      { githubUsername: 'testuser' },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          skills: [],
+          education: [],
+          experience: [],
+        }),
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('returns 200 when optional fields are completely omitted', async () => {
+    vi.mocked(StudentProfile.findOneAndUpdate).mockResolvedValueOnce({} as never);
+
+    const response = await POST(
+      makeRequest({
+        githubUsername: 'testuser',
+        data: {
+          name: 'John Doe',
+          email: 'john@example.com',
+          // Omitting skills, education, experience, phone
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+
+    expect(StudentProfile.findOneAndUpdate).toHaveBeenCalledWith(
+      { githubUsername: 'testuser' },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          skills: [],
+          education: [],
+          experience: [],
+          phone: '',
+        }),
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('returns 400 when required fields are empty strings', async () => {
+    const response = await POST(
+      makeRequest({
+        githubUsername: 'testuser',
+        data: {
+          name: '   ', // whitespace only
+          email: '',
+        },
+      })
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Name and email are required');
+    expect(StudentProfile.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when data object is entirely empty', async () => {
+    const response = await POST(
+      makeRequest({
+        githubUsername: 'testuser',
+        data: {},
+      })
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Name and email are required');
+    expect(StudentProfile.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when null is provided for arrays', async () => {
+    const response = await POST(
+      makeRequest({
+        githubUsername: 'testuser',
+        data: {
+          name: 'John Doe',
+          email: 'john@example.com',
+          skills: null,
+          education: null,
+        },
+      })
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    // Zod will return an invalid_type error because it expects an array, not null
+    expect(body.error).toBeDefined();
+    expect(StudentProfile.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4206

This PR adds comprehensive unit testing to the `app/api/student/resume/confirm/route.ts` endpoint focusing specifically on edge cases and missing/empty inputs. 

The new test file (`route.empty-fallback.test.ts`) verifies the following without modifying any production code:
- Proper fallback to defaults when optional arrays (`skills`, `education`, `experience`) are explicitly sent as empty or completely omitted.
- Validation catching required strings sent as empty/whitespace strings.
- Graceful `400 Bad Request` handling for completely empty JSON objects (`{}`) and null payloads, preventing unhandled server exceptions.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

*(Not applicable — API Unit Tests Only)*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
