### PR TITLE
feat: add substack to social platforms (#6371)

### DIFF
--- a/app/generator/data/socials.ts
+++ b/app/generator/data/socials.ts
@@ -471,6 +471,16 @@ export const SOCIALS: Social[] = [
     baseUrl: 'https://',
     placeholder: 'e.g. https://yourwebsite.com',
   },
+  {
+    id: 'substack',
+    name: 'Substack',
+    category: 'Portfolio',
+    iconUrl: SI('substack'),
+    type: 'simpleicon',
+    siSlug: 'substack',
+    baseUrl: 'https://substack.com/@',
+    placeholder: 'e.g. https://substack.com/@yourusername',
+  },
 
   {
     id: 'buymeacoffee',


### PR DESCRIPTION
**Title:**
feat: Add Substack to supported social platforms in the generator (#6371)

**Description:**
Fixes #6371

### Summary of Changes
- Updated `app/generator/data/socials.ts` to include a new entry for **Substack**.
- Configured the platform under the `Portfolio` category so users can effortlessly link to their newsletters or technical blogs.
- Ensured consistency with the rest of the file by mapping `iconUrl` using the `simpleicons` (SI) helper with the `substack` slug.

### Motivation and Context
Substack is widely used by developers for newsletters and technical blogging. However, it was previously missing from the generator's social options. Adding it improves content-sharing flexibility, allowing users to better showcase their written work on their profiles.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Verification
- [x] Verified `app/generator/data/socials.ts` structure and syntax.
- [x] Verified that Substack has the correct `placeholder`, `baseUrl`, and `siSlug` mapping.
