### PR TITLE
test(aiinsights): add responsive breakpoint coverage

### DIFF
--- a/components/dashboard/AIInsights.responsive-breakpoints.test.tsx
+++ b/components/dashboard/AIInsights.responsive-breakpoints.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import AIInsights from './AIInsights';
+import type { ReactNode } from 'react';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, className }: { children: ReactNode; className?: string }) => (
+      <div className={className}>{children}</div>
+    ),
+  },
+}));
+
+vi.mock('@/context/TranslationContext', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('lucide-react', () => ({
+  Sparkles: () => <div>SparklesIcon</div>,
+  Moon: () => <div>MoonIcon</div>,
+  Sun: () => <div>SunIcon</div>,
+  Zap: () => <div>ZapIcon</div>,
+  Calendar: () => <div>CalendarIcon</div>,
+  Flame: () => <div>FlameIcon</div>,
+  Code: () => <div>CodeIcon</div>,
+  Star: () => <div>StarIcon</div>,
+}));
+
+describe('AIInsights responsive breakpoints', () => {
+  const insights = Array.from({ length: 20 }, (_, index) => ({
+    id: `${index}`,
+    icon: 'Zap',
+    text: `Insight item ${index + 1}`,
+  }));
+
+  beforeEach(() => {
+    window.innerWidth = 375;
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes('max-width'),
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it('renders all insight cards correctly on mobile viewport widths', () => {
+    render(<AIInsights insights={insights} />);
+
+    expect(screen.getAllByText(/Insight item/i)).toHaveLength(20);
+  });
+
+  it('maintains vertical flex layout styling for mobile screens', () => {
+    const { container } = render(<AIInsights insights={insights} />);
+
+    const flexContainer = container.querySelector('.flex.flex-col.gap-6');
+
+    expect(flexContainer).toBeTruthy();
+  });
+
+  it('does not apply fixed width classes that could cause horizontal overflow', () => {
+    const { container } = render(<AIInsights insights={insights} />);
+
+    const fixedWidthElements = container.querySelectorAll('[class*="w-["], [class*="min-w-["]');
+
+    expect(fixedWidthElements.length).toBe(0);
+  });
+
+  it('renders responsive content without clipping at narrow widths', () => {
+    render(<AIInsights insights={insights} />);
+
+    expect(screen.getByText('Insight item 1')).toBeTruthy();
+    expect(screen.getByText('Insight item 20')).toBeTruthy();
+  });
+
+  it('preserves readable stacked layout structure across mobile devices', () => {
+    const { container } = render(<AIInsights insights={insights} />);
+
+    const cards = container.querySelectorAll('.rounded-lg');
+
+    expect(cards.length).toBe(20);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2499

Added responsive breakpoint test coverage for `AIInsights.tsx`.

### Included coverage

* Verified rendering on mobile viewport widths.
* Checked stacked vertical flex layouts for small screens.
* Ensured no fixed-width classes introduce horizontal overflow.
* Validated content visibility at narrow breakpoints.
* Confirmed responsive card layout integrity with large datasets.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — test-only change.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
