### PR TITLE
test(export-panel): add empty input fallback coverage

### DIFF
--- a/app/customize/components/ExportPanel.empty-fallback.test.tsx
+++ b/app/customize/components/ExportPanel.empty-fallback.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExportPanel } from './ExportPanel';
+
+vi.mock('../utils', () => ({
+  getPlaceholderSnippet: vi.fn((format: string) => `placeholder-${format}`),
+}));
+
+vi.mock('@/context/TranslationContext', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options?.defaultValue ? String(options.defaultValue) : key,
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('lucide-react', () => ({
+  Copy: () => <svg data-testid="copy-icon" />,
+  Check: () => <svg data-testid="check-icon" />,
+}));
+
+const defaultProps = {
+  format: 'markdown' as const,
+  snippet: '[badge](https://example.com/badge.svg)',
+  copied: false,
+  copyStatusMessage: '',
+  hasUsername: true,
+  username: 'testuser',
+  onFormatChange: vi.fn(),
+  onCopy: vi.fn(),
+};
+
+describe('ExportPanel Empty/Missing Inputs Verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders safely when username is empty and username-dependent features are unavailable', () => {
+    render(<ExportPanel {...defaultProps} username="" hasUsername={false} />);
+
+    expect(screen.getByLabelText(/export format/i)).toBeInTheDocument();
+  });
+
+  it('falls back to placeholder snippet when username is unavailable and snippet is empty', () => {
+    render(<ExportPanel {...defaultProps} username="" hasUsername={false} snippet="" />);
+
+    expect(screen.getByText('placeholder-markdown')).toBeInTheDocument();
+  });
+
+  it('keeps copy action disabled when username is missing', () => {
+    render(<ExportPanel {...defaultProps} username="" hasUsername={false} />);
+
+    const copyButton = screen.getByRole('button', {
+      name: /copy/i,
+    });
+
+    expect(copyButton).toBeDisabled();
+  });
+
+  it('keeps SVG and PNG download controls disabled when username is missing', () => {
+    render(<ExportPanel {...defaultProps} username="" hasUsername={false} />);
+
+    const buttons = screen.getAllByRole('button');
+
+    const disabledButtons = buttons.filter((button) => (button as HTMLButtonElement).disabled);
+
+    expect(disabledButtons.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('handles empty snippet and empty status message without runtime errors', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ExportPanel
+        {...defaultProps}
+        snippet=""
+        copyStatusMessage=""
+        username=""
+        hasUsername={false}
+      />
+    );
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    const codeBlock = document.querySelector('code');
+
+    expect(codeBlock).toBeInTheDocument();
+
+    const markdownButton = screen.getByRole('button', {
+      pressed: true,
+    });
+
+    await user.click(markdownButton);
+
+    expect(markdownButton).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4222

### Summary

Added `ExportPanel.empty-fallback.test.tsx` to verify resilient behavior when required inputs are missing, empty, or unavailable.

### Test Coverage

* Verifies the component renders safely when the username is empty.
* Verifies fallback content is displayed when snippet data is unavailable.
* Verifies copy-related actions remain safely disabled when required inputs are missing.
* Verifies SVG and PNG export controls remain non-breaking in empty-input scenarios.
* Verifies the component maintains stable rendering without runtime errors when status messages and export data are empty.

### Why

The ExportPanel depends on user-provided values and generated export content. These tests ensure the component gracefully handles incomplete configurations, preserves UI stability, and prevents unexpected runtime failures when optional or required inputs are unavailable.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
