### PR TITLE
feat: add Replay My Year animation to 3D contribution monolith

### DIFF
--- a/components/dashboard/ContributionCity3D.tsx
+++ b/components/dashboard/ContributionCity3D.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import type { ActivityData } from '@/types/dashboard';
 
 // ─── Theme palette (mirrors lib/svg/themes.ts accent colours) ────────────────
@@ -96,20 +96,67 @@ export default function ContributionCity3D({
 
   const palette = THEME_PALETTES[theme] ?? DEFAULT_PALETTE;
 
+  // ── Replay My Year state ───────────────────────────────────────────────────
+  const [isReplaying, setIsReplaying] = useState(false);
+  const [replayIndex, setReplayIndex] = useState<number | null>(null);
+  const replayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const totalDays = useMemo(() => data.slice(-days).length, [data, days]);
+
+  const stopReplay = useCallback(() => {
+    if (replayTimerRef.current) clearTimeout(replayTimerRef.current);
+    setIsReplaying(false);
+    setReplayIndex(null);
+  }, []);
+
+  const startReplay = useCallback(() => {
+    if (replayTimerRef.current) clearTimeout(replayTimerRef.current);
+    setIsReplaying(true);
+    setReplayIndex(1);
+  }, []);
+
+  // Advance the replay frame-by-frame
+  useEffect(() => {
+    if (!isReplaying || replayIndex === null) return;
+    if (replayIndex >= totalDays) {
+      // Finished – hold full view for a moment then stop
+      replayTimerRef.current = setTimeout(() => stopReplay(), 800);
+      return;
+    }
+    // Speed: faster at the start, steady in the middle — ~12ms per day
+    const delay = replayIndex < 10 ? 30 : 12;
+    replayTimerRef.current = setTimeout(() => {
+      setReplayIndex((prev) => (prev !== null ? prev + 1 : null));
+    }, delay);
+    return () => {
+      if (replayTimerRef.current) clearTimeout(replayTimerRef.current);
+    };
+  }, [isReplaying, replayIndex, totalDays, stopReplay]);
+
+  // Cleanup on unmount
+  useEffect(
+    () => () => {
+      if (replayTimerRef.current) clearTimeout(replayTimerRef.current);
+    },
+    []
+  );
+
   // ── Build cube specs from ActivityData ─────────────────────────────────────
   const cubes = useCallback((): CubeSpec[] => {
     const recent = data.slice(-days);
+    // When replaying, slice to current frame; zero out future cubes for clean build-up
+    const visibleCount = replayIndex !== null ? replayIndex : recent.length;
     const max = Math.max(...recent.map((d) => d.count), 1);
 
     return recent.map((d, i) => ({
-      col: Math.floor(i / 7), // week column
-      row: i % 7, // day-of-week row
-      height: d.count === 0 ? 0.04 : 0.1 + 0.9 * (d.count / max),
-      count: d.count,
+      col: Math.floor(i / 7),
+      row: i % 7,
+      height: i >= visibleCount ? 0.04 : d.count === 0 ? 0.04 : 0.1 + 0.9 * (d.count / max),
+      count: i >= visibleCount ? 0 : d.count,
       date: d.date,
-      intensity: d.intensity,
+      intensity: i >= visibleCount ? 0 : d.intensity,
     }));
-  }, [data, days]);
+  }, [data, days, replayIndex]);
 
   // ── Draw ───────────────────────────────────────────────────────────────────
   const draw = useCallback(() => {
@@ -411,6 +458,65 @@ export default function ContributionCity3D({
           style={{ display: 'block' }}
         />
       </div>
+
+      {/* Replay My Year button */}
+      <div className="absolute top-3 left-4 flex items-center gap-2">
+        <button
+          onClick={isReplaying ? stopReplay : startReplay}
+          className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-all"
+          style={{
+            background: isReplaying ? `${palette.accent}22` : `${palette.accent}18`,
+            color: palette.accent,
+            border: `1px solid ${palette.accent}44`,
+          }}
+          title={isReplaying ? 'Stop replay' : 'Replay My Year'}
+        >
+          {isReplaying ? (
+            // Stop icon
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor" aria-hidden>
+              <rect x="1" y="1" width="8" height="8" rx="1" />
+            </svg>
+          ) : (
+            // Play icon
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor" aria-hidden>
+              <polygon points="2,1 9,5 2,9" />
+            </svg>
+          )}
+          {isReplaying ? 'Stop' : 'Replay My Year'}
+        </button>
+
+        {/* Month label during replay */}
+        {isReplaying &&
+          replayIndex !== null &&
+          (() => {
+            const recent = data.slice(-days);
+            const currentDay = recent[Math.min(replayIndex - 1, recent.length - 1)];
+            const month = currentDay
+              ? new Date(currentDay.date).toLocaleString('default', {
+                  month: 'short',
+                  year: 'numeric',
+                })
+              : '';
+            return (
+              <span className="text-xs font-mono opacity-60" style={{ color: palette.accent }}>
+                {month}
+              </span>
+            );
+          })()}
+      </div>
+
+      {/* Progress bar */}
+      {isReplaying && replayIndex !== null && (
+        <div
+          className="absolute bottom-0 left-0 h-0.5 transition-all"
+          style={{
+            width: `${(replayIndex / totalDays) * 100}%`,
+            background: palette.accent,
+            borderRadius: '0 2px 2px 0',
+            opacity: 0.7,
+          }}
+        />
+      )}
 
       {/* Tooltip */}
       {tooltip && (


### PR DESCRIPTION
## Description

Adds a new "Replay My Year" interactive feature to the 3D contribution city view. 
When clicked, the monolith animates chronologically from January to December, 
letting users watch their GitHub activity evolve over time.

Fixes #3485 

## Changes
- Added play/stop button in the top-left corner of the 3D city view
- Monolith builds up day by day with smooth animation
- Live month label updates as the replay progresses
- Progress bar along the bottom tracks replay position
- Auto-stops after completing the full year
- Only one file changed: `components/dashboard/ContributionCity3D.tsx`

##Screenshots
<img width="1920" height="831" alt="Screenshot (575)" src="https://github.com/user-attachments/assets/3ef08c4f-7062-483b-8f98-b8aa277a5bee" />

## Pillar
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:
- [x] I have tested these changes locally
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors
- [x] My commits follow the Conventional Commits format
- [x] I have made sure that I have only one commit to merge in this PR