### PR TITLE
fix(i18n): wire the Portuguese (pt) locale into the language switcher

### DIFF
--- a/context/TranslationContext.tsx
+++ b/context/TranslationContext.tsx
@@ -17,8 +17,9 @@ import zh from '@/locales/zh.json';
 import ja from '@/locales/ja.json';
 import ko from '@/locales/ko.json';
 import de from '@/locales/de.json';
+import pt from '@/locales/pt.json';
 
-export type Language = 'en' | 'es' | 'hi' | 'fr' | 'zh' | 'ja' | 'ko' | 'de';
+export type Language = 'en' | 'es' | 'hi' | 'fr' | 'zh' | 'ja' | 'ko' | 'de' | 'pt';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const translations: Record<Language, any> = {
@@ -30,6 +31,7 @@ const translations: Record<Language, any> = {
   ja,
   ko,
   de,
+  pt,
 };
 
 export const LANGUAGE_LABELS: Record<Language, string> = {
@@ -41,6 +43,7 @@ export const LANGUAGE_LABELS: Record<Language, string> = {
   ja: '\u65e5\u672c\u8a9e',
   ko: '\ud55c\uad6d\uc5b4',
   de: 'Deutsch',
+  pt: 'Português',
 };
 
 interface TranslationContextType {

--- a/locales/pt.test.ts
+++ b/locales/pt.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { LANGUAGE_LABELS } from '@/context/TranslationContext';
+import en from './en.json';
+import pt from './pt.json';
+
+// Flatten a nested locale object into dot-paths -> string leaves. We compare the
+// *entire* key surface (not just the top level) because a single missing nested
+// key silently falls back to English in the UI via the t() helper, which is the
+// kind of gap a reviewer can't spot by eye across 200+ strings.
+function flatten(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === 'object') {
+      Object.assign(out, flatten(value as Record<string, unknown>, path));
+    } else {
+      out[path] = String(value);
+    }
+  }
+  return out;
+}
+
+// Collect the {{placeholder}} tokens a string exposes to t()'s param replacement,
+// sorted so order differences between languages don't cause false failures.
+function placeholders(value: string): string[] {
+  return (value.match(/{{\s*\w+\s*}}/g) ?? []).sort();
+}
+
+const enFlat = flatten(en);
+const ptFlat = flatten(pt);
+
+describe('Portuguese (pt) locale', () => {
+  it('is registered in the language switcher as Português', () => {
+    expect(LANGUAGE_LABELS.pt).toBe('Português');
+  });
+
+  it('defines exactly the same keys as the English source of truth', () => {
+    expect(Object.keys(ptFlat).sort()).toEqual(Object.keys(enFlat).sort());
+  });
+
+  it('has a non-empty translation for every key', () => {
+    const blank = Object.entries(ptFlat)
+      .filter(([, value]) => value.trim().length === 0)
+      .map(([path]) => path);
+    expect(blank).toEqual([]);
+  });
+
+  it('preserves the same {{placeholder}} tokens as English in every value', () => {
+    const mismatched = Object.keys(enFlat).filter(
+      (path) => placeholders(enFlat[path]).join(',') !== placeholders(ptFlat[path] ?? '').join(',')
+    );
+    expect(mismatched).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #6347

`locales/pt.json` shipped with a full set of translations, but Portuguese was never wired into the UI translation system in `context/TranslationContext.tsx`, so it was not selectable in the language switcher and the file was dead.

This change wires `pt` in, mirroring exactly how `de` is registered:

- adds `'pt'` to the `Language` type;
- imports `pt` from `@/locales/pt.json` and adds it to the `translations` map;
- adds `pt: 'Português'` to `LANGUAGE_LABELS` (the navbar switcher maps over `LANGUAGE_LABELS`, so this makes it appear).

No translations were added or changed; `pt.json` already contains all 226 keys, so Portuguese works immediately once registered.

Added `locales/pt.test.ts` (mirroring `locales/de.test.ts`) that asserts Portuguese is registered in the switcher and stays at full key parity and `{{placeholder}}` parity with the English source of truth, so it cannot silently drift out of sync.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

The navbar language switcher now lists "Português" alongside the other languages, and selecting it renders the UI in Portuguese.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (new `locales/pt.test.ts` and the existing `locales/de.test.ts` pass; navbar tests pass; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). (Not an SVG change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
