### PR TITLE
fix(api): add general rate limiting to /api/streak Fixes #5857

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -32,6 +32,9 @@ import { quotaMonitor } from '@/services/github/quota-monitor';
 import { refreshPolicy } from '@/services/github/refresh-policy';
 import { refreshRateLimiter } from '@/services/github/refresh-rate-limiter';
 
+// ─── NEW: Import rateLimit and getRateLimitHeaders ──────────────────────────
+import { rateLimit, getRateLimitHeaders } from '@/lib/rate-limit';
+
 const SVG_CSP_HEADER =
   "default-src 'none'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src https://fonts.gstatic.com;";
 
@@ -152,6 +155,23 @@ export async function GET(request: Request) {
     const themeName = theme || 'dark';
 
     const ip = getClientIp(request);
+
+    // ─── NEW: General rate limiting (10 requests per IP per minute) ──────────
+    // This runs before any GitHub API call to protect the token quota.
+    const rateLimitResult = await rateLimit(ip, 10, 60000);
+    if (!rateLimitResult.success) {
+      const svg = generateRateLimitSVG('#0d1117', '#58a6ff', '#c9d1d9', 8, '8s', false);
+      return new NextResponse(svg, {
+        status: 429,
+        headers: {
+          'Content-Type': 'image/svg+xml',
+          'Cache-Control': 'no-store',
+          'Content-Security-Policy': SVG_CSP_HEADER,
+          ...getRateLimitHeaders(rateLimitResult),
+        },
+      });
+    }
+    // ─────────────────────────────────────────────────────────────────────────
 
     // Treat either ?refresh=true or ?bypassCache=true as a cache-bypass request
     const isRefreshRequested = refresh || bypassCacheParam;


### PR DESCRIPTION
## Description

Fixes #5857

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🔧 Other (Bug fix, refactoring, docs)

## What changed
Added general per-IP rate limiting to `/api/streak` using the existing
`rateLimit()` function from `lib/rate-limit.ts`. This prevents burst
traffic from exhausting the GitHub GraphQL token quota (5000 pts/hr)
for all users.

- Imported `rateLimit` and `getRateLimitHeaders` from `@/lib/rate-limit`
- Added rate limit check (10 req/IP/min) right after `getClientIp()`
- Returns `429` with proper `X-RateLimit-*` headers when exceeded
- Uses existing `generateRateLimitSVG` for consistent error response

## Visual Preview

No visual change — this is a backend-only fix.

## Test Results
Ran 15 concurrent requests locally:
- Requests 1–10 → reached the API normally ✅
- Requests 11–15 → returned `429 Too Many Requests` ✅

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=torvalds`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format (`fix(api): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard.
- [x] (Recommended) I joined the CommitPulse Discord community.