### PR TITLE
fix(config): replace hardcoded dev origin IP with env variable

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -44,3 +44,8 @@ TRUSTED_PROXIES=
 # Set to "true" to automatically trust private IPs (10.x, 192.168.x).
 # Defaults to "false" (automatically enabled in development).
 TRUST_PRIVATE_PROXIES=false
+
+# Comma-separated list of allowed dev origins for local development.
+# Set this to your local machine's IP if you face CORS errors during dev.
+# Example: NEXT_ALLOWED_DEV_ORIGINS=192.168.1.100,172.31.128.1
+NEXT_ALLOWED_DEV_ORIGINS=

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   serverExternalPackages: ['next/og', '@resvg/resvg-js'],
-  allowedDevOrigins: ['172.31.128.1'],
+  allowedDevOrigins: process.env.NEXT_ALLOWED_DEV_ORIGINS
+    ? process.env.NEXT_ALLOWED_DEV_ORIGINS.split(',')
+    : [],
   devIndicators: false,
   async headers() {
     return [


### PR DESCRIPTION
## Description
Fixes #5569

`next.config.ts` had a hardcoded private IP address `172.31.128.1` in `allowedDevOrigins` which broke local development for all contributors not on the same subnet — with no obvious error message to debug.

**Problems with the old approach:**
- **Contributor friction** — any developer on a different subnet would hit silent CORS/origin errors during `npm run dev` with no clear cause
- **Network info leak** — a private IP was committed to a public repository, exposing internal network topology

**What this PR does:**
- Replaces the hardcoded IP with an environment variable `NEXT_ALLOWED_DEV_ORIGINS` that each contributor can set locally
- Falls back to an empty array `[]` if the variable is not set (safe default)
- Adds `NEXT_ALLOWED_DEV_ORIGINS=` to `.env.local.example` with a usage comment so contributors know how to configure it

**Before:**
```ts
allowedDevOrigins: ['172.31.128.1'],
```

**After:**
```ts
allowedDevOrigins: process.env.NEXT_ALLOWED_DEV_ORIGINS
  ? process.env.NEXT_ALLOWED_DEV_ORIGINS.split(',')
  : [],
```

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes — this is a config fix.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.