### PR TITLE
fix(svg): sanitize border and labelColor attributes to prevent XSS

### DIFF
--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -812,7 +812,9 @@ export function generateSVG(
 
   const text = `#${sanitizeHexColor(params.text, 'ffffff')}`;
 
-  const borderAttr = params.border ? `stroke="#${sanitizeHexColor(params.border, '000000')}" stroke-width="2"` : '';
+  const borderAttr = params.border
+    ? `stroke="#${sanitizeHexColor(params.border, '000000')}" stroke-width="2"`
+    : '';
 
   const sanitizedFont = sanitizeFont(params.font);
   const selectedFont = resolveFont(sanitizedFont);
@@ -1609,7 +1611,9 @@ export function generateHeatmapSVG(
   const accent = `#${sanitizeHexColor(rawAccent, '00ffaa')}`;
   const text = `#${sanitizeHexColor(params.text, 'ffffff')}`;
 
-  const borderAttr = params.border ? `stroke="#${sanitizeHexColor(params.border, '000000')}" stroke-width="2"` : '';
+  const borderAttr = params.border
+    ? `stroke="#${sanitizeHexColor(params.border, '000000')}" stroke-width="2"`
+    : '';
 
   const sanitizedFont = sanitizeFont(params.font);
   const selectedFont = resolveFont(sanitizedFont);
@@ -3131,7 +3135,9 @@ export function generateLanguagesSVG(
   const accent = `#${sanitizeHexColor(accentStr, '00ffaa')}`;
 
   const text = `#${sanitizeHexColor(params.text, 'ffffff')}`;
-  const borderAttr = params.border ? `stroke="#${sanitizeHexColor(params.border, '000000')}" stroke-width="2"` : '';
+  const borderAttr = params.border
+    ? `stroke="#${sanitizeHexColor(params.border, '000000')}" stroke-width="2"`
+    : '';
 
   const sanitizedFont = sanitizeFont(params.font);
   const selectedFont = resolveFont(sanitizedFont);

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -715,8 +715,11 @@ function renderIsometricLabels(
       prevMonthStr = monthStr;
     }
   });
-
-  const labelColorHex = params.labelColor ? `#${params.labelColor}` : color;
+  let labelColorHex = color;
+  if (params.labelColor) {
+    const fallbackHex = color.replace(/^#/, '') || 'ffffff';
+    labelColorHex = `#${sanitizeHexColor(params.labelColor, fallbackHex)}`;
+  }
 
   monthLabels.forEach((label) => {
     const tx = s(GRID_ORIGIN_X + (label.col - MONTH_LABEL_ROW_OFFSET) * TILE_WIDTH_HALF + 8);
@@ -809,7 +812,7 @@ export function generateSVG(
 
   const text = `#${sanitizeHexColor(params.text, 'ffffff')}`;
 
-  const borderAttr = params.border ? `stroke="#${params.border}" stroke-width="2"` : '';
+  const borderAttr = params.border ? `stroke="#${sanitizeHexColor(params.border, '000000')}" stroke-width="2"` : '';
 
   const sanitizedFont = sanitizeFont(params.font);
   const selectedFont = resolveFont(sanitizedFont);
@@ -1606,7 +1609,7 @@ export function generateHeatmapSVG(
   const accent = `#${sanitizeHexColor(rawAccent, '00ffaa')}`;
   const text = `#${sanitizeHexColor(params.text, 'ffffff')}`;
 
-  const borderAttr = params.border ? `stroke="#${params.border}" stroke-width="2"` : '';
+  const borderAttr = params.border ? `stroke="#${sanitizeHexColor(params.border, '000000')}" stroke-width="2"` : '';
 
   const sanitizedFont = sanitizeFont(params.font);
   const selectedFont = resolveFont(sanitizedFont);
@@ -3128,7 +3131,7 @@ export function generateLanguagesSVG(
   const accent = `#${sanitizeHexColor(accentStr, '00ffaa')}`;
 
   const text = `#${sanitizeHexColor(params.text, 'ffffff')}`;
-  const borderAttr = params.border ? `stroke="#${params.border}" stroke-width="2"` : '';
+  const borderAttr = params.border ? `stroke="#${sanitizeHexColor(params.border, '000000')}" stroke-width="2"` : '';
 
   const sanitizedFont = sanitizeFont(params.font);
   const selectedFont = resolveFont(sanitizedFont);


### PR DESCRIPTION
## Description

Fixes #6159

This PR addresses an SVG injection (XSS) vulnerability by applying strict hex color sanitization to the `labelColor` and `border` query parameters in the SVG generator. These parameters were previously interpolated directly into the SVG template without validation.

- Wrapped `params.labelColor` with `sanitizeHexColor` using the theme's base color as a secure fallback.
- Wrapped all `params.border` occurrences with `sanitizeHexColor` using `#000000` as a secure fallback.
- Ensures malformed colors or malicious HTML payloads fall back gracefully without breaking the SVG or allowing script execution.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

*N/A — Security fix. No visual changes under normal usage. Malformed or malicious inputs now gracefully fallback to safe default colors.*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
