### PR TITLE
fix: remove persistent contributors loading placeholder

### DIFF
--- a/app/contributors/loading.accessibility.test.tsx
+++ b/app/contributors/loading.accessibility.test.tsx
@@ -17,15 +17,14 @@ describe('Contributors loading accessibility', () => {
     const status = screen.getByRole('status');
 
     expect(status.getAttribute('aria-live')).toBe('polite');
-    expect(status.textContent).toContain('Loading the collective...');
-    expect(status.textContent).toContain('Fetching contributor data from GitHub');
+    expect(status.getAttribute('aria-label')).toBe('Loading contributors');
   });
 
-  it('keeps descriptive loading text available to assistive technologies', () => {
+  it('does not keep contributor loading placeholder text in the DOM', () => {
     render(<Loading />);
 
-    expect(screen.getByText('Loading the collective...')).toBeTruthy();
-    expect(screen.getByText('Fetching contributor data from GitHub')).toBeTruthy();
+    expect(screen.queryByText('Loading the collective...')).toBeNull();
+    expect(screen.queryByText('Fetching contributor data from GitHub')).toBeNull();
   });
 
   it('does not expose decorative spinner elements as interactive controls', () => {
@@ -62,9 +61,7 @@ describe('Contributors loading accessibility', () => {
     const status = screen.getByRole('status');
     const children = Array.from(status.children);
 
-    expect(children.length).toBeGreaterThanOrEqual(3);
+    expect(children).toHaveLength(1);
     expect(children[0].tagName.toLowerCase()).toBe('div');
-    expect(children[1].textContent).toBe('Loading the collective...');
-    expect(children[2].textContent).toBe('Fetching contributor data from GitHub');
   });
 });

--- a/app/contributors/loading.empty-fallback.test.tsx
+++ b/app/contributors/loading.empty-fallback.test.tsx
@@ -15,12 +15,12 @@ describe('Contributors loading empty fallback', () => {
     expect(() => render(<Loading />)).not.toThrow();
   });
 
-  it('shows a clear fallback loading state', () => {
+  it('shows a clear fallback loading state without persistent copy', () => {
     render(<Loading />);
 
     expect(screen.getByRole('status')).toBeTruthy();
-    expect(screen.getByText('Loading the collective...')).toBeTruthy();
-    expect(screen.getByText('Fetching contributor data from GitHub')).toBeTruthy();
+    expect(screen.queryByText('Loading the collective...')).toBeNull();
+    expect(screen.queryByText('Fetching contributor data from GitHub')).toBeNull();
   });
 
   it('keeps accessible fallback markers available', () => {
@@ -29,7 +29,8 @@ describe('Contributors loading empty fallback', () => {
     const status = screen.getByRole('status');
 
     expect(status.getAttribute('aria-live')).toBe('polite');
-    expect(status.children.length).toBeGreaterThanOrEqual(2);
+    expect(status.getAttribute('aria-label')).toBe('Loading contributors');
+    expect(status.children.length).toBe(1);
   });
 
   it('maintains default fallback layout styles', () => {

--- a/app/contributors/loading.massive-scaling.test.tsx
+++ b/app/contributors/loading.massive-scaling.test.tsx
@@ -17,7 +17,7 @@ describe('ContributorsLoading massive scaling behavior', () => {
     }).not.toThrow();
   });
 
-  it('preserves loading text across repeated high-volume renders', () => {
+  it('does not duplicate loading text across repeated high-volume renders', () => {
     render(
       <>
         {Array.from({ length: 100 }, (_, index) => (
@@ -26,10 +26,10 @@ describe('ContributorsLoading massive scaling behavior', () => {
       </>
     );
 
-    expect(screen.getAllByText('Loading the collective...')).toHaveLength(100);
+    expect(screen.queryAllByText('Loading the collective...')).toHaveLength(0);
   });
 
-  it('preserves contributor fetch messaging at scale', () => {
+  it('does not duplicate contributor fetch messaging at scale', () => {
     render(
       <>
         {Array.from({ length: 100 }, (_, index) => (
@@ -38,7 +38,7 @@ describe('ContributorsLoading massive scaling behavior', () => {
       </>
     );
 
-    expect(screen.getAllByText('Fetching contributor data from GitHub')).toHaveLength(100);
+    expect(screen.queryAllByText('Fetching contributor data from GitHub')).toHaveLength(0);
   });
 
   it('renders spinner elements consistently under heavy load', () => {

--- a/app/contributors/loading.mock-integrations.test.tsx
+++ b/app/contributors/loading.mock-integrations.test.tsx
@@ -54,7 +54,7 @@ describe('ContributorsLoading - Mock Integrations & Local Cache Stubs', () => {
     render(<Loading />);
 
     expect(screen.getByRole('status')).toBeInTheDocument();
-    expect(screen.getByText('Loading the collective...')).toBeInTheDocument();
+    expect(screen.queryByText('Loading the collective...')).not.toBeInTheDocument();
 
     // Resolve the pending fetch
     resolvePromise([{ id: 1, login: 'contributor-1' }]);
@@ -98,7 +98,7 @@ describe('ContributorsLoading - Mock Integrations & Local Cache Stubs', () => {
 
     expect(result).toEqual([]);
     expect(screen.getByRole('status')).toBeInTheDocument();
-    expect(screen.getByText('Loading the collective...')).toBeInTheDocument();
+    expect(screen.queryByText('Loading the collective...')).not.toBeInTheDocument();
   });
 
   // --- Test Case 5 ---

--- a/app/contributors/loading.mouse-interactivity.test.tsx
+++ b/app/contributors/loading.mouse-interactivity.test.tsx
@@ -42,8 +42,8 @@ describe('ContributorsLoading Interactivity & Touch Events (Real Component Verif
     render(<InteractiveLoadingHarness />);
     const wrapper = screen.getByTestId('interactive-wrapper');
 
-    // Assert the real component text is present in the rendered tree
-    expect(screen.getByText('Loading the collective...')).toBeDefined();
+    // Assert stale loading copy is not present in the rendered tree.
+    expect(screen.queryByText('Loading the collective...')).toBeNull();
 
     fireEvent.mouseEnter(wrapper);
     expect(screen.getByTestId('interactive-tooltip')).toBeDefined();
@@ -117,10 +117,10 @@ describe('Contributors Loading — structure & accessibility', () => {
     expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
   });
 
-  it('contains both the primary and secondary loading messages', () => {
+  it('does not contain persistent primary or secondary loading messages', () => {
     render(<Loading />);
-    expect(screen.getByText('Loading the collective...')).toBeInTheDocument();
-    expect(screen.getByText('Fetching contributor data from GitHub')).toBeInTheDocument();
+    expect(screen.queryByText('Loading the collective...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Fetching contributor data from GitHub')).not.toBeInTheDocument();
   });
 
   it('renders the spinning ring with the correct Tailwind animation class', () => {
@@ -163,16 +163,13 @@ describe('Contributors Loading — structure & accessibility', () => {
     expect(focusable.length).toBe(0);
   });
 
-  it('primary message uses light typography appropriate for a dark background', () => {
+  it('does not render the old primary loading message', () => {
     render(<Loading />);
-    const primary = screen.getByText('Loading the collective...');
-    expect(primary.tagName.toLowerCase()).toBe('p');
-    expect(primary).toHaveClass('text-zinc-400');
+    expect(screen.queryByText('Loading the collective...')).not.toBeInTheDocument();
   });
 
-  it('secondary message is rendered in monospace font for a technical feel', () => {
+  it('does not render the old secondary loading message', () => {
     render(<Loading />);
-    const secondary = screen.getByText('Fetching contributor data from GitHub');
-    expect(secondary).toHaveClass('font-mono');
+    expect(screen.queryByText('Fetching contributor data from GitHub')).not.toBeInTheDocument();
   });
 });

--- a/app/contributors/loading.test.tsx
+++ b/app/contributors/loading.test.tsx
@@ -10,12 +10,11 @@ describe('Contributors Loading', () => {
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
-  it('renders loading messages correctly', () => {
+  it('does not render persistent loading copy', () => {
     render(<Loading />);
 
-    expect(screen.getByText(/loading the collective/i)).toBeInTheDocument();
-
-    expect(screen.getByText(/fetching contributor data from github/i)).toBeInTheDocument();
+    expect(screen.queryByText(/loading the collective/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/fetching contributor data from github/i)).not.toBeInTheDocument();
   });
 
   it('contains animated loader elements', () => {
@@ -44,5 +43,6 @@ describe('Contributors Loading', () => {
     const status = screen.getByRole('status');
 
     expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(status).toHaveAttribute('aria-label', 'Loading contributors');
   });
 });

--- a/app/contributors/loading.theme-contrast.test.tsx
+++ b/app/contributors/loading.theme-contrast.test.tsx
@@ -17,8 +17,7 @@ describe('Contributors loading theme contrast', () => {
     const status = screen.getByRole('status');
 
     expect(status.getAttribute('aria-live')).toBe('polite');
-    expect(screen.getByText('Loading the collective...')).toBeTruthy();
-    expect(screen.getByText('Fetching contributor data from GitHub')).toBeTruthy();
+    expect(status.getAttribute('aria-label')).toBe('Loading contributors');
   });
 
   it('applies cohesive dark visual shell classes', () => {
@@ -36,14 +35,11 @@ describe('Contributors loading theme contrast', () => {
     ]);
   });
 
-  it('keeps contributor loading text visually readable', () => {
+  it('does not render contributor loading text that can linger after data loads', () => {
     render(<Loading />);
 
-    const primaryText = screen.getByText('Loading the collective...');
-    const secondaryText = screen.getByText('Fetching contributor data from GitHub');
-
-    hasClasses(primaryText, ['text-zinc-400', 'font-light', 'text-lg']);
-    hasClasses(secondaryText, ['text-sm', 'text-zinc-600', 'font-mono']);
+    expect(screen.queryByText('Loading the collective...')).toBeNull();
+    expect(screen.queryByText('Fetching contributor data from GitHub')).toBeNull();
   });
 
   it('uses premium spinner styling with visible foreground contrast', () => {

--- a/app/contributors/loading.timezone-boundaries.test.tsx
+++ b/app/contributors/loading.timezone-boundaries.test.tsx
@@ -22,7 +22,7 @@ describe('ContributorsLoading - Timezone Boundaries & Calendar Alignment', () =>
 
       // Ensure layout elements are present and unchanged
       expect(screen.getByRole('status')).toBeInTheDocument();
-      expect(screen.getByText('Loading the collective...')).toBeInTheDocument();
+      expect(screen.queryByText('Loading the collective...')).not.toBeInTheDocument();
       expect(container.querySelector('.animate-spin')).toBeInTheDocument();
 
       // Clean up DOM and mocks between iterations
@@ -49,7 +49,7 @@ describe('ContributorsLoading - Timezone Boundaries & Calendar Alignment', () =>
     vi.setSystemTime(new Date('2026-03-08T02:00:00Z'));
 
     render(<Loading />);
-    expect(screen.getByText('Loading the collective...')).toBeInTheDocument();
+    expect(screen.queryByText('Loading the collective...')).not.toBeInTheDocument();
 
     vi.useRealTimers();
   });
@@ -72,7 +72,7 @@ describe('ContributorsLoading - Timezone Boundaries & Calendar Alignment', () =>
 
     render(<Loading />);
     expect(screen.getByRole('status')).toBeInTheDocument();
-    expect(screen.getByText('Fetching contributor data from GitHub')).toBeInTheDocument();
+    expect(screen.queryByText('Fetching contributor data from GitHub')).not.toBeInTheDocument();
 
     vi.unstubAllGlobals();
   });

--- a/app/contributors/loading.tsx
+++ b/app/contributors/loading.tsx
@@ -1,16 +1,17 @@
 export default function Loading() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-[#050505] text-white">
-      <div className="flex flex-col items-center gap-6" role="status" aria-live="polite">
+      <div
+        className="flex flex-col items-center gap-6"
+        role="status"
+        aria-live="polite"
+        aria-label="Loading contributors"
+      >
         {/* Pulsing ring loader */}
         <div className="relative">
           <div className="h-16 w-16 animate-spin rounded-full border-2 border-white/10 border-t-cyan-400" />
           <div className="absolute inset-0 h-16 w-16 rounded-full bg-cyan-400/20 blur-xl animate-pulse" />
         </div>
-
-        <p className="text-zinc-400 font-light text-lg">Loading the collective...</p>
-
-        <p className="text-sm text-zinc-600 font-mono">Fetching contributor data from GitHub</p>
       </div>
     </div>
   );


### PR DESCRIPTION
Summary: Removes the visible contributor loading placeholder copy from the /contributors route fallback so it cannot persist beside loaded content, while keeping an accessible status label and spinner. 
Test plan: node node_modules/vitest/vitest.mjs run app/contributors/loading.test.tsx app/contributors/loading.accessibility.test.tsx app/contributors/loading.empty-fallback.test.tsx app/contributors/loading.mock-integrations.test.tsx app/contributors/loading.mouse-interactivity.test.tsx app/contributors/loading.theme-contrast.test.tsx app/contributors/loading.massive-scaling.test.tsx app/contributors/loading.timezone-boundaries.test.tsx app/contributors/loading.responsive-breakpoints.test.tsx.
 Closes #5906

