### PR TITLE
test(sectionlabel): add empty fallback coverage

### DIFF
--- a/app/customize/components/SectionLabel.empty-fallback.test.tsx
+++ b/app/customize/components/SectionLabel.empty-fallback.test.tsx
@@ -1,0 +1,59 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { SectionLabel } from './SectionLabel';
+
+describe('SectionLabel Empty/Missing Inputs Verification', () => {
+  it('renders safely with empty string children', () => {
+    const { container } = render(<SectionLabel>{''}</SectionLabel>);
+
+    const label = container.querySelector('p');
+
+    expect(label).toBeInTheDocument();
+    expect(label?.textContent).toBe('');
+  });
+
+  it('renders safely with whitespace-only children', () => {
+    const { container } = render(<SectionLabel>{'   '}</SectionLabel>);
+
+    const label = container.querySelector('p');
+
+    expect(label).toBeInTheDocument();
+    expect(label?.textContent).toBe('   ');
+  });
+
+  it('renders safely with null children', () => {
+    const { container } = render(<SectionLabel>{null}</SectionLabel>);
+
+    const label = container.querySelector('p');
+
+    expect(label).toBeInTheDocument();
+    expect(label?.textContent).toBe('');
+  });
+
+  it('renders safely with undefined children', () => {
+    const { container } = render(<SectionLabel>{undefined}</SectionLabel>);
+
+    const label = container.querySelector('p');
+
+    expect(label).toBeInTheDocument();
+    expect(label?.textContent).toBe('');
+  });
+
+  it('preserves default styling classes when children are missing', () => {
+    const { container } = render(<SectionLabel>{null}</SectionLabel>);
+
+    const label = container.querySelector('p');
+
+    expect(label).toBeInTheDocument();
+    expect(label).toHaveClass(
+      'text-[10px]',
+      'font-bold',
+      'uppercase',
+      'tracking-[0.22em]',
+      'text-gray-600',
+      'dark:text-white/60',
+      'mb-2'
+    );
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4223

### Summary

* Added `SectionLabel.empty-fallback.test.tsx`.
* Added 5 focused test cases covering empty and missing children scenarios.
* Verified the component renders safely with:

  * Empty string children
  * Whitespace-only children
  * `null` children
  * `undefined` children
  * Missing content while preserving default styling
* Confirmed no runtime errors occur during rendering.
* Verified default DOM structure and styling remain intact in fallback states.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.