### PR TITLE
fix(stats): report correct cache status for cold requests

### DIFF
--- a/app/api/stats/route.empty-fallback.test.ts
+++ b/app/api/stats/route.empty-fallback.test.ts
@@ -4,6 +4,8 @@ import type { ContributionCalendar } from '../../../types';
 
 vi.mock('../../../lib/github', () => ({
   fetchGitHubContributions: vi.fn(),
+  contributionsCache: { has: vi.fn().mockResolvedValue(false) },
+  cacheKey: vi.fn().mockReturnValue('key'),
 }));
 
 import { fetchGitHubContributions } from '../../../lib/github';

--- a/app/api/stats/route.mouse-interactivity.test.ts
+++ b/app/api/stats/route.mouse-interactivity.test.ts
@@ -8,6 +8,8 @@ import type { ContributionCalendar, ExtendedContributionData } from '@/types';
 
 vi.mock('@/lib/github', () => ({
   fetchGitHubContributions: vi.fn(),
+  contributionsCache: { has: vi.fn().mockResolvedValue(false) },
+  cacheKey: vi.fn().mockReturnValue('key'),
 }));
 
 const mockCalendar: ContributionCalendar = {

--- a/app/api/stats/route.test.ts
+++ b/app/api/stats/route.test.ts
@@ -3,6 +3,8 @@ import { GET } from './route';
 
 vi.mock('../../../lib/github', () => ({
   fetchGitHubContributions: vi.fn(),
+  contributionsCache: { has: vi.fn().mockResolvedValue(false) },
+  cacheKey: vi.fn().mockReturnValue('key'),
 }));
 
 import { fetchGitHubContributions } from '../../../lib/github';

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,6 +1,6 @@
 // app/api/stats/route.ts
 import { NextResponse } from 'next/server';
-import { fetchGitHubContributions } from '@/lib/github';
+import { fetchGitHubContributions, contributionsCache, cacheKey } from '@/lib/github';
 import { calculateStreak } from '@/lib/calculate';
 import { statsParamsSchema } from '@/lib/validations';
 import { getClientIp } from '@/utils/getClientIp';
@@ -122,6 +122,9 @@ export async function GET(request: Request) {
   }
 
   try {
+    const key = cacheKey('contributions', user);
+    const wasCachedBefore = await contributionsCache.has(key);
+
     // Authenticated -> user's OAuth token (their quota); anonymous -> undefined (global PAT).
     const userToken = await getUserGitHubToken();
     const userData = await fetchGitHubContributions(user, {
@@ -144,7 +147,7 @@ export async function GET(request: Request) {
       headers.set('Pragma', 'no-cache');
       headers.set('Expires', '0');
     }
-    headers.set('X-Cache-Status', shouldBypassCache ? 'MISS' : 'HIT');
+    headers.set('X-Cache-Status', shouldBypassCache ? 'MISS' : wasCachedBefore ? 'HIT' : 'MISS');
     headers.set(
       'X-Refresh-Status',
       shouldBypassCache ? 'Fresh' : isRefreshRequested ? 'Cooldown-Served-Cached' : 'Cached'

--- a/app/api/stats/route.validation.test.ts
+++ b/app/api/stats/route.validation.test.ts
@@ -3,6 +3,12 @@ import { GET } from './route';
 
 vi.mock('@/lib/github', () => ({
   fetchGitHubContributions: vi.fn(),
+  contributionsCache: { has: vi.fn().mockResolvedValue(true) },
+  cacheKey: vi.fn().mockReturnValue('key'),
+}));
+
+vi.mock('@/lib/githubtoken', () => ({
+  getUserGitHubToken: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { fetchGitHubContributions } from '@/lib/github';


### PR DESCRIPTION
## Related Issue
Fixes #5503

## Type of Change
- [x] Bug fix

## Description
Check if cache had data before fetch using `contributionsCache.has()`. Now correctly reports:
- `MISS` for cold requests (no cache entry)
- `HIT` for requests served from cache
- `MISS` for bypass requests

## Testing
- All existing tests pass (37/37)
- Added mocks for `contributionsCache` and `cacheKey` in test files

## Checklist
- [x] Code follows project style
- [x] Tests pass
- [x] No console.log statements
- [x] Related issue linked