### PR TITLE
chore(types): replace any[] with typed interfaces in burnout-analyzer.ts

### DIFF
--- a/services/github/burnout-analyzer.ts
+++ b/services/github/burnout-analyzer.ts
@@ -1,6 +1,26 @@
 import { getGitHubTokens } from '@/lib/github';
 import { DistributedCache } from '@/lib/cache';
 
+interface ContributorWeekData {
+  w: number; // week timestamp (Unix)
+  a: number; // additions
+  d: number; // deletions
+  c: number; // commits
+}
+
+interface ContributorStats {
+  author: { login: string; avatar_url: string };
+  weeks: ContributorWeekData[];
+  total: number;
+}
+
+interface InactivityAlert {
+  username: string;
+  avatarUrl: string;
+  previousAvgWeeklyCommits: number;
+  weeksSilent: number;
+}
+
 const GITHUB_REST_URL = 'https://api.github.com';
 
 export interface ContributorMetric {
@@ -130,8 +150,7 @@ async function analyzeRepositoryUncached(
     throw new Error(`Failed to fetch contributor stats: ${res.statusText}`);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rawData: any[] = await res.json();
+  const rawData: ContributorStats[] = await res.json();
   if (!Array.isArray(rawData) || rawData.length === 0) {
     throw new Error('No contribution data found for this repository.');
   }
@@ -395,10 +414,10 @@ async function generateRecommendationsWithGemini(
   busFactor: number,
   dependencyRisk: string,
   sustainabilityScore: number,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  topContributors: any[],
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  inactivityAlerts: any[]
+
+  topContributors: ContributorMetric[],
+
+  inactivityAlerts: InactivityAlert[]
 ): Promise<string[]> {
   const prompt = `
   You are an expert AI repository consultant. Analyze these contributor metrics for GitHub repository ${owner}/${repo}:


### PR DESCRIPTION
## Description
Fixes #5819

`services/github/burnout-analyzer.ts` was using `any[]` for GitHub API responses and function parameters in multiple places, suppressing TypeScript's type safety with `// eslint-disable-next-line @typescript-eslint/no-explicit-any` comments:

```ts
const rawData: any[] = await res.json();

topContributors: any[],
inactivityAlerts: any[]
```

**Problems with the old approach:**
- **No type safety** — `any[]` bypasses TypeScript completely, hiding potential runtime errors and making refactoring risky
- **ESLint suppression** — each `any` usage required a disable comment, indicating these were known workarounds not intentional design
- **Poor developer experience** — no autocomplete or type hints for API response fields

**What this PR does:**
- Defines `ContributorWeekData` interface for GitHub REST API weekly stats shape (`w`, `a`, `d`, `c` fields)
- Defines `ContributorStats` interface for full contributor response (`author`, `weeks`, `total`)
- Defines `InactivityAlert` interface for inactivity alert objects (`username`, `avatarUrl`, `weeksSilent`, `previousAvgWeeklyCommits`)
- Replaces `topContributors: any[]` with already-exported `ContributorMetric[]` interface
- Removes all `eslint-disable-next-line @typescript-eslint/no-explicit-any` comments that were suppressing type errors

**After:**
```ts
const rawData: ContributorStats[] = await res.json();

topContributors: ContributorMetric[],
inactivityAlerts: InactivityAlert[]
```

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes — this is a type safety refactor.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.