### PR TITLE
test(hooks): add boundary robustness tests for useDebounce

### DIFF
--- a/hooks/useDebounce.boundary-robustness.test.ts
+++ b/hooks/useDebounce.boundary-robustness.test.ts
@@ -1,0 +1,192 @@
+import { useEffect } from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useDebounce } from './useDebounce';
+
+// Helper hook used to observe how many times the debounced value settles.
+// We rely on a useEffect that runs on every debounced value change so that
+// we can assert the exact number of resolutions across rapid input bursts.
+function useObservedDebounce(value: string, delay: number, onResolved: (value: string) => void) {
+  const debouncedValue = useDebounce(value, delay);
+
+  useEffect(() => {
+    onResolved(debouncedValue);
+  }, [debouncedValue, onResolved]);
+}
+
+describe('useDebounce Boundary Robustness Tests', () => {
+  it('resolves exactly once after a high-frequency burst of synchronous inputs', () => {
+    // Boundary case: many rapid inputs in a single tick must still collapse
+    // into a single resolution after the timer expires.
+    vi.useFakeTimers();
+    const onResolved = vi.fn();
+
+    try {
+      const { rerender } = renderHook(
+        ({ value }: { value: string }) => useObservedDebounce(value, 300, onResolved),
+        { initialProps: { value: '' } }
+      );
+
+      // Ignore the initial mount call so we only measure burst behaviour.
+      onResolved.mockClear();
+
+      // Fire ten rapid synchronous updates — simulates a user typing a long
+      // username faster than the debounce window.
+      const burst = [
+        'o',
+        'oc',
+        'oct',
+        'octo',
+        'octoc',
+        'octoca',
+        'octocat',
+        'octocat1',
+        'octocat12',
+        'octocat123',
+      ];
+      burst.forEach((value) => rerender({ value }));
+
+      // Just below the boundary — nothing should have settled yet.
+      act(() => {
+        vi.advanceTimersByTime(299);
+      });
+      expect(onResolved).not.toHaveBeenCalled();
+
+      // Crossing the boundary should trigger exactly one resolution
+      // carrying the final value from the burst.
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(onResolved).toHaveBeenCalledTimes(1);
+      expect(onResolved).toHaveBeenCalledWith('octocat123');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resolves on the next tick when the delay boundary is zero', () => {
+    // Boundary case: a delay of 0ms is the smallest legal timer value and
+    // must still flush the value through the setTimeout queue exactly once.
+    vi.useFakeTimers();
+    const onResolved = vi.fn();
+
+    try {
+      const { rerender } = renderHook(
+        ({ value }: { value: string }) => useObservedDebounce(value, 0, onResolved),
+        { initialProps: { value: '' } }
+      );
+
+      onResolved.mockClear();
+
+      rerender({ value: 'a' });
+      rerender({ value: 'ab' });
+      rerender({ value: 'abc' });
+
+      // Even with a zero delay, the resolution is queued via setTimeout
+      // and only fires after the timer loop advances.
+      act(() => {
+        vi.advanceTimersByTime(0);
+      });
+
+      expect(onResolved).toHaveBeenCalledTimes(1);
+      expect(onResolved).toHaveBeenCalledWith('abc');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('holds the previous value until a very large delay boundary fully elapses', () => {
+    // Boundary case: an unusually large delay must not resolve early under
+    // any circumstance — the hook must wait the full duration.
+    vi.useFakeTimers();
+
+    try {
+      const { result, rerender } = renderHook(({ value }) => useDebounce(value, 10000), {
+        initialProps: { value: 'initial' },
+      });
+
+      rerender({ value: 'updated' });
+
+      // One millisecond before the boundary — value must still be stale.
+      act(() => {
+        vi.advanceTimersByTime(9999);
+      });
+      expect(result.current).toBe('initial');
+
+      // Crossing the exact boundary settles the value.
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(result.current).toBe('updated');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resolves exactly once when the rapid burst contains identical repeated values', () => {
+    // Boundary case: repeated identical inputs still trigger rerenders, but
+    // the debounced output must collapse them into a single resolution.
+    vi.useFakeTimers();
+    const onResolved = vi.fn();
+
+    try {
+      const { rerender } = renderHook(
+        ({ value }: { value: string }) => useObservedDebounce(value, 300, onResolved),
+        { initialProps: { value: '' } }
+      );
+
+      onResolved.mockClear();
+
+      rerender({ value: 'repeat' });
+      rerender({ value: 'repeat' });
+      rerender({ value: 'repeat' });
+      rerender({ value: 'repeat' });
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(onResolved).toHaveBeenCalledTimes(1);
+      expect(onResolved).toHaveBeenCalledWith('repeat');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resolves exactly once per burst across two consecutive settled bursts', () => {
+    // Boundary case: after a burst fully settles, a second burst must be
+    // treated as an independent debounce cycle and resolve exactly once on
+    // its own boundary — no leaking timers from the first cycle.
+    vi.useFakeTimers();
+    const onResolved = vi.fn();
+
+    try {
+      const { rerender } = renderHook(
+        ({ value }: { value: string }) => useObservedDebounce(value, 300, onResolved),
+        { initialProps: { value: '' } }
+      );
+
+      onResolved.mockClear();
+
+      // First burst.
+      rerender({ value: 'a' });
+      rerender({ value: 'ab' });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(onResolved).toHaveBeenCalledTimes(1);
+      expect(onResolved).toHaveBeenLastCalledWith('ab');
+
+      // Second independent burst after the first one fully resolved.
+      rerender({ value: 'abc' });
+      rerender({ value: 'abcd' });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(onResolved).toHaveBeenCalledTimes(2);
+      expect(onResolved).toHaveBeenLastCalledWith('abcd');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1577

Adds a new Vitest test file `hooks/useDebounce.boundary-robustness.test.ts` covering boundary conditions of the `useDebounce` hook (Variation 3 of the utils boundary-robustness test series).

The test file verifies that the hook resolves **exactly once** after the timer expires across multiple boundary conditions:

- High-frequency burst of 10 rapid synchronous inputs collapses into a single resolution
- Zero-delay boundary (`delay = 0`) still flushes through the setTimeout queue exactly once
- Very large delay boundary (10,000 ms) holds the previous value until the full duration elapses
- Identical repeated values in a burst still resolve exactly once
- Two consecutive bursts each settle independently with exactly one resolution per cycle

No production code is touched — this PR is test-only.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — this PR adds unit tests only, no visual SVG output is affected.

**Test run output:**

```
✓ hooks/useDebounce.boundary-robustness.test.ts (5 tests) 41ms
   ✓ useDebounce Boundary Robustness Tests (5)
     ✓ resolves exactly once after a high-frequency burst of synchronous inputs
     ✓ resolves on the next tick when the delay boundary is zero
     ✓ holds the previous value until a very large delay boundary fully elapses
     ✓ resolves exactly once when the rapid burst contains identical repeated values
     ✓ resolves exactly once per burst across two consecutive settled bursts

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] I have run `npm run test` and all tests pass locally (6803 passed).
- [x] I have run `npm run test:coverage` and branch coverage is at or above 70% (70.94% overall).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter. (N/A — test-only change)
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). (N/A — test-only change)
- [ ] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.