### PR TITLE
test(ThemeQuickPresets-empty-fallback): verify Edge Cases & Empty/Missing Inputs Verification

### DIFF
--- a/app/customize/components/ThemeQuickPresets.empty-fallback.test.tsx
+++ b/app/customize/components/ThemeQuickPresets.empty-fallback.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+import { ThemeQuickPresets } from './ThemeQuickPresets';
+
+describe('ThemeQuickPresets Edge Cases & Empty/Missing Inputs Verification', () => {
+  it('renders successfully with an unknown theme value', () => {
+    expect(() =>
+      render(<ThemeQuickPresets theme="unknown-theme" onThemeChange={vi.fn()} />)
+    ).not.toThrow();
+
+    expect(screen.getAllByRole('button').length).toBeGreaterThan(0);
+  });
+
+  it('renders preset buttons while no active theme matches', () => {
+    render(<ThemeQuickPresets theme="missing-theme" onThemeChange={vi.fn()} />);
+
+    const activeButtons = screen
+      .getAllByRole('button')
+      .filter((button) => button.getAttribute('aria-pressed') === 'true');
+
+    expect(activeButtons).toHaveLength(0);
+  });
+
+  it('maintains default layout structure when active indicators are absent', () => {
+    const { container } = render(
+      <ThemeQuickPresets theme="invalid-theme" onThemeChange={vi.fn()} />
+    );
+
+    const wrapper = container.querySelector('.theme-quick-presets');
+
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper?.children.length).toBeGreaterThan(0);
+
+    expect(container.querySelector('.tqp-ring')).toBeNull();
+    expect(container.querySelector('.tqp-dot')).toBeNull();
+  });
+
+  it('renders buttons with fallback styling and accessible labels', () => {
+    render(<ThemeQuickPresets theme="not-configured" onThemeChange={vi.fn()} />);
+
+    const buttons = screen.getAllByRole('button');
+
+    expect(buttons.length).toBeGreaterThan(0);
+
+    buttons.forEach((button) => {
+      expect(button).toHaveClass('tqp-btn');
+      expect(button).toHaveAttribute('aria-label');
+      expect(button).toHaveAttribute('style');
+    });
+  });
+
+  it('renders theme preview icons and structural markers without runtime failures', () => {
+    const { container } = render(<ThemeQuickPresets theme="" onThemeChange={vi.fn()} />);
+
+    const svgs = container.querySelectorAll('svg');
+
+    expect(svgs.length).toBeGreaterThan(0);
+
+    svgs.forEach((svg) => {
+      expect(svg).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    expect(container.querySelector('.theme-quick-presets')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4224 

Adds a dedicated empty-fallback test suite for `ThemeQuickPresets` focused on handling edge cases and missing configuration states safely.

The test suite validates:

- Safe rendering when an unknown theme value is provided.
- Proper behavior when no preset matches the active theme.
- Preservation of default layout structure when active theme indicators are absent.
- Rendering of accessible preset buttons with expected fallback styling.
- Successful rendering of SVG preview icons and key DOM structures without runtime failures.

The tests are based on the component's actual implementation and verify stability, accessibility attributes, styling markers, and fallback rendering behavior without introducing assumptions about unsupported null-state handling.

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

- N/A (test-only changes)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
