### PR TITLE
fix(calculate): prevent date shift in normalizeCalendarToTimezone for non-UTC users

### DIFF
--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -2750,4 +2750,64 @@ describe('normalizeCalendarToTimezone', () => {
     );
     expect(totalContributions).toBe(20);
   });
+
+  it('does not shift dates for users in UTC-5 (regression: timezone date shift bug)', () => {
+    const calendar: ContributionCalendar = {
+      totalContributions: 10,
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 4, date: '2024-01-01' },
+            { contributionCount: 6, date: '2024-01-02' },
+          ],
+        },
+      ],
+    };
+
+    const normalized = normalizeCalendarToTimezone(calendar, 'America/New_York');
+    const allDays = normalized.weeks.flatMap((w) => w.contributionDays);
+    const dates = allDays.map((d) => d.date);
+
+    expect(dates).toContain('2024-01-01');
+    expect(dates).toContain('2024-01-02');
+    expect(dates).not.toContain('2023-12-31'); // ghost date from the old bug
+  });
+
+  it('does not shift dates for users in UTC+9 (Tokyo)', () => {
+    const calendar: ContributionCalendar = {
+      totalContributions: 5,
+      weeks: [
+        {
+          contributionDays: [{ contributionCount: 5, date: '2024-03-15' }],
+        },
+      ],
+    };
+
+    const normalized = normalizeCalendarToTimezone(calendar, 'Asia/Tokyo');
+    const allDays = normalized.weeks.flatMap((w) => w.contributionDays);
+
+    expect(allDays[0].date).toBe('2024-03-15');
+    expect(allDays[0].contributionCount).toBe(5);
+  });
+
+  it('accumulates duplicate dates from multi-user data without shifting', () => {
+    const calendar: ContributionCalendar = {
+      totalContributions: 12,
+      weeks: [
+        {
+          contributionDays: [
+            { contributionCount: 7, date: '2024-06-10' },
+            { contributionCount: 5, date: '2024-06-10' },
+          ],
+        },
+      ],
+    };
+
+    const normalized = normalizeCalendarToTimezone(calendar, 'America/Los_Angeles');
+    const allDays = normalized.weeks.flatMap((w) => w.contributionDays);
+
+    expect(allDays).toHaveLength(1);
+    expect(allDays[0].date).toBe('2024-06-10');
+    expect(allDays[0].contributionCount).toBe(12);
+  });
 });

--- a/lib/calculate.ts
+++ b/lib/calculate.ts
@@ -576,34 +576,8 @@ export function normalizeCalendarToTimezone(
   for (const day of allDays) {
     if (!day || !day.date) continue;
 
-    // Parse the date (YYYY-MM-DD) as a UTC date
-    const [yearStr, monthStr, dayStr] = day.date.split('-');
-    const year = parseInt(yearStr, 10);
-    const month = parseInt(monthStr, 10);
-    const dayNum = parseInt(dayStr, 10);
-
-    // Create a UTC date for midnight on this day
-    const utcMidnight = new Date(Date.UTC(year, month - 1, dayNum, 0, 0, 0));
-
-    // Get the date in the target timezone
-    const formatter = new Intl.DateTimeFormat('en-CA', {
-      timeZone: targetTimezone,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-    });
-
-    const parts = formatter.formatToParts(utcMidnight);
-    const tzYear = parseInt(parts.find((p) => p.type === 'year')?.value || yearStr, 10);
-    const tzMonth = parseInt(parts.find((p) => p.type === 'month')?.value || monthStr, 10);
-    const tzDay = parseInt(parts.find((p) => p.type === 'day')?.value || dayStr, 10);
-
-    // Create the normalized date string
-    const normalizedDate = `${tzYear}-${String(tzMonth).padStart(2, '0')}-${String(tzDay).padStart(2, '0')}`;
-
-    // Accumulate contribution count
-    const currentCount = dateMap.get(normalizedDate) || 0;
-    dateMap.set(normalizedDate, currentCount + (day.contributionCount || 0));
+    const currentCount = dateMap.get(day.date) || 0;
+    dateMap.set(day.date, currentCount + (day.contributionCount || 0));
   }
 
   // Sort dates and create weeks


### PR DESCRIPTION
… non-UTC users

## Description

Fixes a bug in `normalizeCalendarToTimezone` where contribution dates were 
shifted one day back for users in UTC-1 or further west (e.g. New York, 
Los Angeles), producing wrong streak counts and versus-view comparisons.

## Root Cause
GitHub's API returns contribution dates as plain `YYYY-MM-DD` strings that 
already represent the user's local calendar date — not UTC timestamps.

The old code incorrectly treated them as UTC timestamps:

// OLD — takes UTC midnight of the date, re-formats in target timezone
const utcMidnight = new Date(Date.UTC(year, month - 1, dayNum, 0, 0, 0));
const parts = formatter.formatToParts(utcMidnight); // shifts date for UTC- users
```
For a user in `America/New_York` (UTC-5), UTC midnight of `2024-01-01` is 
`2023-12-31` in New York — shifting every contribution one day into the past.

## Fix
Removed the `Intl.DateTimeFormat` conversion entirely. GitHub already provides 
the correct local date — use `day.date` directly as the map key.

// NEW — treat date as an opaque local label, no conversion needed
const currentCount = dateMap.get(day.date) || 0;
dateMap.set(day.date, currentCount + (day.contributionCount || 0));
```

## Files Changed
| File | Change |
| `lib/calculate.ts` | Removed UTC midnight → timezone conversion loop (~25 lines → 4 lines) |
| `lib/calculate.test.ts` | Added 3 regression tests |

## Tests
Added 3 regression tests inside `describe('normalizeCalendarToTimezone')`:
- UTC-5 (America/New_York) — dates must not shift back a day
- UTC+9 (Asia/Tokyo) — positive-offset zones stay stable  
- Duplicate date accumulation from multi-user org data

All 8 tests in the describe block pass.

Fixes #5824 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
