### PR TITLE
fix(landing): restore commented-out auto-reset timeout for copied indicator

### DIFF
--- a/app/components/LandingPageClient.tsx
+++ b/app/components/LandingPageClient.tsx
@@ -505,8 +505,8 @@ export default function LandingPageClient() {
     scrollTimeoutRef.current = setTimeout(() => {
       guideRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }, 80);
-    //if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
-    //copiedTimeoutRef.current = setTimeout(() => setCopied(false), 3000);
+    if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+    copiedTimeoutRef.current = setTimeout(() => setCopied(false), 3000);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Description
Fixes #6248

In `app/components/LandingPageClient.tsx`, after a successful clipboard copy, `setCopied(true)` is called, but the corresponding reset timeout was commented out:

```ts
setCopied(true);
scrollTimeoutRef.current = setTimeout(() => {
  guideRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
}, 80);
//if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
//copiedTimeoutRef.current = setTimeout(() => setCopied(false), 3000);
```

**Problem with the old approach:**
- The "copied" success indicator stayed visible indefinitely after a copy action, instead of auto-dismissing after ~3 seconds like the equivalent pattern used everywhere else in the codebase (`CompareClient.tsx`, `customize/page.tsx`, `PreviewPanel.tsx`, `code-block.tsx`, `ProfileOptimizerModal.tsx` — all of which call `setTimeout(() => setCopied(false), ...)` after `setCopied(true)`)
- The component already has a `copiedTimeoutRef` and a cleanup effect that clears it on unmount, but since the timeout was never scheduled, the cleanup had nothing to clear and the UI state never reset during normal usage

**What this PR does:**
- Uncomments and restores the auto-reset timeout, consistent with the pattern used elsewhere in the codebase
- Reuses the existing `copiedTimeoutRef` and cleanup logic that were already in place but unused
- No new state or refs introduced — purely restoring intended existing behavior

**After:**
```ts
setCopied(true);
scrollTimeoutRef.current = setTimeout(() => {
  guideRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
}, 80);
if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
copiedTimeoutRef.current = setTimeout(() => setCopied(false), 3000);
```

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes — this fixes a UI state reset bug, not styling.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.