### PR TITLE
fix(burnout-analyzer): validate exactly owner/repo and URL-encode the request params

### DIFF
--- a/app/burnout-analyzer/page.test.tsx
+++ b/app/burnout-analyzer/page.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import BurnoutAnalyzerPage from './page';
+
+describe('BurnoutAnalyzerPage repository input handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a path that is not exactly owner/repo and does not call the API', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<BurnoutAnalyzerPage />);
+    fireEvent.change(screen.getByPlaceholderText(/facebook\/react/i), {
+      target: { value: 'facebook/react/tree/main' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /analyze/i }));
+
+    expect(await screen.findByText(/valid repository path/i)).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('URL-encodes owner and repo so the typed input is what gets validated, not a different repo', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'Invalid repo name format' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<BurnoutAnalyzerPage />);
+    fireEvent.change(screen.getByPlaceholderText(/facebook\/react/i), {
+      target: { value: 'foo/bar&x=1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /analyze/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain(`repo=${encodeURIComponent('bar&x=1')}`);
+    // Without encoding the "&x=1" would split into a spurious query param and the
+    // server would receive repo=bar (a different, valid repo) instead of the typed value.
+    expect(calledUrl).not.toContain('repo=bar&x=1');
+  });
+
+  it('sends a correctly encoded request for a valid owner/repo', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'stop here' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<BurnoutAnalyzerPage />);
+    fireEvent.change(screen.getByPlaceholderText(/facebook\/react/i), {
+      target: { value: 'facebook/react' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /analyze/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/repo-burnout?owner=facebook&repo=react');
+  });
+});

--- a/app/burnout-analyzer/page.tsx
+++ b/app/burnout-analyzer/page.tsx
@@ -43,20 +43,23 @@ export default function BurnoutAnalyzerPage() {
 
   const handleSearch = async (e?: React.FormEvent, targetRepo?: string) => {
     if (e) e.preventDefault();
-    const repoPath = targetRepo || query;
-    if (!repoPath.trim() || !repoPath.includes('/')) {
+    const repoPath = (targetRepo || query).trim();
+    const segments = repoPath.split('/');
+    if (segments.length !== 2 || !segments[0].trim() || !segments[1].trim()) {
       setError('Please enter a valid repository path in "owner/repo" format.');
       return;
     }
+    const owner = segments[0].trim();
+    const repo = segments[1].trim();
 
     setIsLoading(true);
     setError(null);
     setReport(null);
 
-    const [owner, repo] = repoPath.trim().split('/');
-
     try {
-      const res = await fetch(`/api/repo-burnout?owner=${owner}&repo=${repo}`);
+      const res = await fetch(
+        `/api/repo-burnout?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(repo)}`
+      );
       const data = await res.json();
 
       if (!res.ok) {
@@ -80,7 +83,9 @@ export default function BurnoutAnalyzerPage() {
     const [owner, repo] = report.repoName.split('/');
 
     try {
-      const res = await fetch(`/api/repo-burnout?owner=${owner}&repo=${repo}&refresh=true`);
+      const res = await fetch(
+        `/api/repo-burnout?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(repo)}&refresh=true`
+      );
       const data = await res.json();
 
       if (!res.ok) {


### PR DESCRIPTION
## Description

Fixes #6341

`app/burnout-analyzer/page.tsx` mishandled the owner/repo text input:

- The only validation was `repoPath.includes('/')`, then `const [owner, repo] = ...split('/')`, so a path with extra segments (for example `facebook/react/tree/main`) passed and was silently analyzed as `facebook/react` (the rest dropped).
- `owner`/`repo` were interpolated into the request URL without encoding, so a typed value containing `&`, `#`, or a space corrupted the query string (for example `foo/bar&x=1` became `...?owner=foo&repo=bar&x=1`, so the server received a different repo plus a spurious param).

This change:

- Validates exactly two non-empty segments and rejects anything else with the existing error message.
- URL-encodes `owner` and `repo` with `encodeURIComponent` in both the analyze and refresh requests, so the value the user typed is exactly what is sent (and validated by the route).

Scope note: I also looked at the request-race and "disable the button while loading" angles and found them already mitigated by the existing UI. When `isLoading` is true the search form (with its Analyze button and the suggestion buttons) unmounts and is replaced by the loading skeleton, so a second concurrent analyze cannot be triggered from this page; and the refresh button is already `disabled={isRefreshing}` in `RepoHeader`. So I did not add an AbortController or further button-disabling, to keep the change minimal.

Added `app/burnout-analyzer/page.test.tsx` covering the rejection of a 3-segment path (no API call is made) and the URL-encoding of special characters; both tests fail against the old code.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No layout change. Malformed paths now show the existing validation error instead of silently analyzing a different repo, and special characters in the input are encoded into the request.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (new `app/burnout-analyzer/page.test.tsx`, 3 tests, pass; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). (Not an SVG change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
