### PR TITLE
fix: add per-IP rate limiting to prevent GitHub quota exhaustion

### DIFF
--- a/app/api/achievements/route.test.ts
+++ b/app/api/achievements/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from './route';
+import { getFullDashboardData } from '@/lib/github';
+import { RateLimiter } from '@/lib/rate-limit';
+
+vi.mock('@/lib/github', () => ({
+  getFullDashboardData: vi.fn(),
+}));
+
+vi.mock('@/lib/githubtoken', () => ({
+  getUserGitHubToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+function makeRequest(params: Record<string, string> = {}): Request {
+  const url = new URL('http://localhost/api/achievements');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new Request(url.toString());
+}
+
+describe('GET /api/achievements', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(RateLimiter.prototype, 'check').mockResolvedValue(true);
+  });
+
+  it('returns 400 when username is missing', async () => {
+    const response = await GET(makeRequest());
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 429 when rate limit is exceeded', async () => {
+    vi.spyOn(RateLimiter.prototype, 'check').mockResolvedValueOnce(false);
+    const response = await GET(makeRequest({ username: 'octocat' }));
+    expect(response.status).toBe(429);
+    expect(getFullDashboardData).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/achievements/route.ts
+++ b/app/api/achievements/route.ts
@@ -11,6 +11,10 @@ import type {
   AchievementsResponse,
 } from '@/types/achievements';
 import { getUserGitHubToken } from '@/lib/githubtoken';
+import { getClientIp } from '@/utils/getClientIp';
+import { RateLimiter } from '@/lib/rate-limit';
+
+const achievementsLimiter = new RateLimiter(10, 60_000, 1);
 
 const ACHIEVEMENT_DEFS: AchievementDef[] = [
   // 🔥 Contribution
@@ -548,6 +552,17 @@ function computeDeveloperLevel(totalXp: number): {
 }
 
 export async function GET(request: Request) {
+  const ip = getClientIp(request);
+  const rateLimitKey =
+    ip && ip !== 'unknown' ? ip : `unknown:${request.headers.get('user-agent') ?? 'no-agent'}`;
+
+  if (!(await achievementsLimiter.check(rateLimitKey))) {
+    return NextResponse.json(
+      { error: 'Too many requests. Please try again later.' },
+      { status: 429 }
+    );
+  }
+
   const { searchParams } = new URL(request.url);
   const username = searchParams.get('username');
 


### PR DESCRIPTION


## Description

Fixes #5889 

## Problem
`app/api/achievements/route.ts` had zero rate limiting, the most expensive 
endpoint in the codebase, since `getFullDashboardData` fires 7 parallel 
GitHub API calls per request (profile, repos, contributions, contributed 
repos, popular repos, pinned repos, starred repos).

Unlike every other route in this codebase, /api/achievements had no 
RateLimiter and no per-IP check, making it the easiest endpoint to use 
for exhausting the shared GitHub API token pool.

Also confirmed this route is not covered by the proxy.ts middleware matcher, 
and that middleware itself is non-functional due to a separate naming bug 
(tracked separately).

## Fix
Added per-IP rate limiting (10 requests/minute (lower than other routes 
given the 7x GitHub API cost per request) at the top of the GET handler, 
consistent with the pattern used in /api/og, /api/notify, /api/user-details, 
and /api/ci-analytics.

Added a new test file covering the 400 (missing username) and 429 
(rate limited) cases.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [X] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [X] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [X] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [X] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

Suggested labels: level:critical, bug, security
