### PR TITLE
fix(ui): add unoptimized and onError fallback to avatar images

### DIFF
--- a/app/components/LandingPageClient.tsx
+++ b/app/components/LandingPageClient.tsx
@@ -738,6 +738,12 @@ export default function LandingPageClient() {
                           width={24}
                           height={24}
                           className="w-6 h-6 rounded-full border border-emerald-500/20"
+                          unoptimized
+                          onError={(e) => {
+                            const img = e.currentTarget as HTMLImageElement;
+                            img.onerror = null;
+                            img.src = `https://github.com/${userDetails.login}.png`;
+                          }}
                         />
                         <div className="flex flex-col">
                           <span className="text-xs font-bold text-zinc-200">
@@ -794,7 +800,14 @@ export default function LandingPageClient() {
                               width={16}
                               height={16}
                               className="w-4 h-4 rounded-full border border-zinc-200/20 dark:border-white/20"
+                              unoptimized
+                              onError={(e) => {
+                                const img = e.currentTarget as HTMLImageElement;
+                                img.onerror = null;
+                                img.style.display = 'none';
+                              }}
                             />
+
                             <button
                               type="button"
                               onClick={() => selectDemoUser(displayName)}


### PR DESCRIPTION
## Description

Fixes #6018 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

> Tested locally: after this fix, the avatar in the Verified Profile card
> loads correctly from GitHub REST API avatar_url. If the URL fails,
> it gracefully falls back to github.com/{login}.png. For Recent chips,
> the avatar hides cleanly on error instead of showing a broken icon.

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
