### PR TITLE
fix(wrapped): use tz parameter for default year calculation

### DIFF
--- a/app/api/wrapped/route.ts
+++ b/app/api/wrapped/route.ts
@@ -60,7 +60,11 @@ export async function GET(request: Request) {
       tz,
     } = parseResult.data;
 
-    const year = customYear || new Date().getFullYear().toString();
+    const year =
+      customYear ||
+      (tz
+        ? new Intl.DateTimeFormat('en-CA', { timeZone: tz, year: 'numeric' }).format(new Date())
+        : new Date().getFullYear().toString());
 
     const themeName = theme || 'dark';
     const isAutoTheme = themeName === 'auto';


### PR DESCRIPTION
## Description
Fixes #6242

In `app/api/wrapped/route.ts`, the default year (used when `customYear` is not provided) was calculated using the server's local timezone:

```ts
const year = customYear || new Date().getFullYear().toString();
```

However, the same route already accepts and uses a `tz` parameter for fetching timezone-aware wrapped stats elsewhere in the handler:

```ts
const wrappedStats = tz
  ? await getWrappedData(user, year, { bypassCache: shouldBypassCache }, tz)
  : await getWrappedData(user, year, { bypassCache: shouldBypassCache });
```

**Problem with the old approach:**
- A user near a year boundary (e.g. New Year's Eve/Day) in a timezone different from the server could get the wrong default year
- For example, if the server is on UTC and a user is in UTC+13 (New Zealand), the server might still report the previous year while the user has already entered the new year locally — or vice versa
- This mirrors a pattern already correctly handled elsewhere in the codebase — `app/api/streak/route.ts` uses `Intl.DateTimeFormat` with an explicit timezone for the equivalent calculation

**What this PR does:**
- Uses the existing `tz` parameter (when provided) to compute the default year via `Intl.DateTimeFormat`, consistent with `app/api/streak/route.ts`
- Falls back to `new Date().getFullYear()` only when no `tz` is supplied
- No changes to the cache or data-fetching logic — only the year calculation is timezone-aware now

**After:**
```ts
const year =
  customYear ||
  (tz
    ? new Intl.DateTimeFormat('en-CA', { timeZone: tz, year: 'numeric' }).format(new Date())
    : new Date().getFullYear().toString());
```

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [x] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes — this is a timezone correctness fix.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.