### PR TITLE
fix(contributors): sort contributors before slicing the top 6 leaderboard

### DIFF
--- a/app/contributors/page.top-contributors.test.tsx
+++ b/app/contributors/page.top-contributors.test.tsx
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+type Contributor = {
+  id: number;
+  login: string;
+  avatar_url: string;
+  contributions: number;
+  html_url: string;
+};
+
+type ContributorsClientProps = {
+  contributors: Contributor[];
+  totalContributions: number;
+  topContributors: Contributor[];
+};
+
+const mockContributorsClient = vi.fn((props: ContributorsClientProps) => {
+  void props;
+
+  return <div data-testid="contributors-client">Contributors Client</div>;
+});
+
+vi.mock('./ContributorsClient', () => ({
+  default: (props: ContributorsClientProps) => mockContributorsClient(props),
+}));
+
+function contributor(id: number, contributions: number): Contributor {
+  return {
+    id,
+    login: `contributor-${id}`,
+    avatar_url: `https://avatars.githubusercontent.com/u/${id}?v=4`,
+    contributions,
+    html_url: `https://github.com/contributor-${id}`,
+  };
+}
+
+describe('ContributorsPage top contributors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('ranks the global top 6 by contributions even when the highest contributors are not first in API order', async () => {
+    // The two highest contributors are at positions 7 and 8, beyond the first 6.
+    // A slice-before-sort would miss them; a sort-before-slice keeps them.
+    const unordered = [
+      contributor(1, 1),
+      contributor(2, 2),
+      contributor(3, 3),
+      contributor(4, 4),
+      contributor(5, 5),
+      contributor(6, 6),
+      contributor(7, 100),
+      contributor(8, 99),
+    ];
+
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => unordered,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { default: ContributorsPage } = await import('./page');
+    const page = await ContributorsPage();
+    render(page);
+
+    const props = mockContributorsClient.mock.calls[0][0] as ContributorsClientProps;
+
+    expect(props.topContributors).toHaveLength(6);
+    expect(props.topContributors.map((c) => c.contributions)).toEqual([100, 99, 6, 5, 4, 3]);
+    // The full contributors list is passed through untouched (not mutated by the ranking).
+    expect(props.contributors.map((c) => c.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+});

--- a/app/contributors/page.tsx
+++ b/app/contributors/page.tsx
@@ -89,9 +89,9 @@ export default async function ContributorsPage() {
     0
   );
 
-  const topContributors = contributors
-    .slice(0, 6)
-    .sort((a, b) => b.contributions - a.contributions);
+  const topContributors = [...contributors]
+    .sort((a, b) => b.contributions - a.contributions)
+    .slice(0, 6);
 
   return (
     <ContributorsClient


### PR DESCRIPTION
## Description

Fixes #6339

The `/contributors` "Vanguard" leaderboard sliced the contributors list before sorting it:

```ts
const topContributors = contributors
  .slice(0, 6)
  .sort((a, b) => b.contributions - a.contributions);
```

`.slice(0, 6)` ran first, so only the first 6 entries in GitHub's returned order were ever ranked. It looked correct only because the GitHub `/contributors` endpoint usually returns descending order, which is not guaranteed for ties / anonymous contributors or if the array is ever reordered.

This change sorts first, then slices, so the leaderboard always reflects the global top 6:

```ts
const topContributors = [...contributors]
  .sort((a, b) => b.contributions - a.contributions)
  .slice(0, 6);
```

It uses a copy (`[...contributors]`) so the full `contributors` list passed to `ContributorsClient` is not mutated by the ranking.

Added `app/contributors/page.top-contributors.test.tsx`, which feeds an unsorted array whose two highest contributors sit at positions 7 and 8 and asserts the top 6 are ranked correctly (and that the passed-through list is not reordered). The test fails against the old slice-before-sort code.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No layout change. The leaderboard now shows the actual top 6 contributors by contribution count regardless of the order the data arrives in.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (new `page.top-contributors.test.tsx` plus the existing contributors page suite, 46 tests, pass; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). (Not an SVG change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
