### PR TITLE
test(SocialsSection-empty-fallback): verify Edge Cases & Empty/Missing Inputs Verification

### DIFF
--- a/app/generator/components/sections/SocialsSection.empty-fallback.test.tsx
+++ b/app/generator/components/sections/SocialsSection.empty-fallback.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SocialsSection } from './SocialsSection';
+
+vi.mock('../../data/socials', () => ({
+  SOCIALS: [
+    {
+      id: 'github',
+      name: 'GitHub',
+      type: 'simpleicon',
+      iconUrl: '/github.svg',
+      category: 'Development',
+      placeholder: 'https://github.com/username',
+    },
+    {
+      id: 'twitter',
+      name: 'Twitter',
+      type: 'simpleicon',
+      iconUrl: '/twitter.svg',
+      category: 'Social',
+      placeholder: 'https://twitter.com/username',
+    },
+  ],
+  SOCIAL_CATEGORIES: ['Development', 'Social'],
+}));
+
+describe('SocialsSection Edge Cases & Empty/Missing Inputs Verification', () => {
+  const mockOnSelectedChange = vi.fn();
+  const mockOnLinkChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders safely with empty selected array and empty social links', () => {
+    render(
+      <SocialsSection
+        selected={[]}
+        socialLinks={{}}
+        onSelectedChange={mockOnSelectedChange}
+        onLinkChange={mockOnLinkChange}
+      />
+    );
+
+    expect(screen.getByText('Socials')).toBeInTheDocument();
+    expect(screen.getByText('2 platforms')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search platforms...')).toBeInTheDocument();
+  });
+
+  it('shows fallback message when links tab is opened with no selected platforms', () => {
+    render(
+      <SocialsSection
+        selected={[]}
+        socialLinks={{}}
+        onSelectedChange={mockOnSelectedChange}
+        onLinkChange={mockOnLinkChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /add links/i }));
+
+    expect(screen.getByText('No platforms selected yet')).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: /pick platforms first/i })).toBeInTheDocument();
+  });
+
+  it('shows empty search fallback when no platforms match search query', () => {
+    render(
+      <SocialsSection
+        selected={[]}
+        socialLinks={{}}
+        onSelectedChange={mockOnSelectedChange}
+        onLinkChange={mockOnLinkChange}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Search platforms...'), {
+      target: { value: 'nonexistent-platform' },
+    });
+
+    expect(screen.getByText('No platforms match your search')).toBeInTheDocument();
+  });
+
+  it('ignores selected ids that do not exist in socials dataset', () => {
+    render(
+      <SocialsSection
+        selected={['missing-platform']}
+        socialLinks={{}}
+        onSelectedChange={mockOnSelectedChange}
+        onLinkChange={mockOnLinkChange}
+      />
+    );
+
+    expect(screen.getByText('Selected (1)')).toBeInTheDocument();
+
+    expect(screen.queryByText('missing-platform')).not.toBeInTheDocument();
+  });
+
+  it('renders selected platform with empty link state indicator', () => {
+    render(
+      <SocialsSection
+        selected={['github']}
+        socialLinks={{}}
+        onSelectedChange={mockOnSelectedChange}
+        onLinkChange={mockOnLinkChange}
+      />
+    );
+
+    expect(screen.getByText('Selected (1)')).toBeInTheDocument();
+
+    expect(screen.getAllByText('GitHub').length).toBeGreaterThan(0);
+
+    expect(screen.getByText('(no link)')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4236 

Adds dedicated empty-fallback coverage for `SocialsSection` to verify stability when handling empty arrays, missing inputs, unconfigured selections, and no-result states.

The test suite validates:

- Safe rendering with empty `selected` and `socialLinks` props.
- Fallback UI when no platforms are selected in the Links tab.
- Empty search result behavior.
- Graceful handling of selected IDs that do not exist in the socials dataset.
- Display of missing-link indicators for selected platforms without URLs.

All tests pass successfully with Vitest and focus on real component behavior without introducing runtime errors.

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

- N/A (test-only changes)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
