### PR TITLE
fix(github): handle org member rate limits

### DIFF
--- a/lib/github.fetch-org-members-rate-limit.test.ts
+++ b/lib/github.fetch-org-members-rate-limit.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function createGitHubResponse(
+  status: number,
+  headers: Record<string, string> = {},
+  body: unknown = { message: 'GitHub API error' }
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      ...headers,
+    },
+  });
+}
+
+async function loadFetchOrgMembers() {
+  vi.resetModules();
+
+  const github = await import('./github');
+
+  github.clearGitHubApiCacheForTests();
+
+  return github.fetchOrgMembers;
+}
+
+describe('fetchOrgMembers rate limit handling', () => {
+  const originalGithubToken = process.env.GITHUB_TOKEN;
+  const originalGithubPat = process.env.GITHUB_PAT;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    delete process.env.GITHUB_PAT;
+    process.env.GITHUB_TOKEN = 'test-token';
+
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+
+    if (originalGithubToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalGithubToken;
+    }
+
+    if (originalGithubPat === undefined) {
+      delete process.env.GITHUB_PAT;
+    } else {
+      process.env.GITHUB_PAT = originalGithubPat;
+    }
+  });
+
+  it('throws a rate-limit error when org members request exhausts GitHub quota', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+
+    fetchMock.mockResolvedValue(
+      createGitHubResponse(403, {
+        'x-ratelimit-limit': '5000',
+        'x-ratelimit-remaining': '0',
+        'x-ratelimit-reset': '1893456000',
+        'retry-after': '10',
+      })
+    );
+
+    const fetchOrgMembers = await loadFetchOrgMembers();
+
+    await expect(fetchOrgMembers('octo-org')).rejects.toThrow(/rate limit/i);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws a rate-limit error when org members request receives 429', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+
+    fetchMock.mockResolvedValue(
+      createGitHubResponse(429, {
+        'retry-after': '10',
+      })
+    );
+
+    const fetchOrgMembers = await loadFetchOrgMembers();
+
+    await expect(fetchOrgMembers('octo-org')).rejects.toThrow(/rate limit/i);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the generic org members error for non-rate-limited failures', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+
+    fetchMock.mockResolvedValue(createGitHubResponse(500));
+
+    const fetchOrgMembers = await loadFetchOrgMembers();
+
+    await expect(fetchOrgMembers('octo-org')).rejects.toThrow(
+      'Failed to fetch members for org octo-org'
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+});

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1277,7 +1277,10 @@ export async function fetchOrgMembers(orgName: string, userToken?: string): Prom
         cache: 'no-store',
       }
     );
-    if (!res.ok) throw new Error(`Failed to fetch members for org ${orgName}`);
+    if (!res.ok) {
+      throwIfRateLimited(res);
+      throw new Error(`Failed to fetch members for org ${orgName}`);
+    }
     const members = (await res.json()) as { login: string }[];
     if (members.length === 0) break;
 


### PR DESCRIPTION
## Description

Fixes #6166

This PR is intentionally scoped only to `fetchOrgMembers()` rate-limit handling.

`fetchOrgMembers()` previously returned a generic organization-member fetch error when GitHub returned a non-OK response. This skipped the existing rate-limit detection path, so exhausted quota responses from the org members endpoint were not surfaced as rate-limit errors.

This PR updates `fetchOrgMembers()` to call the existing `throwIfRateLimited(res)` helper before falling back to the generic org-member error.

## Security / reliability impact

This ensures organization member fetches correctly detect GitHub rate-limit responses instead of hiding them behind a generic fetch failure.

The fix helps preserve the existing GitHub API recovery behavior by ensuring exhausted quota responses are classified as rate-limit failures.

## Regression coverage added

The new tests verify that:

* `403` responses with exhausted GitHub quota throw a rate-limit error
* `429` responses throw a rate-limit error
* non-rate-limited failures still use the existing generic org-member error

## Scope control

This PR only changes org-member rate-limit handling.

Touched files only:
* `lib/github.ts`
* `lib/github.fetch-org-members-rate-limit.test.ts`


## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A — this is a backend GitHub API reliability/security fix. No SVG/theme UI output is changed.

## Testing

```bash
git diff --check
npx eslint lib/github.ts lib/github.fetch-org-members-rate-limit.test.ts
npm run test -- lib/github.fetch-org-members-rate-limit.test.ts
npm run typecheck
```

Result:

```txt
✓ lib/github.fetch-org-members-rate-limit.test.ts (3 tests)
✓ 3 tests passed
✓ ESLint passed
✓ Typecheck passed
```

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
