### PR TITLE
test(lang-hi): verify Hindi translation labels

### DIFF
--- a/lib/i18n/languages/hi.test.ts
+++ b/lib/i18n/languages/hi.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getLabels, labels } from '../badgeLabels';
+
+const requiredKeys = [
+  'CURRENT_STREAK',
+  'ANNUAL_SYNC_TOTAL',
+  'PEAK_STREAK',
+  'COMMITS_THIS_MONTH',
+  'VS_LAST_MONTH',
+] as const;
+
+const expectedHindiLabels = {
+  CURRENT_STREAK: 'वर्तमान_स्ट्रीक',
+  ANNUAL_SYNC_TOTAL: 'वार्षिक_कुल',
+  PEAK_STREAK: 'अधिकतम_स्ट्रीक',
+  COMMITS_THIS_MONTH: 'इस महीने के कमिट्स',
+  VS_LAST_MONTH: 'पिछले महीने की तुलना में',
+};
+
+function renderMockBadge(lang: string) {
+  const badgeLabels = getLabels(lang);
+
+  return `
+    <svg role="img" data-lang="${lang}">
+      <text>${badgeLabels.CURRENT_STREAK}</text>
+      <text>${badgeLabels.ANNUAL_SYNC_TOTAL}</text>
+      <text>${badgeLabels.PEAK_STREAK}</text>
+      <text>${badgeLabels.COMMITS_THIS_MONTH}</text>
+      <text>${badgeLabels.VS_LAST_MONTH}</text>
+    </svg>
+  `;
+}
+
+describe('Hindi badge labels', () => {
+  it('includes the hi language key in the labels dictionary', () => {
+    expect(labels.hi).toBeDefined();
+  });
+
+  it('returns the exact Hindi translation mapping through getLabels', () => {
+    expect(getLabels('hi')).toEqual(expectedHindiLabels);
+  });
+
+  it('returns the Hindi mapping when lang code casing differs', () => {
+    expect(getLabels('HI')).toEqual(expectedHindiLabels);
+  });
+
+  it('sets every required Hindi label to a non-empty string', () => {
+    const hindiLabels = getLabels('hi');
+
+    for (const key of requiredKeys) {
+      expect(typeof hindiLabels[key]).toBe('string');
+      expect(hindiLabels[key].trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('renders a mock SVG with Hindi translated labels', () => {
+    const svg = renderMockBadge('hi');
+
+    expect(svg).toContain('data-lang="hi"');
+
+    for (const value of Object.values(expectedHindiLabels)) {
+      expect(svg).toContain(value);
+    }
+  });
+});


### PR DESCRIPTION
## Description
Adds unit tests for Hindi badge translations (hi) to ensure localization correctness and prevent regressions.
Validates existence of language key, correctness of translation mapping, required label completeness, and rendering consistency in a mock SVG output.

Fixes #2333 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A
## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
