### PR TITLE
test: add regression test for webhook IP spoofing prevention (#6288)

### DIFF
--- a/app/api/webhook/route.test.ts
+++ b/app/api/webhook/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import crypto from 'crypto';
+import { getClientIp } from '@/utils/getClientIp';
 
 // Mock getClientIp before importing the route so we control the IP per test
 let mockIp = '127.0.0.1';
@@ -210,5 +211,28 @@ describe('POST /api/webhook', () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.error).toBe('Invalid JSON');
+  });
+
+  it('uses getClientIp instead of raw x-forwarded-for header to prevent IP spoofing', async () => {
+    const secret = 'secret_key';
+    process.env.GITHUB_WEBHOOK_SECRET = secret;
+    mockIp = 'trusted-client-ip';
+
+    const payload = '{"test":"data"}';
+    const hmac = crypto.createHmac('sha256', secret);
+    const signature = 'sha256=' + hmac.update(payload).digest('hex');
+
+    const req = makeRequest(
+      {
+        'content-length': payload.length.toString(),
+        'x-hub-signature-256': signature,
+        'x-forwarded-for': '1.2.3.4',
+      },
+      payload
+    );
+
+    await POST(req);
+
+    expect(getClientIp).toHaveBeenCalledWith(req);
   });
 });


### PR DESCRIPTION
## Summary

This PR addresses Issue #6288 by adding a regression test to ensure the webhook endpoint uses the secure `getClientIp()` helper instead of the raw `x-forwarded-for` header.

## What was found

The webhook route (`app/api/webhook/route.ts:80`) already uses `getClientIp(req)` - the fix for this issue was already in place. However, there was no test to prevent regression.

## Changes Made

- `app/api/webhook/route.test.ts`:
  - Added import for `getClientIp`
  - Added regression test that verifies the webhook uses `getClientIp()` and not the raw `x-forwarded-for` header

## Testing

- All 10 webhook tests pass including the new regression test

Fixes #6288
