### PR TITLE
feat(pr-insights): add interactive pulse animations to metric cards

### DIFF
--- a/components/dashboard/PRInsights/AnimatedMetricIcon.tsx
+++ b/components/dashboard/PRInsights/AnimatedMetricIcon.tsx
@@ -1,0 +1,300 @@
+import { motion } from 'framer-motion';
+
+interface AnimatedMetricIconProps {
+  type: string;
+  hovered: boolean;
+}
+
+export default function AnimatedMetricIcon({ type, hovered }: AnimatedMetricIconProps) {
+  const baseTransition = {
+    duration: 2.2,
+    repeat: Infinity,
+    ease: 'linear' as const,
+  };
+
+  return (
+    <div className="absolute top-0 right-0 p-4 pointer-events-none">
+      <svg
+        width="80"
+        height="80"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={`transition-all duration-300 ${
+          hovered ? 'text-white/25 opacity-100' : 'text-white/10 opacity-100'
+        }`}
+      >
+        <defs>
+          <filter id="metricGlow" x="-200%" y="-200%" width="500%" height="500%">
+            <feGaussianBlur stdDeviation="2.5" result="blur" />
+            <feMerge>
+              <feMergeNode in="blur" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+        </defs>
+
+        {/* TOTAL PRs — GitPullRequest icon */}
+        {type === 'Total PRs' && (
+          <>
+            {/* Icon paths */}
+            <circle cx="18" cy="18" r="3" />
+            <circle cx="6" cy="6" r="3" />
+            <path d="M13 6h3a2 2 0 0 1 2 2v7" />
+            <line x1="6" x2="6" y1="9" y2="21" />
+
+            {hovered && (
+              <>
+                <motion.circle
+                  r="1.1"
+                  fill="#ffffff"
+                  filter="url(#metricGlow)"
+                  animate={{
+                    cx: [6, 6, 6, 6, 6],
+                    cy: [9, 13, 17, 21, 21],
+                  }}
+                  transition={{ ...baseTransition, duration: 2.2 }}
+                />
+                <motion.circle
+                  r="2.4"
+                  fill="transparent"
+                  stroke="#ffffff"
+                  strokeWidth="0.3"
+                  filter="url(#metricGlow)"
+                  animate={{
+                    cx: [6, 6, 6, 6, 6],
+                    cy: [9, 13, 17, 21, 21],
+                    opacity: [0.9, 0.4, 0.9, 0.2, 0],
+                    scale: [1, 1.5, 1, 1.8, 1],
+                  }}
+                  transition={{ ...baseTransition, duration: 2.2 }}
+                />
+
+                <motion.circle
+                  r="1.1"
+                  fill="#ffffff"
+                  filter="url(#metricGlow)"
+                  animate={{
+                    cx: [13, 15, 18, 18, 18, 18, 18, 18, 18, 18, 16, 13],
+                    cy: [6, 6, 6, 9, 12, 15, 18, 15, 12, 9, 6, 6],
+                  }}
+                  transition={{ ...baseTransition, duration: 3.2 }}
+                />
+                <motion.circle
+                  r="2.4"
+                  fill="transparent"
+                  stroke="#ffffff"
+                  strokeWidth="0.3"
+                  filter="url(#metricGlow)"
+                  animate={{
+                    cx: [13, 15, 18, 18, 18, 18, 18, 18, 18, 18, 16, 13],
+                    cy: [6, 6, 6, 9, 12, 15, 18, 15, 12, 9, 6, 6],
+                    opacity: [0.9, 0.6, 0.4, 0.6, 0.8, 0.6, 0.2, 0.4, 0.6, 0.8, 0.6, 0.9],
+                    scale: [1, 1.3, 1.6, 1.3, 1, 1.3, 2, 1.5, 1, 1.3, 1.5, 1],
+                  }}
+                  transition={{ ...baseTransition, duration: 3.2 }}
+                />
+              </>
+            )}
+          </>
+        )}
+
+        {/* MERGE RATE — GitMerge icon */}
+        {type === 'Merge Rate' && (
+          <>
+            <circle cx="18" cy="18" r="3" />
+            <circle cx="6" cy="6" r="3" />
+            <path d="M6 21V9a9 9 0 0 0 9 9" />
+
+            {hovered &&
+              (() => {
+                const arcXs = [
+                  6, 6.028, 6.111, 6.249, 6.44, 6.685, 6.981, 7.326, 7.719, 8.156, 8.636, 9.155,
+                  9.71, 10.298, 10.914, 11.556, 12.219, 12.899, 13.592, 14.294, 15,
+                ];
+                const arcYs = [
+                  9, 9.706, 10.408, 11.101, 11.781, 12.444, 13.086, 13.702, 14.29, 14.845, 15.364,
+                  15.844, 16.281, 16.674, 17.019, 17.315, 17.56, 17.751, 17.889, 17.972, 18,
+                ];
+
+                const extendedXs = [18, 18, ...arcXs.slice().reverse()];
+                const extendedYs = [21, 18, ...arcYs.slice().reverse()];
+
+                const dot2cx = [...extendedXs, ...extendedXs.slice().reverse()];
+                const dot2cy = [...extendedYs, ...extendedYs.slice().reverse()];
+
+                return (
+                  <>
+                    <motion.circle
+                      r="1.1"
+                      fill="#ffffff"
+                      filter="url(#metricGlow)"
+                      animate={{
+                        cx: [6, 6, 6, 6, 6, 6],
+                        cy: [9, 12, 15, 17, 20, 21],
+                      }}
+                      transition={{ ...baseTransition, duration: 2.4 }}
+                    />
+                    <motion.circle
+                      r="2.4"
+                      fill="transparent"
+                      stroke="#ffffff"
+                      strokeWidth="0.3"
+                      filter="url(#metricGlow)"
+                      animate={{
+                        cx: [6, 6, 6, 6, 6, 6],
+                        cy: [9, 12, 15, 17, 20, 21],
+                        opacity: [0.9, 0.7, 0.6, 0.5, 0.3, 0.05],
+                        scale: [1, 1.3, 1.5, 1.4, 1.6, 2],
+                      }}
+                      transition={{ ...baseTransition, duration: 2.4 }}
+                    />
+
+                    <motion.circle
+                      r="1.1"
+                      fill="#ffffff"
+                      filter="url(#metricGlow)"
+                      animate={{
+                        cx: dot2cx,
+                        cy: dot2cy,
+                      }}
+                      transition={{ ...baseTransition, duration: 4.8, delay: 1.2 }}
+                    />
+                    <motion.circle
+                      r="2.4"
+                      fill="transparent"
+                      stroke="#ffffff"
+                      strokeWidth="0.3"
+                      filter="url(#metricGlow)"
+                      animate={{
+                        cx: dot2cx,
+                        cy: dot2cy,
+                        opacity: [
+                          0, 0.5, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.15, 0.1, 0.08, 0.06,
+                          0.05, 0.04, 0.03, 0.02, 0.02, 0.01, 0.01, 0.01, 0.0, 0.0, 0.01, 0.01,
+                          0.01, 0.02, 0.02, 0.03, 0.04, 0.05, 0.06, 0.08, 0.1, 0.15, 0.2, 0.3, 0.4,
+                          0.5, 0.6, 0.7, 0.8, 0.9, 0.5, 0,
+                        ],
+                        scale: [
+                          1.8, 1.4, 1, 1.1, 1.2, 1.3, 1.3, 1.4, 1.4, 1.5, 1.5, 1.6, 1.6, 1.7, 1.7,
+                          1.8, 1.8, 1.9, 1.9, 2, 2, 2, 2, 2, 2, 2, 1.9, 1.9, 1.8, 1.8, 1.7, 1.7,
+                          1.6, 1.6, 1.5, 1.5, 1.4, 1.4, 1.3, 1.3, 1.2, 1.1, 1, 1.4, 1.8,
+                        ],
+                      }}
+                      transition={{ ...baseTransition, duration: 4.8, delay: 1.2 }}
+                    />
+                  </>
+                );
+              })()}
+          </>
+        )}
+
+        {/* AVG CYCLE TIME */}
+        {type === 'Avg Cycle Time' && (
+          <>
+            <circle cx="12" cy="12" r="10" />
+            <polyline points="12 6 12 12 16 14" />
+
+            {hovered && (
+              <>
+                {(() => {
+                  const cx = 12;
+                  const cy = 12;
+                  const r = 10;
+                  const steps = 60;
+
+                  const xs: number[] = [];
+                  const ys: number[] = [];
+
+                  for (let i = 0; i <= steps; i++) {
+                    const angle = (i / steps) * 2 * Math.PI - Math.PI / 2;
+
+                    xs.push(Number((cx + r * Math.cos(angle)).toFixed(3)));
+                    ys.push(Number((cy + r * Math.sin(angle)).toFixed(3)));
+                  }
+
+                  return (
+                    <>
+                      <motion.circle
+                        r="1.1"
+                        fill="#ffffff"
+                        filter="url(#metricGlow)"
+                        animate={{
+                          cx: xs,
+                          cy: ys,
+                        }}
+                        transition={{
+                          duration: 4,
+                          repeat: Infinity,
+                          ease: 'linear',
+                        }}
+                      />
+
+                      <motion.circle
+                        r="2.2"
+                        fill="transparent"
+                        stroke="#ffffff"
+                        strokeWidth="0.3"
+                        filter="url(#metricGlow)"
+                        animate={{
+                          cx: xs,
+                          cy: ys,
+                          opacity: [0.8, 0.4, 0.8],
+                          scale: [1, 1.8, 1],
+                        }}
+                        transition={{
+                          duration: 4,
+                          repeat: Infinity,
+                          ease: 'linear',
+                        }}
+                      />
+                    </>
+                  );
+                })()}
+              </>
+            )}
+          </>
+        )}
+
+        {/* FIRST REVIEW */}
+        {type === 'First Review' && (
+          <>
+            <path d="M3 12h3l2-4 4 8 2-4h7" />
+
+            {hovered && (
+              <>
+                <motion.circle
+                  r="1.1"
+                  fill="#ffffff"
+                  filter="url(#metricGlow)"
+                  animate={{
+                    cx: [3, 6, 8, 10, 12, 14, 17, 21],
+                    cy: [12, 12, 8, 12, 16, 12, 12, 12],
+                  }}
+                  transition={baseTransition}
+                />
+                <motion.circle
+                  r="2.4"
+                  fill="transparent"
+                  stroke="#ffffff"
+                  strokeWidth="0.3"
+                  filter="url(#metricGlow)"
+                  animate={{
+                    cx: [3, 6, 8, 10, 12, 14, 17, 21],
+                    cy: [12, 12, 8, 12, 16, 12, 12, 12],
+                    opacity: [0.8, 0, 0.8],
+                    scale: [1, 2, 1],
+                  }}
+                  transition={baseTransition}
+                />
+              </>
+            )}
+          </>
+        )}
+      </svg>
+    </div>
+  );
+}

--- a/components/dashboard/PRInsights/TopMetricsRow.tsx
+++ b/components/dashboard/PRInsights/TopMetricsRow.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { GitPullRequest, GitMerge, Clock, Activity } from 'lucide-react';
 import type { PRInsightData } from '@/services/github/pr-insights';
+import AnimatedMetricIcon from './AnimatedMetricIcon';
 
 interface MetricCardProps {
   title: string;
@@ -19,37 +20,49 @@ const MetricCard = ({
   trend,
   delay = 0,
   suffix = '',
-}: MetricCardProps) => (
-  <motion.div
-    initial={{ opacity: 0, y: 20 }}
-    animate={{ opacity: 1, y: 0 }}
-    transition={{ duration: 0.5, delay }}
-    className="bg-white dark:bg-zinc-900/50 border border-black/10 dark:border-white/10 rounded-2xl p-6 flex flex-col gap-4 relative overflow-hidden group hover:border-cyan-500/50 transition-colors"
-  >
-    <div className="absolute top-0 right-0 p-4 opacity-5 group-hover:opacity-10 transition-opacity">
-      <Icon size={80} />
-    </div>
-    <div className="flex items-center gap-3">
-      <div className="p-2.5 bg-cyan-500/10 text-cyan-600 dark:text-cyan-400 rounded-xl">
-        <Icon size={20} />
+}: MetricCardProps) => {
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay }}
+      whileHover={{
+        y: -4,
+        scale: 1.02,
+      }}
+      onHoverStart={() => setHovered(true)}
+      onHoverEnd={() => setHovered(false)}
+      className="bg-white dark:bg-zinc-900/50 border border-black/10 dark:border-white/10 rounded-2xl p-6 flex flex-col gap-4 relative overflow-hidden group hover:border-cyan-500/50 transition-colors"
+    >
+      <AnimatedMetricIcon type={title} hovered={hovered} />
+
+      <div className="flex items-center gap-3 relative z-10">
+        <div className="p-2.5 bg-cyan-500/10 text-cyan-600 dark:text-cyan-400 rounded-xl">
+          <Icon size={20} />
+        </div>
+
+        <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">
+          {title}
+        </h3>
       </div>
-      <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">
-        {title}
-      </h3>
-    </div>
-    <div className="flex items-end gap-2">
-      <span className="text-4xl font-bold text-gray-900 dark:text-white">
-        {value}
-        <span className="text-xl text-gray-500 font-medium ml-1">{suffix}</span>
-      </span>
-    </div>
-    {trend && (
-      <div className="text-xs font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 w-fit px-2.5 py-1 rounded-full">
-        {trend}
+
+      <div className="flex items-end gap-2 relative z-10">
+        <span className="text-4xl font-bold text-gray-900 dark:text-white">
+          {value}
+          <span className="text-xl text-gray-500 font-medium ml-1">{suffix}</span>
+        </span>
       </div>
-    )}
-  </motion.div>
-);
+
+      {trend && (
+        <div className="relative z-10 text-xs font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 w-fit px-2.5 py-1 rounded-full">
+          {trend}
+        </div>
+      )}
+    </motion.div>
+  );
+};
 
 export default function TopMetricsRow({ data }: { data: PRInsightData }) {
   return (
@@ -65,6 +78,7 @@ export default function TopMetricsRow({ data }: { data: PRInsightData }) {
         }
         delay={0.1}
       />
+
       <MetricCard
         title="Merge Rate"
         value={data.mergeRate.toFixed(1)}
@@ -72,6 +86,7 @@ export default function TopMetricsRow({ data }: { data: PRInsightData }) {
         icon={GitMerge}
         delay={0.2}
       />
+
       <MetricCard
         title="Avg Cycle Time"
         value={data.avgCycleTime.toFixed(1)}
@@ -79,6 +94,7 @@ export default function TopMetricsRow({ data }: { data: PRInsightData }) {
         icon={Clock}
         delay={0.3}
       />
+
       <MetricCard
         title="First Review"
         value={data.avgTimeToFirstReview.toFixed(1)}


### PR DESCRIPTION
## Description

Fixes #5455

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (UI Enhancement)

## Summary

Enhanced the PR Insights metric cards with CommitPulse-inspired interactive animations while preserving all existing functionality and layout.

### Changes Made

* Added animated SVG metric icons for:

  * Total PRs
  * Merge Rate
  * Avg Cycle Time
  * First Review

* Implemented pulse-path tracing animations that follow each metric icon's visual structure.

* Added interactive hover effects:

  * Pulse node animations
  * SVG path tracing
  * Smooth card elevation and visual emphasis

* Extracted animation logic into a dedicated `AnimatedMetricIcon` component for better maintainability and separation of concerns.

* Kept animations lightweight and performance-friendly using Framer Motion.

* Preserved existing dashboard functionality, responsiveness, and accessibility behavior.

## Visual Preview

### Before

<img width="1920" height="921" alt="image" src="https://github.com/user-attachments/assets/bc632703-a99e-4716-9c58-827a63b4f522" />

### After

## Screen Recording

https://github.com/user-attachments/assets/717d3fd3-93c1-4d71-b6c2-4b8e5651d70c

## Testing

* Verified all metric cards render correctly.
* Verified hover interactions across all four metrics.
* Verified responsive behavior across screen sizes.
* Tested locally using dashboard PR Insights data.
* Ran formatting and lint checks.
* Existing functionality remains unchanged.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if required.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The UI output matches the CommitPulse design language and visual quality standards.
