### PR TITLE
fix(burnout): link contributor names and avatars to GitHub profiles

### DIFF
--- a/components/burnout/BurnoutRiskTable.tsx
+++ b/components/burnout/BurnoutRiskTable.tsx
@@ -121,7 +121,12 @@ export default function BurnoutRiskTable({ contributors }: BurnoutRiskTableProps
               >
                 {/* Contributor Profile */}
                 <td className="py-4 pl-1">
-                  <div className="flex items-center gap-3">
+                  <a
+                    href={`https://github.com/${c.username}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-3 cursor-pointer"
+                  >
                     <div className="relative w-8 h-8 rounded-full overflow-hidden border border-black/10 dark:border-white/10">
                       <Image
                         src={c.avatarUrl}
@@ -140,7 +145,7 @@ export default function BurnoutRiskTable({ contributors }: BurnoutRiskTableProps
                         {c.totalCommits.toLocaleString()} commits
                       </span>
                     </div>
-                  </div>
+                  </a>
                 </td>
 
                 {/* Workload Share */}

--- a/components/burnout/InactivityDetector.tsx
+++ b/components/burnout/InactivityDetector.tsx
@@ -69,7 +69,12 @@ export default function InactivityDetector({ alerts }: InactivityDetectorProps) 
               }`}
             />
 
-            <div className="relative w-9 h-9 rounded-full overflow-hidden border border-black/10 dark:border-white/10 shrink-0">
+            <a
+              href={`https://github.com/${alert.username}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="relative w-9 h-9 rounded-full overflow-hidden border border-black/10 dark:border-white/10 shrink-0 cursor-pointer"
+            >
               <Image
                 src={alert.avatarUrl}
                 alt={alert.username}
@@ -77,12 +82,17 @@ export default function InactivityDetector({ alerts }: InactivityDetectorProps) 
                 sizes="36px"
                 className="object-cover"
               />
-            </div>
+            </a>
 
             <div className="flex flex-col min-w-0">
-              <span className="font-semibold text-sm text-gray-900 dark:text-white truncate">
+              <a
+                href={`https://github.com/${alert.username}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-sm text-gray-900 dark:text-white truncate hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors cursor-pointer"
+              >
                 @{alert.username}
-              </span>
+              </a>
               <span className="text-xs text-gray-500 dark:text-zinc-400 mt-1 flex items-center gap-1">
                 <Calendar size={12} className="shrink-0" />
                 Silent for{' '}


### PR DESCRIPTION
## Description

Fixes #5971 

 Clicking a contributor's avatar or name in the `/burnout-analyzer` page now opens their GitHub profile (`https://github.com/{username}`) in a new tab. Previously the cells were static the hover color hinted at interactivity but nothing happened on click.
## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

 ## Changes

   - `components/burnout/BurnoutRiskTable.tsx` wrapped contributor cell contents in an `<a>` linking to `https://github.com/{username}`
   - `components/burnout/InactivityDetector.tsx` wrapped avatar and username in separate `<a>` tags with the same target URL and a matching hover color

## Checklist before requesting a review:

- [ ] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
