### PR TITLE
fix: remove notification management token from URL query parameters

### DIFF
--- a/app/api/notify/route.test.ts
+++ b/app/api/notify/route.test.ts
@@ -47,13 +47,19 @@ import { gitHubUserValidator } from '@/services/github/validate-user';
 import { getClientIp } from '@/utils/getClientIp';
 import { verifyGitHubOwner } from '@/lib/github-owner-verification';
 
-const makeRequest = (method: string, body?: object, search?: string) => {
+const makeRequest = (
+  method: string,
+  body?: object,
+  search?: string,
+  headers?: Record<string, string>
+) => {
   const url = `http://localhost:3000/api/notify${search ? '?' + search : ''}`;
   return new NextRequest(url, {
     method,
     headers: {
       'x-forwarded-for': '127.0.0.1',
       Authorization: 'Bearer test-owner-token',
+      ...headers,
     },
     body: body ? JSON.stringify(body) : undefined,
   });
@@ -593,7 +599,9 @@ describe('DELETE /api/notify', () => {
     vi.mocked(Notification.deleteOne).mockResolvedValue({ deletedCount: 1 } as never);
 
     const res = await DELETE(
-      makeRequest('DELETE', undefined, `user=testuser&managementToken=${managementToken}`)
+      makeRequest('DELETE', undefined, 'user=testuser', {
+        'x-notification-token': managementToken,
+      })
     );
     const data = await res.json();
 

--- a/app/api/notify/route.ts
+++ b/app/api/notify/route.ts
@@ -321,7 +321,7 @@ export async function DELETE(req: NextRequest) {
       );
     }
 
-    const providedManagementToken = getNotificationManagementToken(req, undefined, searchParams);
+    const providedManagementToken = getNotificationManagementToken(req);
     const authorization = await authorizeNotificationMutation(
       req,
       normalizedUsername,

--- a/lib/notification-management-token.empty-fallback.test.ts
+++ b/lib/notification-management-token.empty-fallback.test.ts
@@ -68,16 +68,16 @@ describe('notification management token empty / missing inputs', () => {
       expect(getNotificationManagementToken(req, body)).toBe('body-token-xyz');
     });
 
-    it('extracts token from search params managementToken', () => {
+    it('ignores managementToken in query parameters (security: no URL leakage)', () => {
       const req = mockRequest();
       const params = new URLSearchParams({ managementToken: 'query-token-123' });
-      expect(getNotificationManagementToken(req, undefined, params)).toBe('query-token-123');
+      expect(getNotificationManagementToken(req, undefined)).toBeNull();
     });
 
-    it('extracts token from search params token fallback', () => {
+    it('ignores token query parameter (security: no URL leakage)', () => {
       const req = mockRequest();
       const params = new URLSearchParams({ token: 'fallback-token-456' });
-      expect(getNotificationManagementToken(req, undefined, params)).toBe('fallback-token-456');
+      expect(getNotificationManagementToken(req, undefined)).toBeNull();
     });
 
     it('prefers header over body when both are present', () => {
@@ -90,7 +90,7 @@ describe('notification management token empty / missing inputs', () => {
       const req = mockRequest();
       const body = { managementToken: 'body-value' };
       const params = new URLSearchParams({ managementToken: 'query-value' });
-      expect(getNotificationManagementToken(req, body, params)).toBe('body-value');
+      expect(getNotificationManagementToken(req, body)).toBe('body-value');
     });
 
     it('ignores body managementToken when it is not a string', () => {

--- a/lib/notification-management-token.ts
+++ b/lib/notification-management-token.ts
@@ -13,8 +13,7 @@ export function hashNotificationManagementToken(token: string): string {
 
 export function getNotificationManagementToken(
   request: Request,
-  body?: { managementToken?: unknown },
-  searchParams?: URLSearchParams
+  body?: { managementToken?: unknown }
 ): string | null {
   const headerToken = request.headers.get('x-notification-token')?.trim();
   if (headerToken) return headerToken;
@@ -24,9 +23,7 @@ export function getNotificationManagementToken(
     return bodyToken.trim();
   }
 
-  const queryToken =
-    searchParams?.get('managementToken')?.trim() || searchParams?.get('token')?.trim();
-  return queryToken || null;
+  return null;
 }
 
 export function verifyNotificationManagementToken(


### PR DESCRIPTION
## Summary

Removes the query parameter fallback (`managementToken`, `token`) from `getNotificationManagementToken()`. The notification management token is now only accepted via:

- `x-notification-token` HTTP header
- `managementToken` field in the POST request body

## Problem

URL query parameters are persisted and exposed through channels outside the application's security perimeter:

- **Server access logs** — Vercel, nginx, CDN, and load balancer logs record full request URLs including query strings
- **HTTP `Referer` headers** — If the page with the token loads any third-party resource, the full URL including the token leaks to that third party
- **CDN/proxy logs** — Vercel's edge network and intermediate proxies log query strings

An attacker with access to any of these sources can obtain any user's management token and modify or delete their notification preferences.

## Changes

1. **`lib/notification-management-token.ts`** — Removed `searchParams` parameter and query parameter extraction logic from `getNotificationManagementToken()`
2. **`app/api/notify/route.ts`** — Updated DELETE handler to stop passing `searchParams` to `getNotificationManagementToken()`
3. **`lib/notification-management-token.empty-fallback.test.ts`** — Updated tests to verify query parameters are now ignored (security regression tests)

## Testing

- All 26 notification management token tests pass
- All 5 DELETE route tests pass
- All 5 mouse-interactivity tests pass
- Lint passes (0 errors)

Fixes #6132

Human Coded