### PR TITLE
fix(useLocalStorage): use lazy useState initializer to eliminate stale initialValue on first render

### DIFF
--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -1,21 +1,37 @@
 'use client';
-
 import { useEffect, useState } from 'react';
 
+/**
+ * Reads from localStorage synchronously with an SSR guard.
+ * Used as a lazy useState initializer so the stored value is available
+ * on the first render — consistent with useRecentSearches.ts.
+ * Returns initialValue when running on the server or when the key is absent.
+ */
+function readFromStorage<T>(key: string, initialValue: T): T {
+  if (typeof window === 'undefined') return initialValue;
+  try {
+    const item = window.localStorage.getItem(key);
+    return item !== null ? (JSON.parse(item) as T) : initialValue;
+  } catch {
+    return initialValue;
+  }
+}
+
 export function useLocalStorage<T>(key: string, initialValue: T): readonly [T, (value: T) => void] {
-  const [storedValue, setStoredValue] = useState<T>(initialValue);
+  // Lazy initializer reads from localStorage synchronously on first render
+  // instead of deferring to a useEffect — eliminates the stale initialValue
+  // flash on mount and prevents setValue from overwriting stored data before
+  // the deferred read had a chance to run.
+  const [storedValue, setStoredValue] = useState<T>(() => readFromStorage(key, initialValue));
 
+  // Re-sync when the key changes (e.g. component reused with a different key).
+  // setState inside an effect is intentional here — we are synchronising React
+  // state with an external system (localStorage) when the key prop changes,
+  // which is exactly the use-case effects are designed for per React docs.
   useEffect(() => {
-    try {
-      const item = window.localStorage.getItem(key);
-
-      if (item !== null) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        setStoredValue(JSON.parse(item) as T);
-      }
-    } catch {
-      // Gracefully fall back to initialValue
-    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setStoredValue(readFromStorage(key, initialValue));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key]);
 
   const setValue = (value: T): void => {


### PR DESCRIPTION
## Description
Fixes #5437

`hooks/useLocalStorage.ts` read from `window.localStorage` inside a deferred `useEffect` — on the first render `storedValue` was always `initialValue` even when localStorage had a saved value. If `setValue` was called before the deferred effect fired, it overwrote previously saved data:

```ts
// Before — deferred read causes stale first render
const [storedValue, setStoredValue] = useState<T>(initialValue);
useEffect(() => {
  const item = window.localStorage.getItem(key);
  if (item !== null) setStoredValue(JSON.parse(item));
}, [key]);
```

Fixed by using a lazy `useState` initializer that reads from localStorage synchronously with an SSR guard — consistent with the pattern already used in `useRecentSearches.ts`:

```ts
// After — synchronous read on first render, SSR-safe
function readFromStorage<T>(key: string, initialValue: T): T {
  if (typeof window === 'undefined') return initialValue;
  try {
    const item = window.localStorage.getItem(key);
    return item !== null ? JSON.parse(item) : initialValue;
  } catch { return initialValue; }
}

const [storedValue, setStoredValue] = useState<T>(() => readFromStorage(key, initialValue));
```

Changes made:
- Extracted `readFromStorage` helper with SSR guard
- Replaced `useState(initialValue)` + deferred `useEffect` read with `useState(() => readFromStorage(key, initialValue))`
- Kept a `useEffect` to re-sync when the `key` prop changes
- `setValue` is unchanged — writes remain synchronous
- Verified zero new TypeScript errors introduced by this change

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — hook behaviour fix with no visual output.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.