### PR TITLE
test(crypto): add unit test coverage for encryptToken / decryptToken (empty-fallback, massive-scaling)

### DIFF
--- a/lib/crypto.empty-fallback.test.ts
+++ b/lib/crypto.empty-fallback.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { encryptToken, decryptToken } from './crypto';
+
+beforeEach(() => {
+  vi.stubEnv('ENCRYPTION_KEY', 'abcdefghijklmnopqrstuvwxyz012345');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('crypto empty / missing inputs verification', () => {
+  it('encrypts and decrypts a normal token string', () => {
+    const plain = 'gho_abc123def456token';
+    const encrypted = encryptToken(plain);
+    expect(encrypted).toBeDefined();
+    expect(encrypted).not.toBe(plain);
+    expect(encrypted.split('.')).toHaveLength(3);
+    expect(decryptToken(encrypted)).toBe(plain);
+  });
+
+  it('handles empty string encryption and decryption', () => {
+    const encrypted = encryptToken('');
+    expect(encrypted.split('.')).toHaveLength(3);
+    expect(decryptToken(encrypted)).toBe('');
+  });
+
+  it('rejects malformed payload with wrong number of parts', () => {
+    expect(() => decryptToken('only-one-part')).toThrow();
+    expect(() => decryptToken('two.parts')).toThrow();
+    expect(() => decryptToken('a.b.c.d')).toThrow();
+  });
+
+  it('rejects payload with invalid base64', () => {
+    const payload = '!!!invalid-base64!!!.aaaa.aaaa';
+    expect(() => decryptToken(payload)).toThrow();
+  });
+
+  it('rejects empty payload string', () => {
+    expect(() => decryptToken('')).toThrow();
+  });
+
+  it('rejects tampered ciphertext (modified encrypted part)', () => {
+    const plain = 'gho_secret_token';
+    const encrypted = encryptToken(plain);
+    const parts = encrypted.split('.');
+    const tampered = [parts[0], parts[1], '////'].join('.');
+    expect(() => decryptToken(tampered)).toThrow();
+  });
+
+  it('rejects tampered auth tag (modified tag part)', () => {
+    const plain = 'gho_secret_token';
+    const encrypted = encryptToken(plain);
+    const parts = encrypted.split('.');
+    const tampered = [parts[0], '////', parts[2]].join('.');
+    expect(() => decryptToken(tampered)).toThrow();
+  });
+
+  it('rejects tampered IV (modified iv part)', () => {
+    const plain = 'gho_secret_token';
+    const encrypted = encryptToken(plain);
+    const parts = encrypted.split('.');
+    const tampered = ['////', parts[1], parts[2]].join('.');
+    expect(() => decryptToken(tampered)).toThrow();
+  });
+});
+
+describe('crypto key errors', () => {
+  it('throws when ENCRYPTION_KEY is missing', () => {
+    vi.stubEnv('ENCRYPTION_KEY', '');
+    expect(() => encryptToken('test')).toThrow(/ENCRYPTION_KEY/i);
+  });
+
+  it('throws when ENCRYPTION_KEY is too short', () => {
+    vi.stubEnv('ENCRYPTION_KEY', 'short');
+    expect(() => encryptToken('test')).toThrow(/ENCRYPTION_KEY/i);
+  });
+
+  it('throws on decrypt with wrong key', () => {
+    const encrypted = encryptToken('secret');
+    vi.stubEnv('ENCRYPTION_KEY', 'a-different-key-that-is-32-char!!');
+    expect(() => decryptToken(encrypted)).toThrow();
+  });
+});

--- a/lib/crypto.massive-scaling.test.ts
+++ b/lib/crypto.massive-scaling.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { encryptToken, decryptToken } from './crypto';
+
+beforeEach(() => {
+  vi.stubEnv('ENCRYPTION_KEY', 'abcdefghijklmnopqrstuvwxyz012345');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('crypto massive scaling', () => {
+  it('handles very long token strings without truncation', () => {
+    const long = 'a'.repeat(10_000);
+    const encrypted = encryptToken(long);
+    expect(decryptToken(encrypted)).toBe(long);
+  });
+
+  it('handles unicode characters including emoji', () => {
+    const unicode = '🚀🔥💯 commitpulse 测试 テスト тест';
+    const encrypted = encryptToken(unicode);
+    expect(decryptToken(encrypted)).toBe(unicode);
+  });
+
+  it('handles strings with special characters', () => {
+    const special = '!@#$%^&*()_+-=[]{}|;:\'",.<>?/`~';
+    const encrypted = encryptToken(special);
+    expect(decryptToken(encrypted)).toBe(special);
+  });
+
+  it('handles JSON-serialized payload', () => {
+    const payload = JSON.stringify({
+      access_token: 'gho_xxx',
+      scope: 'repo,user',
+      token_type: 'bearer',
+    });
+    const encrypted = encryptToken(payload);
+    expect(decryptToken(encrypted)).toBe(payload);
+  });
+
+  it('maintains round-trip integrity for repeated encryptions of same plaintext (different IV)', () => {
+    const plain = 'gho_consistent_token_value';
+    const results = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      results.add(encryptToken(plain));
+    }
+    expect(results.size).toBe(10);
+    results.forEach((enc) => {
+      expect(decryptToken(enc)).toBe(plain);
+    });
+  });
+
+  it('handles maximum token length (512 bytes) typical for GitHub tokens', () => {
+    const typical = 'ghp_' + 'a'.repeat(508);
+    expect(typical.length).toBe(512);
+    const encrypted = encryptToken(typical);
+    expect(decryptToken(encrypted)).toBe(typical);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #5870

Adds comprehensive test coverage for `lib/crypto.ts` (AES-256-GCM token encryption/decryption) following the project's established test patterns.

### Files added

- `lib/crypto.empty-fallback.test.ts` (11 tests):
  - Round-trip encrypt/decrypt for normal tokens
  - Empty string encryption/decryption
  - Malformed payload rejection (wrong parts, invalid base64)
  - Tampered ciphertext/auth tag/IV rejection
  - Missing/short/wrong ENCRYPTION_KEY error handling

- `lib/crypto.massive-scaling.test.ts` (6 tests):
  - Very long token strings (10,000 chars)
  - Unicode/emoji content
  - Special characters
  - JSON-serialized payload
  - IV uniqueness verification (10 rounds, same plaintext)
  - Max token length (512 bytes)

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
