### PR TITLE
fix(user-details): add per-IP rate limiting 

### DIFF
--- a/app/api/user-details/route.test.ts
+++ b/app/api/user-details/route.test.ts
@@ -101,4 +101,13 @@ describe('GET /api/user-details', () => {
       totalContributions: 0,
     });
   });
+  it('returns 429 when rate limit is exceeded', async () => {
+    const { RateLimiter } = await import('@/lib/rate-limit');
+    vi.spyOn(RateLimiter.prototype, 'check').mockResolvedValueOnce(false);
+
+    const response = await GET(makeRequest({ username: 'testuser' }));
+    expect(response.status).toBe(429);
+    const body = await response.json();
+    expect(body.error).toBe('Too many requests. Please try again later.');
+  });
 });

--- a/app/api/user-details/route.ts
+++ b/app/api/user-details/route.ts
@@ -2,8 +2,23 @@ import { NextResponse } from 'next/server';
 import { fetchUserProfile, fetchGitHubContributions } from '@/lib/github';
 import { calculateStreak } from '@/lib/calculate';
 import { validateGitHubUsername } from '@/lib/validations';
+import { getClientIp } from '@/utils/getClientIp';
+import { RateLimiter } from '@/lib/rate-limit';
+
+const userDetailsLimiter = new RateLimiter(20, 60_000, 1);
 
 export async function GET(request: Request) {
+  const ip = getClientIp(request);
+  const rateLimitKey =
+    ip && ip !== 'unknown' ? ip : `unknown:${request.headers.get('user-agent') ?? 'no-agent'}`;
+
+  if (!(await userDetailsLimiter.check(rateLimitKey))) {
+    return NextResponse.json(
+      { error: 'Too many requests. Please try again later.' },
+      { status: 429 }
+    );
+  }
+
   const { searchParams } = new URL(request.url);
   const username = searchParams.get('username')?.trim();
 


### PR DESCRIPTION
## Description

Fixes #5805 


## Problem
`app/api/user-details/route.ts` had zero rate limiting, making it uniquely 
dangerous compared to other unprotected routes, each request fires TWO 
parallel GitHub API calls:

```const [profile, contributions] = await Promise.all([
  fetchUserProfile(username),
  fetchGitHubContributions(username),
]);
```
An attacker hammering this endpoint burns GitHub API quota at 2x the rate 
of a normal endpoint, potentially exhausting the shared token pool and 
taking down /api/streak and /api/stats for all users globally.

## Fix
Added per-IP rate limiting (20 requests/minute) at the top of the GET 
handler using the same pattern as /api/og, /api/notify, /api/reviews, 
and /api/webhook. Limit is set to 20 (vs 30 for /api/og) to account for 
the doubled GitHub API cost per request.

Added a test verifying 429 is returned when the limit is exceeded.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [X] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A
## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [X] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [X] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [X] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

Suggested labels: level:critical, bug, security
