### PR TITLE
test(generator): add empty fallback coverage

### DIFF
--- a/app/generator/types.empty-fallback.test.ts
+++ b/app/generator/types.empty-fallback.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+
+import type {
+  GeneratorState,
+  Technology,
+  Social,
+  TechCategory,
+  SocialCategory,
+  IconType,
+} from './types';
+
+describe('GeneratorTypes Edge Cases & Empty/Missing Inputs Verification', () => {
+  it('supports empty generator state structures safely', () => {
+    const state: GeneratorState = {
+      name: '',
+      description: '',
+      selectedTechs: [],
+      selectedSocials: [],
+      socialLinks: {},
+      githubUsername: '',
+      showCommitPulse: false,
+      commitPulseAccent: '',
+      showSnakeGraph: false,
+      showPacmanGraph: false,
+      graphPlacement: 'top',
+    };
+
+    expect(state.selectedTechs).toEqual([]);
+    expect(state.socialLinks).toEqual({});
+  });
+
+  it('handles empty technology objects with minimal valid fallback values', () => {
+    const tech: Technology = {
+      id: '',
+      name: '',
+      category: 'Other',
+      iconUrl: '',
+      type: 'devicon',
+    };
+
+    expect(tech.category).toBe('Other');
+  });
+
+  it('handles empty social objects with optional fields omitted', () => {
+    const social: Social = {
+      id: '',
+      name: '',
+      category: 'Social Media',
+      iconUrl: '',
+      type: 'simpleicon',
+      baseUrl: '',
+      placeholder: '',
+    };
+
+    expect(social.siSlug).toBeUndefined();
+  });
+
+  it('supports all valid icon type fallbacks', () => {
+    const iconTypes: IconType[] = ['devicon', 'simpleicon'];
+
+    expect(iconTypes).toContain('devicon');
+    expect(iconTypes).toContain('simpleicon');
+  });
+
+  it('supports valid category fallback assignments', () => {
+    const techCategory: TechCategory = 'Other';
+    const socialCategory: SocialCategory = 'Support';
+
+    expect(techCategory).toBe('Other');
+    expect(socialCategory).toBe('Support');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4241

Added isolated empty fallback and edge-case coverage for `app/generator/types.ts`.

### Coverage added

* validates empty `GeneratorState` handling
* verifies safe fallback values for `Technology`
* verifies optional `Social` fields remain stable when omitted
* checks valid `IconType` fallback handling
* validates category fallback assignments

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
