### PR TITLE
fix(compare): prevent avatar failures caused by Vercel image optimization

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -375,15 +375,15 @@ function CompareProfileCard({ user, side }: { user: CompareUserData; side: 'left
         {/* Avatar */}
         <div className="relative mb-4">
           <div className="w-20 h-20 rounded-full overflow-hidden border-2 border-black/10 dark:border-[rgba(255,255,255,0.12)]">
-            <Image
+            <img
               src={
                 profile.avatarUrl.startsWith('http')
                   ? `${profile.avatarUrl}${profile.avatarUrl.includes('?') ? '&' : '?'}s=120`
                   : profile.avatarUrl
               }
               alt={profile.name}
-              width={80}
-              height={80}
+              width="80"
+              height="80"
               className="w-full h-full object-cover"
             />
           </div>
@@ -1489,15 +1489,14 @@ export default function CompareClient() {
                               @{user.profile.username}
                             </span>
                           </div>
-                          <Image
+                          <img
                             data-monolith-img="true"
                             key={`${user.profile.username}-${monolithKey}`}
                             src={`/api/streak?user=${encodeURIComponent(user.profile.username)}&theme=neon&entrance=none&_k=${monolithKey}`}
                             alt={`${user.profile.username}'s CommitPulse monolith`}
-                            width={300}
-                            height={400}
+                            width="300"
+                            height="400"
                             className="w-full h-auto"
-                            unoptimized
                           />
                         </motion.div>
                       ))}

--- a/app/components/LandingPageClient.tsx
+++ b/app/components/LandingPageClient.tsx
@@ -738,13 +738,12 @@ export default function LandingPageClient() {
                         exit={{ opacity: 0 }}
                         className="flex items-center gap-3 bg-emerald-500/5 border border-emerald-500/10 rounded-xl px-3 py-2"
                       >
-                        <Image
+                        <img
                           src={userDetails.avatar_url}
                           alt={userDetails.login}
-                          width={25}
-                          height={25}
-                          className="w-6 h-6 rounded-full border border-emerald-500/20"
-                          unoptimized
+                          width="25"
+                          height="25"
+                          className="w-6 h-6 rounded-full border border-emerald-500/20 object-cover"
                           onError={(e) => {
                             const img = e.currentTarget as HTMLImageElement;
                             img.onerror = null;
@@ -800,13 +799,12 @@ export default function LandingPageClient() {
                             key={s}
                             className="inline-flex items-center gap-1.5 rounded-full border border-zinc-200/10 bg-zinc-200/5 dark:border-white/5 dark:bg-[#111] pl-2 pr-1.5 py-1 text-xs text-zinc-700 dark:text-white/70 transition-all duration-300 hover:border-emerald-500/30 hover:bg-zinc-200/10 dark:hover:bg-white/10 dark:hover:text-white select-none group/pill"
                           >
-                            <Image
+                            <img
                               src={`https://github.com/${displayName}.png?size=40`}
                               alt={displayName}
-                              width={17}
-                              height={17}
-                              className="w-4 h-4 rounded-full border border-zinc-200/20 dark:border-white/20"
-                              unoptimized
+                              width="17"
+                              height="17"
+                              className="w-4 h-4 rounded-full border border-zinc-200/20 dark:border-white/20 object-cover"
                               onError={(e) => {
                                 const img = e.currentTarget as HTMLImageElement;
                                 img.onerror = null;

--- a/app/contributors/ContributorsSearch.tsx
+++ b/app/contributors/ContributorsSearch.tsx
@@ -180,12 +180,12 @@ export default function ContributorsSearch({
                   {/* AVATAR */}
                   <div className="relative mb-5">
                     <div className="absolute inset-0 rounded-full bg-cyan-500/30 blur-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-700 scale-[2]" />
-                    <Image
+                    <img
                       src={contributor.avatar_url}
                       alt={contributor.login}
-                      width={90}
-                      height={90}
-                      className="relative rounded-full border-2 border-black/10 dark:border-white/10 transition-all duration-500 group-hover:border-cyan-500/50 dark:group-hover:border-cyan-400/50 group-hover:scale-105"
+                      width="90"
+                      height="90"
+                      className="relative rounded-full border-2 border-black/10 dark:border-white/10 transition-all duration-500 group-hover:border-cyan-500/50 dark:group-hover:border-cyan-400/50 group-hover:scale-105 object-cover"
                     />
                     {/* Online indicator */}
                     <div className="absolute bottom-1 right-1 w-4 h-4 rounded-full bg-emerald-500 border-2 border-[#0a0a0a] opacity-0 group-hover:opacity-100 transition-opacity" />

--- a/app/generator/components/sections/CommitPulseSection.tsx
+++ b/app/generator/components/sections/CommitPulseSection.tsx
@@ -298,12 +298,12 @@ export function CommitPulseSection({
                   )
                 ) : userDetails ? (
                   <div className="flex items-center gap-2.5 rounded-xl bg-emerald-500/5 border border-emerald-500/15 px-3 py-2">
-                    <Image
+                    <img
                       src={userDetails.avatar_url}
                       alt={`@${userDetails.login}`}
-                      width={22}
-                      height={22}
-                      className="rounded-full border border-emerald-500/20 flex-shrink-0"
+                      width="22"
+                      height="22"
+                      className="rounded-full border border-emerald-500/20 flex-shrink-0 object-cover"
                     />
                     <div className="flex flex-col min-w-0">
                       <span className="text-xs font-semibold text-gray-900 dark:text-white truncate">

--- a/components/DeveloperArena.tsx
+++ b/components/DeveloperArena.tsx
@@ -521,11 +521,10 @@ export default function DeveloperArena({ onSelectBattle }: DeveloperArenaProps) 
                     className="flex items-start gap-4"
                   >
                     <div className="relative w-16 h-16 rounded-xl overflow-hidden border border-white/10 shrink-0">
-                      <Image
+                      <img
                         src={`https://github.com/${currentChallenge.username}.png`}
                         alt={currentChallenge.name}
-                        fill
-                        className="object-cover"
+                        className="w-full h-full object-cover"
                       />
                     </div>
                     <div className="space-y-1">
@@ -723,11 +722,10 @@ export default function DeveloperArena({ onSelectBattle }: DeveloperArenaProps) 
                   </div>
                   <div className="flex items-center gap-3">
                     <div className="relative w-12 h-12 rounded-full overflow-hidden border border-white/10 bg-zinc-800 shrink-0">
-                      <Image
+                      <img
                         src={`https://github.com/${legend.username}.png`}
                         alt={legend.name}
-                        fill
-                        className="object-cover"
+                        className="w-full h-full object-cover"
                       />
                     </div>
                     <div className="space-y-0.5">

--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -108,12 +108,10 @@ export default function Leaderboard({ contributors = [] }: LeaderboardProps) {
               {/* Avatar */}
               <div className="relative w-10 h-10 rounded-full overflow-hidden border border-black/10 dark:border-white/10 group-hover:border-cyan-400/40 transition-colors">
                 {contributor.avatar_url ? (
-                  <Image
+                  <img
                     src={contributor.avatar_url}
                     alt={contributor.login}
-                    fill
-                    unoptimized
-                    className="object-cover"
+                    className="w-full h-full object-cover"
                   />
                 ) : (
                   <div className="w-full h-full bg-zinc-200 dark:bg-white/10" />
@@ -224,12 +222,10 @@ function PodiumItem({ contributor, height, variant, delay, isFirst }: PodiumItem
             style={{ width: isFirst ? 88 : 72, height: isFirst ? 88 : 72 }}
           >
             {contributor.avatar_url ? (
-              <Image
+              <img
                 src={contributor.avatar_url}
                 alt={contributor.login}
-                fill
-                unoptimized
-                className="rounded-full object-cover"
+                className="rounded-full object-cover w-full h-full"
               />
             ) : (
               <div className="w-full h-full rounded-full bg-zinc-200 dark:bg-white/10" />

--- a/components/burnout/BurnoutRiskTable.tsx
+++ b/components/burnout/BurnoutRiskTable.tsx
@@ -128,13 +128,10 @@ export default function BurnoutRiskTable({ contributors }: BurnoutRiskTableProps
                     className="flex items-center gap-3 cursor-pointer"
                   >
                     <div className="relative w-8 h-8 rounded-full overflow-hidden border border-black/10 dark:border-white/10">
-                      <Image
+                      <img
                         src={c.avatarUrl}
                         alt={c.username}
-                        fill
-                        sizes="32px"
-                        priority={i < 5}
-                        className="object-cover"
+                        className="w-full h-full object-cover"
                       />
                     </div>
                     <div className="flex flex-col">

--- a/components/burnout/InactivityDetector.tsx
+++ b/components/burnout/InactivityDetector.tsx
@@ -75,12 +75,10 @@ export default function InactivityDetector({ alerts }: InactivityDetectorProps) 
               rel="noopener noreferrer"
               className="relative w-9 h-9 rounded-full overflow-hidden border border-black/10 dark:border-white/10 shrink-0 cursor-pointer"
             >
-              <Image
+              <img
                 src={alert.avatarUrl}
                 alt={alert.username}
-                fill
-                sizes="36px"
-                className="object-cover"
+                className="w-full h-full object-cover"
               />
             </a>
 

--- a/components/dashboard/GithubWrapped.tsx
+++ b/components/dashboard/GithubWrapped.tsx
@@ -50,16 +50,16 @@ export default function GithubWrapped({ profile, wrappedData }: GithubWrappedPro
         {/* Header */}
         <motion.div variants={itemVariants} className="flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <Image
+            <img
               src={
                 profile.avatarUrl.startsWith('http') || profile.avatarUrl.startsWith('/')
                   ? profile.avatarUrl
                   : `/${profile.avatarUrl}`
               }
               alt={profile.name || 'GitHub profile avatar'}
-              width={64}
-              height={64}
-              className="w-16 h-16 rounded-full border-2 border-white/20"
+              width="64"
+              height="64"
+              className="w-16 h-16 rounded-full border-2 border-white/20 object-cover"
             />
             <div>
               <h2 className="text-2xl font-bold tracking-tight">{profile.name}</h2>

--- a/components/dashboard/HallOfFame.tsx
+++ b/components/dashboard/HallOfFame.tsx
@@ -93,13 +93,12 @@ export default function HallOfFame({ data }: HallOfFameProps) {
                 {/* Middle/Bottom: Repo Name & Avatar */}
                 <div className="group flex items-center gap-4 p-4 bg-gray-100 dark:bg-[#111] rounded-xl border border-black/10 dark:border-[rgba(255,255,255,0.05)]">
                   {award.repoAvatar ? (
-                    <Image
+                    <img
                       src={award.repoAvatar}
                       alt={award.repoName}
-                      width={40}
-                      height={40}
-                      className="rounded-full shadow-md bg-white border border-black/10 dark:border-white/10"
-                      unoptimized
+                      width="40"
+                      height="40"
+                      className="rounded-full shadow-md bg-white border border-black/10 dark:border-white/10 object-cover"
                     />
                   ) : (
                     <div className="w-10 h-10 rounded-full bg-gray-100 dark:bg-[#111] border border-black/10 dark:border-white/10 flex items-center justify-center">

--- a/components/dashboard/ProfileCard.tsx
+++ b/components/dashboard/ProfileCard.tsx
@@ -46,15 +46,15 @@ export default function ProfileCard({ user, exportData, badges }: ProfileCardPro
         <div className="flex flex-col items-center text-center">
           <div className="relative mb-5">
             <div className="w-24 h-24 rounded-full overflow-hidden border border-black/10 dark:border-[rgba(255,255,255,0.12)]">
-              <Image
+              <img
                 src={
                   user.avatarUrl.startsWith('http')
                     ? `${user.avatarUrl}${user.avatarUrl.includes('?') ? '&' : '?'}s=120`
                     : user.avatarUrl
                 }
                 alt={user.name || 'Contributor Avatar'}
-                width={96}
-                height={96}
+                width="96"
+                height="96"
                 className="w-full h-full aspect-square object-cover"
               />
             </div>

--- a/components/dashboard/ShareSheet.tsx
+++ b/components/dashboard/ShareSheet.tsx
@@ -123,13 +123,12 @@ function GitHubAvatar({ username }: { username: string }) {
 
   if (src) {
     return (
-      <NextImage
+      <img
         src={src}
         alt={username}
-        width={36}
-        height={36}
+        width="36"
+        height="36"
         className="w-9 h-9 rounded-full ring-2 ring-zinc-200 dark:ring-zinc-700 object-cover shrink-0"
-        unoptimized
       />
     );
   }


### PR DESCRIPTION
## Description
GitHub avatars were failing to render in production, causing avatar placeholders and alt text to appear instead of profile images.

Investigation revealed that avatar requests were being routed through Next.js image optimization (`/_next/image`) and failing with:

`x-vercel-error: OPTIMIZED_IMAGE_REQUEST_PAYMENT_REQUIRED`

Because GitHub avatars are externally hosted and publicly accessible, image optimization is not required for correct rendering. This change replaces Next.js `Image` components used for GitHub avatars with native `img` elements throughout the codebase, allowing browsers to fetch avatar images directly from `avatars.githubusercontent.com`.

Changes:

* Replaced GitHub avatar `Image` components with native `img` elements across all affected views.
* Removed dependency on Next.js/Vercel image optimization for avatar rendering.
* Preserved existing avatar styling, sizing, and layout behavior.

Expected result:

* GitHub avatars render correctly even when Vercel image optimization requests fail.
* Avatar loading no longer depends on the `/_next/image` optimization endpoint.
* Consistent avatar rendering across compare pages, profile cards, leaderboards, and other avatar-based UI components.

Fixes #6252 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

<img width="1919" height="1079" alt="Screenshot 2026-06-22 220039" src="https://github.com/user-attachments/assets/0e54b377-931d-497a-ac88-6606fff0af3c" />

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
