### PR TITLE
fix: keep GitHub OAuth token material server-side only

### DIFF
--- a/auth.session.test.ts
+++ b/auth.session.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { buildClientSession } from './auth';
+
+describe('buildClientSession', () => {
+  it('exposes hasGitHubToken without leaking encrypted token material', () => {
+    const session = buildClientSession(
+      {
+        user: { name: 'Octocat', email: 'octocat@github.com' },
+        expires: '2099-01-01T00:00:00.000Z',
+      },
+      { ghToken: 'encrypted.token.material' }
+    );
+
+    expect(session.hasGitHubToken).toBe(true);
+    expect(session).not.toHaveProperty('ghToken');
+  });
+
+  it('marks hasGitHubToken false when the JWT has no GitHub token', () => {
+    const session = buildClientSession(
+      {
+        user: { name: 'Guest', email: 'guest@example.com' },
+        expires: '2099-01-01T00:00:00.000Z',
+      },
+      {}
+    );
+
+    expect(session.hasGitHubToken).toBe(false);
+    expect(session).not.toHaveProperty('ghToken');
+  });
+});

--- a/auth.ts
+++ b/auth.ts
@@ -1,6 +1,13 @@
 import NextAuth from 'next-auth';
+import type { Session } from 'next-auth';
 import GitHub from 'next-auth/providers/github';
 import { encryptToken } from '@/lib/crypto';
+
+/** Shapes the session payload returned to clients — never includes token material. */
+export function buildClientSession(session: Session, token: { ghToken?: unknown }): Session {
+  session.hasGitHubToken = Boolean(token.ghToken);
+  return session;
+}
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [
@@ -19,9 +26,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       return token;
     },
     async session({ session, token }) {
-      session.hasGitHubToken = Boolean(token.ghToken);
-      session.ghToken = token.ghToken as string | undefined;
-      return session;
+      return buildClientSession(session, token);
     },
   },
 });

--- a/lib/githubtoken.test.ts
+++ b/lib/githubtoken.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { encryptToken } from './crypto';
+import { getUserGitHubToken } from './githubtoken';
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}));
+
+vi.mock('next-auth/jwt', () => ({
+  getToken: vi.fn(),
+}));
+
+import { cookies } from 'next/headers';
+import { getToken } from 'next-auth/jwt';
+
+describe('getUserGitHubToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('ENCRYPTION_KEY', 'abcdefghijklmnopqrstuvwxyz012345');
+    vi.mocked(cookies).mockResolvedValue({
+      toString: () => 'authjs.session-token=test',
+    } as never);
+  });
+
+  it('decrypts the GitHub token from the JWT cookie', async () => {
+    const plainToken = 'gho_test_access_token';
+    vi.mocked(getToken).mockResolvedValue({ ghToken: encryptToken(plainToken) });
+
+    await expect(getUserGitHubToken()).resolves.toBe(plainToken);
+    expect(getToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        req: { headers: { cookie: 'authjs.session-token=test' } },
+      })
+    );
+  });
+
+  it('returns undefined when the JWT has no GitHub token', async () => {
+    vi.mocked(getToken).mockResolvedValue({ sub: 'user-1' });
+
+    await expect(getUserGitHubToken()).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when encrypted token material is corrupt', async () => {
+    vi.mocked(getToken).mockResolvedValue({ ghToken: 'not-valid-ciphertext' });
+
+    await expect(getUserGitHubToken()).resolves.toBeUndefined();
+  });
+});

--- a/lib/githubtoken.ts
+++ b/lib/githubtoken.ts
@@ -1,17 +1,31 @@
 import 'server-only';
-import { auth } from '@/auth';
+import { cookies } from 'next/headers';
+import { getToken } from 'next-auth/jwt';
 import { decryptToken } from '@/lib/crypto';
 
 /**
  * Returns the authenticated user's GitHub OAuth token (decrypted), or
  * undefined when there is no session. Pass the result as FetchOptions.token.
  * When undefined, lib/github.ts falls back to the global PAT pool.
+ *
+ * Token material is read from the encrypted JWT cookie server-side only —
+ * it is never exposed through the client session API.
  */
 export async function getUserGitHubToken(): Promise<string | undefined> {
-  const session = await auth();
-  if (!session?.ghToken) return undefined;
+  const cookieStore = await cookies();
+  const jwt = await getToken({
+    req: {
+      headers: {
+        cookie: cookieStore.toString(),
+      },
+    },
+    secret: process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET,
+  });
+
+  if (!jwt?.ghToken || typeof jwt.ghToken !== 'string') return undefined;
+
   try {
-    return decryptToken(session.ghToken);
+    return decryptToken(jwt.ghToken);
   } catch {
     return undefined; // corrupt/expired -> use global fallback
   }

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -9,6 +9,5 @@ declare module 'next-auth/jwt' {
 declare module 'next-auth' {
   interface Session {
     hasGitHubToken?: boolean;
-    ghToken?: string;
   }
 }


### PR DESCRIPTION
## Summary

Fixes the exposure of GitHub OAuth token material through client-visible session responses.

### Changes

* Remove `ghToken` from the session object returned to the browser.
* Keep GitHub OAuth tokens exclusively server-side within JWT processing.
* Retain `hasGitHubToken` for frontend state checks without exposing credential material.
* Update session typings to remove client-side access to `ghToken`.
* Preserve existing GitHub API integrations and authenticated functionality.

### Security Impact

Previously, the authentication flow copied encrypted GitHub OAuth token material from the JWT into the session object:

```ts
async session({ session, token }) {
  session.hasGitHubToken = Boolean(token.ghToken);
  session.ghToken = token.ghToken;
  return session;
}
```

As a result, authenticated users could access the encrypted token through:

```js
const session = await fetch('/api/auth/session').then(r => r.json());
console.log(session.ghToken);
```

Although encrypted, OAuth token material should not be exposed to client-side JavaScript. This unnecessarily increases the impact of XSS vulnerabilities and violates the principle of keeping credentials server-side.

This change ensures:

* OAuth token material is never returned to browsers.
* Sensitive credentials remain server-side only.
* Existing authentication flows continue to work as expected.
* Frontend components can still determine token availability through `hasGitHubToken`.

### Testing

Verified:

* `/api/auth/session` no longer includes `ghToken`.
* `hasGitHubToken` remains available to the frontend.
* GitHub-authenticated features continue functioning correctly.
* Login, logout, and session refresh flows remain operational.

### Issue

Closes #6320 
