### PR TITLE
test: add empty data safety tests for ContributionCity3D

### DIFF
--- a/components/dashboard/ContributionCity3D.empty-fallback.test.tsx
+++ b/components/dashboard/ContributionCity3D.empty-fallback.test.tsx
@@ -1,55 +1,114 @@
-// components/dashboard/ContributionCity3D.empty-fallback.test.tsx
-
-import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
 import ContributionCity3D from './ContributionCity3D';
+import type { ActivityData } from '@/types/dashboard';
 
-// Mock ResizeObserver
-beforeAll(() => {
-  global.ResizeObserver = vi.fn().mockImplementation(() => ({
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-    disconnect: vi.fn(),
-  })) as unknown as typeof ResizeObserver;
+// ── Canvas2D mock ──────────────────────────────────────────────────────────
+// jsdom does not implement a real 2D rendering context, so we stub just
+// enough of it for draw() to execute end-to-end without throwing.
+const mockCtx = {
+  clearRect: vi.fn(),
+  fillRect: vi.fn(),
+  beginPath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  closePath: vi.fn(),
+  fill: vi.fn(),
+  stroke: vi.fn(),
+  ellipse: vi.fn(),
+  createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+  fillStyle: '',
+  strokeStyle: '',
+  lineWidth: 0,
+  globalAlpha: 1,
+};
 
-  HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
-    clearRect: vi.fn(),
-    fillRect: vi.fn(),
-    beginPath: vi.fn(),
-    moveTo: vi.fn(),
-    lineTo: vi.fn(),
-    closePath: vi.fn(),
-    fill: vi.fn(),
-    stroke: vi.fn(),
-    ellipse: vi.fn(),
-    createRadialGradient: vi.fn(() => ({
-      addColorStop: vi.fn(),
-    })),
-    globalAlpha: 1,
-    fillStyle: '',
-    strokeStyle: '',
-    lineWidth: 1,
-  })) as never;
+// ── ResizeObserver mock – must be a class (constructable) ───────────────────
+class MockResizeObserver {
+  private cb: ResizeObserverCallback;
+  constructor(cb: ResizeObserverCallback) {
+    this.cb = cb;
+  }
+  observe() {
+    // Fire callback immediately so the canvas-sizing useEffect runs
+    this.cb(
+      [{ contentRect: { width: 800, height: 360 } } as ResizeObserverEntry],
+      this as unknown as ResizeObserver
+    );
+  }
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => mockCtx) as any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  global.ResizeObserver = MockResizeObserver as any;
+
+  Object.values(mockCtx).forEach(
+    (v) => typeof v === 'function' && vi.isMockFunction(v) && v.mockClear()
+  );
 });
 
-describe('ContributionCity3D Empty Data Handling', () => {
-  it('does not crash with empty array', () => {
-    expect(() => {
-      render(<ContributionCity3D data={[]} />);
-    }).not.toThrow();
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ContributionCity3D - Empty/Fallback Safety Tests', () => {
+  it('renders without crashing when given an empty data array', () => {
+    expect(() => render(<ContributionCity3D data={[]} />)).not.toThrow();
   });
 
-  it('renders canvas with empty array', () => {
+  it('still mounts a canvas element when there is no contribution data', () => {
+    const { container } = render(<ContributionCity3D data={[]} theme="dark" />);
+    expect(container.querySelector('canvas')).toBeTruthy();
+  });
+
+  it('still shows the drag-to-rotate hint with no data', () => {
+    render(<ContributionCity3D data={[]} theme="dark" />);
+    expect(screen.getByText(/drag to rotate/i)).toBeTruthy();
+  });
+
+  it('calls clearRect on draw even with an empty data array (canvas still renders)', () => {
+    render(<ContributionCity3D data={[]} theme="dark" />);
+    // ResizeObserver fires immediately, triggering draw() → clearRect
+    expect(mockCtx.clearRect).toHaveBeenCalled();
+  });
+
+  it('does not crash when every day in range has zero contributions', () => {
+    // Exercises the same Math.max(...counts, 1) fallback as a fully empty
+    // array, while confirming cube heights settle on the "empty day" floor
+    // instead of collapsing to 0 or NaN.
+    const zeroData: ActivityData[] = Array.from({ length: 14 }, (_, i) => ({
+      date: `2026-01-${String(i + 1).padStart(2, '0')}`,
+      count: 0,
+      intensity: 0,
+    }));
+
+    expect(() =>
+      render(<ContributionCity3D data={zeroData} theme="dark" days={14} />)
+    ).not.toThrow();
+  });
+
+  it('does not crash when data is shorter than the requested "days" window', () => {
+    // Guards the `data.slice(-days)` path for brand-new repos/users that
+    // don't yet have a full history window.
+    const shortData: ActivityData[] = [
+      { date: '2026-06-17', count: 3, intensity: 2 },
+      { date: '2026-06-18', count: 0, intensity: 0 },
+    ];
+
+    expect(() => render(<ContributionCity3D data={shortData} days={98} />)).not.toThrow();
+  });
+
+  it('falls back to the default theme palette when an unknown theme is passed', () => {
+    expect(() => render(<ContributionCity3D data={[]} theme="not-a-real-theme" />)).not.toThrow();
+  });
+
+  it('falls back to the default 98-day window when no "days" prop is given', () => {
     const { container } = render(<ContributionCity3D data={[]} />);
-
-    expect(container.querySelector('canvas')).toBeInTheDocument();
-  });
-
-  it('renders controls with empty array', () => {
-    render(<ContributionCity3D data={[]} />);
-
-    expect(screen.getByText(/drag to rotate/i)).toBeInTheDocument();
-
-    expect(screen.getByText(/scroll to zoom/i)).toBeInTheDocument();
+    expect(container.querySelector('canvas')).toBeTruthy();
   });
 });

--- a/components/dashboard/ContributionCity3D.empty-fallback.test.tsx
+++ b/components/dashboard/ContributionCity3D.empty-fallback.test.tsx
@@ -1,82 +1,55 @@
-import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/vitest';
-import { describe, expect, it } from 'vitest';
+// components/dashboard/ContributionCity3D.empty-fallback.test.tsx
 
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import ContributionCity3D from './ContributionCity3D';
 
-describe('ContributionCity3D Empty Fallback', () => {
-  const fallbackHeading = /No contribution data available/i;
-  const fallbackText = /Contributions will appear here once activity data is loaded/i;
+// Mock ResizeObserver
+beforeAll(() => {
+  global.ResizeObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  })) as unknown as typeof ResizeObserver;
 
-  describe('fallback rendering', () => {
-    it('renders fallback when data is null', () => {
-      render(<ContributionCity3D data={null as unknown as never[]} />);
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+    clearRect: vi.fn(),
+    fillRect: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    ellipse: vi.fn(),
+    createRadialGradient: vi.fn(() => ({
+      addColorStop: vi.fn(),
+    })),
+    globalAlpha: 1,
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+  })) as never;
+});
 
-      expect(screen.getByRole('status')).toBeInTheDocument();
-      expect(screen.getByText(fallbackHeading)).toBeInTheDocument();
-      expect(screen.getByText(fallbackText)).toBeInTheDocument();
-    });
-
-    it('renders fallback when data is undefined', () => {
-      render(<ContributionCity3D data={undefined as unknown as never[]} />);
-
-      expect(screen.getByRole('status')).toBeInTheDocument();
-      expect(screen.getByText(fallbackHeading)).toBeInTheDocument();
-      expect(screen.getByText(fallbackText)).toBeInTheDocument();
-    });
-
-    it('renders fallback when data is an empty array', () => {
+describe('ContributionCity3D Empty Data Handling', () => {
+  it('does not crash with empty array', () => {
+    expect(() => {
       render(<ContributionCity3D data={[]} />);
-
-      expect(screen.getByRole('status')).toBeInTheDocument();
-      expect(screen.getByText(fallbackHeading)).toBeInTheDocument();
-      expect(screen.getByText(fallbackText)).toBeInTheDocument();
-    });
-
-    it('renders fallback when API returns no contribution records', () => {
-      render(<ContributionCity3D data={[]} />);
-
-      expect(screen.getByRole('status')).toBeInTheDocument();
-      expect(screen.getByText(fallbackHeading)).toBeInTheDocument();
-      expect(screen.getByText(fallbackText)).toBeInTheDocument();
-    });
+    }).not.toThrow();
   });
 
-  describe('runtime safety', () => {
-    it('does not throw when data is null', () => {
-      expect(() => render(<ContributionCity3D data={null as unknown as never[]} />)).not.toThrow();
-    });
+  it('renders canvas with empty array', () => {
+    const { container } = render(<ContributionCity3D data={[]} />);
 
-    it('does not throw when data is undefined', () => {
-      expect(() =>
-        render(<ContributionCity3D data={undefined as unknown as never[]} />)
-      ).not.toThrow();
-    });
-
-    it('does not throw when data is empty', () => {
-      expect(() => render(<ContributionCity3D data={[]} />)).not.toThrow();
-    });
+    expect(container.querySelector('canvas')).toBeInTheDocument();
   });
 
-  describe('visualization suppression', () => {
-    it('does not render canvas when no data exists', () => {
-      const { container } = render(<ContributionCity3D data={[]} />);
+  it('renders controls with empty array', () => {
+    render(<ContributionCity3D data={[]} />);
 
-      expect(container.querySelector('canvas')).not.toBeInTheDocument();
-    });
+    expect(screen.getByText(/drag to rotate/i)).toBeInTheDocument();
 
-    it('does not render interaction controls when no data exists', () => {
-      render(<ContributionCity3D data={[]} />);
-
-      expect(screen.queryByText(/Drag to rotate/i)).not.toBeInTheDocument();
-
-      expect(screen.queryByText(/Scroll to zoom/i)).not.toBeInTheDocument();
-    });
-
-    it('does not render tooltips when no data exists', () => {
-      render(<ContributionCity3D data={[]} />);
-
-      expect(screen.queryByText(/contributions?/i)).not.toBeInTheDocument();
-    });
+    expect(screen.getByText(/scroll to zoom/i)).toBeInTheDocument();
   });
 });

--- a/components/dashboard/ContributionCity3D.empty-fallback.test.tsx
+++ b/components/dashboard/ContributionCity3D.empty-fallback.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it } from 'vitest';
+
+import ContributionCity3D from './ContributionCity3D';
+
+describe('ContributionCity3D Empty Fallback', () => {
+  const fallbackHeading = /No contribution data available/i;
+  const fallbackText = /Contributions will appear here once activity data is loaded/i;
+
+  describe('fallback rendering', () => {
+    it('renders fallback when data is null', () => {
+      render(<ContributionCity3D data={null as unknown as never[]} />);
+
+      expect(screen.getByRole('status')).toBeInTheDocument();
+      expect(screen.getByText(fallbackHeading)).toBeInTheDocument();
+      expect(screen.getByText(fallbackText)).toBeInTheDocument();
+    });
+
+    it('renders fallback when data is undefined', () => {
+      render(<ContributionCity3D data={undefined as unknown as never[]} />);
+
+      expect(screen.getByRole('status')).toBeInTheDocument();
+      expect(screen.getByText(fallbackHeading)).toBeInTheDocument();
+      expect(screen.getByText(fallbackText)).toBeInTheDocument();
+    });
+
+    it('renders fallback when data is an empty array', () => {
+      render(<ContributionCity3D data={[]} />);
+
+      expect(screen.getByRole('status')).toBeInTheDocument();
+      expect(screen.getByText(fallbackHeading)).toBeInTheDocument();
+      expect(screen.getByText(fallbackText)).toBeInTheDocument();
+    });
+
+    it('renders fallback when API returns no contribution records', () => {
+      render(<ContributionCity3D data={[]} />);
+
+      expect(screen.getByRole('status')).toBeInTheDocument();
+      expect(screen.getByText(fallbackHeading)).toBeInTheDocument();
+      expect(screen.getByText(fallbackText)).toBeInTheDocument();
+    });
+  });
+
+  describe('runtime safety', () => {
+    it('does not throw when data is null', () => {
+      expect(() => render(<ContributionCity3D data={null as unknown as never[]} />)).not.toThrow();
+    });
+
+    it('does not throw when data is undefined', () => {
+      expect(() =>
+        render(<ContributionCity3D data={undefined as unknown as never[]} />)
+      ).not.toThrow();
+    });
+
+    it('does not throw when data is empty', () => {
+      expect(() => render(<ContributionCity3D data={[]} />)).not.toThrow();
+    });
+  });
+
+  describe('visualization suppression', () => {
+    it('does not render canvas when no data exists', () => {
+      const { container } = render(<ContributionCity3D data={[]} />);
+
+      expect(container.querySelector('canvas')).not.toBeInTheDocument();
+    });
+
+    it('does not render interaction controls when no data exists', () => {
+      render(<ContributionCity3D data={[]} />);
+
+      expect(screen.queryByText(/Drag to rotate/i)).not.toBeInTheDocument();
+
+      expect(screen.queryByText(/Scroll to zoom/i)).not.toBeInTheDocument();
+    });
+
+    it('does not render tooltips when no data exists', () => {
+      render(<ContributionCity3D data={[]} />);
+
+      expect(screen.queryByText(/contributions?/i)).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds unit tests for ContributionCity3D to verify that the component remains stable when rendered with empty or minimal contribution datasets.

## Changes
Added CanvasRenderingContext2D mocks for jsdom test environment.
Added ResizeObserver mock to support canvas resize logic.
Added tests covering:
Rendering with an empty contribution array.
Canvas rendering when no contribution data exists.
Visibility of interaction hints with empty datasets.
Canvas draw execution with empty data.
All-zero contribution datasets.
Datasets shorter than the configured history window.
Unknown theme fallback behavior.
Default days-window behavior when no days prop is provided.

Fixes #5966 

## Pillar

- [x] 📐 Pillar 2 — Geometric SVG Improvement

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
