### PR TITLE
fix: make feature cards equal height regardless of description length

### DIFF
--- a/components/FeatureCards.tsx
+++ b/components/FeatureCards.tsx
@@ -323,7 +323,7 @@ export function FeatureCard({ icon, title, desc, accent, index, accentColor }: F
   return (
     <div
       ref={cardRef}
-      className="relative cursor-pointer"
+      className="relative cursor-pointer h-full"
       style={{
         transformStyle: 'preserve-3d',
         perspective: '800px',
@@ -333,7 +333,7 @@ export function FeatureCard({ icon, title, desc, accent, index, accentColor }: F
       {/* Animated rotating conic gradient border on hover */}
       <AnimatedBorder color={accentColor} isHovered={hovered} />
 
-      <div className="group relative overflow-hidden rounded-3xl border border-black/5 bg-white/60 p-8 shadow-xl shadow-black/5 dark:border-white/[0.08] dark:bg-[#0a0a0a]/90 dark:shadow-2xl dark:shadow-black/50 backdrop-blur-xl transition-colors duration-300">
+      <div className="group relative overflow-hidden rounded-3xl border border-black/5 bg-white/60 p-8 shadow-xl shadow-black/5 dark:border-white/[0.08] dark:bg-[#0a0a0a]/90 dark:shadow-2xl dark:shadow-black/50 backdrop-blur-xl transition-colors duration-300 h-full flex flex-col">
         {/* Spotlight glow following cursor */}
         <div
           ref={glowRef}
@@ -398,7 +398,7 @@ export function FeatureCard({ icon, title, desc, accent, index, accentColor }: F
         {/* Description */}
         <p
           ref={descRef}
-          className="relative z-10 text-sm leading-relaxed text-gray-600 dark:text-gray-400"
+          className="relative z-10 text-sm leading-relaxed text-gray-600 dark:text-gray-400 flex-1"
         >
           {desc}
         </p>


### PR DESCRIPTION
## Description

Fixes #5978 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.


Before :
<img width="1513" height="449" alt="image" src="https://github.com/user-attachments/assets/8f26860f-ad0a-4eec-9f9b-9a10a8622d99" />

After :
<img width="1581" height="578" alt="{CF596218-C71C-49A4-8AED-E2BDC10C8F9C}" src="https://github.com/user-attachments/assets/83700909-8a53-4842-bd9f-3ea11972488c" />
