### PR TITLE
test(time): add theme contrast tests

### DIFF
--- a/utils/time.theme-contrast.test.ts
+++ b/utils/time.theme-contrast.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getSecondsUntilUTCMidnight, getSecondsUntilMidnightInTimezone } from './time';
+
+describe('time theme contrast', () => {
+  it('should work correctly in light theme environment', () => {
+    document.documentElement.dataset.theme = 'light';
+
+    const result = getSecondsUntilUTCMidnight();
+
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThanOrEqual(86400);
+  });
+
+  it('should work correctly in dark theme environment', () => {
+    document.documentElement.dataset.theme = 'dark';
+
+    const result = getSecondsUntilUTCMidnight();
+
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThanOrEqual(86400);
+  });
+
+  it('should return valid time values in both themes', () => {
+    const themes = ['light', 'dark'];
+
+    themes.forEach((theme) => {
+      document.documentElement.dataset.theme = theme;
+
+      const result = getSecondsUntilMidnightInTimezone('Asia/Kolkata');
+
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThanOrEqual(86400);
+    });
+  });
+
+  it('should not depend on theme preference for UTC calculation', () => {
+    document.documentElement.dataset.theme = 'light';
+
+    const lightResult = getSecondsUntilUTCMidnight();
+
+    document.documentElement.dataset.theme = 'dark';
+
+    const darkResult = getSecondsUntilUTCMidnight();
+
+    expect(Math.abs(lightResult - darkResult)).toBeLessThan(5);
+  });
+
+  it('should preserve timezone calculation with theme switching', () => {
+    document.documentElement.dataset.theme = 'light';
+
+    const lightResult = getSecondsUntilMidnightInTimezone('Asia/Kolkata');
+
+    document.documentElement.dataset.theme = 'dark';
+
+    const darkResult = getSecondsUntilMidnightInTimezone('Asia/Kolkata');
+
+    expect(Math.abs(lightResult - darkResult)).toBeLessThan(5);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4540 

## Summary
- Added theme contrast tests for time utilities
- Verified behaviour in light and dark theme environments
- Added 5 Vitest test cases

## Testing
npx vitest run utils/time.theme-contrast.test.ts

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:

- [x ] I have read the `CONTRIBUTING.md` file.
- [ x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [ x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ x] I have updated `README.md` if I added a new theme or URL parameter.
- [ x] I have started the repo.
- [ x] I have made sure that i have only one commit to merge in this PR.
- [ x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
