### PR TITLE
test(DescriptionSection-empty-fallback): add edge case and empty input fallback coverage

### DIFF
--- a/app/compare/CompareClient.test.tsx
+++ b/app/compare/CompareClient.test.tsx
@@ -171,8 +171,8 @@ describe('CompareClient', () => {
       expect(screen.getByText(/stats showdown/i)).toBeInTheDocument();
     });
 
-    expect(screen.getByText('5,000')).toBeInTheDocument();
-    expect(screen.getByText('3,000')).toBeInTheDocument();
+    expect(screen.getByText((5000).toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText((3000).toLocaleString())).toBeInTheDocument();
   });
 
   it('updates route when compare button is clicked', async () => {

--- a/app/generator/components/sections/DescriptionSection.empty-fallback.test.tsx
+++ b/app/generator/components/sections/DescriptionSection.empty-fallback.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { DescriptionSection } from './DescriptionSection';
+
+vi.mock('../SectionCard', () => ({
+  SectionCard: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+    description?: string;
+    defaultOpen?: boolean;
+  }) => (
+    <div data-testid="section-card">
+      <span data-testid="section-title">{title}</span>
+      {children}
+    </div>
+  ),
+  FieldLabel: ({ children, htmlFor }: { children: React.ReactNode; htmlFor?: string }) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  ),
+}));
+
+describe('DescriptionSection - Edge Cases & Empty/Missing Inputs Verification', () => {
+  it('renders without runtime errors when value is an empty string', () => {
+    expect(() => render(<DescriptionSection value="" onChange={vi.fn()} />)).not.toThrow();
+  });
+
+  it('shows 280 characters remaining when value is empty', () => {
+    render(<DescriptionSection value="" onChange={vi.fn()} />);
+
+    expect(screen.getByText('280 characters remaining')).toBeInTheDocument();
+  });
+
+  it('displays placeholder text and empty value in the empty state', () => {
+    render(<DescriptionSection value="" onChange={vi.fn()} />);
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute(
+      'placeholder',
+      'e.g. Full-stack developer passionate about building great products. Open source enthusiast. Coffee addict.'
+    );
+    expect(textarea).toHaveValue('');
+  });
+
+  it('maintains non-amber gray counter style in empty state since remaining 280 is well above the 40-character near-limit threshold', () => {
+    render(<DescriptionSection value="" onChange={vi.fn()} />);
+
+    const counter = screen.getByText('280 characters remaining');
+    expect(counter).toHaveClass('text-gray-400');
+    expect(counter).not.toHaveClass('text-amber-500');
+  });
+
+  it('renders all key DOM structures correctly in the empty layout state', () => {
+    render(<DescriptionSection value="" onChange={vi.fn()} />);
+
+    expect(screen.getByTestId('section-card')).toBeInTheDocument();
+    expect(screen.getByTestId('section-title')).toHaveTextContent('Description');
+    expect(screen.getByText('Bio / Tagline')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toHaveAttribute('id', 'editor-bio');
+    expect(screen.getByText('280 characters remaining')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION

## Description

Fixes #4234

## Summary
Adds `DescriptionSection.empty-fallback.test.tsx` with 5 focused test cases  targeting Edge Cases & Empty/Missing Inputs Verification for `DescriptionSection.tsx`.

## Tests added
- Renders without runtime errors when value is an empty string
- Shows 280 characters remaining in empty state
- Displays placeholder text and empty value in the empty state textarea
- Maintains non-amber gray counter style when remaining is above the near-limit threshold
- Verifies all key DOM structures exist in the empty layout state

## Files touched
- `app/generator/components/sections/DescriptionSection.empty-fallback.test.tsx` (new)
- `app/compare/CompareClient.test.tsx` — fixed pre-existing `renders comparative scores 
  correctly` test failure; replaced hardcoded `'5,000'` / `'3,000'` with `(5000).toLocaleString()` / `(3000).toLocaleString()` so the test matches the component's runtime number format regardless of Node.js ICU availability.

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.
