### PR TITLE
chore(types): narrow NextRequest ip access with explicit intersection type

### DIFF
--- a/utils/getClientIp.ts
+++ b/utils/getClientIp.ts
@@ -73,7 +73,8 @@ export function getClientIp(
   const config = opt.proxyConfig || loadTrustedProxyConfig();
 
   // 1. NextRequest has a secure, platform-populated request.ip property on Vercel/Next.js
-  const requestIp = (request as unknown as { ip?: string }).ip;
+  const requestIp =
+    request instanceof NextRequest ? (request as NextRequest & { ip?: string }).ip : undefined;
   if (request instanceof NextRequest && requestIp) {
     const rawXff = headers.get('x-forwarded-for');
     if (rawXff) {


### PR DESCRIPTION
## Description
Fixes #5922

`utils/getClientIp.ts` was accessing the `.ip` property of `NextRequest` via an unsafe double cast:

```ts
const requestIp = (request as unknown as { ip?: string }).ip;
```

**Problems with the old approach:**
- **Unsafe double cast** — `as unknown as` bypasses TypeScript's type system completely, hiding potential type mismatches
- **No narrowing** — the cast was applied to `Request | NextRequest` without first checking if the request is actually a `NextRequest`
- **Poor readability** — the intent of the cast is unclear without context

**What this PR does:**
- Replaces the double cast with an explicit intersection type that first narrows to `NextRequest` using `instanceof`
- Uses `(request as NextRequest & { ip?: string }).ip` which is safer — cast only applied after confirming the request is a `NextRequest`
- No logic changes — runtime behaviour is identical

**Before:**
```ts
const requestIp = (request as unknown as { ip?: string }).ip;
```

**After:**
```ts
const requestIp = request instanceof NextRequest 
  ? (request as NextRequest & { ip?: string }).ip 
  : undefined;
```

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes — this is a type safety refactor.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.