### PR TITLE
fix(svg): add missing negative color parameter to cyberpunk theme

### DIFF
--- a/lib/svg/themes.ts
+++ b/lib/svg/themes.ts
@@ -37,7 +37,7 @@ export const themes: Record<string, BadgeTheme> = {
   glacier: makeTheme('e0f2fe', '0369a1', '06b6d4', 'ef4444'),
   lumos: makeTheme('0a0a0a', 'a7f3d0', 'fbbf24', 'ef4444'),
   tokyonight: makeTheme('1a1b26', 'c0caf5', 'f7768e'),
-  cyberpunk: makeTheme('fce22a', '111111', 'ff003c'),
+  cyberpunk: makeTheme('fce22a', '111111', 'ff003c', '2d0000'),
   tokyo_night: makeTheme('1a1b26', 'c0caf5', '7aa2f7'),
   monokai: makeTheme('272822', 'f8f8f2', 'a6e22e', 'f92672'),
   midnight_ocean: makeTheme('020c1b', 'ccd6f6', '0af5ff', 'ff4d6d'),


### PR DESCRIPTION
## Description

Fixes #6194

This PR adds the missing negative color parameter to the `cyberpunk` SVG theme.

Previously, the theme only defined background, text, and accent colors:

```ts
makeTheme('fce22a', '111111', 'ff003c')
```

The theme now includes a dedicated negative color value:

```ts
makeTheme('fce22a', '111111', 'ff003c', '2d0000')
```

## Changes made

* Added the missing negative color parameter to the `cyberpunk` theme.
* Used a dark red (`2d0000`) consistent with the cyberpunk aesthetic.
* Aligned the theme with other theme definitions that support negative contribution rendering.

## Benefits

* Ensures negative contribution values render consistently.
* Prevents undefined negative color behavior.
* Improves visual consistency across all SVG themes.
* No changes to existing theme APIs or rendering logic.

## Notes

This change follows the recommended fix from the issue and only affects the `cyberpunk` theme definition.
