### PR TITLE
fix(generator): prevent form submission when pressing Enter in GitHub username inputs

### DIFF
--- a/app/generator/components/EditorPanel.tsx
+++ b/app/generator/components/EditorPanel.tsx
@@ -49,8 +49,14 @@ export function EditorPanel({
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
 
   return (
-    <form role="form" aria-label="Readme Configuration Editor" className="flex flex-col gap-4">
+    <form
+      role="form"
+      aria-label="Readme Configuration Editor"
+      className="flex flex-col gap-4"
+      onSubmit={(e) => e.preventDefault()}
+    >
       <button
+        type="button"
         onClick={() => setIsImportModalOpen(true)}
         className="w-full group relative flex items-center justify-center gap-2.5 px-4 py-3.5 rounded-2xl bg-white dark:bg-[#111111] border border-gray-200 dark:border-white/10 hover:border-emerald-500/30 dark:hover:border-emerald-500/30 shadow-sm transition-all overflow-hidden"
       >

--- a/app/generator/components/GitHubImportModal.tsx
+++ b/app/generator/components/GitHubImportModal.tsx
@@ -114,6 +114,7 @@ export function GitHubImportModal({ isOpen, onClose, onApply }: GitHubImportModa
             Import from GitHub
           </h2>
           <button
+            type="button"
             onClick={handleClose}
             className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-white transition-colors rounded-lg hover:bg-gray-100 dark:hover:bg-white/10"
             aria-label="Close modal"
@@ -155,12 +156,14 @@ export function GitHubImportModal({ isOpen, onClose, onApply }: GitHubImportModa
 
               <div className="pt-2 flex justify-end gap-3">
                 <button
+                  type="button"
                   onClick={handleClose}
                   className="px-4 py-2 rounded-xl text-sm font-medium text-gray-600 dark:text-white/70 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors"
                 >
                   Cancel
                 </button>
                 <button
+                  type="button"
                   onClick={handleFetch}
                   disabled={!username.trim() || status === 'loading'}
                   className="px-5 py-2 rounded-xl text-sm font-bold bg-gray-900 dark:bg-white text-white dark:text-black hover:bg-gray-800 dark:hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 transition-colors"
@@ -259,12 +262,14 @@ export function GitHubImportModal({ isOpen, onClose, onApply }: GitHubImportModa
 
               <div className="pt-2 flex justify-end gap-3">
                 <button
+                  type="button"
                   onClick={() => setStatus('idle')}
                   className="px-4 py-2 rounded-xl text-sm font-medium text-gray-600 dark:text-white/70 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors"
                 >
                   Back
                 </button>
                 <button
+                  type="button"
                   onClick={handleApply}
                   className="px-5 py-2 rounded-xl text-sm font-bold bg-emerald-500 text-white hover:bg-emerald-600 transition-colors"
                 >


### PR DESCRIPTION
## Description

Fixed an issue on the Generator page where pressing **Enter** inside GitHub username inputs (Display Name, CommitPulse Badge, and Contribution Visualizer sections) triggered a full page reload, causing all Generator state to be lost.

## Root Cause

The Generator editor was wrapped in a `<form>` element without a submit handler. When users pressed Enter inside an input field, the browser performed a native form submission, resulting in a page navigation and complete loss of React state.

Additionally, several buttons rendered within the form hierarchy did not specify a `type` attribute. In HTML, buttons inside forms default to `type="submit"`, creating multiple unintended form submission paths.

## Changes

### EditorPanel.tsx

* Added `onSubmit={(e) => e.preventDefault()}` to prevent native form submission.
* Added `type="button"` to the "Import from GitHub" button.

### GitHubImportModal.tsx

Added `type="button"` to all modal action buttons:

* Close (×)
* Cancel
* Import Profile
* Back
* Apply Selected

## Result

* Pressing Enter in GitHub username inputs no longer triggers a page reload.
* Generator state is preserved.
* GitHub import, validation, and fetch logic continue to work as expected.
* All buttons within the editor and modal now behave independently of form submission.


Fixes #6253 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview


https://github.com/user-attachments/assets/e8098d7d-dcbd-462f-a25f-8cd2403d8ea7



## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
