### PR TITLE
fix: resolve hardcoded age in hidden-gem developer achievement calcul…

### DIFF
--- a/app/api/achievements/route.ts
+++ b/app/api/achievements/route.ts
@@ -606,6 +606,7 @@ export async function GET(request: Request) {
       name: string;
       description: string | null;
       stargazerCount: number;
+      createdAt: string;
     }>;
     const aiRepoCount = popularRepos.filter((repo) =>
       AI_KEYWORDS.some(
@@ -616,7 +617,11 @@ export async function GET(request: Request) {
     ).length;
     let topStarDensity = 0;
     for (const repo of popularRepos) {
-      const density = repo.stargazerCount / 6;
+      const ageInYears = Math.max(
+        0.1,
+        (Date.now() - new Date(repo.createdAt).getTime()) / (1000 * 60 * 60 * 24 * 365.25)
+      );
+      const density = repo.stargazerCount / ageInYears;
       if (density > topStarDensity) topStarDensity = density;
     }
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1549,6 +1549,7 @@ export interface PopularRepo {
   stargazerCount: number;
   forkCount: number;
   url: string;
+  createdAt: string;
   primaryLanguage: { name: string; color: string } | null;
 }
 
@@ -1564,6 +1565,7 @@ export async function fetchPinnedRepos(username: string, token?: string): Promis
               stargazerCount
               forkCount
               url
+              createdAt
               primaryLanguage {
                 name
                 color
@@ -1606,6 +1608,7 @@ async function fetchPopularRepos(username: string, token?: string): Promise<Popu
             stargazerCount
             forkCount
             url
+            createdAt
             primaryLanguage {
               name
               color
@@ -1647,6 +1650,7 @@ async function fetchStarredRepos(username: string, token?: string): Promise<Popu
             stargazerCount
             forkCount
             url
+            createdAt
             primaryLanguage {
               name
               color


### PR DESCRIPTION
## Description

Fixes #6019 

This PR resolves the logical bug in the "Hidden Gem" developer achievement. Instead of using a hardcoded placeholder division of `repo.stargazerCount / 6` to calculate star density, it now dynamically calculates star density based on the repository's actual age.

### What Changed:
1. **GraphQL Query Fetch Layer (`lib/github.ts`):** Included `createdAt` in the `PopularRepo` interface and updated GraphQL query nodes for popular, pinned, and starred repos to fetch the `createdAt` timestamp.
2. **Achievements API Endpoint (`app/api/achievements/route.ts`):** 
   - Extended the `popularRepos` type cast to accept `createdAt`.
   - Calculated repository age in years: `Math.max(0.1, (Date.now() - new Date(repo.createdAt).getTime()) / (1000 * 60 * 60 * 24 * 365.25))`.
   - Replaced the hardcoded division by `6` with the dynamic age-in-years calculation.
3. **Verification:** All 149 tests in `lib/github.test.ts` and achievements API tests passed successfully, and the production build compiled cleanly without TypeScript or bundling warnings.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
*N/A (Backend logic fix only)*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have starred the repo.
- [ ] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.