### PR TITLE
Fix/compare rate limit

### DIFF
--- a/app/api/architecture/route.ts
+++ b/app/api/architecture/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import fs from 'fs';
-import { readdir, stat } from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import * as ts from 'typescript';
@@ -332,8 +331,8 @@ export async function POST(req: NextRequest) {
     const filesList: string[] = [];
     const allFilesSet = new Set<string>();
 
-    async function traverseDir(currentDir: string) {
-      const entries = await readdir(currentDir, { withFileTypes: true });
+    function traverseDir(currentDir: string) {
+      const entries = fs.readdirSync(currentDir, { withFileTypes: true });
 
       for (const entry of entries) {
         const fullPath = path.join(currentDir, entry.name);
@@ -342,7 +341,7 @@ export async function POST(req: NextRequest) {
         if (entry.isDirectory()) {
           if (IGNORED_DIRS.has(entry.name)) continue;
           folders.push(relativePath);
-          await traverseDir(fullPath);
+          traverseDir(fullPath);
         } else if (entry.isFile()) {
           const ext = path.extname(entry.name).toLowerCase();
           if (TEXT_EXTENSIONS.has(ext)) {
@@ -353,7 +352,7 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    await traverseDir(tempDir);
+    traverseDir(tempDir);
 
     // Limit files to analyze to prevent resource starvation or serverless timeouts
     const MAX_FILES_TO_ANALYZE = 150;
@@ -362,24 +361,17 @@ export async function POST(req: NextRequest) {
     );
 
     // Prioritize shallower file structures first, then sort by size
-    const fileMetadata = await Promise.all(
-      parsableFiles.map(async (file) => {
+    const prioritizedFiles = parsableFiles
+      .map((file) => {
         const fullPath = path.join(tempDir, file);
-        const fileStat = await stat(fullPath);
+        const stats = fs.statSync(fullPath);
         const depth = file.split('/').length;
-
-        return {
-          file,
-          depth,
-          size: fileStat.size,
-        };
+        return { file, depth, size: stats.size };
       })
-    );
-
-    const prioritizedFiles = fileMetadata
       .sort((a, b) => a.depth - b.depth || b.size - a.size)
       .slice(0, MAX_FILES_TO_ANALYZE)
       .map((item) => item.file);
+
     const prioritizedFilesSet = new Set(prioritizedFiles);
 
     // Analyze each file (Git history & AST parsing)
@@ -391,7 +383,7 @@ export async function POST(req: NextRequest) {
           const fullPath = path.join(tempDir, file);
           const ext = path.extname(file).toLowerCase();
           const fileContent = fs.readFileSync(fullPath, 'utf-8');
-          const fileStat = await stat(fullPath);
+          const stats = fs.statSync(fullPath);
           const lines = fileContent.split('\n').length;
 
           // Parse Imports & Exports
@@ -439,7 +431,7 @@ export async function POST(req: NextRequest) {
             path: file,
             name: path.basename(file),
             type: ext.slice(1),
-            size: fileStat.size,
+            size: stats.size,
             linesOfCode: lines,
             commits: commitsCount,
             lastModified,

--- a/app/api/architecture/route.ts
+++ b/app/api/architecture/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import fs from 'fs';
+import { readdir, stat } from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import * as ts from 'typescript';
@@ -331,8 +332,8 @@ export async function POST(req: NextRequest) {
     const filesList: string[] = [];
     const allFilesSet = new Set<string>();
 
-    function traverseDir(currentDir: string) {
-      const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+    async function traverseDir(currentDir: string) {
+      const entries = await readdir(currentDir, { withFileTypes: true });
 
       for (const entry of entries) {
         const fullPath = path.join(currentDir, entry.name);
@@ -341,7 +342,7 @@ export async function POST(req: NextRequest) {
         if (entry.isDirectory()) {
           if (IGNORED_DIRS.has(entry.name)) continue;
           folders.push(relativePath);
-          traverseDir(fullPath);
+          await traverseDir(fullPath);
         } else if (entry.isFile()) {
           const ext = path.extname(entry.name).toLowerCase();
           if (TEXT_EXTENSIONS.has(ext)) {
@@ -352,7 +353,7 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    traverseDir(tempDir);
+    await traverseDir(tempDir);
 
     // Limit files to analyze to prevent resource starvation or serverless timeouts
     const MAX_FILES_TO_ANALYZE = 150;
@@ -361,17 +362,24 @@ export async function POST(req: NextRequest) {
     );
 
     // Prioritize shallower file structures first, then sort by size
-    const prioritizedFiles = parsableFiles
-      .map((file) => {
+    const fileMetadata = await Promise.all(
+      parsableFiles.map(async (file) => {
         const fullPath = path.join(tempDir, file);
-        const stats = fs.statSync(fullPath);
+        const fileStat = await stat(fullPath);
         const depth = file.split('/').length;
-        return { file, depth, size: stats.size };
+
+        return {
+          file,
+          depth,
+          size: fileStat.size,
+        };
       })
+    );
+
+    const prioritizedFiles = fileMetadata
       .sort((a, b) => a.depth - b.depth || b.size - a.size)
       .slice(0, MAX_FILES_TO_ANALYZE)
       .map((item) => item.file);
-
     const prioritizedFilesSet = new Set(prioritizedFiles);
 
     // Analyze each file (Git history & AST parsing)
@@ -383,7 +391,7 @@ export async function POST(req: NextRequest) {
           const fullPath = path.join(tempDir, file);
           const ext = path.extname(file).toLowerCase();
           const fileContent = fs.readFileSync(fullPath, 'utf-8');
-          const stats = fs.statSync(fullPath);
+          const fileStat = await stat(fullPath);
           const lines = fileContent.split('\n').length;
 
           // Parse Imports & Exports
@@ -431,7 +439,7 @@ export async function POST(req: NextRequest) {
             path: file,
             name: path.basename(file),
             type: ext.slice(1),
-            size: stats.size,
+            size: fileStat.size,
             linesOfCode: lines,
             commits: commitsCount,
             lastModified,

--- a/app/api/compare/githubFetch.test.ts
+++ b/app/api/compare/githubFetch.test.ts
@@ -5,6 +5,9 @@ import { getFullDashboardData } from '../../../lib/github';
 vi.mock('../../../lib/github', () => ({
   getFullDashboardData: vi.fn(),
 }));
+vi.mock('@/lib/githubtoken', () => ({
+  getUserGitHubToken: vi.fn().mockResolvedValue(undefined),
+}));
 
 function makeRequest(user1?: string, user2?: string): Request {
   const url = new URL('http://localhost/api/compare');

--- a/app/api/compare/route.empty-fallback.test.ts
+++ b/app/api/compare/route.empty-fallback.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { GET } from './route';
-
 vi.mock('@/lib/github', () => ({
   getFullDashboardData: vi.fn(),
 }));
 
+vi.mock('@/lib/githubtoken', () => ({
+  getUserGitHubToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: vi.fn().mockResolvedValue({
+    success: true,
+  }),
+}));
+import { GET } from './route';
 import { getFullDashboardData } from '@/lib/github';
 
 function makeRequest(search: string, headers: Record<string, string> = {}): Request {

--- a/app/api/compare/route.mouse-interactivity.test.ts
+++ b/app/api/compare/route.mouse-interactivity.test.ts
@@ -6,6 +6,16 @@ vi.mock('@/lib/github', () => ({
   getFullDashboardData: vi.fn(),
 }));
 
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: vi.fn().mockResolvedValue({
+    success: true,
+  }),
+}));
+
+vi.mock('@/lib/githubtoken', () => ({
+  getUserGitHubToken: vi.fn().mockResolvedValue(undefined),
+}));
+
 function makeRequest(params: Record<string, string> = {}): Request {
   const url = new URL('http://localhost/api/compare');
   for (const [key, value] of Object.entries(params)) {

--- a/app/api/compare/route.test.ts
+++ b/app/api/compare/route.test.ts
@@ -1,10 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { GET } from './route';
 
 vi.mock('@/lib/github', () => ({
   getFullDashboardData: vi.fn(),
 }));
 
+vi.mock('@/lib/githubtoken', () => ({
+  getUserGitHubToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: vi.fn().mockResolvedValue({
+    success: true,
+  }),
+}));
+
+import { GET } from './route';
 import { getFullDashboardData } from '@/lib/github';
 
 const makeRequest = (search: string) => new Request(`http://localhost:3000/api/compare?${search}`);

--- a/app/api/compare/route.theme-contrast.test.ts
+++ b/app/api/compare/route.theme-contrast.test.ts
@@ -5,6 +5,14 @@ import { getFullDashboardData } from '@/lib/github';
 vi.mock('@/lib/github', () => ({
   getFullDashboardData: vi.fn(),
 }));
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: vi.fn().mockResolvedValue({
+    success: true,
+  }),
+}));
+vi.mock('@/lib/githubtoken', () => ({
+  getUserGitHubToken: vi.fn().mockResolvedValue(undefined),
+}));
 
 describe('ApiCompareRoute – Dark and Light Prefers-Color-Scheme Visual Cohesion', () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -3,6 +3,8 @@ import { getFullDashboardData } from '@/lib/github';
 import { getUserGitHubToken } from '@/lib/githubtoken';
 import { compareParamsSchema, coerceQueryParams } from '@/lib/validations';
 import crypto from 'crypto';
+import { rateLimit } from '@/lib/rate-limit';
+import { getClientIp } from '@/utils/getClientIp';
 
 export const revalidate = 3600;
 
@@ -51,6 +53,14 @@ function buildCompareFetchErrorResponse(user: string, reason: unknown): NextResp
 }
 
 export async function GET(request: Request) {
+  const ip = getClientIp(request);
+
+  const limit = await rateLimit(ip, 5, 30000);
+
+  if (!limit.success) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
   const { searchParams } = new URL(request.url);
 
   const parseResult = compareParamsSchema.safeParse(coerceQueryParams(searchParams));

--- a/app/api/compare/tests/comparisonStats.test.ts
+++ b/app/api/compare/tests/comparisonStats.test.ts
@@ -5,6 +5,9 @@ import { NextRequest } from 'next/server';
 vi.mock('@/lib/github', () => ({
   getFullDashboardData: vi.fn(),
 }));
+vi.mock('@/lib/githubtoken', () => ({
+  getUserGitHubToken: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { getFullDashboardData } from '@/lib/github';
 

--- a/app/api/compare/tests/validation.test.ts
+++ b/app/api/compare/tests/validation.test.ts
@@ -4,6 +4,9 @@ import { GET } from '../route';
 vi.mock('@/lib/github', () => ({
   getFullDashboardData: vi.fn(),
 }));
+vi.mock('@/lib/githubtoken', () => ({
+  getUserGitHubToken: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { getFullDashboardData } from '@/lib/github';
 


### PR DESCRIPTION
## Description

Fixes #6187 

Add rate limiting protection to the compare API endpoint (`app/api/compare/route.ts`).

### Changes Made

* Added IP-based rate limiting using the existing `rateLimit()` utility.
* Added client IP extraction using `getClientIp()`.
* Configured the compare endpoint to allow a maximum of **5 requests per 30 seconds per IP**.
* Return HTTP **429 Too Many Requests** when the limit is exceeded.
* Ensure rate limiting occurs before expensive `getFullDashboardData()` calls are executed.

### Why

The compare endpoint fetches dashboard data for two GitHub users on every request, making it significantly more expensive than single-user endpoints. Adding rate limiting helps prevent abuse, GitHub API token exhaustion, and unnecessary server load.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (API endpoint change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [ ] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
