### PR TITLE
refactor(logging): replace console.error with structured logger in webhook route

### DIFF
--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import crypto from 'crypto';
 import { rateLimit } from '@/lib/rate-limit';
+import { logger } from '@/lib/logger';
 
 const MAX_PAYLOAD_SIZE = 1024 * 1024; // 1MB
 const SIGNATURE_PREFIX = 'sha256=';
@@ -42,7 +43,9 @@ export async function POST(req: Request) {
 
   const webhookSecret = getWebhookSecret();
   if (!webhookSecret) {
-    console.error('CRITICAL: GITHUB_WEBHOOK_SECRET is not configured. Webhook rejected.');
+    logger.error('Webhook rejected: GITHUB_WEBHOOK_SECRET is not configured', {
+      route: '/api/webhook',
+    });
     return NextResponse.json({ error: 'Webhook secret is not configured' }, { status: 500 });
   }
 


### PR DESCRIPTION
## Description
Fixes #6090

`app/api/webhook/route.ts` used a raw `console.error()` call to log a critical security misconfiguration:

```ts
console.error('CRITICAL: GITHUB_WEBHOOK_SECRET is not configured. Webhook rejected.');
```

**Problem with the old approach:**
- The project already has a structured logger utility (`lib/logger.ts`) used by other routes like `app/api/track-user/route.ts` — it outputs JSON-formatted logs in production and colored, readable logs in development
- Using raw `console.error` bypasses this, resulting in unstructured production logs that are harder to parse, filter, and alert on — especially problematic for a **critical security event** like a missing webhook secret
- Inconsistent logging approach across the codebase makes log aggregation and monitoring tooling harder to configure reliably

**What this PR does:**
- Imports the shared `logger` utility from `lib/logger.ts`
- Replaces the raw `console.error()` call with `logger.error()`, passing route context as structured metadata
- No logic changes — runtime behaviour is identical, only the log output format changes

**After:**
```ts
import { logger } from '@/lib/logger';

logger.error('Webhook rejected: GITHUB_WEBHOOK_SECRET is not configured', {
  route: '/api/webhook',
});
```

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes — this is a logging consistency refactor.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.