### PR TITLE
test: add empty state fallback coverage for ShareButtons

### DIFF
--- a/components/ShareButtons.empty-fallback.test.tsx
+++ b/components/ShareButtons.empty-fallback.test.tsx
@@ -1,43 +1,20 @@
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import { describe, it, expect } from 'vitest';
 import ShareButtons from './ShareButtons';
 
 describe('ShareButtons - Empty/Fallback Safety Tests', () => {
-  // Test 1: Minimal Valid Render
-  it('renders successfully with only the required url prop', () => {
-    const { container } = render(<ShareButtons url="https://example.com" />);
-
-    const links = screen.getAllByRole('link');
-    expect(links).toHaveLength(2);
-    expect(screen.getByRole('link', { name: /share on linkedin/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /share on x \/ twitter/i })).toBeInTheDocument();
-    expect(container.querySelector('svg')).toBeInTheDocument();
-  });
-
-  // Test 2: Missing Optional Inputs
-  it('handles omitted optional title prop gracefully', () => {
-    render(<ShareButtons url="https://example.com" />);
-
-    const twitter = screen.getByRole('link', { name: /share on x \/ twitter/i });
-    expect(twitter).toHaveAttribute(
-      'href',
-      'https://x.com/intent/tweet?url=https%3A%2F%2Fexample.com'
-    );
-    expect(twitter.getAttribute('href')).not.toContain('&text=');
-
-    // All links still render
-    expect(screen.getByRole('link', { name: /share on linkedin/i })).toBeInTheDocument();
-  });
-
-  // Test 3: Empty Values Handling
+  // ---------------------------------------------------------------------------
+  // 1.  Empty or missing primary data renders safely
+  // ---------------------------------------------------------------------------
   it('renders without crashing when url is an empty string', () => {
     expect(() => render(<ShareButtons url="" />)).not.toThrow();
 
+    // Both share links must still be present
     const links = screen.getAllByRole('link');
     expect(links).toHaveLength(2);
 
-    // LinkedIn URL with empty encoded string
+    // LinkedIn URL is still formed, just with an empty encoded value
     const linkedin = screen.getByRole('link', { name: /share on linkedin/i });
     expect(linkedin).toHaveAttribute(
       'href',
@@ -45,44 +22,88 @@ describe('ShareButtons - Empty/Fallback Safety Tests', () => {
     );
   });
 
-  // Test 4: Null and Undefined Inputs
-  it('handles undefined title via default parameter without errors', () => {
+  // ---------------------------------------------------------------------------
+  // 2.  Null / undefined inputs trigger fallback behavior
+  // ---------------------------------------------------------------------------
+  it('handles omitted optional title via default parameter without errors', () => {
+    // The component declares title? → title = '' at the destructuring level,
+    // so omitting the prop or passing undefined is safe.
     const props: { url: string; title?: string } = {
       url: 'https://example.com',
     };
 
     expect(() => render(<ShareButtons url={props.url} />)).not.toThrow();
 
+    // Twitter link must NOT contain a text parameter when title is not provided
     const twitter = screen.getByRole('link', { name: /share on x \/ twitter/i });
-    expect(twitter).toHaveAttribute(
-      'href',
-      'https://x.com/intent/tweet?url=https%3A%2F%2Fexample.com'
-    );
     expect(twitter.getAttribute('href')).not.toContain('&text=');
   });
 
-  // Test 5: Structural Integrity Verification
-  it('maintains expected DOM structure in empty-edge state', () => {
-    const { container } = render(<ShareButtons url="https://example.com" />);
+  // ---------------------------------------------------------------------------
+  // 3.  Empty state preserves expected wrapper structure
+  // ---------------------------------------------------------------------------
+  it('preserves expected DOM structure even with edge-case inputs', () => {
+    const { container } = render(<ShareButtons url="" />);
 
-    // Root div with flex classes
-    const rootDiv = container.firstElementChild;
-    expect(rootDiv).toBeInTheDocument();
-    expect(rootDiv?.className).toContain('flex');
-    expect(rootDiv?.className).toContain('gap-3');
+    // Root container must exist
+    const root = container.firstElementChild;
+    expect(root).toBeInTheDocument();
 
-    // Both links have correct security attributes
+    // Both links must have correct security attributes
     const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
     links.forEach((link) => {
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
-    // SVG icons are rendered within each link
+    // SVG icons must be present and marked as decorative
     const svgIcons = container.querySelectorAll('svg');
     expect(svgIcons).toHaveLength(2);
     svgIcons.forEach((icon) => {
       expect(icon).toHaveAttribute('aria-hidden', 'true');
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4.  Default styling / layout remains intact during empty rendering
+  // ---------------------------------------------------------------------------
+  it('retains standard layout classes when rendered with empty string url', () => {
+    const { container } = render(<ShareButtons url="" />);
+
+    // The wrapper div must keep its structural flex classes
+    const rootDiv = container.firstElementChild;
+    expect(rootDiv).toBeInTheDocument();
+    expect(rootDiv?.className).toContain('flex');
+    expect(rootDiv?.className).toContain('gap-3');
+
+    // Both accessible labels must still be rendered
+    expect(screen.getByRole('link', { name: /share on linkedin/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /share on x \/ twitter/i })).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5.  Rerendering between valid and empty states does not throw
+  // ---------------------------------------------------------------------------
+  it('survives rerender transitions between valid and empty url values', () => {
+    const { rerender } = render(<ShareButtons url="https://example.com" />);
+
+    // Initial render: both links present
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+
+    // Transition to empty string
+    expect(() => rerender(<ShareButtons url="" />)).not.toThrow();
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+
+    // Transition back to a valid URL
+    expect(() => rerender(<ShareButtons url="https://commitpulse.vercel.app" />)).not.toThrow();
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+
+    // Final state must produce correct LinkedIn share URLs
+    const linkedin = screen.getByRole('link', { name: /share on linkedin/i });
+    expect(linkedin).toHaveAttribute(
+      'href',
+      'https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fcommitpulse.vercel.app'
+    );
   });
 });


### PR DESCRIPTION
## Description

- Added ShareButtons.empty-fallback.test.tsx
- Added coverage for empty and missing input scenarios
- Verified fallback rendering behavior
- Verified layout stability during empty states
- Verified rerendering does not introduce runtime errors

Fixes #2763

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [ ] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
