### PR TITLE
fix(github): avoid mutating request headers with auth token

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -149,10 +149,14 @@ export async function fetchWithRetry(
   if (isGitHubRequest) {
     try {
       currentToken = userToken || getGitHubToken();
-      // Ensure your headers instantiation copies existing layout keys safely
-      options.headers = {
-        ...options.headers,
-        Authorization: `bearer ${currentToken}`,
+
+      const headers = new Headers(options.headers);
+
+      headers.set('Authorization', `bearer ${currentToken}`);
+
+      options = {
+        ...options,
+        headers,
       };
     } catch (e) {
       // Problem 3 Fix: Never swallow or compromise a structural RateLimitError instance


### PR DESCRIPTION
## Description

## Description

Fixes #6172 

This PR fixes the header mutation issue in `fetchWithRetry` where the caller-provided `options.headers` object was being modified while injecting the GitHub Authorization token.

Previously, adding the token directly to `options.headers` could cause the bearer token to remain inside the original request options object. If that object was later logged, stored, or reused, it could expose sensitive authentication data.

## Changes Made

- Created a new `Headers` instance from the existing request headers.
- Added the Authorization token to the cloned headers object.
- Updated the request options with a shallow copy instead of mutating the original object.

## Impact

- Prevents accidental GitHub token leakage through reused request options, debugging logs, or error contexts.
- Keeps existing request behavior unchanged.

## Testing

- Verified the diff only affects `lib/github.ts`.
- Tested that request headers are no longer mutated.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [ ] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x ] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [ ] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
