### PR TITLE
refactor(recommendationEngine): remove non-null assertion and redundant Map lookup

### DIFF
--- a/lib/graph/recommendationEngine.ts
+++ b/lib/graph/recommendationEngine.ts
@@ -29,10 +29,12 @@ export function getRecommendations(selectedIds: string[]): RecommendedTechnology
         continue; // Exclude already selected technologies
       }
 
-      if (!candidatesMap.has(edge.targetId)) {
-        candidatesMap.set(edge.targetId, { edges: [] });
+      let candidate = candidatesMap.get(edge.targetId);
+      if (!candidate) {
+        candidate = { edges: [] };
+        candidatesMap.set(edge.targetId, candidate);
       }
-      candidatesMap.get(edge.targetId)!.edges.push(edge);
+      candidate.edges.push(edge);
     }
   }
 


### PR DESCRIPTION
## Description
Fixes #6086

In `lib/graph/recommendationEngine.ts`, `candidatesMap` was checked for key existence, conditionally populated, then immediately looked up again using a non-null assertion:

```ts
if (!candidatesMap.has(edge.targetId)) {
  candidatesMap.set(edge.targetId, { edges: [] });
}
candidatesMap.get(edge.targetId)!.edges.push(edge);
```

**Problems with the old approach:**
- **Redundant Map operations** — this pattern performs up to 3 Map operations (`has`, `set`, `get`) for what should be a single lookup per edge
- **Non-null assertion** — `.get(edge.targetId)!` bypasses type safety, relying on the assumption that the preceding `set()` call guarantees the key exists

**What this PR does:**
- Captures the `Map.get()` result once into a `candidate` variable
- Only calls `set()` when the candidate doesn't already exist
- Reuses the captured reference to push the edge, eliminating the need for a second `get()` call and the non-null assertion
- No logic changes — runtime behaviour is identical

**After:**
```ts
let candidate = candidatesMap.get(edge.targetId);
if (!candidate) {
  candidate = { edges: [] };
  candidatesMap.set(edge.targetId, candidate);
}
candidate.edges.push(edge);
```

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes — this is a code quality refactor.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.