### PR TITLE
docs: add CHANGELOG.md following Keep a Changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable changes to CommitPulse will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project does not currently use semantic versioning. Historical milestones are
+recorded under named sections that reflect the project's public development phases.
+
+---
+
+## [Unreleased]
+
+### Added
+
+- `?year=` URL parameter to render contribution monoliths for past calendar years (PR #94)
+- `?font=` URL parameter to load any Google Font family dynamically into the SVG (PR #96, Issue #81)
+- `?theme=auto` preset that switches between light and dark palettes using CSS `@media (prefers-color-scheme)` — no JavaScript required (PR #102, Issue #75)
+- Ghost City mode: zero-contribution days are rendered as thin wireframe-style blueprint foundations (4 px high) instead of empty space, preserving the 3D aesthetic during rest periods
+- `?theme=random` preset that selects a surprise theme on each uncached request
+- `?grace=` URL parameter (range 0–7) to configure the number of inactive days before a streak resets; values outside the valid range are clamped automatically
+- MongoDB user-tracking endpoint (`/api/track-user`) that records GitHub usernames of visitors who generate a monolith from the landing page; gracefully skips the write when `MONGODB_URI` is not set
+- `.env.local.example` file to simplify local environment setup for new contributors
+- `SECURITY.md` documenting the project's security policy and responsible disclosure process
+- `THEMES.md` gallery with live preview images for all 20 available theme presets
+- Expanded theme library to 20 presets, including: `ocean`, `sunset`, `forest`, `rose`, `nord`, `synthwave`, `gruvbox`, `aurora_cyberpunk`, `highcontrast`, `catppuccin_latte`, `solarized_light`, `gruvbox_light`, `nord_light`, `obsidian`, `cyber-pulse`
+- GitHub Actions-powered automated issue management system: self-claiming via `/claim`, one-active-issue-per-contributor rule, stale-expiry chron job, self-service `/addlabel` command, and AI-powered semantic duplicate detection using Google Gemini embeddings
+- `CODE_OF_CONDUCT.md` establishing community participation standards
+- `CONTRIBUTING.md` with full local setup guide, three contribution pillars, branch/commit conventions, and CI quality gates
+- Discord community server for contributor coordination and PR feedback
+
+### Changed
+
+- Environment variable renamed from `GITHUB_PAT` to `GITHUB_TOKEN` for consistency with GitHub's standard naming convention; all documentation and setup instructions updated accordingly
+- Architecture expanded from pure API to full Next.js App Router application with a landing page, components directory, and MongoDB integration layer (`lib/mongodb.ts`, `models/User.ts`)
+
+---
+
+## [Initial Release — Core API]
+
+> This section documents the foundational features present at the project's public launch.
+> Exact release dates are not recorded; entries are derived from the README, source architecture,
+> and repository structure as of the initial commit set.
+
+### Added
+
+- Next.js 16 App Router API route (`app/api/streak/route.ts`) that returns a fully self-contained SVG badge
+- GitHub GraphQL API v4 client (`lib/github.ts`) using the `contributionsCollection` query with `cache: 'no-store'` to bypass Next.js internal fetch caching
+- Streak calculation engine (`lib/calculate.ts`) computing current streak, longest streak, and grace-period logic
+- 3D isometric SVG renderer (`lib/svg/generator.ts`) producing a grid of towers whose height is proportional to daily contribution count
+- CSS animation layer using native SVG `<animate>` elements: radar scan line and current-day block pulsing — no external animation libraries
+- `<feGaussianBlur>`-based SVG glow filter applied to tower geometry
+- UTC midnight cache synchronisation (`utils/time.ts`): CDN `Cache-Control: s-maxage` TTL is anchored to the exact next UTC midnight, ensuring cache expiry is synchronised with GitHub's contribution window boundaries
+- TypeScript interfaces (`types/index.ts`): `StreakStats`, `BadgeParams`, `BadgeTheme`
+- Five built-in theme presets: `dark` (default), `light`, `neon`, `github`, `dracula`
+- URL parameter system: `user` (required), `theme`, `bg`, `accent`, `text`, `radius`, `speed`, `scale`, `refresh`
+- `scale` parameter supporting `linear` (default) and `log` (logarithmic) tower height modes
+- `refresh=true` parameter to bypass CDN cache for real-time data
+- Vercel one-click deploy button with `GITHUB_TOKEN` environment variable prompt
+- Prettier configuration (`.prettierrc`) and ESLint configuration (`eslint.config.mjs`)
+- Vitest configuration (`vitest.config.ts`) for unit and integration testing
+- MIT licence
+
+---
+
+[Unreleased]: https://github.com/JhaSourav07/commitpulse/compare/HEAD...HEAD

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ### _Your GitHub contributions — as a cinematic SVG monolith._
 
 [![Deployed on Vercel](https://img.shields.io/badge/Deployed%20on-Vercel-black?style=flat-square&logo=vercel)](https://commitpulse.vercel.app)
+[![Changelog](https://img.shields.io/badge/Changelog-View-blue?style=flat-square)](./CHANGELOG.md)
 [![GSSOC 2026](https://img.shields.io/badge/GSSOC-2026-blue.svg)](https://gssoc.girlscript.org)
 [![Next.js](https://img.shields.io/badge/Next.js-16-black?style=flat-square&logo=next.js)](https://nextjs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?style=flat-square&logo=typescript)](https://www.typescriptlang.org)


### PR DESCRIPTION
## What does this PR do?
Adds a `CHANGELOG.md` file at the project root to track CommitPulse's
feature history and ongoing development milestones.

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] npm run lint passes
- [x] npm run format passes
- [x] npm run test passes (22 pre-existing test file failures confirmed 
      present on clean main branch before any changes — all failures are 
      in PNG route worker timeout tests unrelated to this docs-only PR.
      Verified by running `git stash` + `npm run test` on upstream main.)
- [x] No source files modified — docs-only PR (CHANGELOG.md + README.md)

## Files changed
- `CHANGELOG.md` — new file following keepachangelog.com/en/1.1.0 format
- `README.md` — added changelog badge to the existing badge row

## Evidence for changelog entries
All entries are sourced from verifiable repository artifacts:
- Ghost City mode, ?grace=, UTC sync — README.md
- 20 theme presets — THEMES.md  
- ?year= — PR #94
- ?font= — PR #96, Issue #81
- ?theme=auto — PR #102, Issue #75
- MongoDB /api/track-user — README architecture table
- .env.local.example — repo file tree
- No dates or version numbers were invented

## Related issue
Closes #5702