### PR TITLE
fix(github): paginate contributed repositories

### DIFF
--- a/lib/github.contributed-repos-pagination.test.ts
+++ b/lib/github.contributed-repos-pagination.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function createGraphQLResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json',
+    },
+  });
+}
+
+async function loadFetchContributedRepos() {
+  vi.resetModules();
+
+  const github = await import('./github');
+
+  github.clearGitHubApiCacheForTests();
+
+  return github.fetchContributedRepos;
+}
+
+describe('fetchContributedRepos pagination', () => {
+  const originalGithubToken = process.env.GITHUB_TOKEN;
+  const originalGithubPat = process.env.GITHUB_PAT;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    delete process.env.GITHUB_PAT;
+    process.env.GITHUB_TOKEN = 'test-token';
+
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+
+    if (originalGithubToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalGithubToken;
+    }
+
+    if (originalGithubPat === undefined) {
+      delete process.env.GITHUB_PAT;
+    } else {
+      process.env.GITHUB_PAT = originalGithubPat;
+    }
+  });
+
+  it('fetches contributed repositories across multiple GraphQL pages', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+
+    fetchMock
+      .mockResolvedValueOnce(
+        createGraphQLResponse({
+          data: {
+            user: {
+              repositoriesContributedTo: {
+                nodes: Array.from({ length: 100 }, (_, index) => ({
+                  name: `repo-${index + 1}`,
+                  nameWithOwner: `octo-org/repo-${index + 1}`,
+                  owner: { login: 'octo-org' },
+                  stargazerCount: index,
+                  forkCount: index,
+                  primaryLanguage: { name: 'TypeScript' },
+                  updatedAt: '2026-06-22T00:00:00Z',
+                })),
+                pageInfo: {
+                  hasNextPage: true,
+                  endCursor: 'cursor-page-2',
+                },
+              },
+            },
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        createGraphQLResponse({
+          data: {
+            user: {
+              repositoriesContributedTo: {
+                nodes: Array.from({ length: 25 }, (_, index) => ({
+                  name: `repo-${index + 101}`,
+                  nameWithOwner: `octo-org/repo-${index + 101}`,
+                  owner: { login: 'octo-org' },
+                  stargazerCount: index,
+                  forkCount: index,
+                  primaryLanguage: { name: 'JavaScript' },
+                  updatedAt: '2026-06-22T00:00:00Z',
+                })),
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null,
+                },
+              },
+            },
+          },
+        })
+      );
+
+    const fetchContributedRepos = await loadFetchContributedRepos();
+
+    const repos = await fetchContributedRepos('octocat', { bypassCache: true });
+
+    expect(repos).toHaveLength(125);
+    expect(repos[0].nameWithOwner).toBe('octo-org/repo-1');
+    expect(repos[124].nameWithOwner).toBe('octo-org/repo-125');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const firstRequestBody = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    const secondRequestBody = JSON.parse(fetchMock.mock.calls[1][1]?.body as string);
+
+    expect(firstRequestBody.variables).toEqual({
+      login: 'octocat',
+      after: null,
+    });
+
+    expect(secondRequestBody.variables).toEqual({
+      login: 'octocat',
+      after: 'cursor-page-2',
+    });
+
+    expect(firstRequestBody.query).toContain('after: $after');
+    expect(firstRequestBody.query).toContain('pageInfo');
+    expect(firstRequestBody.query).toContain('hasNextPage');
+    expect(firstRequestBody.query).toContain('endCursor');
+  });
+
+  it('stops at the configured contributed repository safety cap', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+
+    for (let page = 0; page < 6; page++) {
+      fetchMock.mockResolvedValueOnce(
+        createGraphQLResponse({
+          data: {
+            user: {
+              repositoriesContributedTo: {
+                nodes: Array.from({ length: 100 }, (_, index) => ({
+                  name: `repo-${page * 100 + index + 1}`,
+                  nameWithOwner: `octo-org/repo-${page * 100 + index + 1}`,
+                  owner: { login: 'octo-org' },
+                  stargazerCount: index,
+                  forkCount: index,
+                  primaryLanguage: { name: 'TypeScript' },
+                  updatedAt: '2026-06-22T00:00:00Z',
+                })),
+                pageInfo: {
+                  hasNextPage: true,
+                  endCursor: `cursor-page-${page + 2}`,
+                },
+              },
+            },
+          },
+        })
+      );
+    }
+
+    const fetchContributedRepos = await loadFetchContributedRepos();
+
+    const repos = await fetchContributedRepos('octocat', { bypassCache: true });
+
+    expect(repos).toHaveLength(500);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+});

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -76,6 +76,8 @@ export function shouldFallbackOnError(err: unknown): boolean {
 const GRAPHQL_TIMEOUT_MS = 8000; // 8s for GraphQL endpoint
 const REST_TIMEOUT_MS = 5000; // 5s for REST endpoints
 const ORG_MEMBER_LIMIT = 100;
+const GRAPHQL_REPOSITORY_PAGE_SIZE = 100;
+const MAX_GRAPHQL_REPOSITORY_RESULTS = 500;
 
 let currentTokenIndex = 0;
 const rateLimitedTokens = new Map<string, number>();
@@ -457,6 +459,21 @@ interface GitHubGraphQLResponse {
         contributionCalendar: ContributionCalendar;
         commitContributionsByRepository: RepoContribution[];
       };
+    } | null;
+  };
+  errors?: unknown;
+}
+
+interface GitHubContributedReposResponse {
+  data?: {
+    user: {
+      repositoriesContributedTo: {
+        nodes: ContributedRepo[];
+        pageInfo: {
+          hasNextPage: boolean;
+          endCursor: string | null;
+        };
+      } | null;
     } | null;
   };
   errors?: unknown;
@@ -1547,63 +1564,92 @@ export async function fetchContributedRepos(
 
   const load = async () => {
     const query = `
-      query($login: String!) {
-        user(login: $login) {
-          repositoriesContributedTo(first: 100, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY], orderBy: {field: UPDATED_AT, direction: DESC}) {
-            nodes {
-              name
-              nameWithOwner
-              owner { login }
-              stargazerCount
-              forkCount
-              primaryLanguage { name }
-              updatedAt
-            }
+    query($login: String!, $after: String) {
+      user(login: $login) {
+        repositoriesContributedTo(first: ${GRAPHQL_REPOSITORY_PAGE_SIZE}, after: $after, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY], orderBy: {field: UPDATED_AT, direction: DESC}) {
+          nodes {
+            name
+            nameWithOwner
+            owner { login }
+            stargazerCount
+            forkCount
+            primaryLanguage { name }
+            updatedAt
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
           }
         }
       }
-    `;
+    }
+  `;
 
-    const res = await fetchGraphQLWithRetry(
-      GITHUB_GRAPHQL_URL,
-      {
-        method: 'POST',
-        headers: getHeaders(options.token),
-        body: JSON.stringify({
-          query,
-          variables: { login: username },
-        }),
-        cache: 'no-store',
-        signal: options.signal,
-      },
-      0,
-      undefined,
-      options.token
-    );
+    const allRepos: ContributedRepo[] = [];
+    let after: string | null = null;
+    let hasNextPage = true;
 
-    if (!res.ok) {
-      throwIfRateLimited(res);
-      throw new Error(
-        `GitHub GraphQL API returned status ${res.status} after ${MAX_RETRIES} retries`
+    while (hasNextPage && allRepos.length < MAX_GRAPHQL_REPOSITORY_RESULTS) {
+      const res = await fetchGraphQLWithRetry(
+        GITHUB_GRAPHQL_URL,
+        {
+          method: 'POST',
+          headers: getHeaders(options.token),
+          body: JSON.stringify({
+            query,
+            variables: { login: username, after },
+          }),
+          cache: 'no-store',
+          signal: options.signal,
+        },
+        0,
+        undefined,
+        options.token
       );
-    }
 
-    const data = await res.json();
-
-    if (data?.errors !== undefined) {
-      if (Array.isArray(data.errors)) {
-        const isRateLimit = data.errors.some((e: unknown) => {
-          const err = e as { message?: string; type?: string };
-          return err?.message?.toLowerCase().includes('rate limit') || err?.type === 'RATE_LIMITED';
-        });
-        if (isRateLimit) {
-          throw new Error('API Rate Limit Exceeded');
-        }
+      if (!res.ok) {
+        throwIfRateLimited(res);
+        throw new Error(
+          `GitHub GraphQL API returned status ${res.status} after ${MAX_RETRIES} retries`
+        );
       }
-      throw new Error(getGraphQLErrorMessage(data.errors));
+
+      const data = (await res.json()) as GitHubContributedReposResponse;
+
+      if (data?.errors !== undefined) {
+        if (Array.isArray(data.errors)) {
+          const isRateLimit = data.errors.some((e: unknown) => {
+            const err = e as { message?: string; type?: string };
+            return (
+              err?.message?.toLowerCase().includes('rate limit') || err?.type === 'RATE_LIMITED'
+            );
+          });
+          if (isRateLimit) {
+            throw new Error('API Rate Limit Exceeded');
+          }
+        }
+        throw new Error(getGraphQLErrorMessage(data.errors));
+      }
+
+      const connection = data?.data?.user?.repositoriesContributedTo;
+      const nodes = connection?.nodes ?? [];
+
+      allRepos.push(...nodes);
+
+      const pageInfo = connection?.pageInfo;
+
+      after = pageInfo?.endCursor ?? null;
+      hasNextPage =
+        Boolean(pageInfo?.hasNextPage) &&
+        after !== null &&
+        allRepos.length < MAX_GRAPHQL_REPOSITORY_RESULTS;
+
+      if (nodes.length === 0) {
+        break;
+      }
     }
 
-    return data?.data?.user?.repositoriesContributedTo?.nodes || [];
+    return allRepos.slice(0, MAX_GRAPHQL_REPOSITORY_RESULTS);
   };
 
   if (options.bypassCache || options.forceRefresh) {


### PR DESCRIPTION
## Description

Fixes #6167

This PR is intentionally scoped only to contributed repository pagination in `lib/github.ts`.

The issue describes silent truncation when GitHub repository contribution data is limited to the first 100 repositories. This PR fixes the paginatable contributed repository path by adding cursor-based pagination to `repositoriesContributedTo`.

Instead of fetching only:

```graphql
repositoriesContributedTo(first: 100)
```

the query now requests:

```graphql
repositoriesContributedTo(first: 100, after: $after) {
  nodes { ... }
  pageInfo {
    hasNextPage
    endCursor
  }
}
```

and continues fetching pages until there are no more pages or the configured safety cap is reached.

## Reliability impact

This reduces silent data loss for users who have contributed to more than 100 repositories.

The implementation also includes a bounded safety cap of 500 contributed repositories so the API path cannot loop indefinitely or make unbounded GraphQL requests.

## Regression coverage added

The new tests verify that:

* `fetchContributedRepos()` follows `pageInfo.endCursor` and fetches additional pages
* results from multiple pages are combined
* the first request uses `after: null`
* subsequent requests use the returned cursor
* pagination stops at the configured safety cap

## Scope control

This PR only changes contributed repository GraphQL pagination.

Touched files only:

* `lib/github.ts`
* `lib/github.contributed-repos-pagination.test.ts`

## Note on GraphQL field shape

This PR focuses on `repositoriesContributedTo`, which is a proper cursor-paginated GraphQL connection.

I did not add unsupported cursor arguments to `commitContributionsByRepository(maxRepositories: 100)` because that field is not shaped like the same `first/after/pageInfo` connection in the current query.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — this is a backend GitHub GraphQL pagination fix. No SVG/theme UI output is changed.

## Testing

```bash
git diff --check
npx eslint lib/github.ts lib/github.contributed-repos-pagination.test.ts
npm run test -- lib/github.contributed-repos-pagination.test.ts
npm run typecheck
```

Result:

```txt
✓ lib/github.contributed-repos-pagination.test.ts (2 tests)
✓ 2 tests passed
✓ ESLint passed
✓ Typecheck passed
```

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
