### PR TITLE
fix(validations): use UTC year for streak/wrapped year validation upper bound

### DIFF
--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -321,7 +321,7 @@ const baseStreakParamsSchema = z.object({
       (val) => {
         if (!val) return true;
         const yearNum = parseInt(val, 10);
-        const currentYear = new Date().getFullYear();
+        const currentYear = new Date().getUTCFullYear();
         return /^\d{4}$/.test(val) && yearNum >= 2008 && yearNum <= currentYear;
       },
       {
@@ -672,7 +672,7 @@ export const wrappedParamsSchema = z.object({
       (val) => {
         if (!val) return true;
         const yearNum = parseInt(val, 10);
-        const currentYear = new Date().getFullYear();
+        const currentYear = new Date().getUTCFullYear();
         return /^\d{4}$/.test(val) && yearNum >= 2008 && yearNum <= currentYear;
       },
       {

--- a/lib/validations.year.test.ts
+++ b/lib/validations.year.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { streakParamsSchema, wrappedParamsSchema } from './validations';
 
-const CURRENT_YEAR = new Date().getFullYear();
+const CURRENT_YEAR = new Date().getUTCFullYear();
 const EXPECTED_ERROR = 'GitHub was founded in 2008. Please provide a year of 2008 or later.';
 
 function getYearError(result: {


### PR DESCRIPTION
## Description
Fixes #6244

In `lib/validations.ts`, both `streakParamsSchema` and `wrappedParamsSchema` validate the `year` query parameter's upper bound using:

```ts
const currentYear = new Date().getFullYear();
return /^\d{4}$/.test(val) && yearNum >= 2008 && yearNum <= currentYear;
```

**Problem with the old approach:**
- `new Date().getFullYear()` returns the year in the **server's local timezone**, not UTC
- Near a year boundary (e.g. Dec 31 / Jan 1), this can cause inconsistent validation behavior depending on the server's local time offset from UTC
- This is the same class of inconsistency already addressed in `app/api/wrapped/route.ts` (#6242), where the default year calculation was changed to avoid server-local-time dependency

**What this PR does:**
- Replaces `new Date().getFullYear()` with `new Date().getUTCFullYear()` in both `streakParamsSchema` and `wrappedParamsSchema` validation refinements
- Updates the corresponding test file `lib/validations.year.test.ts` to compute `CURRENT_YEAR` via `getUTCFullYear()` for consistency, ensuring tests remain accurate regardless of the test runner's local timezone
- No change to the validation logic itself — only removes the server-timezone dependency

**Note:** The `refine()` callback only receives the field value, not other parsed fields like `tz`, so full per-user timezone-aware validation would require `superRefine`. Switching to UTC removes the core server-local-time dependency, which was the primary issue.

**After:**
```ts
const currentYear = new Date().getUTCFullYear();
return /^\d{4}$/.test(val) && yearNum >= 2008 && yearNum <= currentYear;
```

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [x] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes — this is a validation correctness fix.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.