### PR TITLE
test(api): add empty-fallback edge cases verification for student resume upload route (#4207)

### DIFF
--- a/app/api/student/resume/upload/route.empty-fallback.test.ts
+++ b/app/api/student/resume/upload/route.empty-fallback.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { POST } from './route';
+
+vi.mock('@/lib/rate-limit', () => {
+  class MockRateLimiter {
+    check = vi.fn().mockResolvedValue(true);
+  }
+  return { RateLimiter: MockRateLimiter };
+});
+
+vi.mock('@/utils/getClientIp', () => ({
+  getClientIp: vi.fn().mockReturnValue('127.0.0.1'),
+}));
+
+function makeRequest(formDataFn: () => Promise<FormData> | FormData): Request {
+  return {
+    headers: new Headers(),
+    formData: async () => formDataFn(),
+  } as unknown as Request;
+}
+
+describe('POST /api/student/resume/upload - Edge Cases & Empty/Missing Inputs Verification', () => {
+  it('returns 400 when the resume field is missing from FormData', async () => {
+    const form = new FormData(); // no 'resume' key
+    const req = makeRequest(() => form);
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('No resume file provided');
+  });
+
+  it('returns 400 when the resume field is an empty string, not a File', async () => {
+    const form = new FormData();
+    form.append('resume', ''); // empty string, not a File
+    const req = makeRequest(() => form);
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+  });
+
+  it('returns 400 when file MIME type is empty', async () => {
+    const file = new File(['content'], 'resume.pdf', { type: '' });
+    const form = new FormData();
+    form.append('resume', file);
+    const req = makeRequest(() => form);
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Invalid file type');
+  });
+
+  it('returns 400 when the file is empty (zero bytes)', async () => {
+    const file = new File([], 'resume.pdf', { type: 'application/pdf' });
+    const form = new FormData();
+    form.append('resume', file);
+    const req = makeRequest(() => form);
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('does not match');
+  });
+
+  it('returns 400 when formData() throws due to malformed body', async () => {
+    const req = {
+      headers: new Headers(),
+      formData: async () => {
+        throw new Error('Malformed multipart body');
+      },
+    } as unknown as Request;
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Invalid form data');
+  });
+});


### PR DESCRIPTION
Closes #4207


## Description

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A (API Route Unit/Integration Tests)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] My branch is up to date and has no conflicts.
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
