### PR TITLE
fix: forward per-user token to deployment tracker requests

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -1211,7 +1211,64 @@ describe('getFullDashboardData', () => {
     ]);
     expect(result.insights).toBeDefined();
   });
+  it('forwards the per-user token to deployment tracker requests instead of using the shared pool', async () => {
+    const capturedAuthHeaders: string[] = [];
 
+    vi.mocked(fetch).mockImplementation(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : (url?.toString() ?? '');
+
+      if (urlStr.includes('/actions/runs') || urlStr.includes('/deployments')) {
+        const headers = init?.headers as Record<string, string> | undefined;
+        capturedAuthHeaders.push(headers?.Authorization ?? '');
+        if (urlStr.includes('/actions/runs')) {
+          return mockResponse({ workflow_runs: [] });
+        }
+        return mockResponse([]);
+      }
+      if (urlStr.includes('/users/octocat/repos')) {
+        return mockResponse([
+          {
+            name: 'repo1',
+            stargazers_count: 10,
+            language: 'TypeScript',
+            fork: false,
+            owner: { login: 'octocat' },
+          },
+        ]);
+      }
+      if (urlStr.includes('/users/octocat')) {
+        return mockResponse({
+          login: 'octocat',
+          name: 'The Octocat',
+          avatar_url: 'avatar.png',
+          public_repos: 1,
+          followers: 1,
+          following: 1,
+          created_at: '2020-01-01T00:00:00Z',
+          bio: null,
+          location: null,
+        });
+      }
+      return mockResponse({
+        data: {
+          user: {
+            contributionsCollection: {
+              contributionCalendar: mockCalendar,
+              commitContributionsByRepository: [],
+            },
+          },
+        },
+      });
+    });
+
+    const userToken = 'user-personal-oauth-token';
+    await getFullDashboardData('octocat', { token: userToken });
+
+    expect(capturedAuthHeaders.length).toBeGreaterThan(0);
+    for (const authHeader of capturedAuthHeaders) {
+      expect(authHeader).toBe(`bearer ${userToken}`);
+    }
+  });
   it('caps developerScore at 100 for extreme profile metrics', async () => {
     const saturatedCalendar: ContributionCalendar = {
       totalContributions: 500,

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1721,17 +1721,19 @@ function mapConclusionToStatus(
 /** Fetch the most recent workflow run for a single repo (used for the status badge). */
 async function fetchLatestWorkflowRun(
   owner: string,
-  repo: string
+  repo: string,
+  token?: string
 ): Promise<GitHubWorkflowRun | null> {
   try {
     const res = await fetchWithRetry(
       `${GITHUB_REST_URL}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions/runs?per_page=1`,
       {
-        headers: getHeaders(),
+        headers: getHeaders(token),
         cache: 'no-store',
       },
       0,
-      REST_TIMEOUT_MS
+      REST_TIMEOUT_MS,
+      token
     );
     if (!res.ok) return null;
     const data = await res.json();
@@ -1745,7 +1747,8 @@ async function fetchLatestWorkflowRun(
 /** Fetch the most recent deployment + its latest status for a single repo. */
 async function fetchLatestDeployment(
   owner: string,
-  repo: string
+  repo: string,
+  token?: string
 ): Promise<{
   deployment: GitHubDeployment;
   deploymentStatus: GitHubDeploymentStatus | null;
@@ -1754,11 +1757,12 @@ async function fetchLatestDeployment(
     const res = await fetchWithRetry(
       `${GITHUB_REST_URL}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/deployments?per_page=1&environment=production`,
       {
-        headers: getHeaders(),
+        headers: getHeaders(token),
         cache: 'no-store',
       },
       0,
-      REST_TIMEOUT_MS
+      REST_TIMEOUT_MS,
+      token
     );
     if (!res.ok) return null;
     const deployments = (await res.json()) as GitHubDeployment[];
@@ -1768,11 +1772,12 @@ async function fetchLatestDeployment(
     const statusRes = await fetchWithRetry(
       `${GITHUB_REST_URL}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/deployments/${deployment.id}/statuses?per_page=1`,
       {
-        headers: getHeaders(),
+        headers: getHeaders(token),
         cache: 'no-store',
       },
       0,
-      REST_TIMEOUT_MS
+      REST_TIMEOUT_MS,
+      token
     );
     const statuses = statusRes.ok ? ((await statusRes.json()) as GitHubDeploymentStatus[]) : [];
     return { deployment, deploymentStatus: statuses?.[0] ?? null };
@@ -1791,7 +1796,8 @@ async function fetchLatestDeployment(
 async function fetchDeploymentTrackerData(
   username: string,
   reposData: GitHubRepo[],
-  limit = 3
+  limit = 3,
+  token?: string
 ): Promise<import('../types/dashboard').DeploymentData[]> {
   // Only consider non-fork repos, most-recently-pushed first (reposData is
   // already sorted by `pushed` from fetchUserRepos). Check a slightly larger
@@ -1803,8 +1809,8 @@ async function fetchDeploymentTrackerData(
     candidates.map(async (repo) => {
       const owner = repo.owner?.login || username;
       const [workflowRun, deploymentInfo] = await Promise.all([
-        fetchLatestWorkflowRun(owner, repo.name),
-        fetchLatestDeployment(owner, repo.name),
+        fetchLatestWorkflowRun(owner, repo.name, token),
+        fetchLatestDeployment(owner, repo.name, token),
       ]);
 
       // Skip repos with no shipping signal at all
@@ -1898,7 +1904,9 @@ export async function getFullDashboardData(username: string, options: FetchOptio
   const pinnedRepos = pinnedReposResult.status === 'fulfilled' ? pinnedReposResult.value : [];
   const starredRepos = starredReposResult.status === 'fulfilled' ? starredReposResult.value : [];
 
-  const deployments = await fetchDeploymentTrackerData(username, reposData).catch(() => []);
+  const deployments = await fetchDeploymentTrackerData(username, reposData, 3, options.token).catch(
+    () => []
+  );
 
   const streakStats = calculateStreak(calendarData);
   const totalStars = reposData.reduce((acc, r) => acc + r.stargazers_count, 0);


### PR DESCRIPTION
## Description

Fixes #6066 

## Problem
The deployment tracker (fetchLatestWorkflowRun, fetchLatestDeployment, 
fetchDeploymentTrackerData) never accepted or forwarded a per-user token, 
unlike every other fetch function in lib/github.ts. It always fell back 
to the shared GitHub PAT pool.

## Impact
Every dashboard load (/api/achievements, /api/compare, /api/pr-insights) 
burned up to 6 shared-pool requests regardless of whether the caller 
supplied a per-user token defeating per-user token forwarding and 
accelerating shared pool exhaustion for all users.

## Fix
Threaded `token` through all 4 call sites so deployment tracker requests 
use the per-user token when provided, matching the pattern used 
everywhere else in the file. Added a test verifying the Authorization 
header carries the per-user token.
## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [X] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [X] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [X] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [X] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
