### PR TITLE
test(quota-monitor): add timezone boundary coverage

### DIFF
--- a/services/github/quota-monitor.timezone-boundaries.test.ts
+++ b/services/github/quota-monitor.timezone-boundaries.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import quotaMonitor from './quota-monitor';
+
+describe('QuotaMonitor Timezone Boundaries', () => {
+  beforeEach(() => {
+    quotaMonitor.reset();
+  });
+
+  it('stores UTC midnight reset timestamps correctly', () => {
+    const utcMidnight = 1704067200; // 2024-01-01T00:00:00Z
+
+    quotaMonitor.updateQuotaFromHeaders({
+      'x-ratelimit-reset': String(utcMidnight),
+    });
+
+    expect(quotaMonitor.getQuota().resetTime).toBe(1704067200000);
+  });
+
+  it('preserves reset timestamps near EST calendar boundaries', () => {
+    const estBoundary = 1704085199;
+
+    quotaMonitor.updateQuotaFromHeaders({
+      'x-ratelimit-reset': String(estBoundary),
+    });
+
+    expect(quotaMonitor.getQuota().resetTime).toBe(estBoundary * 1000);
+  });
+
+  it('updates correctly when moving between IST and JST boundary timestamps', () => {
+    const istBoundary = 1704047400;
+    const jstBoundary = 1704034800;
+
+    quotaMonitor.updateQuotaFromHeaders({
+      'x-ratelimit-reset': String(istBoundary),
+    });
+
+    expect(quotaMonitor.getQuota().resetTime).toBe(istBoundary * 1000);
+
+    quotaMonitor.updateQuotaFromHeaders({
+      'x-ratelimit-reset': String(jstBoundary),
+    });
+
+    expect(quotaMonitor.getQuota().resetTime).toBe(jstBoundary * 1000);
+  });
+
+  it('handles leap year reset dates without losing precision', () => {
+    const leapYearReset = Math.floor(new Date('2024-02-29T00:00:00Z').getTime() / 1000);
+
+    quotaMonitor.updateQuotaFromHeaders({
+      'x-ratelimit-reset': String(leapYearReset),
+    });
+
+    expect(quotaMonitor.getQuota().resetTime).toBe(leapYearReset * 1000);
+  });
+
+  it('tracks DST transition timestamps while preserving quota state', () => {
+    quotaMonitor.updateQuotaFromHeaders({
+      'x-ratelimit-limit': '5000',
+      'x-ratelimit-remaining': '4500',
+      'x-ratelimit-reset': '1710054000',
+    });
+
+    const quota = quotaMonitor.getQuota();
+
+    expect(quota.limit).toBe(5000);
+    expect(quota.remaining).toBe(4500);
+    expect(quota.resetTime).toBe(1710054000000);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2930

Added `services/github/quota-monitor.timezone-boundaries.test.ts` to provide isolated test coverage for timezone normalization and calendar boundary scenarios in the quota monitor.

### Added Test Coverage

* UTC midnight reset timestamp handling
* EST calendar boundary timestamp preservation
* IST and JST boundary timestamp updates
* Leap-year reset timestamp processing
* Daylight-saving transition timestamp handling while preserving quota state

### Validation

* Added 5 test cases
* Verified locally using Vitest
* `npm run typecheck` passes successfully
* All new tests passing successfully

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [x] 🕐 Pillar 3 — Timezone Logic Optimization
* [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
