### PR TITLE
fix: validate doughnut chart radius input

### DIFF
--- a/lib/svg/doughnut.ts
+++ b/lib/svg/doughnut.ts
@@ -2,7 +2,7 @@
 
 import type { BadgeParams, ContributionCalendar, StreakStats } from '../../types';
 import { truncateUsername, getSizeScale } from './generator';
-import { escapeXML } from './sanitizer';
+import { escapeXML, sanitizeRadius } from './sanitizer';
 
 const DOUGHNUT_SVG_WIDTH = 400;
 const DOUGHNUT_SVG_HEIGHT = 200;
@@ -138,6 +138,9 @@ export function generateDoughnutSVG(
   const weekendStr = (weekendPercent * 100).toFixed(1) + '%';
   const weekdayStr = (weekdayPercent * 100).toFixed(1) + '%';
 
+  // Validate the corner radius before interpolation into SVG attributes
+  const safeRadius = sanitizeRadius(params.radius, 8);
+
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${Math.round(DOUGHNUT_SVG_WIDTH * sf)}" height="${Math.round(DOUGHNUT_SVG_HEIGHT * sf)}" viewBox="0 0 ${DOUGHNUT_SVG_WIDTH} ${DOUGHNUT_SVG_HEIGHT}" role="img" aria-labelledby="cp-doughnut-title cp-doughnut-desc">
   <title id="cp-doughnut-title">CommitPulse ${viewTitle} for ${safeUser}</title>
   <desc id="cp-doughnut-desc">A ${viewTitle.toLowerCase()} showing weekday vs weekend commits for ${safeUser}.</desc>
@@ -150,7 +153,7 @@ export function generateDoughnutSVG(
     </style>
   </defs>
 
-  <rect width="${DOUGHNUT_SVG_WIDTH}" height="${DOUGHNUT_SVG_HEIGHT}" fill="#${bgColor}" rx="${params.radius ?? 8}" />
+  <rect width="${DOUGHNUT_SVG_WIDTH}" height="${DOUGHNUT_SVG_HEIGHT}" fill="#${bgColor}" rx="${safeRadius}" />
   
   <g id="chart">
 ${slicesSVG}


### PR DESCRIPTION
## Description

This PR adds strict validation for the radius parameter used in doughnut chart SVG generation to prevent invalid input from being interpolated into SVG attributes. The implementation improves security and rendering stability while preserving existing behavior for valid values.

Changes Made
Added validation for the radius parameter before SVG rendering.
Ensured only finite, positive numeric values are accepted.
Enforced a reasonable radius range to prevent malformed or oversized SVGs.
Rejected invalid or malformed inputs with a clear error instead of attempting to render.
Preserved the existing rendering logic for all valid radius values.

Fixes # (issue number)

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
