### PR TITLE
fix: add explicit SVG content type and cache headers

### DIFF
--- a/app/api/streak/png/route.test.ts
+++ b/app/api/streak/png/route.test.ts
@@ -39,7 +39,7 @@ describe('PNG Route', () => {
     const mockSvgResponse = new NextResponse('<svg>test</svg>', {
       status: 200,
       headers: {
-        'Content-Type': 'image/svg+xml',
+        'Content-Type': 'image/svg+xml; charset=utf-8',
         'Cache-Control': 'public, max-age=3600',
       },
     });
@@ -76,7 +76,7 @@ describe('PNG Route', () => {
     const mockSvgResponse = new NextResponse('<svg>invalid</svg>', {
       status: 200,
       headers: {
-        'Content-Type': 'image/svg+xml',
+        'Content-Type': 'image/svg+xml; charset=utf-8',
       },
     });
     vi.mocked(getStreakSvg).mockResolvedValue(mockSvgResponse);

--- a/app/api/streak/png/route.ts
+++ b/app/api/streak/png/route.ts
@@ -6,7 +6,7 @@ export async function GET(request: Request) {
   // Call the original endpoint which returns the SVG text
   const response = await getStreakSvg(request);
 
-  if (!response.ok || response.headers.get('Content-Type') !== 'image/svg+xml') {
+  if (!response.ok || !response.headers.get('Content-Type')?.includes('image/svg+xml')) {
     // Return errors as is
     return response;
   }

--- a/app/api/streak/route.mouse-interactivity.test.ts
+++ b/app/api/streak/route.mouse-interactivity.test.ts
@@ -120,7 +120,7 @@ describe('ApiStreakRoute Tests', () => {
     const response = await GET(request);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+    expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
     expect(response.headers.get('Content-Security-Policy')).toContain("default-src 'none';");
     const svgText = await response.text();
     expect(svgText).toContain('<svg');

--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -296,7 +296,7 @@ describe('GET /api/streak', () => {
     it('returns 200 with SVG content type', async () => {
       const response = await GET(makeRequest({ user: 'octocat' }));
       expect(response.status).toBe(200);
-      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
     });
 
     it('returns a well-formed SVG body', async () => {
@@ -311,7 +311,7 @@ describe('GET /api/streak', () => {
     it('returns valid SVG when mode=loc is given', async () => {
       const response = await GET(makeRequest({ user: 'octocat', mode: 'loc' }));
       expect(response.status).toBe(200);
-      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
       const body = await response.text();
       expect(body).toContain('<svg');
     });
@@ -742,17 +742,17 @@ describe('GET /api/streak', () => {
 
     it('returns SVG content type for theme=neon', async () => {
       const response = await GET(makeRequest({ user: 'octocat', theme: 'neon' }));
-      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
     });
 
     it('returns SVG content type for theme=dracula', async () => {
       const response = await GET(makeRequest({ user: 'octocat', theme: 'dracula' }));
-      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
     });
 
     it('returns SVG content type for theme=auto', async () => {
       const response = await GET(makeRequest({ user: 'octocat', theme: 'auto' }));
-      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
     });
 
     it('returns auto-theme SVG markup with dark-mode CSS variables when theme=auto', async () => {
@@ -874,7 +874,7 @@ describe('GET /api/streak', () => {
       const response = await GET(makeRequest({ user: 'octocat' }));
 
       expect(response.status).toBe(500);
-      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
     });
 
     it('embeds the thrown error message in the error SVG', async () => {

--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -434,7 +434,7 @@ describe('GET /api/streak', () => {
     it('caches until UTC midnight by default, using the value from getSecondsUntilUTCMidnight', async () => {
       const response = await GET(makeRequest({ user: 'octocat' }));
       expect(response.headers.get('Cache-Control')).toBe(
-        'public, s-maxage=3600, stale-while-revalidate=86400'
+        'public, max-age=14400, s-maxage=3600, stale-while-revalidate=7200'
       );
     });
 
@@ -442,7 +442,7 @@ describe('GET /api/streak', () => {
       vi.mocked(getSecondsUntilUTCMidnight).mockReturnValue(7200);
       const response = await GET(makeRequest({ user: 'octocat' }));
       expect(response.headers.get('Cache-Control')).toBe(
-        'public, s-maxage=7200, stale-while-revalidate=86400'
+        'public, max-age=14400, s-maxage=7200, stale-while-revalidate=7200'
       );
     });
 
@@ -977,7 +977,7 @@ describe('GET /api/streak', () => {
       const response = await GET(makeRequest({ user: 'octocat', tz: 'America/New_York' }));
 
       expect(response.headers.get('Cache-Control')).toBe(
-        'public, s-maxage=7200, stale-while-revalidate=86400'
+        'public, max-age=14400, s-maxage=7200, stale-while-revalidate=7200'
       );
       expect(getSecondsUntilMidnightInTimezone).toHaveBeenCalledWith('America/New_York');
       expect(getSecondsUntilUTCMidnight).not.toHaveBeenCalled();
@@ -1311,7 +1311,7 @@ describe('GET /api/streak', () => {
     it('returns no-cache header when ?theme=random is given', async () => {
       const response = await GET(makeRequest({ user: 'octocat', theme: 'random' }));
 
-      expect(response.headers.get('Cache-Control')).toMatch(/public, s-maxage=/);
+      expect(response.headers.get('Cache-Control')).toMatch(/public, max-age=14400, s-maxage=/);
     });
   });
 
@@ -1500,16 +1500,16 @@ describe('GET /api/streak', () => {
   });
 
   describe('stale-while-revalidate cache header', () => {
-    it('contains stale-while-revalidate=86400 for normal request', async () => {
+    it('contains stale-while-revalidate=7200 for normal request', async () => {
       const response = await GET(makeRequest({ user: 'octocat' }));
 
-      expect(response.headers.get('Cache-Control')).toContain('stale-while-revalidate=86400');
+      expect(response.headers.get('Cache-Control')).toContain('stale-while-revalidate=7200');
     });
 
     it('does NOT contain stale-while-revalidate when ?refresh=true', async () => {
       const response = await GET(makeRequest({ user: 'octocat', refresh: 'true' }));
 
-      expect(response.headers.get('Cache-Control')).not.toContain('stale-while-revalidate=86400');
+      expect(response.headers.get('Cache-Control')).not.toContain('stale-while-revalidate=7200');
     });
   });
 

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -546,8 +546,8 @@ export async function GET(request: Request) {
     const cacheControl = isRefreshRequested
       ? 'no-cache, no-store, must-revalidate'
       : isHistoricalYear
-        ? 'public, s-maxage=31536000, immutable'
-        : `public, s-maxage=${secondsToMidnight}, stale-while-revalidate=86400`;
+        ? 'public, max-age=31536000, s-maxage=31536000, immutable'
+        : `public, max-age=14400, s-maxage=${secondsToMidnight}, stale-while-revalidate=7200`;
 
     const etag = crypto.createHash('sha256').update(svg).digest('hex');
     const weakEtag = `W/"${etag}"`;
@@ -568,7 +568,7 @@ export async function GET(request: Request) {
 
     return new NextResponse(svg, {
       headers: {
-        'Content-Type': 'image/svg+xml',
+        'Content-Type': 'image/svg+xml; charset=utf-8',
         'Cache-Control': cacheControl,
         'Content-Security-Policy': SVG_CSP_HEADER,
         'X-CommitPulse-Grace-Applied': String(grace),
@@ -659,7 +659,7 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
     const svg = generateRateLimitSVG(errBg, errAccent, errText, errRadius, errSpeed, isCircuitOpen);
 
     const headers: Record<string, string> = {
-      'Content-Type': 'image/svg+xml',
+      'Content-Type': 'image/svg+xml; charset=utf-8',
       'Cache-Control': 'no-cache, no-store, must-revalidate',
       'Content-Security-Policy': SVG_CSP_HEADER,
     };
@@ -686,7 +686,7 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
     return new NextResponse(svg, {
       status: 404,
       headers: {
-        'Content-Type': 'image/svg+xml',
+        'Content-Type': 'image/svg+xml; charset=utf-8',
         'Cache-Control': 'no-cache',
         'Content-Security-Policy': SVG_CSP_HEADER,
       },
@@ -700,7 +700,7 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
     return new NextResponse(validationSvg, {
       status: 400,
       headers: {
-        'Content-Type': 'image/svg+xml',
+        'Content-Type': 'image/svg+xml; charset=utf-8',
         'Cache-Control': 'no-store',
         'Content-Security-Policy': SVG_CSP_HEADER,
       },
@@ -715,7 +715,7 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
   return new NextResponse(errorSvg, {
     status: 500,
     headers: {
-      'Content-Type': 'image/svg+xml',
+      'Content-Type': 'image/svg+xml; charset=utf-8',
       'Cache-Control': 'no-store',
       'Content-Security-Policy': SVG_CSP_HEADER,
     },

--- a/app/api/streak/tests/dateRange.test.ts
+++ b/app/api/streak/tests/dateRange.test.ts
@@ -58,7 +58,7 @@ describe('GET /api/streak dateRange parameter', () => {
     const res = await GET(makeRequest({ user: 'octocat', from: '2024-06-01', to: '2024-06-30' }));
 
     expect(res.status).toBe(200);
-    expect(res.headers.get('Content-Type')).toBe('image/svg+xml');
+    expect(res.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
     expect(res.headers.get('Content-Security-Policy')).toContain("default-src 'none'");
 
     const body = await res.text();
@@ -116,7 +116,7 @@ describe('GET /api/streak dateRange parameter', () => {
     const res = await GET(makeRequest({ user: 'octocat', from: '2024-06-01', to: '2024-06-30' }));
 
     expect(res.status).toBe(200);
-    expect(res.headers.get('Content-Type')).toBe('image/svg+xml');
+    expect(res.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
     expect(res.headers.get('Cache-Control')).toBe(
       'public, s-maxage=3600, stale-while-revalidate=86400'
     );

--- a/app/api/streak/tests/dateRange.test.ts
+++ b/app/api/streak/tests/dateRange.test.ts
@@ -118,7 +118,7 @@ describe('GET /api/streak dateRange parameter', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
     expect(res.headers.get('Cache-Control')).toBe(
-      'public, s-maxage=3600, stale-while-revalidate=86400'
+      'public, max-age=14400, s-maxage=3600, stale-while-revalidate=7200'
     );
   });
 });

--- a/app/api/streak/tests/grace.test.ts
+++ b/app/api/streak/tests/grace.test.ts
@@ -74,7 +74,7 @@ describe('Grace Parameter Integration Tests', () => {
       const response = await GET(request);
 
       expect(response.status).toBe(200);
-      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
 
       const svgContent = await response.text();
       expect(svgContent).toContain('<svg');
@@ -120,7 +120,7 @@ describe('Grace Parameter Integration Tests', () => {
       const response = await GET(request);
 
       expect(response.status).toBe(200);
-      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
 
       const svgContent = await response.text();
       expect(svgContent).toContain('<svg');
@@ -180,7 +180,7 @@ describe('Grace Parameter Integration Tests', () => {
       const response = await GET(request);
 
       expect(response.status).toBe(200);
-      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
 
       const svgContent = await response.text();
       expect(svgContent).toContain('<svg');
@@ -268,7 +268,7 @@ describe('Grace Parameter Integration Tests', () => {
         const response = await GET(request);
 
         expect(response.status).toBe(200);
-        expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+        expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
       }
     });
 

--- a/app/api/streak/tests/languages.test.ts
+++ b/app/api/streak/tests/languages.test.ts
@@ -63,7 +63,7 @@ describe('GET /api/streak — languages (lang) parameter', () => {
     const response = await GET(makeRequest({ user: 'octocat', lang: 'de' }));
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+    expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
   });
 
   it('returns a well-formed SVG body when lang=pt is given', async () => {

--- a/app/api/streak/tests/languages.test.ts
+++ b/app/api/streak/tests/languages.test.ts
@@ -98,7 +98,7 @@ describe('GET /api/streak — languages (lang) parameter', () => {
   it('sets Cache-Control and Content-Security-Policy headers for a valid lang parameter', async () => {
     const response = await GET(makeRequest({ user: 'octocat', lang: 'de' }));
 
-    expect(response.headers.get('Cache-Control')).toMatch(/public, s-maxage=\d+/);
+    expect(response.headers.get('Cache-Control')).toMatch(/public, max-age=14400, s-maxage=\d+/);
     const csp = response.headers.get('Content-Security-Policy');
     expect(csp).toContain("default-src 'none'");
     expect(csp).toContain("style-src 'unsafe-inline'");

--- a/app/api/streak/tests/refresh.test.ts
+++ b/app/api/streak/tests/refresh.test.ts
@@ -101,7 +101,7 @@ describe('GET /api/streak - refresh parameter group', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get('Cache-Control')).toBe(
-      'public, s-maxage=3600, stale-while-revalidate=86400'
+      'public, max-age=14400, s-maxage=3600, stale-while-revalidate=7200'
     );
     expect(response.headers.get('X-Cache-Status')).toBe('HIT');
   });

--- a/app/api/streak/tests/views.test.ts
+++ b/app/api/streak/tests/views.test.ts
@@ -95,7 +95,7 @@ describe('GET /api/streak view parameter integration', () => {
     const response = await GET(makeRequest({ user: 'octocat', view: 'default' }));
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+    expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
     expect(response.headers.get('Content-Security-Policy')).toContain("default-src 'none'");
 
     const body = await response.text();
@@ -157,7 +157,7 @@ describe('GET /api/streak view parameter integration', () => {
     const response = await GET(makeRequest({ user: 'octocat', view: 'default' }));
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+    expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
     expect(response.headers.get('Cache-Control')).toBe(
       'public, s-maxage=3600, stale-while-revalidate=86400'
     );

--- a/app/api/streak/tests/views.test.ts
+++ b/app/api/streak/tests/views.test.ts
@@ -159,7 +159,7 @@ describe('GET /api/streak view parameter integration', () => {
     expect(response.status).toBe(200);
     expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
     expect(response.headers.get('Cache-Control')).toBe(
-      'public, s-maxage=3600, stale-while-revalidate=86400'
+      'public, max-age=14400, s-maxage=3600, stale-while-revalidate=7200'
     );
     expect(response.headers.get('X-Cache-Status')).toBe('HIT');
   });

--- a/app/api/wrapped/route.test.ts
+++ b/app/api/wrapped/route.test.ts
@@ -102,7 +102,7 @@ describe('GET /api/wrapped', () => {
     it('returns 200 with SVG content type', async () => {
       const response = await GET(makeRequest({ user: 'octocat' }));
       expect(response.status).toBe(200);
-      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
     });
 
     it('returns a well-formed SVG body representing Wrapped stats', async () => {
@@ -203,7 +203,7 @@ describe('GET /api/wrapped', () => {
       vi.mocked(getWrappedData).mockRejectedValue(new Error('GitHub is down'));
       const response = await GET(makeRequest({ user: 'octocat' }));
       expect(response.status).toBe(500);
-      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
       const body = await response.text();
       expect(body).toContain('Something went wrong. Please try again later.');
     });
@@ -212,7 +212,7 @@ describe('GET /api/wrapped', () => {
       vi.mocked(getWrappedData).mockRejectedValue(new Error('User not found'));
       const response = await GET(makeRequest({ user: 'not-real-user' }));
       expect(response.status).toBe(404);
-      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
       const body = await response.text();
       expect(body).toContain('NOT FOUND');
     });

--- a/app/api/wrapped/route.test.ts
+++ b/app/api/wrapped/route.test.ts
@@ -174,7 +174,7 @@ describe('GET /api/wrapped', () => {
     it('caches for 24 hours by default', async () => {
       const response = await GET(makeRequest({ user: 'octocat' }));
       expect(response.headers.get('Cache-Control')).toBe(
-        'public, s-maxage=86400, stale-while-revalidate=86400'
+        'public, max-age=14400, s-maxage=86400, stale-while-revalidate=7200'
       );
     });
 

--- a/app/api/wrapped/route.ts
+++ b/app/api/wrapped/route.ts
@@ -131,11 +131,11 @@ export async function GET(request: Request) {
     // Clients can bust with ?refresh=true or ?bypassCache=true.
     const cacheControl = isRefreshRequested
       ? 'no-cache, no-store, must-revalidate'
-      : 'public, s-maxage=86400, stale-while-revalidate=86400';
+      : 'public, max-age=14400, s-maxage=86400, stale-while-revalidate=7200';
 
     return new NextResponse(svg, {
       headers: {
-        'Content-Type': 'image/svg+xml',
+        'Content-Type': 'image/svg+xml; charset=utf-8',
         'Cache-Control': cacheControl,
         'Content-Security-Policy': SVG_CSP_HEADER,
         'X-Cache-Status': shouldBypassCache ? `BYPASS, fetched=${new Date().toISOString()}` : 'HIT',
@@ -184,7 +184,7 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
     const svg = generateRateLimitSVG(errBg, errAccent, errText, errRadius, errSpeed, isCircuitOpen);
 
     const headers: Record<string, string> = {
-      'Content-Type': 'image/svg+xml',
+      'Content-Type': 'image/svg+xml; charset=utf-8',
       'Cache-Control': 'no-cache, no-store, must-revalidate',
       'Content-Security-Policy': SVG_CSP_HEADER,
     };
@@ -209,7 +209,7 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
     return new NextResponse(svg, {
       status: 404,
       headers: {
-        'Content-Type': 'image/svg+xml',
+        'Content-Type': 'image/svg+xml; charset=utf-8',
         'Cache-Control': 'no-cache',
         'Content-Security-Policy': SVG_CSP_HEADER,
       },
@@ -229,7 +229,7 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
     return new NextResponse(validationSvg, {
       status: 400,
       headers: {
-        'Content-Type': 'image/svg+xml',
+        'Content-Type': 'image/svg+xml; charset=utf-8',
         'Cache-Control': 'no-store',
         'Content-Security-Policy': SVG_CSP_HEADER,
       },
@@ -250,7 +250,7 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
   return new NextResponse(errorSvg, {
     status: 500,
     headers: {
-      'Content-Type': 'image/svg+xml',
+      'Content-Type': 'image/svg+xml; charset=utf-8',
       'Cache-Control': 'no-store',
       'Content-Security-Policy': SVG_CSP_HEADER,
     },


### PR DESCRIPTION
## Description

Fixes #5859

Adds explicit SVG response headers to SVG-generating API endpoints.

### Changes

* Set `Content-Type` to `image/svg+xml; charset=utf-8`
* Added explicit cache-control headers for SVG responses
* Updated tests to validate the new header values
* Improves compatibility with browsers and image proxies that consume generated SVG cards

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (header-only change)

## Checklist before requesting a review

* [x] I have read the CONTRIBUTING.md
* [x] My code follows the project's style guidelines
* [x] I have tested my changes locally
* [x] Existing tests pass
* [x] Updated tests validate the new behavior
