### PR TITLE
fix(themes): normalize theme query parameter lookup to make theme selection case-insensitive

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -27,7 +27,7 @@ import { generateRadarSVG } from '@/lib/svg/radar';
 import { generateDoughnutSVG } from '@/lib/svg/doughnut';
 import { getSecondsUntilUTCMidnight, getSecondsUntilMidnightInTimezone } from '@/utils/time';
 import type { BadgeParams, RepoContribution, ExtendedContributionData } from '@/types';
-import { themes } from '@/lib/svg/themes';
+import { getNormalizedThemeKey, themes } from '@/lib/svg/themes';
 import { streakParamsSchema } from '@/lib/validations';
 import { sanitizeHexColor, sanitizeRadius, escapeXML } from '@/lib/svg/sanitizer';
 import { getClientIp } from '@/utils/getClientIp';
@@ -174,7 +174,9 @@ export async function GET(request: Request) {
       | 'doughnut'
       | 'pie'
       | 'activity_graph';
-    const themeName = theme || 'dark';
+
+    const themeKey = getNormalizedThemeKey(theme);
+    const themeName = themeKey === 'default' && theme ? theme : themeKey;
 
     const ip = getClientIp(request);
 
@@ -286,8 +288,8 @@ export async function GET(request: Request) {
     const currentYear = new Date().getUTCFullYear();
     const isHistoricalYear = !!year && Number(year) < currentYear;
 
-    const isAutoTheme = themeName === 'auto';
-    const isRandomTheme = themeName === 'random';
+    const isAutoTheme = themeName.toLowerCase() === 'auto';
+    const isRandomTheme = themeName.toLowerCase() === 'random';
     const selectedTheme = (() => {
       if (isAutoTheme) return themes.light;
       if (isRandomTheme) {
@@ -296,7 +298,7 @@ export async function GET(request: Request) {
         const stableKey = keys[hash % keys.length];
         return themes[stableKey] || themes.dark;
       }
-      return themes[theme] || themes.dark;
+      return themes[themeKey] || themes.dark;
     })();
 
     // If 'org' is provided, we use it as the display user

--- a/lib/svg/themes.test.ts
+++ b/lib/svg/themes.test.ts
@@ -4,7 +4,7 @@
 // structure integrity, and AUTO_THEME pair safety checks.
 
 import { describe, it, expect } from 'vitest';
-import { themes, AUTO_THEME_LIGHT, AUTO_THEME_DARK } from './themes';
+import { themes, AUTO_THEME_LIGHT, AUTO_THEME_DARK, getNormalizedThemeKey } from './themes';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -227,5 +227,26 @@ describe('known theme palette regression guards', () => {
     expect(themes['cyber-pulse'].bg).toBe('000000');
     expect(themes['cyber-pulse'].text).toBe('ffffff');
     expect(themes['cyber-pulse'].accent).toBe('00ffee');
+  });
+});
+
+// ── Normalization Behavior Checks ─────────────────────────────────────────────
+
+describe('getNormalizedThemeKey', () => {
+  it('matches kebab-case keys when user provides all lowercase mashed inputs', () => {
+    expect(getNormalizedThemeKey('cyber-pulse')).toBe('cyber-pulse');
+  });
+
+  it('matches keys when user provides screaming uppercase inputs', () => {
+    expect(getNormalizedThemeKey('DRACULA')).toBe('dracula');
+  });
+
+  it('returns default fallback when theme name does not exist', () => {
+    expect(getNormalizedThemeKey('invalidThemeNonexistent')).toBe('default');
+  });
+
+  it('returns default fallback gracefully when theme parameter is undefined or null', () => {
+    expect(getNormalizedThemeKey(undefined)).toBe('default');
+    expect(getNormalizedThemeKey(null)).toBe('default');
   });
 });

--- a/lib/svg/themes.ts
+++ b/lib/svg/themes.ts
@@ -47,3 +47,16 @@ export const themes: Record<string, BadgeTheme> = {
 // viewer's OS-level light/dark setting without any JavaScript.
 export const AUTO_THEME_LIGHT: BadgeTheme = themes.light;
 export const AUTO_THEME_DARK: BadgeTheme = themes.dark;
+
+/**
+ * Resolves a theme case-insensitively by matching the normalized user input
+ * against the normalized theme registry keys. Returns the standard theme key.
+ */
+export function getNormalizedThemeKey(themeInput: string | undefined | null): string {
+  if (!themeInput) return 'default'; // fallback key
+
+  const target = themeInput.toLowerCase();
+  const matchedKey = Object.keys(themes).find((key) => key.toLowerCase() === target);
+
+  return matchedKey || 'default';
+}


### PR DESCRIPTION
## Description

Fixes #6143 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix)

## Visual Preview

No visual changes to the themes themselves. However, passing parameters like `?theme=CYANPULSE` or `?theme=cyanpulse` will now correctly load the `cyanPulse` theme style instead of crashing or breaking back to an unstyled fallback default state.

## What this PR does

Previously, the incoming `theme` query parameter string was matched exactly against keys of the `THEMES` object. This meant strict case sensitivity was expected from end-users (`cyanPulse` worked, but `cyanpulse` or uppercase equivalents failed).

This PR introduces a `getNormalizedThemeKey()` utility inside `lib/svg/themes.ts` to scan and safely match theme names case-insensitively.

## Changes

| File | Change |
|------|--------|
| `lib/svg/themes.ts` | Added `getNormalizedThemeKey()` case-insensitive lookup helper. |
| `app/api/streak/route.ts` | Updated the API route handler to pass query input through the new safe resolver. |
| `lib/svg/themes.test.ts` | Added 3 unit tests verifying lowercase, uppercase, and non-existent fallback handling. |

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
- [x] My branch has only one clean commit to merge.