### PR TITLE
fix: Replace SHA-256 key derivation with PBKDF2

### DIFF
--- a/lib/crypto.empty-fallback.test.ts
+++ b/lib/crypto.empty-fallback.test.ts
@@ -15,13 +15,13 @@ describe('crypto empty / missing inputs verification', () => {
     const encrypted = encryptToken(plain);
     expect(encrypted).toBeDefined();
     expect(encrypted).not.toBe(plain);
-    expect(encrypted.split('.')).toHaveLength(3);
+    expect(encrypted.split('.')).toHaveLength(4);
     expect(decryptToken(encrypted)).toBe(plain);
   });
 
   it('handles empty string encryption and decryption', () => {
     const encrypted = encryptToken('');
-    expect(encrypted.split('.')).toHaveLength(3);
+    expect(encrypted.split('.')).toHaveLength(4);
     expect(decryptToken(encrypted)).toBe('');
   });
 

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -3,25 +3,26 @@ import crypto from 'node:crypto';
 
 const ALGO = 'aes-256-gcm';
 
-function key(): Buffer {
+function key(salt: Buffer): Buffer {
   const k = process.env.ENCRYPTION_KEY;
   if (!k || k.length < 32) {
     throw new Error('ENCRYPTION_KEY must be at least 32 characters');
   }
-  return crypto.createHash('sha256').update(k).digest();
+  return crypto.pbkdf2Sync(k, salt, 100000, 32, 'sha512');
 }
 
 export function encryptToken(plain: string): string {
+  const salt = crypto.randomBytes(16);
   const iv = crypto.randomBytes(12);
-  const cipher = crypto.createCipheriv(ALGO, key(), iv);
+  const cipher = crypto.createCipheriv(ALGO, key(salt), iv);
   const enc = Buffer.concat([cipher.update(plain, 'utf8'), cipher.final()]);
   const tag = cipher.getAuthTag();
-  return [iv, tag, enc].map((b) => b.toString('base64')).join('.');
+  return [salt, iv, tag, enc].map((b) => b.toString('base64')).join('.');
 }
 
 export function decryptToken(payload: string): string {
-  const [iv, tag, enc] = payload.split('.').map((p) => Buffer.from(p, 'base64'));
-  const decipher = crypto.createDecipheriv(ALGO, key(), iv);
+  const [salt, iv, tag, enc] = payload.split('.').map((p) => Buffer.from(p, 'base64'));
+  const decipher = crypto.createDecipheriv(ALGO, key(salt), iv);
   decipher.setAuthTag(tag);
   return Buffer.concat([decipher.update(enc), decipher.final()]).toString('utf8');
 }


### PR DESCRIPTION
## Description

Fixes #6201

This PR replaces the existing single-iteration SHA-256 key derivation with PBKDF2 to improve the security of encryption key generation.

Changes made:

* Replaced `crypto.createHash('sha256')` with `crypto.pbkdf2Sync`.
* Added a random 16-byte salt for each encryption operation.
* Stored the generated salt alongside the encrypted payload.
* Updated decryption logic to extract and reuse the stored salt.
* Configured PBKDF2 with 100,000 iterations and SHA-512.
* Continued deriving a 32-byte key for AES-256-GCM compatibility.
* Updated crypto tests to validate the new salted encrypted payload structure and expected segment count.

Security improvements:

* Introduces a computational work factor against brute-force attacks.
* Prevents identical passwords from generating identical encryption keys.
* Aligns key derivation with modern cryptographic best practices.
* Reduces risks associated with low-entropy passwords or secrets.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Security improvement)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [x] I have updated documentation if required.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
