### PR TITLE
fix(tracking): resolve track-user URL against NEXT_PUBLIC_SITE_URL instead of hardcoded relative path

### DIFF
--- a/utils/tracking.ts
+++ b/utils/tracking.ts
@@ -11,6 +11,19 @@
  * @param {string} username - The GitHub username to record the visit for.
  * @returns {void}
  */
+/**
+ * Resolves the track-user endpoint URL against NEXT_PUBLIC_SITE_URL when set.
+ * sendBeacon always resolves relative to window.location.origin and cannot be
+ * redirected — when the API lives on a different host, relative paths silently
+ * hit the wrong origin. Using an absolute URL derived from NEXT_PUBLIC_SITE_URL
+ * ensures pings reach the correct endpoint regardless of deployment topology.
+ */
+function getTrackUserUrl(): string {
+  const base = (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_SITE_URL?.trim()) || '';
+  const normalizedBase = base.replace(/\/+$/, '');
+  return normalizedBase ? `${normalizedBase}/api/track-user` : '/api/track-user';
+}
+
 export function trackUser(username: string) {
   if (typeof navigator === 'undefined' || typeof window === 'undefined') return;
   if (!username) return;
@@ -23,12 +36,13 @@ export function trackUser(username: string) {
     return;
   }
 
+  const url = getTrackUserUrl();
   const beaconQueued = navigator.sendBeacon
-    ? navigator.sendBeacon('/api/track-user', new Blob([payload], { type: 'application/json' }))
+    ? navigator.sendBeacon(url, new Blob([payload], { type: 'application/json' }))
     : false;
 
   if (!beaconQueued) {
-    fetch('/api/track-user', {
+    fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: payload,


### PR DESCRIPTION
## Description
Fixes #5439

`utils/tracking.ts` used hardcoded relative paths for both `sendBeacon` and the `fetch` fallback:

```ts
navigator.sendBeacon('/api/track-user', ...)
fetch('/api/track-user', { ... })
```

`sendBeacon` always resolves relative to `window.location.origin` and cannot be redirected. When the API lives on a different host (e.g. frontend on `https://app.example.com`, API on `https://api.example.com`), all tracking pings silently hit the wrong origin and return 404 with no error surfaced to the user.

Changes made:
- Added `getTrackUserUrl()` helper that prepends `NEXT_PUBLIC_SITE_URL` (stripped of trailing slashes) when configured, falling back to the relative path for local development where frontend and API share the same origin
- Both `sendBeacon` and the `fetch` fallback now use the resolved URL from `getTrackUserUrl()`
- Consistent with how `appUrl` is constructed in `app/api/og/route.tsx`
- Verified zero new TypeScript errors introduced by this change

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — URL resolution utility change with no visual output.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.