### PR TITLE
fix: resolve leaderboard podium overlap on mobile devices

### DIFF
--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -112,6 +112,7 @@ export default function Leaderboard({ contributors = [] }: LeaderboardProps) {
                     src={contributor.avatar_url}
                     alt={contributor.login}
                     fill
+                    unoptimized
                     className="object-cover"
                   />
                 ) : (
@@ -227,6 +228,7 @@ function PodiumItem({ contributor, height, variant, delay, isFirst }: PodiumItem
                 src={contributor.avatar_url}
                 alt={contributor.login}
                 fill
+                unoptimized
                 className="rounded-full object-cover"
               />
             ) : (


### PR DESCRIPTION
## Description

Fixes # (issue number)

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

brfore :
<img width="564" height="815" alt="image" src="https://github.com/user-attachments/assets/298fedc4-f862-475b-adb7-5a57bb9265e4" />

after:
<img width="586" height="812" alt="{01F5E6A3-E4A1-46B7-8FFE-9788B26813DC}" src="https://github.com/user-attachments/assets/91f60a74-f8e7-4acd-9532-0d9684439580" />

