### PR TITLE
fix(ci-analytics): use getClientIp() for per-IP rate limiting

### DIFF
--- a/app/api/ci-analytics/route.test.ts
+++ b/app/api/ci-analytics/route.test.ts
@@ -2,15 +2,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GET } from './route';
 import { RateLimiter } from '@/lib/rate-limit';
 import { fetchCIAnalytics } from '@/services/github/ci-analytics';
+import { getClientIp } from '@/utils/getClientIp';
 
 vi.mock('@/services/github/ci-analytics', () => ({
   fetchCIAnalytics: vi.fn(),
+}));
+
+vi.mock('@/utils/getClientIp', () => ({
+  getClientIp: vi.fn(),
 }));
 
 describe('GET /api/ci-analytics', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(RateLimiter.prototype, 'check').mockResolvedValue(true);
+    vi.mocked(getClientIp).mockReturnValue('127.0.0.1');
   });
 
   it('rejects requests when the endpoint abuse budget is exhausted', async () => {
@@ -26,16 +32,10 @@ describe('GET /api/ci-analytics', () => {
     vi.mocked(fetchCIAnalytics).mockResolvedValue({} as never);
     const checkSpy = vi.spyOn(RateLimiter.prototype, 'check').mockResolvedValue(true);
 
-    await GET(
-      new Request('http://localhost/api/ci-analytics?username=octocat', {
-        headers: { 'x-forwarded-for': '1.2.3.4' },
-      })
-    );
-    await GET(
-      new Request('http://localhost/api/ci-analytics?username=octocat', {
-        headers: { 'x-forwarded-for': '5.6.7.8' },
-      })
-    );
+    vi.mocked(getClientIp).mockReturnValueOnce('1.2.3.4').mockReturnValueOnce('5.6.7.8');
+
+    await GET(new Request('http://localhost/api/ci-analytics?username=octocat'));
+    await GET(new Request('http://localhost/api/ci-analytics?username=octocat'));
     expect(checkSpy).toHaveBeenNthCalledWith(1, '1.2.3.4');
     expect(checkSpy).toHaveBeenNthCalledWith(2, '5.6.7.8');
   });

--- a/app/api/ci-analytics/route.ts
+++ b/app/api/ci-analytics/route.ts
@@ -3,14 +3,12 @@ import { fetchCIAnalytics } from '@/services/github/ci-analytics';
 import { getUserGitHubToken } from '@/lib/githubtoken';
 import { validateGitHubUsername } from '@/lib/validations';
 import { RateLimiter } from '@/lib/rate-limit';
+import { getClientIp } from '@/utils/getClientIp';
 
 const ciAnalyticsLimiter = new RateLimiter(10, 60_000, 1);
 
 export async function GET(request: Request) {
-  const ip =
-    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
-    request.headers.get('x-real-ip') ??
-    'unknown';
+  const ip = getClientIp(request);
 
   if (!(await ciAnalyticsLimiter.check(ip))) {
     return NextResponse.json(


### PR DESCRIPTION
## Description

Fixes #5898

Replaces the hardcoded `'ci-analytics'` rate-limit key with `getClientIp(request)` so each client is rate-limited independently. The previous implementation shared a single rate-limit bucket across all users, meaning one user's requests could exhaust the limit for everyone. It also bypassed the proxy trust validation that `getClientIp()` provides, allowing spoofed `x-forwarded-for` headers to circumvent rate limiting in self-hosted deployments.

## Pillar

- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No visual changes — backend rate-limiting only.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.