### PR TITLE
fix(architecture): Add AbortSignal timeout to Gemini API fetch

### DIFF
--- a/app/api/architecture/route.ts
+++ b/app/api/architecture/route.ts
@@ -10,6 +10,8 @@ import { getGitHubTokens } from '@/lib/github';
 
 const execFilePromise = promisify(execFile);
 
+const REST_TIMEOUT_MS = 5000; // 5s timeout for external API requests
+
 /**
  * Strips credentials (x-access-token:...@) from error messages to prevent
  * leaking tokens into server logs.
@@ -612,24 +614,32 @@ export async function POST(req: NextRequest) {
         `;
 
         const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent`;
-        const response = await fetch(geminiUrl, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'x-goog-api-key': geminiApiKey,
-          },
-          body: JSON.stringify({
-            contents: [{ parts: [{ text: prompt }] }],
-            generationConfig: { responseMaxOutputTokens: 500 },
-          }),
-        });
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), REST_TIMEOUT_MS);
 
-        if (response.ok) {
-          const resJson = await response.json();
-          const text = resJson?.candidates?.[0]?.content?.parts?.[0]?.text;
-          if (text) {
-            summary = text.trim();
+        try {
+          const response = await fetch(geminiUrl, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-goog-api-key': geminiApiKey,
+            },
+            body: JSON.stringify({
+              contents: [{ parts: [{ text: prompt }] }],
+              generationConfig: { responseMaxOutputTokens: 500 },
+            }),
+            signal: controller.signal,
+          });
+
+          if (response.ok) {
+            const resJson = await response.json();
+            const text = resJson?.candidates?.[0]?.content?.parts?.[0]?.text;
+            if (text) {
+              summary = text.trim();
+            }
           }
+        } finally {
+          clearTimeout(timeoutId);
         }
       } catch (err) {
         console.warn('Gemini summary generation failed. Falling back to rules-based summary.', err);


### PR DESCRIPTION
## Description

Fixes #6205

This PR adds timeout handling to the Gemini API request used for repository architecture analysis.

Previously, the external Gemini API fetch could wait indefinitely if the service became slow or unresponsive. This could cause the serverless function to remain active until platform-enforced timeouts were reached.

## Changes made

* Added a shared timeout constant (`REST_TIMEOUT_MS = 5000`).
* Created an `AbortController` for the Gemini API request.
* Added an `AbortSignal` to the fetch call.
* Automatically aborts the request after 5 seconds.
* Ensured timeout cleanup using `clearTimeout()` in a `finally` block.
* Preserved the existing fallback behavior that generates a rules-based summary when Gemini is unavailable.

## Benefits

* Prevents indefinitely hanging external API requests.
* Reduces unnecessary serverless execution time.
* Improves reliability when Gemini is slow or unavailable.
* Frees up concurrent request capacity more quickly.
* Aligns this route with existing timeout patterns used elsewhere in the codebase.

## Notes

The timeout duration follows the existing `REST_TIMEOUT_MS` convention used for other external API requests in the repository.
