### PR TITLE
feat: add keyboard shortcuts modal triggered by ?

### DIFF
--- a/app/components/navbar.accessibility.test.tsx
+++ b/app/components/navbar.accessibility.test.tsx
@@ -14,9 +14,9 @@ vi.mock('lucide-react', () => ({
 
   Search: () => <div>SearchIcon</div>,
   ArrowRight: () => <div>ArrowRightIcon</div>,
-
   ChevronDown: () => <div>ChevronDownIcon</div>,
   Check: () => <div>CheckIcon</div>,
+  Keyboard: () => <div>KeyboardIcon</div>,
 }));
 
 vi.mock('next/navigation', () => ({

--- a/app/components/navbar.test.tsx
+++ b/app/components/navbar.test.tsx
@@ -72,9 +72,9 @@ vi.mock('lucide-react', () => ({
 
   Search: () => <div>SearchIcon</div>,
   ArrowRight: () => <div>ArrowRightIcon</div>,
-
   ChevronDown: () => <div>ChevronDownIcon</div>,
   Check: () => <div>CheckIcon</div>,
+  Keyboard: () => <div>KeyboardIcon</div>,
 }));
 
 vi.mock('next/navigation', () => ({

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -369,7 +369,10 @@ export default function Navbar() {
                 aria-label="Show keyboard shortcuts"
                 className="group inline-flex h-10 w-10 items-center justify-center rounded-xl text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-white dark:focus-visible:ring-gray-400 dark:focus-visible:ring-offset-[#0a0a0a]"
               >
-                <Keyboard size={18} className="transition-transform duration-300 group-hover:scale-110" />
+                <Keyboard
+                  size={18}
+                  className="transition-transform duration-300 group-hover:scale-110"
+                />
               </button>
 
               <button

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Menu, X, Activity, Moon, Sun, Globe, ChevronDown, Check } from 'lucide-react';
+import { Menu, X, Activity, Moon, Sun, Globe, ChevronDown, Check, Keyboard } from 'lucide-react';
 import { useGlowEffect } from '@/hooks/useGlowEffect';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import KeyboardShortcutsModal from '@/components/KeyboardShortcutsModal';
 import { useThemeToggle } from './theme-switch';
 import { useTranslation, LANGUAGE_LABELS, type Language } from '@/context/TranslationContext';
 import NavbarSearch from '@/components/NavbarSearch';
@@ -166,9 +167,8 @@ export default function Navbar() {
   const [open, setOpen] = useState(false);
 
   const [isHidden, setIsHidden] = useState(false);
-
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const pathname = usePathname();
-
   const { t } = useTranslation();
   const lastScrollYRef = useRef(0);
   // Ref so the scroll handler (stale closure) can always read the current open state.
@@ -179,7 +179,8 @@ export default function Navbar() {
     openRef.current = open;
   }, [open]);
 
-  useKeyboardShortcuts();
+  const handleOpenShortcuts = useCallback(() => setShortcutsOpen(true), []);
+  useKeyboardShortcuts({ onOpenShortcuts: handleOpenShortcuts });
 
   const { shellRef, shellVars, handleMouseEnter, handleMouseMove, handleMouseLeave } =
     useGlowEffect();
@@ -361,6 +362,15 @@ export default function Navbar() {
 
               {/* Separator line between links and theme toggle */}
               <div className="mx-2 h-6 w-px bg-gray-200 dark:bg-white/15" />
+
+              <button
+                type="button"
+                onClick={() => setShortcutsOpen(true)}
+                aria-label="Show keyboard shortcuts"
+                className="group inline-flex h-10 w-10 items-center justify-center rounded-xl text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-white dark:focus-visible:ring-gray-400 dark:focus-visible:ring-offset-[#0a0a0a]"
+              >
+                <Keyboard size={18} className="transition-transform duration-300 group-hover:scale-110" />
+              </button>
 
               <button
                 type="button"

--- a/components/KeyboardShortcutsModal.tsx
+++ b/components/KeyboardShortcutsModal.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { X, Keyboard } from 'lucide-react';
+
+interface ShortcutGroup {
+  title: string;
+  shortcuts: { keys: string[]; description: string }[];
+}
+
+const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    title: 'Navigation',
+    shortcuts: [
+      { keys: ['G', 'D'], description: 'Go to Home' },
+      { keys: ['G', 'C'], description: 'Go to Contributors' },
+      { keys: ['G', 'P'], description: 'Go to Compare' },
+      { keys: ['G', 'U'], description: 'Go to Customization Studio' },
+    ],
+  },
+  {
+    title: 'General',
+    shortcuts: [
+      { keys: ['?'], description: 'Open keyboard shortcuts' },
+      { keys: ['Esc'], description: 'Close this modal' },
+    ],
+  },
+];
+
+interface KeyboardShortcutsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+      modalRef.current?.focus();
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Modal */}
+      <div
+        ref={modalRef}
+        tabIndex={-1}
+        className="relative w-full max-w-md rounded-2xl border border-black/10 dark:border-white/10 bg-white dark:bg-zinc-900 shadow-2xl focus:outline-none"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-black/10 dark:border-white/10">
+          <div className="flex items-center gap-2">
+            <Keyboard size={18} className="text-emerald-500" />
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+              Keyboard Shortcuts
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close shortcuts modal"
+            className="inline-flex items-center justify-center w-8 h-8 rounded-lg text-gray-500 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-white/10 transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-4 space-y-5">
+          {SHORTCUT_GROUPS.map((group) => (
+            <div key={group.title}>
+              <p className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-widest mb-3">
+                {group.title}
+              </p>
+              <div className="space-y-2">
+                {group.shortcuts.map((shortcut) => (
+                  <div key={shortcut.description} className="flex items-center justify-between">
+                    <span className="text-sm text-gray-600 dark:text-gray-300">
+                      {shortcut.description}
+                    </span>
+                    <div className="flex items-center gap-1">
+                      {shortcut.keys.map((key, i) => (
+                        <span key={key} className="flex items-center gap-1">
+                          <kbd className="inline-flex items-center justify-center min-w-[28px] h-7 px-1.5 text-xs font-semibold text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-zinc-800 border border-gray-300 dark:border-white/15 rounded-md shadow-sm">
+                            {key}
+                          </kbd>
+                          {i < shortcut.keys.length - 1 && (
+                            <span className="text-xs text-gray-400">then</span>
+                          )}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-3 border-t border-black/10 dark:border-white/10">
+          <p className="text-xs text-gray-400 dark:text-gray-500 text-center">
+            Press{' '}
+            <kbd className="px-1 py-0.5 text-xs bg-gray-100 dark:bg-zinc-800 border border-gray-300 dark:border-white/15 rounded">
+              ?
+            </kbd>{' '}
+            to toggle this modal
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -1,5 +1,4 @@
 'use client';
-
 import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 
@@ -12,9 +11,7 @@ const SHORTCUT_ROUTES: Record<string, string> = {
 
 function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
-
   const tagName = target.tagName.toLowerCase();
-
   return (
     tagName === 'input' ||
     tagName === 'textarea' ||
@@ -23,9 +20,14 @@ function isTypingTarget(target: EventTarget | null): boolean {
   );
 }
 
+interface UseKeyboardShortcutsOptions {
+  onOpenShortcuts?: () => void;
+}
+
 // Global "g then key" quick-nav shortcuts. Navigates via the App Router, so it
 // must be mounted within a Next.js App Router context (useRouter throws otherwise).
-export function useKeyboardShortcuts() {
+
+export function useKeyboardShortcuts(options?: UseKeyboardShortcutsOptions) {
   const router = useRouter();
   const waitingForSecondKey = useRef(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -33,7 +35,6 @@ export function useKeyboardShortcuts() {
   useEffect(() => {
     const resetShortcut = () => {
       waitingForSecondKey.current = false;
-
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
         timeoutRef.current = null;
@@ -42,6 +43,14 @@ export function useKeyboardShortcuts() {
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (isTypingTarget(event.target)) return;
+
+      // ? opens shortcuts modal
+      if (!event.ctrlKey && !event.metaKey && !event.altKey && event.key === '?') {
+        event.preventDefault();
+        options?.onOpenShortcuts?.();
+        return;
+      }
+
       if (event.ctrlKey || event.metaKey || event.altKey) return;
 
       const key = event.key.toLowerCase();
@@ -49,31 +58,26 @@ export function useKeyboardShortcuts() {
       if (!waitingForSecondKey.current) {
         if (key === 'g') {
           waitingForSecondKey.current = true;
-
           timeoutRef.current = setTimeout(() => {
             waitingForSecondKey.current = false;
             timeoutRef.current = null;
           }, 1000);
         }
-
         return;
       }
 
       const route = SHORTCUT_ROUTES[key];
-
       if (route) {
         event.preventDefault();
         router.push(route);
       }
-
       resetShortcut();
     };
 
     window.addEventListener('keydown', handleKeyDown);
-
     return () => {
       resetShortcut();
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [router]);
+  }, [router, options]);
 }


### PR DESCRIPTION
## Description
Adds a keyboard shortcuts modal that opens when the user presses ?. The modal displays all available shortcuts in a grouped layout and can be dismissed with Esc or clicking outside.
Changes:

- Added components/KeyboardShortcutsModal.tsx — accessible modal with grouped shortcuts display
- Updated hooks/useKeyboardShortcuts.ts — added ? key trigger and onOpenShortcuts callback option
- Updated app/components/navbar.tsx — wired modal state and callback

Fixes #6291 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
<img width="1816" height="853" alt="image" src="https://github.com/user-attachments/assets/77ee82a0-fe9c-4718-ba84-a3cc16d217f0" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have made sure that i have only one commit to merge in this PR.
