### PR TITLE
fix: add rate limiting to architecture endpoint (#6013)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -63,5 +63,6 @@ export const config = {
     '/api/wrapped/:path*',
     '/api/student/:path*',
     '/api/pr-insights/:path*',
+    '/api/architecture/:path*',
   ],
 };


### PR DESCRIPTION
## Summary

This PR adds rate limiting to the architecture visualizer endpoint by including it in the middleware matcher.

## Changes

Added  to the middleware matcher in .

## Security Benefits

- Prevents resource exhaustion attacks (filling disk with cloned repos)
- Protects the server's GitHub PAT from being abused through API quota burn
- Applies the same rate limiting as all other protected API endpoints (60 requests per minute)

## Issue

Fixes #6013

## Testing

- All 14 middleware tests pass
- Linting passes with no new errors