### PR TITLE
refactor: remove duplicate buildInlineErrorSVG inside buildErrorResponse

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -662,25 +662,6 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
       }
     );
   }
-  function buildInlineErrorSVG(text: string): string {
-    const MAX_LINE = 48;
-    const truncated = text.length > MAX_LINE * 2 ? text.slice(0, MAX_LINE * 2 - 1) + '…' : text;
-
-    const line1 = escapeXML(truncated.slice(0, MAX_LINE));
-    const line2 = truncated.length > MAX_LINE ? escapeXML(truncated.slice(MAX_LINE)) : null;
-
-    const textY = line2 ? '62' : '75';
-
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="400" height="150" viewBox="0 0 400 150">
-      <rect width="400" height="150" fill="#2d0000" rx="8"/>
-      <text x="200" y="${textY}" text-anchor="middle" dominant-baseline="central" fill="#ffcccc" font-family="sans-serif" font-size="13">${line1}</text>${
-        line2
-          ? `
-      <text x="200" y="91" text-anchor="middle" dominant-baseline="central" fill="#ffcccc" font-family="sans-serif" font-size="13">${line2}</text>`
-          : ''
-      }
-    </svg>`;
-  }
 
   const isNotFound =
     message.toLowerCase().includes('not found') ||


### PR DESCRIPTION
buildInlineErrorSVG was defined twice in route.ts: once at the top level (line 57) and again identically nested inside buildErrorResponse (line 665). The inner copy shadowed the outer one within that scope and was re-created on every call, adding maintenance risk with zero functional benefit.

Remove the inner duplicate so both call sites (Zod validation branch and buildErrorResponse) use the single top-level definition.

## Description

Fixes # (issue number)

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x]I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.


Fixes #5918 
