### PR TITLE
fix(validation): validate managementToken format using regex

### DIFF
--- a/app/api/notify/route.test.ts
+++ b/app/api/notify/route.test.ts
@@ -301,7 +301,7 @@ describe('POST /api/notify', () => {
   });
 
   it('allows updates with a valid notification management token', async () => {
-    const managementToken = 'valid-management-token';
+    const managementToken = 'cpn_valid-management-token';
     vi.mocked(Notification.findOne).mockResolvedValue({
       username: 'tokenuser',
       email: 'old@example.com',

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -815,7 +815,16 @@ export const notifyPostSchema = z.object({
       notifyOnStreak: true,
       notifyOnMilestone: true,
     }),
-  managementToken: z.string().trim().min(16).max(256).optional(),
+  managementToken: z
+    .string()
+    .trim()
+    .min(16)
+    .max(256)
+    .regex(
+      /^cpn_[A-Za-z0-9_-]+$/,
+      'Invalid management token format — must start with "cpn_" and be base64url-encoded'
+    )
+    .optional(),
 });
 
 export const notifyGetSchema = z.object({


### PR DESCRIPTION
## Description

Fixes #6192

This PR adds format validation for the `managementToken` field to ensure malformed tokens are rejected during schema validation instead of failing later during authentication.

## Changes made

* Added regex validation for `managementToken`.
* Enforced the required `cpn_` prefix.
* Restricted token characters to base64url-safe characters (`A-Z`, `a-z`, `0-9`, `_`, `-`).
* Preserved existing length constraints and optional behavior.
* Added a clear validation error message for malformed tokens.
* Updated notification route test fixtures to use management tokens that match the enforced `cpn_` token format.

## Benefits

* Provides immediate feedback for invalid tokens.
* Improves debuggability for developers.
* Reduces confusion caused by generic authentication failures.
* Prevents malformed values from progressing further into the application.

## Validation Rules

Accepted format:

```text
cpn_xxxxxxxxxxxxxxxxx
```

Rejected examples:

```text
abc_token
cpn token
cpn@token
```
