### PR TITLE
docs: add missing retro-terminal theme preview to THEMES.md fixes #5917

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -1,6 +1,6 @@
 # CommitPulse Themes
 
-All 26 available themes for your CommitPulse badge. Use the `?theme=<slug>` query parameter to apply a theme.
+All 27 available themes for your CommitPulse badge. Use the `?theme=<slug>` query parameter to apply a theme.
 
 ```
 https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
@@ -269,6 +269,18 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 | `bg`      | 000000 |
 | `text`    | ffffff |
 | `accent`  | 00ffee |
+
+---
+
+### Retro Terminal
+
+![retro-terminal](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=retro-terminal)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 000000 |
+| `text`    | 00ff41 |
+| `accent`  | 00ff41 |
 
 ---
 


### PR DESCRIPTION
The retro-terminal theme is defined in lib/svg/themes.ts and works as a valid ?theme= value, but was missing from the Preview Gallery in THEMES.md. This caused the stated count (26) to be wrong and left users with no way to discover or preview the theme from the docs.

- Update header count from 26 to 27

- Add retro-terminal preview section with badge image and color table

## Description

Fixes # (issue number)

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

Fixes Issue #5917
