### PR TITLE
fix(ci-analytics): guard successRate against divide-by-zero and exclude zero-duration runs from avg

### DIFF
--- a/services/github/ci-analytics.test.ts
+++ b/services/github/ci-analytics.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { processRuns } from './ci-analytics';
+import type { CIWorkflowRun } from '@/types/ci-analytics';
+
+function makeRun(overrides: Partial<CIWorkflowRun>): CIWorkflowRun {
+  return {
+    id: 1,
+    name: 'CI',
+    repository: 'owner/repo',
+    branch: 'main',
+    status: 'completed',
+    conclusion: 'success',
+    duration: 60,
+    triggerEvent: 'push',
+    startedAt: '2026-01-01T00:00:00Z',
+    finishedAt: '2026-01-01T00:01:00Z',
+    url: 'https://example.test',
+    ...overrides,
+  };
+}
+
+describe('processRuns', () => {
+  it('returns a 0 success rate (never NaN) when no run has a success or failure conclusion', () => {
+    const runs = [
+      makeRun({ conclusion: 'cancelled' }),
+      makeRun({ conclusion: null, status: 'in_progress' }),
+      makeRun({ conclusion: 'skipped' }),
+    ];
+
+    const result = processRuns(runs);
+
+    expect(result.totalRuns).toBe(3);
+    expect(result.successRate).toBe(0);
+    expect(Number.isNaN(result.successRate)).toBe(false);
+  });
+
+  it('computes the success rate over decided runs only (success + failure)', () => {
+    const runs = [
+      makeRun({ conclusion: 'success' }),
+      makeRun({ conclusion: 'success' }),
+      makeRun({ conclusion: 'success' }),
+      makeRun({ conclusion: 'failure' }),
+      makeRun({ conclusion: 'cancelled' }),
+      makeRun({ conclusion: null, status: 'queued' }),
+    ];
+
+    // 3 success out of 4 decided runs = 75%; cancelled and queued runs are excluded.
+    expect(processRuns(runs).successRate).toBe(75);
+  });
+
+  it('excludes zero-duration completed runs from the average build duration', () => {
+    const runs = [
+      makeRun({ conclusion: 'success', duration: 100 }),
+      makeRun({ conclusion: 'failure', duration: 200 }),
+      makeRun({ conclusion: 'cancelled', duration: 0 }),
+    ];
+
+    // Average over the two runs with a real duration: (100 + 200) / 2 = 150.
+    expect(processRuns(runs).avgBuildDuration).toBe(150);
+  });
+});

--- a/services/github/ci-analytics.ts
+++ b/services/github/ci-analytics.ts
@@ -199,7 +199,7 @@ function calculateDurationFallback(startedAt: string, finishedAt: string): numbe
   }
 }
 
-function processRuns(runs: CIWorkflowRun[]) {
+export function processRuns(runs: CIWorkflowRun[]) {
   const totalRuns = runs.length;
   const successfulRuns = runs.filter((r) => r.conclusion === 'success').length;
   const failedRuns = runs.filter((r) => r.conclusion === 'failure').length;
@@ -211,10 +211,10 @@ function processRuns(runs: CIWorkflowRun[]) {
       r.status === 'pending' ||
       r.status === 'waiting'
   ).length;
-  const successRate =
-    totalRuns > 0 ? Math.round((successfulRuns / (successfulRuns + failedRuns)) * 100) : 0;
+  const decidedRuns = successfulRuns + failedRuns;
+  const successRate = decidedRuns > 0 ? Math.round((successfulRuns / decidedRuns) * 100) : 0;
 
-  const completedRuns = runs.filter((r) => r.conclusion !== null);
+  const completedRuns = runs.filter((r) => r.conclusion !== null && r.duration > 0);
   const totalDuration = completedRuns.reduce((sum, r) => sum + r.duration, 0);
   const avgBuildDuration =
     completedRuns.length > 0 ? Math.round(totalDuration / completedRuns.length) : 0;


### PR DESCRIPTION
## Description

Fixes #6337

`processRuns` in `services/github/ci-analytics.ts` computed `successRate` by guarding on `totalRuns > 0` while dividing by `successfulRuns + failedRuns`. For a repo whose fetched runs are all `cancelled` / `skipped` / `queued` / `in_progress` (so `successfulRuns = 0` and `failedRuns = 0`) but `totalRuns > 0`, this is `Math.round(0 / 0)` = `NaN`, which serializes to `null` in the API response.

This change guards on the actual denominator:

```ts
const decidedRuns = successfulRuns + failedRuns;
const successRate = decidedRuns > 0 ? Math.round((successfulRuns / decidedRuns) * 100) : 0;
```

So with no decided runs the rate is `0` (the existing fallback value), never `NaN`/`null`. Repos with at least one success/failure are unaffected (the rate is still success over decided runs).

It also fixes `avgBuildDuration`, which divided by `completedRuns.length` where `completedRuns` only required `conclusion !== null`. Runs whose duration could not be computed fall back to `0` and were inflating the denominator. The filter now also requires `r.duration > 0`, matching `buildInsights`:

```ts
const completedRuns = runs.filter((r) => r.conclusion !== null && r.duration > 0);
```

`processRuns` is now exported so the aggregation can be unit-tested directly.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No UI change. The `/api/ci-analytics` JSON now returns a numeric `successRate` (0 when there are no decided runs) instead of `null`, and `avgBuildDuration` excludes zero-duration runs.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (new `services/github/ci-analytics.test.ts`, 3 tests, plus the existing route test pass; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). (Not an SVG change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
