### PR TITLE
chore(types): replace any[] with typed PRNode interface in pr-insights.ts

### DIFF
--- a/services/github/pr-insights.ts
+++ b/services/github/pr-insights.ts
@@ -1,6 +1,30 @@
 import { fetchWithRetry, getGitHubTokens } from '@/lib/github';
 import { DistributedCache } from '@/lib/cache';
 
+interface PRReviewNode {
+  author: { login: string } | null;
+  createdAt: string;
+  state: string;
+}
+
+interface PRNode {
+  id: string;
+  title: string;
+  url: string;
+  state: string;
+  createdAt: string;
+  closedAt: string | null;
+  mergedAt: string | null;
+  additions: number;
+  deletions: number;
+  repository: { nameWithOwner: string } | null;
+  comments: { totalCount: number } | null;
+  reviews: {
+    nodes: PRReviewNode[];
+    totalCount: number;
+  } | null;
+}
+
 const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql';
 const MAX_PAGES = 3;
 
@@ -133,8 +157,7 @@ async function fetchPRInsightsUncached(
     reviewerQuery: `is:pr reviewed-by:${username} -author:${username} created:>=${dateStr}`,
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let allAuthoredPRs: any[] = [];
+  let allAuthoredPRs: PRNode[] = [];
   let hasNextPage = true;
   let after: string | null = null;
   let reviewsGivenCount = 0;
@@ -155,8 +178,7 @@ async function fetchPRInsightsUncached(
       throw new Error(json.errors[0]?.message || 'GraphQL Error');
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const pageNodes = (json.data?.authored?.nodes || []).filter((n: any) => n && n.title);
+    const pageNodes = (json.data?.authored?.nodes || []).filter((n: PRNode) => n && n.title);
     allAuthoredPRs = allAuthoredPRs.concat(pageNodes);
 
     hasNextPage = json.data?.authored?.pageInfo?.hasNextPage || false;
@@ -238,7 +260,7 @@ async function fetchPRInsightsUncached(
     }
 
     // Comments
-    if (pr.comments?.totalCount > mostDiscussed.comments) {
+    if (pr.comments !== null && (pr.comments?.totalCount ?? 0) > mostDiscussed.comments) {
       mostDiscussed = { title: pr.title, url: pr.url, comments: pr.comments.totalCount };
     }
 


### PR DESCRIPTION
## Description
Fixes #5820

`services/github/pr-insights.ts` was using `any[]` for GitHub GraphQL API response nodes in two places, suppressing TypeScript's type safety with `// eslint-disable-next-line @typescript-eslint/no-explicit-any` comments:

```ts
let allAuthoredPRs: any[] = [];

const pageNodes = (json.data?.authored?.nodes || []).filter((n: any) => n && n.title);
```

**Problems with the old approach:**
- **No type safety** — `any[]` bypasses TypeScript completely, hiding potential runtime errors and making refactoring risky
- **ESLint suppression** — each `any` usage required a disable comment, indicating these were known workarounds not intentional design
- **Poor developer experience** — no autocomplete or type hints for GraphQL response fields

**What this PR does:**
- Defines `PRReviewNode` interface for review node shape (`author`, `createdAt`, `state`)
- Defines `PRNode` interface for full PR node shape matching the GraphQL query response (`id`, `title`, `url`, `state`, `createdAt`, `mergedAt`, `additions`, `deletions`, `repository`, `comments`, `reviews`)
- Replaces `allAuthoredPRs: any[]` with `allAuthoredPRs: PRNode[]`
- Replaces `(n: any)` filter callback with `(n: PRNode)`
- Fixes null safety issue for `pr.comments.totalCount` using nullish coalescing operator (`??`)
- Removes all `eslint-disable-next-line @typescript-eslint/no-explicit-any` comments

**After:**
```ts
let allAuthoredPRs: PRNode[] = [];

const pageNodes = (json.data?.authored?.nodes || []).filter((n: PRNode) => n && n.title);
```

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes — this is a type safety refactor.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.