### PR TITLE
fix(svgRenderer):update duplicate step comment in svgRenderer

### DIFF
--- a/src/utils/svgRenderer.ts
+++ b/src/utils/svgRenderer.ts
@@ -22,7 +22,7 @@ export function generateOptimizedSvg(contributionData: ContributionNode[]): stri
   );
 
   // ==========================================
-  // STEP 1: THE GRID MAP MATRIX SYSTEM
+  // STEP 2: THE GRID MAP DICTIONARY SETUP
   // ==========================================
   const gridMap: Record<string, number> = {};
   for (let i = 0; i < safeData.length; i++) {
@@ -34,7 +34,7 @@ export function generateOptimizedSvg(contributionData: ContributionNode[]): stri
   }
 
   // ==========================================
-  // STEP 2: DEFINE THE MASTER BLUEPRINTS (<defs>)
+  // STEP 3: DEFINE THE MASTER BLUEPRINTS (<defs>)
   // ==========================================
   const svgDefs = `
   <defs>
@@ -67,7 +67,7 @@ export function generateOptimizedSvg(contributionData: ContributionNode[]): stri
   let svgElements = '';
 
   // ==========================================
-  // STEPS 3, 4 & 5: ITERATE, CULL, & INSTANTIATE
+  // STEPS 4, 5 & 6: ITERATE, CULL, & INSTANTIATE
   // ==========================================
   for (const node of sortedData) {
     const x = typeof node.x === 'number' ? node.x : 0;
@@ -78,14 +78,14 @@ export function generateOptimizedSvg(contributionData: ContributionNode[]): stri
     const isoX = (x - y) * (tileWidth / 2);
     const isoY = (x + y) * (tileHeight / 2);
 
-    // STEP 3: Zero-Height Pruning
+    // STEP 4: Zero-Height Pruning
     if (count === 0) {
       // Omit building blocks; just lay a completely flat ground base footprint vector
       svgElements += `<use href="#iso-top" x="${isoX}" y="${isoY}" fill="#1e293b" opacity="0.2"/>\n`;
       continue;
     }
 
-    // STEP 4: Adjacent Occlusion Culling Check
+    // STEP 5: Adjacent Occlusion Culling Check
     // Get the height of the tower directly in front of this one (x+1, y+1)
     const frontTowerHeight = gridMap[`${x + 1},${y + 1}`] || 0;
 
@@ -94,7 +94,7 @@ export function generateOptimizedSvg(contributionData: ContributionNode[]): stri
       continue;
     }
 
-    // STEP 5: Scale blueprints to custom height offsets
+    // STEP 6: Scale blueprints to custom height offsets
     const calculatedHeight = count * blockHeightUnit;
 
     svgElements += `
@@ -107,7 +107,7 @@ export function generateOptimizedSvg(contributionData: ContributionNode[]): stri
   }
 
   // ==========================================
-  // STEP 6: OUTPUT FINISHED ROOT SVG STRING
+  // STEP 7: OUTPUT FINISHED ROOT SVG STRING
   // ==========================================
   return `
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-200 -50 800 600" width="100%" height="100%" role="img" aria-labelledby="svg-title svg-desc">


### PR DESCRIPTION
## Description
In `src/utils/svgRenderer.ts`, the section comment "`STEP 1: THE GRID MAP MATRIX SYSTEM`" appears twice in a row (lines ~22 and ~33), before two different blocks of code.

The second block is actually Step 2 setup work (building the `gridMap` dictionary), but the duplicate label makes it look like Step 1 repeats. This copy-paste mistake causes confusion and should be corrected.

## Changes made
Modified the comments and followed the steps order.

Fixes #6093

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="1206" height="747" alt="image" src="https://github.com/user-attachments/assets/a2c1a1c9-9a62-4c64-a7e3-92fb3cf94cc6" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
