### PR TITLE
test(streak): cover monthly SVG route

### DIFF
--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -1089,12 +1089,17 @@ describe('GET /api/streak', () => {
   });
 
   describe('monthly view parameter', () => {
-    it('returns 200 when view=monthly is given', async () => {
+    it('returns a valid monthly SVG response when view=monthly is given', async () => {
       const response = await GET(makeRequest({ user: 'octocat', view: 'monthly' }));
 
       expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
+
       const body = await response.text();
-      expect(body).toContain('Commits This Month');
+
+      expect(body).toContain('<svg');
+      expect(body).toMatch(/commits this month/i);
+      expect(body).not.toContain('@keyframes grow-up');
     });
 
     it('automatically overrides or widens the query bounds to encompass the start of the previous month when view=monthly is requested with custom from/to params', async () => {


### PR DESCRIPTION
## Description

Fixes #1034

This PR adds focused route-level coverage for the monthly streak SVG route.

The existing `view=monthly` path already returns a monthly SVG response, but the route-level test did not fully assert the expected monthly SVG behavior. This update strengthens the existing monthly-view test in `app/api/streak/route.test.ts`.

Added assertions for:

* `200` response status
* SVG content type
* SVG body containing `<svg`
* monthly output marker: `COMMITS THIS MONTH`
* ensuring the default 3D tower animation marker `@keyframes grow-up` is not present

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — this PR only adds route-level test coverage and does not change SVG UI/output generation.

## Testing

Commands run locally:

* `npx vitest run app/api/streak/route.test.ts`
* `npx eslint app/api/streak/route.test.ts`
* `npm run format`
* `npm run lint`
* `git diff --check`

Result:

* Focused route test file passed: `1 passed`
* Focused tests passed: `194 passed`
* Focused ESLint: no errors
* `npm run format`: completed with no working-tree changes
* `npm run lint`: completed with `0 errors`; repo-wide warnings are pre-existing/unrelated
* Diff check: no whitespace errors

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
