### PR TITLE
fix: remove token from GIT_ASKPASS script body (#6287)

### DIFF
--- a/app/api/architecture/route.ts
+++ b/app/api/architecture/route.ts
@@ -296,11 +296,17 @@ export async function POST(req: NextRequest) {
     try {
       const env = { ...process.env } as NodeJS.ProcessEnv;
       if (token) {
-        // GIT_ASKPASS points to a script that echoes the token when git asks
-        // for credentials, keeping the token out of process arguments.
+        // GIT_ASKPASS points to a script that reads the token from an environment
+        // variable instead of embedding it in the script body. This prevents the
+        // token from persisting on disk if the process crashes.
         const askpassScript = path.join(tempDir, '.git-askpass.sh');
-        fs.writeFileSync(askpassScript, `#!/bin/sh\necho "${token}"`, { mode: 0o700 });
+        fs.writeFileSync(
+          askpassScript,
+          '#!/bin/sh\nif [ -n "$GIT_TOKEN" ]; then\necho "$GIT_TOKEN"\nelse\nexit 1\nfi',
+          { mode: 0o700 }
+        );
         env.GIT_ASKPASS = askpassScript;
+        env.GIT_TOKEN = token;
         env.GIT_TERMINAL_PROMPT = '0';
       }
       await execFilePromise('git', ['clone', '--depth', '1', '--', cloneUrl, tempDir], { env });


### PR DESCRIPTION
## Summary

This PR fixes Issue #6287 by removing the GitHub OAuth token from the GIT_ASKPASS script body.

## Problem

The user's decrypted GitHub OAuth token was being written directly to a shell script on disk:

```javascript
fs.writeFileSync(askpassScript, `#!/bin/sh\necho "${token}"`, { mode: 0o700 });
```

If the Node.js process was killed (OOM, SIGKILL, cold start timeout), the `finally` block never runs, and the script remains readable in `/tmp` until the OS purges it. This is a token exfiltration path.

## Solution

The token is now passed via the `GIT_TOKEN` environment variable instead of being embedded in the script body. The script reads from the environment variable:

```javascript
const askpassScript = path.join(tempDir, '.git-askpass.sh');
fs.writeFileSync(
  askpassScript,
  '#!/bin/sh\nif [ -n "$GIT_TOKEN" ]; then\necho "$GIT_TOKEN"\nelse\nexit 1\nfi',
  { mode: 0o700 }
);
env.GIT_ASKPASS = askpassScript;
env.GIT_TOKEN = token;
```

This ensures:
- The token is never written to disk in plaintext
- The token is only in memory during the git clone operation
- If the process crashes, the token is not persisted

Fixes #6287
