### PR TITLE
fix(a11y): add high-contrast focus-visible ring to custom select components

### DIFF
--- a/app/customize/components/ThemeSelector.tsx
+++ b/app/customize/components/ThemeSelector.tsx
@@ -25,7 +25,7 @@ function StyledSelect({
       aria-label={ariaLabel}
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className="w-full bg-gray-100/80 backdrop-blur-md border border-black/10 dark:bg-white/[0.03] dark:border-white/10 rounded-xl px-4 py-2.5 text-sm text-black dark:text-white outline-none focus:border-emerald-500/50 transition-colors appearance-none cursor-pointer [color-scheme:light] dark:[color-scheme:dark] [&>option]:bg-white [&>option]:text-black dark:[&>option]:bg-[#0a0a0a] dark:[&>option]:text-white"
+      className="w-full bg-gray-100/80 backdrop-blur-md border border-black/10 dark:bg-white/[0.03] dark:border-white/10 rounded-xl px-4 py-2.5 text-sm text-black dark:text-white outline-none focus:border-emerald-500/50 focus-visible:ring-2 focus-visible:ring-purple-500 transition-colors appearance-none cursor-pointer [color-scheme:light] dark:[color-scheme:dark] [&>option]:bg-white [&>option]:text-black dark:[&>option]:bg-[#0a0a0a] dark:[&>option]:text-white"
     >
       {children}
     </select>

--- a/components/dashboard/CIAnalytics/CIFilters.tsx
+++ b/components/dashboard/CIAnalytics/CIFilters.tsx
@@ -97,7 +97,7 @@ export default function CIFilters({
         <select
           value={filters.timeRange}
           onChange={(e) => update('timeRange', e.target.value)}
-          className="px-3 py-2 text-sm bg-white dark:bg-zinc-800/50 border border-black/10 dark:border-white/10 rounded-xl text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-cyan-500/30 transition-all"
+          className="px-3 py-2 text-sm bg-white dark:bg-zinc-800/50 border border-black/10 dark:border-white/10 rounded-xl text-gray-900 dark:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 transition-all"
         >
           {TIME_RANGES.map((t) => (
             <option key={t.value} value={t.value}>
@@ -109,7 +109,7 @@ export default function CIFilters({
         <select
           value={filters.status}
           onChange={(e) => update('status', e.target.value)}
-          className="px-3 py-2 text-sm bg-white dark:bg-zinc-800/50 border border-black/10 dark:border-white/10 rounded-xl text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-cyan-500/30 transition-all"
+          className="px-3 py-2 text-sm bg-white dark:bg-zinc-800/50 border border-black/10 dark:border-white/10 rounded-xl text-gray-900 dark:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 transition-all"
         >
           <option value="">All Statuses</option>
           <option value="success">Success</option>

--- a/components/dashboard/InactiveRepoReminder.tsx
+++ b/components/dashboard/InactiveRepoReminder.tsx
@@ -69,7 +69,7 @@ export default function InactiveRepoReminder({ repos }: InactiveRepoReminderProp
             <select
               value={filter}
               onChange={(e) => setFilter(Number(e.target.value) as InactivityFilter)}
-              className="text-xs font-semibold px-2.5 py-1.5 rounded-lg border border-gray-200 dark:border-neutral-700 bg-gray-50 hover:bg-gray-100 dark:bg-neutral-900 dark:hover:bg-neutral-800 text-gray-600 dark:text-zinc-400 transition-colors outline-none cursor-pointer"
+              className="text-xs font-semibold px-2.5 py-1.5 rounded-lg border border-gray-200 dark:border-neutral-700 bg-gray-50 hover:bg-gray-100 dark:bg-neutral-900 dark:hover:bg-neutral-800 text-gray-600 dark:text-zinc-400 transition-colors outline-none focus-visible:ring-2 focus-visible:ring-purple-500 cursor-pointer"
               aria-label="Inactivity filter"
             >
               {FILTER_OPTIONS.map((opt) => (


### PR DESCRIPTION
## Summary

Adds visible keyboard-focus indicators to every custom `<select>` element that previously relied on browser-default or invisible outlines, improving WCAG 2.1 §2.4.7 (Focus Visible) compliance.

## Problem

Several custom-styled `<select>` elements across the dashboard and customization surfaces suppress the browser's native focus outline (`outline-none`) but do not provide an adequate replacement. This makes it impossible for keyboard-only or assistive-technology users to track which control currently has focus.

## Changes

| File | Change |
|------|--------|
| `app/customize/components/ThemeSelector.tsx` | Added `focus-visible:ring-2 focus-visible:ring-purple-500` to `StyledSelect` |
| `components/dashboard/CIAnalytics/CIFilters.tsx` | Replaced `focus:ring-2 focus:ring-cyan-500/30` with `focus-visible:ring-2 focus-visible:ring-purple-500` on both filter selects |
| `components/dashboard/InactiveRepoReminder.tsx` | Added `focus-visible:ring-2 focus-visible:ring-purple-500` to the inactivity filter select |

## Why `focus-visible` instead of `focus`

`focus-visible` activates only on keyboard navigation, not on mouse clicks, preserving the clean mouse-click UX while guaranteeing visibility for keyboard users. The purple ring (`ring-purple-500`) provides ≥ 3:1 contrast against both light and dark backgrounds per WCAG guidelines.

## Testing

- [x] `npx tsc --noEmit` passes with zero errors
- [x] Keyboard-tabbing through each select shows a visible purple ring
- [x] Mouse clicks do not trigger the focus ring
