### PR TITLE
test(api-resume-upload): create integration tests for resume upload route

### DIFF
--- a/app/api/student/resume/tests/upload.test.ts
+++ b/app/api/student/resume/tests/upload.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { POST } from '../upload/route';
+import { MAX_FILE_SIZE } from '@/lib/resume-parser';
 
 vi.mock('@/lib/rate-limit', () => {
   class MockRateLimiter {
@@ -11,6 +12,12 @@ vi.mock('@/lib/rate-limit', () => {
   };
 });
 
+const originalFormData = globalThis.FormData;
+
+afterEach(() => {
+  globalThis.FormData = originalFormData;
+});
+
 // Build the handler request directly from a real File/FormData so the file bytes are
 // preserved (the multipart transport itself is Next.js's responsibility, not this route's).
 function makeUploadRequest(content: string | number[], type: string, name = 'resume.pdf'): Request {
@@ -19,6 +26,14 @@ function makeUploadRequest(content: string | number[], type: string, name = 'res
   const form = new FormData();
   form.append('resume', file);
 
+  return {
+    headers: new Headers(),
+    formData: async () => form,
+  } as unknown as Request;
+}
+
+function makeEmptyUploadRequest(): Request {
+  const form = new FormData();
   return {
     headers: new Headers(),
     formData: async () => form,
@@ -58,5 +73,31 @@ describe('POST /api/student/resume/upload', () => {
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
     expect(body.data).toBeDefined();
+  });
+
+  it('returns 400 when no resume file is provided in the form data', async () => {
+    const response = await POST(makeEmptyUploadRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('No resume file');
+  });
+
+  it('returns 400 for a file exceeding the size limit', async () => {
+    const oversized = new ArrayBuffer(MAX_FILE_SIZE + 1);
+    const largeFile = new File([oversized], 'large.pdf', { type: 'application/pdf' });
+    const form = new FormData();
+    form.append('resume', largeFile);
+
+    const request = {
+      headers: new Headers(),
+      formData: async () => form,
+    } as unknown as Request;
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('5MB');
   });
 });


### PR DESCRIPTION
## Description

Fixes #2355

Enhances integration test coverage for the `POST /api/student/resume/upload` route.

### Changes
- Added `makeEmptyUploadRequest()` helper for testing missing file scenario
- Added `afterEach` to restore original `FormData`

### Tests (5 total — 3 existing + 2 new)
1. ✅ Returns 400 for disallowed mime type (existing)
2. ✅ Returns 400 when content does not match declared PDF type (existing)
3. ✅ Accepts valid PDF file (existing)
4. **NEW** — Returns 400 when no resume file is provided in the form data
5. **NEW** — Returns 400 for a file exceeding the 5MB size limit

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
