### PR TITLE
fix(layout): restore favicon link by adding explicit icon field to me…

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,6 +31,10 @@ export const metadata: Metadata = {
   creator: 'Sourav Jha',
   manifest: '/manifest.webmanifest',
   icons: {
+    icon: [
+      { url: '/icon.svg', type: 'image/svg+xml' },
+      { url: '/icons/icon-192x192.png', sizes: '192x192', type: 'image/png' },
+    ],
     apple: '/icons/icon-192x192.png',
   },
   appleWebApp: {


### PR DESCRIPTION
## Description

Fixes #5878

The `metadata.icons` object in `app/layout.tsx` only defined an `apple` key. Next.js skips its automatic favicon injection (normally generated from the `app/icon.svg` file convention) whenever `metadata.icons` is manually configured without an explicit `icon` key — that's why the browser tab showed the default icon instead of the CommitPulse pulse-wave mark.

Fix: added an explicit `icon` array to `metadata.icons`, pointing to `/icon.svg` (the existing file-convention asset) with a PNG fallback, alongside the existing `apple` entry.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

Before: browser tab showed the default blank page icon.
After: browser tab shows the CommitPulse heartbeat/pulse mark from `app/icon.svg`.

(drop your before/after screenshot here)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000`, confirmed favicon renders in the browser tab).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter. *(N/A — no new theme or param)*
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). *(N/A — no SVG/visual output change, metadata config only)*
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.