### PR TITLE
fix(i18n): render the landing hero from landing.title so it translates

### DIFF
--- a/app/components/LandingPageClient.tsx
+++ b/app/components/LandingPageClient.tsx
@@ -2,6 +2,7 @@
 import Image from 'next/image';
 import { trackUser } from '@/utils/tracking';
 import { useTranslation } from '@/context/TranslationContext';
+import { renderHeroTitle } from './heroTitle';
 
 import Link from 'next/link';
 import { useRef, useState, useEffect } from 'react';
@@ -581,11 +582,9 @@ export default function LandingPageClient() {
 
           <div ref={heroRef}>
             <h1 className="hero-text opacity-0 translate-y-10 mb-8 bg-gradient-to-br from-gray-900 via-black to-gray-600 dark:from-white dark:via-gray-100 dark:to-gray-500 bg-clip-text text-transparent text-5xl font-black tracking-tighter md:text-8xl pb-2">
-              Elevate Your <br />{' '}
-              <span className="contribution-text inline-block bg-[length:300%_300%] bg-gradient-to-r from-emerald-400 via-cyan-500 to-purple-500 bg-clip-text text-transparent drop-shadow-sm">
-                Contribution
-              </span>{' '}
-              Story.
+              {renderHeroTitle(
+                t('landing.title', { defaultValue: 'Elevate Your\n{Contribution} Story.' })
+              )}
             </h1>
           </div>
 

--- a/app/components/heroTitle.test.tsx
+++ b/app/components/heroTitle.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { renderHeroTitle } from './heroTitle';
+
+describe('renderHeroTitle', () => {
+  it('renders the English default with the braced word in the accent span and a line break', () => {
+    const { container } = render(<h1>{renderHeroTitle('Elevate Your\n{Contribution} Story.')}</h1>);
+
+    expect(container.textContent).toBe('Elevate YourContribution Story.');
+    expect(container.querySelector('br')).not.toBeNull();
+    const highlight = container.querySelector('.contribution-text');
+    expect(highlight?.textContent).toBe('Contribution');
+  });
+
+  it('highlights the braced word wherever it sits in a translated title (mid-line)', () => {
+    // Japanese: the highlight is in the middle of the first line.
+    const { container } = render(
+      <h1>{renderHeroTitle('あなたの{開発の軌跡}を\n立体的に表現する。')}</h1>
+    );
+
+    expect(container.textContent).toBe('あなたの開発の軌跡を立体的に表現する。');
+    expect(container.querySelector('.contribution-text')?.textContent).toBe('開発の軌跡');
+    expect(container.querySelector('br')).not.toBeNull();
+  });
+
+  it('highlights a leading braced word (start of the title)', () => {
+    // Korean: the highlight is the very first token.
+    const { container } = render(<h1>{renderHeroTitle('{기여} 내역을\n더 돋보이게.')}</h1>);
+
+    expect(container.textContent).toBe('기여 내역을더 돋보이게.');
+    expect(container.querySelector('.contribution-text')?.textContent).toBe('기여');
+  });
+
+  it('does not leave brace markers in the rendered output', () => {
+    const { container } = render(
+      <h1>{renderHeroTitle('Eleva tu historia\nde {contribuciones}.')}</h1>
+    );
+
+    expect(container.textContent).not.toContain('{');
+    expect(container.textContent).not.toContain('}');
+    expect(container.querySelector('.contribution-text')?.textContent).toBe('contribuciones');
+  });
+});

--- a/app/components/heroTitle.tsx
+++ b/app/components/heroTitle.tsx
@@ -1,0 +1,24 @@
+import { Fragment, type ReactNode } from 'react';
+
+const HIGHLIGHT_CLASS =
+  'contribution-text inline-block bg-[length:300%_300%] bg-gradient-to-r from-emerald-400 via-cyan-500 to-purple-500 bg-clip-text text-transparent drop-shadow-sm';
+
+// Localized hero title: "\n" is a line break and a single-brace {word} is the
+// gradient-highlighted word (kept as .contribution-text for the GSAP animation).
+export function renderHeroTitle(title: string): ReactNode {
+  return title.split('\n').map((line, lineIndex) => (
+    <Fragment key={lineIndex}>
+      {lineIndex > 0 && <br />}
+      {line.split(/(\{[^}]+\})/g).map((part, partIndex) => {
+        const highlighted = part.match(/^\{([^}]+)\}$/);
+        return highlighted ? (
+          <span key={partIndex} className={HIGHLIGHT_CLASS}>
+            {highlighted[1]}
+          </span>
+        ) : (
+          <Fragment key={partIndex}>{part}</Fragment>
+        );
+      })}
+    </Fragment>
+  ));
+}


### PR DESCRIPTION
## Description

Fixes #6344

The landing hero `<h1>` was hardcoded English ("Elevate Your Contribution Story."), so it never translated, even though every locale already defines `landing.title` (which had no consumer anywhere in the code).

This change renders the hero from `t('landing.title')`. The locale values encode the layout as `\n` for the line break and a single-brace `{word}` for the gradient-highlighted word (the highlighted word sits in a different position per language). A small `renderHeroTitle` helper parses that format: it splits on `\n` into `<br/>`-separated lines and wraps each `{word}` in the existing accent gradient span. The span keeps the `contribution-text` class so the existing GSAP animation still targets it.

For English the rendered text is unchanged (the `en` value is `"Elevate Your\n{Contribution} Story."`, which renders the same hero as before). Non-English visitors now see the translated headline instead of English.

Verification note: the parsing helper (the substantive, format-sensitive part) is unit-tested in `app/components/heroTitle.test.tsx` against the English default and several non-English titles (highlight at the start and in the middle of a line, and confirming no stray brace characters remain). I did not add a full render test of `LandingPageClient` itself because that component pulls in GSAP, framer-motion, routing, fetch, and many child components; the change to it is a direct one-block replacement of the hardcoded markup with `renderHeroTitle(t('landing.title', ...))`.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No layout change for English. On non-English locales the hero headline now renders in the selected language (with the same gradient-highlighted word), instead of always showing English.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (new `app/components/heroTitle.test.tsx`, 4 tests, pass; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). (Not an SVG change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
