### PR TITLE
fix(customization): remove duplicated export footer text

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -135,7 +135,7 @@
       "copied": "Copied!",
       "copy_aria_disabled": "Add a GitHub username to enable copying the {{format}} export snippet",
       "copy_aria_enabled": "Copy {{format}} export snippet to clipboard",
-      "footer_tip": "Paste this into your GitHub profile's README.md. The badge renders server-side, no script required.",
+      "footer_tip": "The badge renders server-side, no script required.",
       "tsx": "React TSX",
       "download_svg": "Download SVG",
       "download_png": "Download PNG"


### PR DESCRIPTION
## Description

Fixes #5832 

Resolved a duplicate instruction text issue in the Export Panel.

The export footer displayed:

> Paste this into your GitHub profile's README.md. Paste this into your GitHub profile's README.md. The badge renders server-side, no script required.

This occurred because the instruction prefix was already rendered by the component while the localized `footer_tip` string contained the same instruction again.

### Changes Made

* Updated the English locale (`locales/en.json`).
* Removed the duplicated README instruction from `footer_tip`.
* Preserved the existing UI structure and formatting.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

### Before

Paste this into your GitHub profile's README.md. Paste this into your GitHub profile's README.md. The badge renders server-side, no script required.

### After

Paste this into your GitHub profile's README.md. The badge renders server-side, no script required.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse quality standards.
* [ ] (Recommended) I joined the CommitPulse Discord community.
