### PR TITLE
fix(security): sanitize raw Zod error details to prevent schema leaks

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -583,8 +583,19 @@ export async function GET(request: Request) {
 
 type ParseResult = ReturnType<typeof streakParamsSchema.safeParse>;
 
+function sanitizeErrorMessage(message: string): string {
+  if (message.includes('ZodError') || message.includes('zod')) {
+    return 'Invalid request parameters';
+  }
+  if (message.includes('schema') || message.includes('Schema')) {
+    return 'Invalid request parameters';
+  }
+  return message;
+}
+
 function buildErrorResponse(error: unknown, parseResult: ParseResult): NextResponse {
-  const message = error instanceof Error ? error.message : String(error);
+  const rawMessage = error instanceof Error ? error.message : String(error);
+  const message = sanitizeErrorMessage(rawMessage);
 
   if (parseResult.success && parseResult.data.format === 'json') {
     const isNotFound =


### PR DESCRIPTION
## Summary

When validation fails, the API dumps the full Zod error object in the JSON response, leaking internal project structures and schema details.

## Changes

- **\pp/api/streak/route.ts\**: Added \sanitizeErrorMessage\ function that replaces messages containing ZodError, zod, or schema references with a safe generic message before returning in JSON responses.

## Testing

- Existing streak route tests pass
- Error messages no longer contain internal schema details

## Issue

Fixes #5269