### PR TITLE
fix(burnout-analyzer): replace any[] with typed params in generateRecommendationsWithGemini

### DIFF
--- a/services/github/burnout-analyzer.ts
+++ b/services/github/burnout-analyzer.ts
@@ -395,10 +395,8 @@ async function generateRecommendationsWithGemini(
   busFactor: number,
   dependencyRisk: string,
   sustainabilityScore: number,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  topContributors: any[],
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  inactivityAlerts: any[]
+  topContributors: ContributorMetric[],
+  inactivityAlerts: BurnoutReport['inactivityAlerts']
 ): Promise<string[]> {
   const prompt = `
   You are an expert AI repository consultant. Analyze these contributor metrics for GitHub repository ${owner}/${repo}:


### PR DESCRIPTION
## Description
`generateRecommendationsWithGemini` in `burnout-analyzer.ts` typed two parameters as `any[]` with `eslint-disable` comments:

```ts
// eslint-disable-next-line @typescript-eslint/no-explicit-any
topContributors: any[],
// eslint-disable-next-line @typescript-eslint/no-explicit-any
inactivityAlerts: any[]
```

Using `any[]` bypassed TypeScript's checks on all field accesses in the Gemini prompt template strings — `c.commitShare`, `c.burnoutScore`, `c.riskLevel`, `a.weeksSilent`, `a.previousAvgWeeklyCommits`. If any field was renamed, the prompt would silently contain `undefined` values producing garbage AI recommendations.

Both correct types are already available in the same file:
- `ContributorMetric` — exported interface at line 6
- `BurnoutReport['inactivityAlerts']` — indexed access type already used at the call site

Changes made:
- Replaced `topContributors: any[]` with `topContributors: ContributorMetric[]`
- Replaced `inactivityAlerts: any[]` with `inactivityAlerts: BurnoutReport['inactivityAlerts']`
- Removed both `eslint-disable-next-line` comments
- Verified zero new TypeScript errors introduced by this change

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — TypeScript type safety fix with no visual output.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [ ] (Recommended) I joined the CommitPulse Discord community.