### PR TITLE
fix: validate lang parameter and fallback to English

### DIFF
--- a/lib/i18n/badgeLabels.ts
+++ b/lib/i18n/badgeLabels.ts
@@ -79,11 +79,29 @@ export const labels: Record<string, BadgeLabels> = {
   },
 };
 
-export const supportedLanguages = Object.keys(labels) as [
-  keyof typeof labels,
-  ...(keyof typeof labels)[],
-];
+export const supportedLanguages = [
+  'en',
+  'zh',
+  'es',
+  'hi',
+  'pt',
+  'ko',
+  'ja',
+  'fr',
+  'ta',
+  'de',
+] as const;
 
 export function getLabels(lang: string = 'en'): BadgeLabels {
-  return labels[lang.toLowerCase()] || labels['en'];
+  if (!lang || typeof lang !== 'string') {
+    return labels['en'];
+  }
+
+  const normalizedLang = lang.toLowerCase();
+
+  if (!(supportedLanguages as readonly string[]).includes(normalizedLang)) {
+    return labels['en'];
+  }
+
+  return labels[normalizedLang] || labels['en'];
 }


### PR DESCRIPTION
## Description

Fixes #5853

Validate the `lang` query parameter against supported language keys and gracefully fall back to English (`en`) when an unsupported language is provided.

This prevents runtime `TypeError` crashes and avoids 500 Internal Server Errors caused by invalid localization lookups.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A – Backend validation fix.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md`
* [x] I have linked the PR to an existing issue
* [x] I have tested the changes locally
