### PR TITLE
fix(resume-parser): filter corrupted skill tokens

### DIFF
--- a/lib/resume-parser.test.ts
+++ b/lib/resume-parser.test.ts
@@ -102,6 +102,43 @@ Random text without any section headers.
     expect(result.education).toEqual([]);
     expect(result.experience).toEqual([]);
   });
+
+  it('filters corrupted skill tokens', async () => {
+    const resume = `
+John Doe
+john@example.com
+
+Skills
+React, TypeScript, Node.js
+?~ L8c n 7 ? ?
+. ~ C _ 0o> ?
+I f
+m
+
+Education
+B.Tech 2020-2024
+`;
+
+    const result = await parseResume(Buffer.from(resume), 'text/plain');
+
+    expect(result.skills).toEqual(['React', 'TypeScript', 'Node.js']);
+  });
+
+  it('preserves short valid skills', async () => {
+    const resume = `
+Skills
+
+C, R, Go, AI, ML, Node.js, C++, C#, .NET
+
+Education
+
+B.Tech 2020-2024
+`;
+
+    const result = await parseResume(Buffer.from(resume), 'text/plain');
+
+    expect(result.skills).toEqual(['C', 'R', 'Go', 'AI', 'ML', 'Node.js', 'C++', 'C#', '.NET']);
+  });
 });
 
 describe('parser constants', () => {

--- a/lib/resume-parser.ts
+++ b/lib/resume-parser.ts
@@ -60,13 +60,30 @@ function extractSection(text: string, headers: RegExp): string[] {
   return sectionLines;
 }
 
+function isValidSkill(skill: string): boolean {
+  const cleaned = skill.trim();
+
+  const shortSkills = new Set(['C', 'R', 'Go', 'AI', 'ML', 'JS', 'TS', 'C++', 'C#', '.NET']);
+
+  if (shortSkills.has(cleaned)) {
+    return true;
+  }
+
+  return (
+    cleaned.length >= 2 &&
+    cleaned.length < 50 &&
+    /^[a-zA-Z0-9.+#\s-]+$/.test(cleaned) &&
+    !/[?~<>]/.test(cleaned) &&
+    !/^[A-Za-z]\s+[A-Za-z]$/.test(cleaned)
+  );
+}
+
 function extractSkills(text: string): string[] {
   const section = extractSection(text, SKILL_SECTION_HEADERS);
-  const allText = section.join(' ');
-  const skills = allText
-    .split(/[,•·\-|/\n]+/)
+  const skills = section
+    .flatMap((line) => line.split(/[,•·|/]+/))
     .map((s) => s.trim())
-    .filter((s) => s.length > 0 && s.length < 50);
+    .filter(isValidSkill);
   return [...new Set(skills)];
 }
 


### PR DESCRIPTION
## Description

Fixes #6275

### Summary

This PR improves resume skill extraction by filtering corrupted parsing artifacts that may appear after processing PDF/DOCX resumes.

Changes made:

* Added `isValidSkill()` validation helper
* Filtered corrupted tokens and parsing artifacts from extracted skills
* Preserved valid short skills such as `C`, `R`, `Go`, `AI`, `ML`, `C++`, `C#`, and `.NET`
* Added regression tests for corrupted skill tokens
* Added regression tests for valid short skills

### Testing

Verified locally with:

```bash
npx vitest run lib/resume-parser.test.ts
npx vitest run lib/resume-parser.test.ts lib/resume-parser.binary.test.ts lib/resume-parser.empty-fallback.test.ts lib/resume-parser.error-resilience.test.ts lib/resume-parser.mock-integrations.test.ts
```

Result:

```text
33/33 tests passing
```

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — Backend parsing logic change only.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.