### PR TITLE
fix: allow stale unassigned issues to be reclaimed

### DIFF
--- a/.github/scripts/issue-management/claim-handler.js
+++ b/.github/scripts/issue-management/claim-handler.js
@@ -11,6 +11,7 @@ async function findExistingAssignments(github, owner, repo, username, currentIss
 }
 
 const MAX_ASSIGNED_ISSUES = 5;
+const COMMUNITY_CLAIM_THRESHOLD_MS = 48 * 60 * 60 * 1000;
 
 async function handleClaim({ github, context }) {
   const { owner, repo } = context.repo;
@@ -28,12 +29,25 @@ async function handleClaim({ github, context }) {
     return;
   }
 
-  const issueAuthor = context.payload.issue.user.login;
+  // Re-fetch to avoid stale assignee data from the webhook payload
+  const { data: freshIssue } = await github.rest.issues.get({
+    owner,
+    repo,
+    issue_number: issueNumber,
+  });
+  const currentAssignees = freshIssue.assignees.map((a) => a.login.toLowerCase());
 
+  const issueAuthor = context.payload.issue.user.login;
   const MAINTAINERS = ['jhasourav07', 'aamod007', 'souravjhahind'];
   const isOpenedByMaintainer = MAINTAINERS.includes(issueAuthor.toLowerCase());
+  const isCommenterAuthor = commenter.toLowerCase() === issueAuthor.toLowerCase();
+  const createdAt = new Date(freshIssue.created_at || context.payload.issue.created_at);
+  const isOldUnassignedIssue =
+    currentAssignees.length === 0 &&
+    Number.isFinite(createdAt.getTime()) &&
+    Date.now() - createdAt.getTime() >= COMMUNITY_CLAIM_THRESHOLD_MS;
 
-  if (!isOpenedByMaintainer && commenter.toLowerCase() !== issueAuthor.toLowerCase()) {
+  if (!isOpenedByMaintainer && !isCommenterAuthor && !isOldUnassignedIssue) {
     await github.rest.issues.createComment({
       owner,
       repo,
@@ -42,14 +56,6 @@ async function handleClaim({ github, context }) {
     });
     return;
   }
-
-  // Re-fetch to avoid stale assignee data from the webhook payload
-  const { data: freshIssue } = await github.rest.issues.get({
-    owner,
-    repo,
-    issue_number: issueNumber,
-  });
-  const currentAssignees = freshIssue.assignees.map((a) => a.login.toLowerCase());
 
   if (currentAssignees.length > 0) {
     if (currentAssignees.includes(commenter.toLowerCase())) {

--- a/.github/scripts/issue-management/claim-handler.test.ts
+++ b/.github/scripts/issue-management/claim-handler.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { handleClaim } = require('./claim-handler');
+
+function createGithubMock(freshIssue: Record<string, unknown>) {
+  return {
+    rest: {
+      issues: {
+        addAssignees: vi.fn().mockResolvedValue({}),
+        createComment: vi.fn().mockResolvedValue({}),
+        get: vi.fn().mockResolvedValue({ data: freshIssue }),
+        listForRepo: vi.fn().mockResolvedValue({ data: [] }),
+      },
+    },
+  };
+}
+
+function createContext(overrides: Record<string, unknown> = {}) {
+  return {
+    repo: { owner: 'JhaSourav07', repo: 'commitpulse' },
+    payload: {
+      issue: {
+        number: 123,
+        state: 'open',
+        user: { login: 'issue-author' },
+        created_at: '2026-06-10T00:00:00.000Z',
+        ...overrides,
+      },
+      comment: {
+        user: { login: 'new-contributor' },
+      },
+    },
+  };
+}
+
+describe('handleClaim', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('allows another contributor to claim an old unassigned issue', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-13T00:00:00.000Z'));
+
+    const github = createGithubMock({
+      assignees: [],
+      created_at: '2026-06-10T00:00:00.000Z',
+    });
+
+    await handleClaim({
+      github,
+      context: createContext(),
+    });
+
+    expect(github.rest.issues.addAssignees).toHaveBeenCalledWith({
+      owner: 'JhaSourav07',
+      repo: 'commitpulse',
+      issue_number: 123,
+      assignees: ['new-contributor'],
+    });
+    expect(github.rest.issues.createComment).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('Only the author'),
+      })
+    );
+  });
+
+  it('still blocks another contributor from claiming a fresh contributor-created issue', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-10T12:00:00.000Z'));
+
+    const github = createGithubMock({
+      assignees: [],
+      created_at: '2026-06-10T00:00:00.000Z',
+    });
+
+    await handleClaim({
+      github,
+      context: createContext(),
+    });
+
+    expect(github.rest.issues.addAssignees).not.toHaveBeenCalled();
+    expect(github.rest.issues.createComment).toHaveBeenCalledWith({
+      owner: 'JhaSourav07',
+      repo: 'commitpulse',
+      issue_number: 123,
+      body: '❌ Only the author of this issue (@issue-author) can claim it.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Allows old unassigned contributor-created issues to be claimed by another contributor after the stale assignment window.
- Keeps the existing author-only restriction for fresh contributor-created issues.
- Adds focused tests for the reclaim path and the fresh-issue block.

## Test plan
- `node node_modules/vitest/vitest.mjs run .github/scripts/issue-management/claim-handler.test.ts`

Closes #5961