### PR TITLE
feat: add README Insight compact card

### DIFF
--- a/app/generator/GeneratorClient.tsx
+++ b/app/generator/GeneratorClient.tsx
@@ -6,6 +6,7 @@ import { PreviewPanel } from './components/PreviewPanel';
 import { CompletionScorePanel } from './components/CompletionScorePanel';
 import { ReadmeInsightsPanel } from './components/ReadmeInsightsPanel';
 import { ReadmeHealthBreakdown } from './components/ReadmeHealthBreakdown';
+import { ReadmeInsight } from './components/ReadmeInsight';
 import { generateReadme, getEmptyReadme } from './utils/readmeGenerator';
 import type { GeneratorState } from './types';
 import type { ImportedData } from './utils/githubMapper';
@@ -101,6 +102,7 @@ export function GeneratorClient() {
         <CompletionScorePanel state={state} />
         <ReadmeInsightsPanel state={state} />
         <ReadmeHealthBreakdown state={state} />
+        <ReadmeInsight state={state} />
       </div>
     </div>
   );

--- a/app/generator/components/ReadmeInsight.test.tsx
+++ b/app/generator/components/ReadmeInsight.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect } from 'vitest';
+import { ReadmeInsight } from './ReadmeInsight';
+import type { GeneratorState } from '../types';
+import React from 'react';
+
+const EMPTY_STATE: GeneratorState = {
+  name: '',
+  description: '',
+  selectedTechs: [],
+  selectedSocials: [],
+  socialLinks: {},
+  githubUsername: '',
+  showCommitPulse: false,
+  commitPulseAccent: '',
+  showSnakeGraph: false,
+  showPacmanGraph: false,
+  graphPlacement: 'bottom',
+};
+
+describe('ReadmeInsight Component Tests', () => {
+  it('renders title and correct default tip when state is completely empty', () => {
+    render(<ReadmeInsight state={EMPTY_STATE} />);
+
+    expect(screen.getByText('README Insight')).toBeInTheDocument();
+    expect(screen.getByText('💡 Improve description clarity')).toBeInTheDocument();
+    expect(screen.getByText('Health Boost +20%')).toBeInTheDocument();
+  });
+
+  it('suggests adding badges when description is filled but showCommitPulse is false', () => {
+    const state = { ...EMPTY_STATE, description: 'Awesome project' };
+    render(<ReadmeInsight state={state} />);
+
+    expect(screen.getByText('💡 Add badges for credibility')).toBeInTheDocument();
+    expect(screen.getByText('Health Boost +10%')).toBeInTheDocument();
+  });
+
+  it('suggests including social links when description and commitPulse are enabled but socials are empty', () => {
+    const state = {
+      ...EMPTY_STATE,
+      description: 'Awesome project',
+      showCommitPulse: true,
+      githubUsername: 'roshesh',
+    };
+    render(<ReadmeInsight state={state} />);
+
+    expect(screen.getByText('💡 Include social links')).toBeInTheDocument();
+    expect(screen.getByText('Health Boost +20%')).toBeInTheDocument();
+  });
+
+  it('suggests adding installation steps when all key items are filled', () => {
+    const state = {
+      ...EMPTY_STATE,
+      name: 'CommitPulse',
+      description: 'Awesome project',
+      showCommitPulse: true,
+      githubUsername: 'roshesh',
+      selectedSocials: ['github'],
+      socialLinks: { github: 'https://github.com/roshesh' },
+    };
+    render(<ReadmeInsight state={state} />);
+
+    expect(screen.getByText('💡 Add installation steps')).toBeInTheDocument();
+    expect(screen.getByText('Health Boost +15%')).toBeInTheDocument();
+  });
+});

--- a/app/generator/components/ReadmeInsight.tsx
+++ b/app/generator/components/ReadmeInsight.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Sparkles } from 'lucide-react';
+import type { GeneratorState } from '../types';
+
+interface ReadmeInsightProps {
+  state: GeneratorState;
+}
+
+export function ReadmeInsight({ state }: ReadmeInsightProps) {
+  const activeTip = useMemo(() => {
+    const hasName = (state.name || '').trim().length > 0;
+    const hasDescription = (state.description || '').trim().length > 0;
+    const hasSocials =
+      (state.selectedSocials?.length || 0) > 0 &&
+      state.selectedSocials.some((id) => (state.socialLinks?.[id] || '').trim().length > 0);
+    const hasCommitPulse = !!state.showCommitPulse;
+
+    if (!hasDescription) {
+      return { text: 'Improve description clarity', boost: '+20%' };
+    }
+    if (!hasCommitPulse) {
+      return { text: 'Add badges for credibility', boost: '+10%' };
+    }
+    if (!hasSocials) {
+      return { text: 'Include social links', boost: '+20%' };
+    }
+    if (!hasName) {
+      return { text: 'Add badges for credibility', boost: '+15%' };
+    }
+
+    // Default fallback
+    return { text: 'Add installation steps', boost: '+15%' };
+  }, [
+    state.name,
+    state.description,
+    state.selectedSocials,
+    state.socialLinks,
+    state.showCommitPulse,
+  ]);
+
+  return (
+    <div
+      className="rounded-2xl border border-gray-200 dark:border-white/10 bg-white dark:bg-[#111111] overflow-hidden shadow-sm hover:border-cyan-500/30 hover:shadow-md dark:hover:shadow-cyan-500/5 transition-all duration-300 w-full p-4 flex flex-col gap-3"
+      aria-label="README Insight"
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 border-b border-gray-100 dark:border-white/5 pb-2">
+        <Sparkles size={14} className="text-cyan-500 dark:text-cyan-400 animate-pulse" />
+        <h3 className="text-xs font-semibold text-gray-900 dark:text-white uppercase tracking-wider">
+          README Insight
+        </h3>
+      </div>
+
+      {/* Tip & Badge Content */}
+      <div className="flex flex-col gap-2.5">
+        <p className="text-xs text-gray-700 dark:text-white/80 font-medium leading-relaxed">
+          💡 {activeTip.text}
+        </p>
+        <div className="flex">
+          <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20">
+            Health Boost {activeTip.boost}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Fixes #6095 

This PR adds a new compact UI widget called **README Insight** inside the Generator section below the “README Health Breakdown” card.

The widget improves dashboard completeness by utilizing the previously empty space and provides quick actionable README improvement tips in a minimal, dark-theme compatible design.

Features added:
- Small card titled README Insight
- Displays a single dynamic tip from a static list:
  - Add badges for credibility
  - Improve description clarity
  - Add installation steps
  - Include social links
- Shows a small badge: Health Boost +X%
- Lightweight hover/fade animation (optional)
- Fully UI-only implementation (no logic/backend changes)

No existing components were modified.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

<img width="1737" height="857" alt="Screenshot 2026-06-20 215303" src="https://github.com/user-attachments/assets/f5d67d1a-c897-43c4-964d-f2ce0f0a5d5c" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat: add README Insight card`).
- [x] I have updated `README.md` if required.
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The UI output matches the CommitPulse aesthetic standard (clean, minimal, smooth).
- [x] I have ensured no backend/API changes were made.