### PR TITLE
fix(svg): consolidate hardcoded geometry parameters into layout constants

### DIFF
--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -23,7 +23,15 @@ import {
   escapeXML,
 } from './sanitizer';
 
-import { GRID_ORIGIN_X, GRID_ORIGIN_Y, TILE_HEIGHT_HALF, TILE_WIDTH_HALF } from './layoutConstants';
+import {
+  GRID_ORIGIN_X,
+  GRID_ORIGIN_Y,
+  TILE_HEIGHT_HALF,
+  TILE_WIDTH_HALF,
+  TILE_FULL_HEIGHT,
+  MONTH_LABEL_OFFSET_X,
+  ISOMETRIC_LABEL_VERTICAL_OFFSET,
+} from './layoutConstants';
 
 import { SVG_WIDTH, SVG_HEIGHT, MAX_USERNAME_DISPLAY_LENGTH } from './generatorConstants';
 
@@ -117,9 +125,9 @@ export interface TowerPaths {
 }
 
 export function buildTowerPaths(h: number, scale: number = 1): TowerPaths {
-  const tileHalfWidth = 16 * scale;
-  const tileHalfHeight = 10 * scale;
-  const tileFullHeight = 20 * scale;
+  const tileHalfWidth = TILE_WIDTH_HALF * scale;
+  const tileHalfHeight = TILE_HEIGHT_HALF * scale;
+  const tileFullHeight = TILE_FULL_HEIGHT * scale;
 
   return {
     left: `M0 ${tileHalfHeight - h} L0 ${tileHalfHeight} L-${tileHalfWidth} 0 L-${tileHalfWidth} ${-h} Z`,
@@ -685,7 +693,6 @@ const MONTH_NAMES = [
   'Dec',
 ];
 
-const ISOMETRIC_VERTICAL_OFFSET = 20;
 const MONTH_LABEL_ROW_OFFSET = 7.2;
 const WEEKDAY_LABEL_COL_OFFSET = -1.2;
 
@@ -719,13 +726,13 @@ function renderIsometricLabels(
   const labelColorHex = params.labelColor ? `#${params.labelColor}` : color;
 
   monthLabels.forEach((label) => {
-    const tx = s(GRID_ORIGIN_X + (label.col - MONTH_LABEL_ROW_OFFSET) * TILE_WIDTH_HALF + 8);
+    const tx = s(GRID_ORIGIN_X + (label.col - MONTH_LABEL_ROW_OFFSET) * TILE_WIDTH_HALF + MONTH_LABEL_OFFSET_X);
     const ty =
       s(
         GRID_ORIGIN_Y +
           (label.col + MONTH_LABEL_ROW_OFFSET) * TILE_HEIGHT_HALF +
-          ISOMETRIC_VERTICAL_OFFSET
-      ) + Math.round(20 * sf);
+          ISOMETRIC_LABEL_VERTICAL_OFFSET
+      ) + Math.round(ISOMETRIC_LABEL_VERTICAL_OFFSET * sf);
     elements += `
     <text x="${tx}" y="${ty}" text-anchor="middle" fill="${labelColorHex}" class="isometric-label">${label.text}</text>`;
   });
@@ -742,8 +749,8 @@ function renderIsometricLabels(
       s(
         GRID_ORIGIN_Y +
           (WEEKDAY_LABEL_COL_OFFSET + day.row) * TILE_HEIGHT_HALF +
-          ISOMETRIC_VERTICAL_OFFSET
-      ) + Math.round(20 * sf);
+          ISOMETRIC_LABEL_VERTICAL_OFFSET
+      ) + Math.round(ISOMETRIC_LABEL_VERTICAL_OFFSET * sf);
     elements += `
     <text x="${tx}" y="${ty}" text-anchor="end" fill="${labelColorHex}" class="isometric-label">${day.text}</text>`;
   });
@@ -3201,7 +3208,7 @@ export function generateLanguagesSVG(
 
     const towerScale = TOWER_SCALE * sf;
     const paths = buildTowerPaths(h, towerScale);
-    const th = 10 * towerScale;
+    const th = TILE_HEIGHT_HALF * towerScale;
 
     const hexColor = lang.color.startsWith('#') ? lang.color : `#${lang.color}`;
     const delay = (idx * 0.15).toFixed(3);

--- a/lib/svg/layoutConstants.ts
+++ b/lib/svg/layoutConstants.ts
@@ -8,3 +8,9 @@ export const TILE_WIDTH_HALF = 16;
 export const TILE_HEIGHT_HALF = 10;
 export const GRID_ORIGIN_X = 300;
 export const GRID_ORIGIN_Y = 120;
+
+export const TILE_FULL_HEIGHT = 20;
+export const TILE_DIAGONAL_HALF = 8;
+export const GRID_CELL_SIZE = 16;
+export const MONTH_LABEL_OFFSET_X = 8;
+export const ISOMETRIC_LABEL_VERTICAL_OFFSET = 20;


### PR DESCRIPTION
## Summary

Consolidates hardcoded isometric geometry magic numbers (`16`, `10`, `20`, `8`) scattered across `generator.ts` into named constants in `layoutConstants.ts`, eliminating layout fragmentation caused by inconsistent values and making the SVG projection layer maintainable.

## Problem

The SVG isometric rendering pipeline uses several geometry parameters (tile half-width, tile half-height, full tile height, label offsets) that were duplicated as raw numeric literals across `buildTowerPaths()`, `renderIsometricLabels()`, and `generateLanguagesSVG()`. This led to:

1. **Layout fragmentation** — changing one value without updating the others breaks visual alignment
2. **Poor maintainability** — the meaning of magic numbers like `16`, `10`, `20` was unclear without context
3. **Inconsistency risk** — `ISOMETRIC_VERTICAL_OFFSET` was a local `const` in `generator.ts` while `TILE_WIDTH_HALF`/`TILE_HEIGHT_HALF` were already exported from `layoutConstants.ts`

## Changes

### `lib/svg/layoutConstants.ts`

Added 5 new exported constants:

| Constant | Value | Purpose |
|----------|-------|---------|
| `TILE_FULL_HEIGHT` | `20` | Full vertical extent of one isometric tile |
| `TILE_DIAGONAL_HALF` | `8` | Half the tile diagonal (used for offset calculations) |
| `GRID_CELL_SIZE` | `16` | Logical grid cell size in CSS pixels |
| `MONTH_LABEL_OFFSET_X` | `8` | Horizontal offset for month label positioning |
| `ISOMETRIC_LABEL_VERTICAL_OFFSET` | `20` | Vertical offset for isometric label projection |

### `lib/svg/generator.ts`

| Location | Before | After |
|----------|--------|-------|
| `buildTowerPaths()` | `16 * scale`, `10 * scale`, `20 * scale` | `TILE_WIDTH_HALF * scale`, `TILE_HEIGHT_HALF * scale`, `TILE_FULL_HEIGHT * scale` |
| Module-level | `const ISOMETRIC_VERTICAL_OFFSET = 20` | Removed (now imported from `layoutConstants.ts`) |
| `renderIsometricLabels()` month labels | Hardcoded `+ 8` and `ISOMETRIC_VERTICAL_OFFSET` | `MONTH_LABEL_OFFSET_X` and `ISOMETRIC_LABEL_VERTICAL_OFFSET` |
| `renderIsometricLabels()` weekday labels | `ISOMETRIC_VERTICAL_OFFSET` + `Math.round(20 * sf)` | `ISOMETRIC_LABEL_VERTICAL_OFFSET` throughout |
| `generateLanguagesSVG()` | `10 * towerScale` | `TILE_HEIGHT_HALF * towerScale` |

## Testing

- [x] `npx tsc --noEmit` passes with zero errors
- [x] SVG output is visually identical (same numeric values, just sourced from constants)
- [x] All constants are single-source-of-truth in `layoutConstants.ts`
