### PR TITLE
fix(webhook): replace inline rate limiter with shared rateLimit utility

### DIFF
--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -1,29 +1,10 @@
 import { NextResponse } from 'next/server';
 import crypto from 'crypto';
+import { rateLimit } from '@/lib/rate-limit';
 
 const MAX_PAYLOAD_SIZE = 1024 * 1024; // 1MB
 const SIGNATURE_PREFIX = 'sha256=';
 const SHA256_HEX_LENGTH = 64;
-
-// In-memory rate limiting map: ip -> { count, resetTime }
-const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
-const RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
-const MAX_REQUESTS_PER_WINDOW = 10;
-
-function checkRateLimit(ip: string): boolean {
-  const now = Date.now();
-  let record = rateLimitMap.get(ip);
-  if (!record || now > record.resetTime) {
-    record = { count: 1, resetTime: now + RATE_LIMIT_WINDOW };
-    rateLimitMap.set(ip, record);
-    return true;
-  }
-  record.count++;
-  if (record.count > MAX_REQUESTS_PER_WINDOW) {
-    return false;
-  }
-  return true;
-}
 
 function getWebhookSecret(): string | null {
   const secret = process.env.GITHUB_WEBHOOK_SECRET?.trim();
@@ -54,7 +35,8 @@ function verifyWebhookSignature(bodyText: string, signature: string, secret: str
 export async function POST(req: Request) {
   // 1. Rate Limiting
   const ip = req.headers.get('x-forwarded-for') || 'unknown_ip';
-  if (!checkRateLimit(ip)) {
+  const limit = await rateLimit(ip, 10, 60000);
+  if (!limit.success) {
     return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
   }
 


### PR DESCRIPTION
## Description
Fixes #5615

The webhook route (`app/api/webhook/route.ts`) had its own bespoke in-memory rate limiter using a `rateLimitMap` and `checkRateLimit` function, completely separate from the project's shared `rateLimit` utility in `lib/rate-limit.ts`.

**Problems with the old approach:**
- **Inconsistency** — every other API route uses `lib/rate-limit.ts`. The webhook route was the only exception with no clear reason.
- **Serverless incompatibility** — `rateLimitMap` was stored in module memory. In serverless environments like Vercel, each function instance has its own memory, so the rate limit was never actually enforced across concurrent requests.

**What this PR does:**
- Removes the inline `rateLimitMap`, `checkRateLimit` function, `RATE_LIMIT_WINDOW`, and `MAX_REQUESTS_PER_WINDOW` constants (~15 lines of duplicate logic)
- Replaces them with the existing `rateLimit()` utility from `lib/rate-limit.ts`
- No behaviour change — same 10 requests per 60 seconds limit is preserved
- Makes the webhook route consistent with all other API routes in the codebase

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes — this is a backend refactor.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.