### PR TITLE
test(qa): add empty state layout validation tests for DeploymentTracker

### DIFF
--- a/components/dashboard/DeploymentTracker.accessibility.test.tsx
+++ b/components/dashboard/DeploymentTracker.accessibility.test.tsx
@@ -1,0 +1,135 @@
+// DeploymentTracker.accessibility.test.tsx
+//
+// Verifies the component exposes a sane accessibility tree: meaningful link
+// text (not just icons), correct use of external-link attributes, heading
+// semantics, and that status information isn't conveyed by color alone.
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import DeploymentTracker from './DeploymentTracker';
+import type { DeploymentData } from '@/types/dashboard';
+
+/** Local mock builder, matching this repo's inline-mock convention. */
+function makeDeployment(overrides: Partial<DeploymentData> = {}): DeploymentData {
+  return {
+    repoName: 'acme/web-app',
+    repoUrl: 'https://github.com/acme/web-app',
+    liveUrl: 'https://web-app.acme.dev',
+    status: 'success',
+    deployedAt: new Date().toISOString(),
+    environment: 'production',
+    workflowName: 'Vercel Production Deployment',
+    ...overrides,
+  };
+}
+
+describe('DeploymentTracker — accessibility', () => {
+  it('renders a heading that names the section', () => {
+    render(<DeploymentTracker data={[makeDeployment()]} />);
+    // The component uses an <h3>; jsdom still exposes it with the "heading" role.
+    const heading = screen.getByRole('heading', { name: /production deployments/i });
+    expect(heading).toBeInTheDocument();
+    expect(heading.tagName).toBe('H3');
+  });
+
+  it('exposes the repo link with accessible, non-empty text', () => {
+    render(
+      <DeploymentTracker
+        data={[
+          makeDeployment({
+            repoName: 'acme/api-gateway',
+            repoUrl: 'https://github.com/acme/api-gateway',
+          }),
+        ]}
+      />
+    );
+    const link = screen.getByRole('link', { name: 'acme/api-gateway' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://github.com/acme/api-gateway');
+  });
+
+  it('sets target and rel="noopener noreferrer" on every external link', () => {
+    render(
+      <DeploymentTracker
+        data={[
+          makeDeployment({
+            repoUrl: 'https://github.com/acme/web-app',
+            liveUrl: 'https://web-app.acme.dev',
+          }),
+        ]}
+      />
+    );
+    const links = screen.getAllByRole('link');
+    expect(links.length).toBeGreaterThan(0);
+    for (const link of links) {
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    }
+  });
+
+  it('gives the repo link a title attribute for assistive tech / truncation', () => {
+    render(<DeploymentTracker data={[makeDeployment({ repoName: 'acme/very-long-repo-name' })]} />);
+    const link = screen.getByRole('link', { name: 'acme/very-long-repo-name' });
+    expect(link).toHaveAttribute('title', 'acme/very-long-repo-name');
+  });
+
+  it('does not rely on color alone to convey status — each badge has a text label', () => {
+    render(
+      <DeploymentTracker
+        data={[
+          makeDeployment({ repoName: 'r1', status: 'success' }),
+          makeDeployment({ repoName: 'r2', status: 'failure' }),
+        ]}
+      />
+    );
+    // Text labels accompany the colored dot for every status.
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+  });
+
+  it("keeps each deployment card's content groupable for screen readers via accessible name on its link", () => {
+    render(
+      <DeploymentTracker
+        data={[
+          makeDeployment({ repoName: 'acme/svc-one' }),
+          makeDeployment({ repoName: 'acme/svc-two' }),
+        ]}
+      />
+    );
+    const svcOne = screen.getByRole('link', { name: 'acme/svc-one' });
+    const svcTwo = screen.getByRole('link', { name: 'acme/svc-two' });
+    expect(svcOne).toBeInTheDocument();
+    expect(svcTwo).toBeInTheDocument();
+  });
+
+  it('"No live URL configured" fallback is plain text, not a dead/empty link', () => {
+    render(<DeploymentTracker data={[makeDeployment({ liveUrl: null })]} />);
+    const fallback = screen.getByText('No live URL configured');
+    expect(fallback.tagName).not.toBe('A');
+    // Confirms there is exactly one link on the card (the repo link), not a broken live-url link.
+    expect(screen.getAllByRole('link')).toHaveLength(1);
+  });
+
+  it('icons used purely for decoration do not introduce extra accessible names', () => {
+    const { container } = render(<DeploymentTracker data={[makeDeployment()]} />);
+    // lucide-react icons render as <svg>; they should not carry role="img" with
+    // a competing accessible name that would duplicate/clutter the link's name.
+    const svgs = container.querySelectorAll('svg');
+    expect(svgs.length).toBeGreaterThan(0);
+    for (const svg of svgs) {
+      expect(svg).not.toHaveAttribute('role', 'img');
+    }
+  });
+
+  it('renders nothing (no stray landmarks) when there is no data, rather than an empty shell', () => {
+    const { container } = render(<DeploymentTracker data={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('keeps environment + timestamp readable as plain text within each card', () => {
+    render(<DeploymentTracker data={[makeDeployment({ environment: 'staging' })]} />);
+    const card = screen.getByText('staging').closest('div');
+    expect(card).not.toBeNull();
+    expect(within(card as HTMLElement).getByText(/deployed/i)).toBeInTheDocument();
+  });
+});

--- a/components/dashboard/DeploymentTracker.empty-fallback.test.tsx
+++ b/components/dashboard/DeploymentTracker.empty-fallback.test.tsx
@@ -1,0 +1,88 @@
+// DeploymentTracker.empty-fallback.test.tsx
+//
+// Covers the component's "nothing to show" and per-field fallback paths:
+// no data array, empty array, undefined prop, null deployedAt, null liveUrl,
+// and unrecognized status values falling back to the "unknown" badge.
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DeploymentTracker from './DeploymentTracker';
+import type { DeploymentData, WorkflowStatus } from '@/types/dashboard';
+
+/** Local mock builder, matching this repo's inline-mock convention. */
+function makeDeployment(overrides: Partial<DeploymentData> = {}): DeploymentData {
+  return {
+    repoName: 'acme/web-app',
+    repoUrl: 'https://github.com/acme/web-app',
+    liveUrl: 'https://web-app.acme.dev',
+    status: 'success',
+    deployedAt: new Date().toISOString(),
+    environment: 'production',
+    workflowName: 'Vercel Production Deployment',
+    ...overrides,
+  };
+}
+
+describe('DeploymentTracker — empty & fallback states', () => {
+  it('renders nothing when data is undefined (uses default prop)', () => {
+    // Removed the unused @ts-expect-error directive because data is optional on the interface
+    const { container } = render(<DeploymentTracker />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when data is an empty array', () => {
+    const { container } = render(<DeploymentTracker data={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when data is explicitly null-ish at runtime', () => {
+    // Simulates an API response that resolved to null despite the TS type.
+    const { container } = render(<DeploymentTracker data={null as unknown as undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows "No live URL configured" italic fallback when liveUrl is null', () => {
+    render(<DeploymentTracker data={[makeDeployment({ liveUrl: null })]} />);
+    const fallback = screen.getByText('No live URL configured');
+    expect(fallback).toBeInTheDocument();
+    expect(fallback.className).toMatch(/italic/);
+  });
+
+  it('does not render the fallback text when liveUrl is present', () => {
+    render(<DeploymentTracker data={[makeDeployment({ liveUrl: 'https://example.com' })]} />);
+    expect(screen.queryByText('No live URL configured')).not.toBeInTheDocument();
+  });
+
+  it('shows "Deployed Unknown" when deployedAt is null', () => {
+    render(<DeploymentTracker data={[makeDeployment({ deployedAt: null })]} />);
+    expect(screen.getByText('Deployed Unknown')).toBeInTheDocument();
+  });
+
+  it('shows "Deployed Unknown" when deployedAt is an unparsable string', () => {
+    render(<DeploymentTracker data={[makeDeployment({ deployedAt: 'not-a-real-date' })]} />);
+    expect(screen.getByText('Deployed Unknown')).toBeInTheDocument();
+  });
+
+  it('falls back to the "Unknown" status badge for a status value outside the known union', () => {
+    // workflowName/status could come from an upstream API drifting from the TS contract.
+    const weirdStatus = 'queued' as unknown as WorkflowStatus;
+    render(<DeploymentTracker data={[makeDeployment({ status: weirdStatus })]} />);
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+  });
+
+  it('renders an empty environment string without crashing', () => {
+    render(<DeploymentTracker data={[makeDeployment({ environment: '' })]} />);
+    expect(screen.getByText(/deployed/i)).toBeInTheDocument();
+  });
+
+  it('handles workflowName being null without affecting the rendered card (field is not displayed)', () => {
+    render(<DeploymentTracker data={[makeDeployment({ workflowName: null })]} />);
+    expect(screen.getByText('Success')).toBeInTheDocument();
+  });
+
+  it('handles an empty repoName gracefully (renders an empty but present link)', () => {
+    render(<DeploymentTracker data={[makeDeployment({ repoName: '' })]} />);
+    const links = screen.getAllByRole('link');
+    expect(links[0]).toHaveAttribute('href', 'https://github.com/acme/web-app');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #5882

This PR introduces a dedicated fallback verification suite (`DeploymentTracker.empty-fallback.test.tsx`) to guarantee the tracking UI component fails gracefully in zero-data conditions.

* **Null Data Footprint**: Verifies that the container component safely yields a `null` layout representation if incoming arrays are unassigned, or null-ish at runtime[cite: 1].
* **Layout Erasure Safety**: Asserts that passing an empty data array triggers an immediate element clearance so no empty UI placeholder boxes are orphaned on the live dashboard[cite: 1].
* **Missing Value Fallbacks**: Validates internal string handling parameters, ensuring clear informational strings (e.g., `"No live URL configured"`) load dynamically if specific optional item links are omitted[cite: 1].

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Empty Fallback States / QA infrastructure)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `test(qa): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.