### PR TITLE
test(structured-clone): add regression test preventing JSON.parse/str…

### DIFF
--- a/lib/structured-clone-regression.test.ts
+++ b/lib/structured-clone-regression.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+const SOURCE_DIRS = ['lib', 'app', 'hooks', 'components', 'services', 'utils'];
+
+function stripComments(code: string): string {
+  return code.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function walkSourceFiles(dir: string): string[] {
+  const result: string[] = [];
+  if (!fs.existsSync(dir)) return result;
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== 'node_modules' && entry.name !== '__tests__') {
+        result.push(...walkSourceFiles(fullPath));
+      }
+    } else if (
+      entry.isFile() &&
+      /\.(ts|tsx)$/.test(entry.name) &&
+      !entry.name.endsWith('.test.ts') &&
+      !entry.name.endsWith('.test.tsx')
+    ) {
+      result.push(fullPath);
+    }
+  }
+  return result;
+}
+
+describe('structuredClone regression prevention', () => {
+  const sourceFiles = SOURCE_DIRS.flatMap((d) => walkSourceFiles(path.join(ROOT, d)));
+
+  it('no source file uses JSON.parse(JSON.stringify(...)) as a deep clone', () => {
+    const deepCloneRe = /JSON\.parse\s*\(\s*JSON\.stringify\s*\(/;
+
+    for (const file of sourceFiles) {
+      const content = fs.readFileSync(file, 'utf8');
+      const code = stripComments(content);
+
+      if (deepCloneRe.test(code)) {
+        throw new Error(
+          `Found JSON.parse(JSON.stringify(...)) deep clone in ${path.relative(ROOT, file)} — use structuredClone instead`
+        );
+      }
+    }
+  });
+
+  it('aggregateCalendars uses structuredClone for deep cloning', () => {
+    const calculatePath = path.join(ROOT, 'lib', 'calculate.ts');
+    const content = fs.readFileSync(calculatePath, 'utf8');
+    expect(content).toContain('structuredClone(baseCalendar)');
+  });
+});


### PR DESCRIPTION
## Description

Migrates the codebase from `JSON.parse(JSON.stringify(...))` deep clone anti-pattern to native `structuredClone()`, and adds a regression test suite to prevent reintroduction.

**Fixes #3701**

### Changes

The only `JSON.parse(JSON.stringify())` deep clone existed in `lib/calculate.ts:400` (`aggregateCalendars`) — it was already migrated to `structuredClone(baseCalendar)`. No runtime changes needed.

**Added `lib/structured-clone-regression.test.ts`** — a regression test suite with 2 tests:

| # | Test | Verification |
|---|------|-------------|
| 1 | No source file uses the anti-pattern | Scans all `.ts`/`.tsx` source files (excluding tests) for `JSON.parse(JSON.stringify(` deep clone usage — fails if any is found |
| 2 | `aggregateCalendars` uses `structuredClone` | Asserts `lib/calculate.ts` contains `structuredClone(baseCalendar)` — validates the migration is in place |

### Why `structuredClone` over `JSON.parse/stringify`

| Aspect | `JSON.parse(JSON.stringify(x))` | `structuredClone(x)` |
|--------|-------------------------------|---------------------|
| `undefined` values | Silently dropped | Preserved as `undefined` |
| `Date` objects | Converted to strings | Preserved as `Date` |
| Circular references | Throws `TypeError` | Correctly cloned |
| `Map`, `Set`, `RegExp` | Converted to `{}` | Preserved |
| Performance | Serialize + parse overhead | Native implementation (~2-4x faster) |
| Availability | Always available | Node.js 17+, all modern browsers |

**Pillar:** 🛠️ Other (Bug fix, refactoring)

**Visual Preview:** N/A — no visual changes.