### PR TITLE
refactor(cache): remove non-null assertions in DistributedCache constructor

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -324,10 +324,12 @@ export class DistributedCache<T> {
     this.localCache = new TTLCache<T>(maxSize, cleanupIntervalMs);
     const url = process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL;
     const token = process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN;
-    this.useRedis = Boolean(url && token);
-    if (this.useRedis) {
-      this.redisUrl = url!.replace(/\/$/, ''); // Remove trailing slash
-      this.redisToken = token!;
+    if (url && token) {
+      this.useRedis = true;
+      this.redisUrl = url.replace(/\/$/, ''); // Remove trailing slash
+      this.redisToken = token;
+    } else {
+      this.useRedis = false;
     }
   }
 


### PR DESCRIPTION
## Description
Fixes #6085

In `lib/cache.ts`, the `DistributedCache` constructor computed `useRedis` via a separate `Boolean()` wrapper, then accessed `url` and `token` inside the `if` block using non-null assertions:

```ts
this.useRedis = Boolean(url && token);
if (this.useRedis) {
  this.redisUrl = url!.replace(/\/$/, ''); // Remove trailing slash
  this.redisToken = token!;
}
```

**Problem with the old approach:**
- TypeScript could not narrow `url` and `token` to non-null inside the `if` block, because the truthiness check happened through a separate boolean variable (`useRedis`) rather than as the direct `if` condition
- This forced the use of non-null assertions (`!`), which bypass type safety and could mask future bugs if the logic around `useRedis` ever changes independently

**What this PR does:**
- Restructures the check to use `url && token` directly as the `if` condition
- This lets TypeScript's control flow analysis narrow `url` and `token` to non-null types automatically within the block
- Removes both non-null assertion operators (`!`)
- No logic changes — runtime behaviour is identical

**After:**
```ts
if (url && token) {
  this.useRedis = true;
  this.redisUrl = url.replace(/\/$/, ''); // Remove trailing slash
  this.redisToken = token;
} else {
  this.useRedis = false;
}
```

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes — this is a type safety refactor.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.