### PR TITLE
feat: add README insights card with grade system and improvement tips

### DIFF
--- a/app/generator/GeneratorClient.tsx
+++ b/app/generator/GeneratorClient.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import { EditorPanel } from './components/EditorPanel';
 import { PreviewPanel } from './components/PreviewPanel';
 import { CompletionScorePanel } from './components/CompletionScorePanel';
+import { ReadmeInsightsPanel } from './components/ReadmeInsightsPanel';
 import { generateReadme, getEmptyReadme } from './utils/readmeGenerator';
 import type { GeneratorState } from './types';
 import type { ImportedData } from './utils/githubMapper';
@@ -97,6 +98,7 @@ export function GeneratorClient() {
       <div className="w-full lg:flex-1 flex flex-col gap-5 xl:gap-6">
         <PreviewPanel markdown={markdown} />
         <CompletionScorePanel state={state} />
+        <ReadmeInsightsPanel state={state} />
       </div>
     </div>
   );

--- a/app/generator/components/ReadmeInsightsPanel.test.tsx
+++ b/app/generator/components/ReadmeInsightsPanel.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect } from 'vitest';
+import { ReadmeInsightsPanel } from './ReadmeInsightsPanel';
+import type { GeneratorState } from '../types';
+import React from 'react';
+
+const EMPTY_STATE: GeneratorState = {
+  name: '',
+  description: '',
+  selectedTechs: [],
+  selectedSocials: [],
+  socialLinks: {},
+  githubUsername: '',
+  showCommitPulse: false,
+  commitPulseAccent: '',
+  showSnakeGraph: false,
+  showPacmanGraph: false,
+  graphPlacement: 'bottom',
+};
+
+describe('ReadmeInsightsPanel Component Tests', () => {
+  it('renders with Beginner grade when state is completely empty (score 0)', () => {
+    render(<ReadmeInsightsPanel state={EMPTY_STATE} />);
+
+    expect(screen.getByText('README Insights')).toBeInTheDocument();
+    expect(screen.getByText('Beginner')).toBeInTheDocument();
+    expect(screen.getByText('Suggested Improvements')).toBeInTheDocument();
+  });
+
+  it('shows up to 4 tips when state is empty', () => {
+    render(<ReadmeInsightsPanel state={EMPTY_STATE} />);
+
+    const list = screen.getByRole('list');
+    expect(list).toBeInTheDocument();
+
+    const items = screen.getAllByRole('listitem');
+    expect(items.length).toBeLessThanOrEqual(4);
+    expect(items.length).toBeGreaterThan(0);
+  });
+
+  it('shows Beginner grade for score <= 30 (name only = 15%)', () => {
+    const state = { ...EMPTY_STATE, name: 'Roshesh' };
+    render(<ReadmeInsightsPanel state={state} />);
+
+    expect(screen.getByText('Beginner')).toBeInTheDocument();
+  });
+
+  it('shows Intermediate grade for score 31–60 (name + description = 35%)', () => {
+    const state = { ...EMPTY_STATE, name: 'Roshesh', description: 'Full-stack developer' };
+    render(<ReadmeInsightsPanel state={state} />);
+
+    expect(screen.getByText('Intermediate')).toBeInTheDocument();
+  });
+
+  it('shows Advanced grade for score 61–85 (name + desc + techs + github = 70%)', () => {
+    const state = {
+      ...EMPTY_STATE,
+      name: 'Roshesh',
+      description: 'Dev',
+      selectedTechs: ['react', 'nextjs', 'typescript'],
+      githubUsername: 'roshesh',
+    };
+    render(<ReadmeInsightsPanel state={state} />);
+
+    expect(screen.getByText('Advanced')).toBeInTheDocument();
+  });
+
+  it('shows Pro grade for score >= 86 (name + desc + techs + socials + github = 90%)', () => {
+    const state = {
+      ...EMPTY_STATE,
+      name: 'Roshesh',
+      description: 'Dev',
+      selectedTechs: ['react', 'nextjs', 'typescript'],
+      selectedSocials: ['twitter'],
+      socialLinks: { twitter: 'https://twitter.com/test' },
+      githubUsername: 'roshesh',
+    };
+    render(<ReadmeInsightsPanel state={state} />);
+
+    expect(screen.getByText('Pro')).toBeInTheDocument();
+  });
+
+  it('generates relevant tips for missing techs and socials', () => {
+    const state = { ...EMPTY_STATE, name: 'Roshesh', description: 'Dev' };
+    render(<ReadmeInsightsPanel state={state} />);
+
+    expect(screen.getByText('Add technologies to showcase your skills.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Connect your social profiles to make collaboration easier.')
+    ).toBeInTheDocument();
+  });
+
+  it('does not show tips for completed sections', () => {
+    const state = {
+      ...EMPTY_STATE,
+      name: 'Roshesh',
+      description: 'Dev',
+      selectedTechs: ['react', 'nextjs', 'typescript'],
+      selectedSocials: ['twitter'],
+      socialLinks: { twitter: 'https://twitter.com/test' },
+      githubUsername: 'roshesh',
+      showCommitPulse: true,
+    };
+    render(<ReadmeInsightsPanel state={state} />);
+
+    expect(
+      screen.getByText('Your README is looking great — all sections are filled!')
+    ).toBeInTheDocument();
+  });
+
+  it('shows specific tip when 2 techs are selected (need 1 more)', () => {
+    const state = {
+      ...EMPTY_STATE,
+      selectedTechs: ['react', 'nextjs'],
+    };
+    render(<ReadmeInsightsPanel state={state} />);
+
+    expect(
+      screen.getByText('Add 1 more technology to better showcase your skills.')
+    ).toBeInTheDocument();
+  });
+
+  it('has correct aria-label for accessibility', () => {
+    render(<ReadmeInsightsPanel state={EMPTY_STATE} />);
+
+    const panel = screen.getByLabelText('README Insights');
+    expect(panel).toBeInTheDocument();
+  });
+});

--- a/app/generator/components/ReadmeInsightsPanel.tsx
+++ b/app/generator/components/ReadmeInsightsPanel.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Lightbulb, Star, Zap, Award, BookOpen } from 'lucide-react';
+import type { GeneratorState } from '../types';
+
+interface ReadmeInsightsPanelProps {
+  state: GeneratorState;
+}
+
+/**
+ * Grade thresholds based on completion score:
+ *   0–30  → Beginner
+ *  31–60  → Intermediate
+ *  61–85  → Advanced
+ *  86–100 → Pro
+ */
+interface GradeInfo {
+  label: string;
+  colorClasses: string;
+  icon: React.ReactNode;
+}
+
+function getGrade(score: number): GradeInfo {
+  if (score >= 86) {
+    return {
+      label: 'Pro',
+      colorClasses:
+        'text-emerald-400 bg-emerald-500/15 border-emerald-500/30 shadow-emerald-500/10',
+      icon: <Award size={13} className="flex-shrink-0" />,
+    };
+  }
+  if (score >= 61) {
+    return {
+      label: 'Advanced',
+      colorClasses: 'text-orange-400 bg-orange-500/15 border-orange-500/30 shadow-orange-500/10',
+      icon: <Star size={13} className="flex-shrink-0" />,
+    };
+  }
+  if (score >= 31) {
+    return {
+      label: 'Intermediate',
+      colorClasses: 'text-yellow-400 bg-yellow-500/15 border-yellow-500/30 shadow-yellow-500/10',
+      icon: <Zap size={13} className="flex-shrink-0" />,
+    };
+  }
+  return {
+    label: 'Beginner',
+    colorClasses: 'text-blue-400 bg-blue-500/15 border-blue-500/30 shadow-blue-500/10',
+    icon: <BookOpen size={13} className="flex-shrink-0" />,
+  };
+}
+
+/**
+ * Computes the same score as CompletionScorePanel to stay in sync
+ * without duplicating state management.
+ */
+function computeScore(state: GeneratorState): number {
+  let score = 0;
+  if ((state.name || '').trim().length > 0) score += 15;
+  if ((state.description || '').trim().length > 0) score += 20;
+  if ((state.selectedTechs?.length || 0) >= 3) score += 25;
+  if (
+    (state.selectedSocials?.length || 0) > 0 &&
+    state.selectedSocials.some((id) => (state.socialLinks?.[id] || '').trim().length > 0)
+  )
+    score += 20;
+  if (state.showCommitPulse) score += 10;
+  if ((state.githubUsername || '').trim().length > 0) score += 10;
+  return score;
+}
+
+interface Tip {
+  id: string;
+  text: string;
+}
+
+/**
+ * Generates up to 4 actionable tips based on what's missing,
+ * prioritised by impact (highest weight items first).
+ */
+function generateTips(state: GeneratorState): Tip[] {
+  const tips: Tip[] = [];
+
+  const techCount = state.selectedTechs?.length || 0;
+  const hasName = (state.name || '').trim().length > 0;
+  const hasDescription = (state.description || '').trim().length > 0;
+  const hasTechs = techCount >= 3;
+  const hasSocials =
+    (state.selectedSocials?.length || 0) > 0 &&
+    state.selectedSocials.some((id) => (state.socialLinks?.[id] || '').trim().length > 0);
+  const hasCommitPulse = !!state.showCommitPulse;
+  const hasGithubUsername = (state.githubUsername || '').trim().length > 0;
+
+  // Order by weight (highest impact first) so the most valuable tips appear at the top
+  if (!hasTechs) {
+    tips.push({
+      id: 'techs',
+      text:
+        techCount === 0
+          ? 'Add technologies to showcase your skills.'
+          : `Add ${3 - techCount} more technolog${3 - techCount === 1 ? 'y' : 'ies'} to better showcase your skills.`,
+    });
+  }
+
+  if (!hasSocials) {
+    tips.push({
+      id: 'socials',
+      text: 'Connect your social profiles to make collaboration easier.',
+    });
+  }
+
+  if (!hasDescription) {
+    tips.push({
+      id: 'description',
+      text: 'Add a longer bio/description to improve profile visibility.',
+    });
+  }
+
+  if (!hasName) {
+    tips.push({
+      id: 'name',
+      text: 'Add your name to personalize your profile.',
+    });
+  }
+
+  if (!hasCommitPulse) {
+    tips.push({
+      id: 'commitpulse',
+      text: 'Enable CommitPulse badge to display GitHub activity.',
+    });
+  }
+
+  if (!hasGithubUsername) {
+    tips.push({
+      id: 'github',
+      text: 'Add your GitHub username to link your profile.',
+    });
+  }
+
+  // If everything is complete, show an encouraging message
+  if (tips.length === 0) {
+    tips.push({
+      id: 'complete',
+      text: 'Your README is looking great — all sections are filled!',
+    });
+  }
+
+  return tips.slice(0, 4);
+}
+
+export function ReadmeInsightsPanel({ state }: ReadmeInsightsPanelProps) {
+  const insights = useMemo(() => {
+    const score = computeScore(state);
+    const grade = getGrade(score);
+    const tips = generateTips(state);
+    return { score, grade, tips };
+  }, [
+    state.name,
+    state.description,
+    state.selectedTechs,
+    state.selectedSocials,
+    state.socialLinks,
+    state.showCommitPulse,
+    state.githubUsername,
+  ]);
+
+  return (
+    <div
+      className="rounded-2xl border border-gray-200 dark:border-white/10 bg-white dark:bg-[#111111] overflow-hidden shadow-sm transition-all duration-300 w-full p-5 flex flex-col gap-4"
+      aria-label="README Insights"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-gray-100 dark:border-white/5 pb-3">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+          <Lightbulb size={15} className="text-amber-400" />
+          README Insights
+        </h3>
+        <span
+          className={`text-xs font-bold px-2.5 py-1 rounded-full border shadow-sm flex items-center gap-1.5 transition-colors duration-300 ${insights.grade.colorClasses}`}
+        >
+          {insights.grade.icon}
+          {insights.grade.label}
+        </span>
+      </div>
+
+      {/* Suggested Improvements */}
+      <div className="flex flex-col gap-2.5">
+        <span className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-white/40">
+          Suggested Improvements
+        </span>
+        <ul className="flex flex-col gap-2" role="list">
+          {insights.tips.map((tip) => (
+            <li
+              key={tip.id}
+              className="flex items-start gap-2.5 text-xs text-gray-700 dark:text-white/70 py-1 transition-all duration-300"
+            >
+              <span
+                className={`mt-0.5 flex-shrink-0 h-1.5 w-1.5 rounded-full ${
+                  tip.id === 'complete' ? 'bg-emerald-400' : 'bg-amber-400'
+                }`}
+                aria-hidden="true"
+              />
+              <span>{tip.text}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Fixes #5818 

Added a new **README Insights** section below the existing README Completion Score card in the Generator page.

### Changes Made

* Added a dynamic README Grade System:

  * Beginner (0–30)
  * Intermediate (31–60)
  * Advanced (61–85)
  * Pro (86–100)
* Added a grade badge that updates automatically based on the completion score.
* Added dynamic improvement tips generated from missing profile information.
* Reused the existing completion score logic without introducing new dependencies.
* Maintained responsiveness and existing UI styling conventions.

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

<img width="1697" height="465" alt="Screenshot 2026-06-16 125432" src="https://github.com/user-attachments/assets/b333a98f-7e9c-4220-acfb-92902c712f72" />

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable).
* [x] (Recommended) I joined the CommitPulse Discord community.
