### PR TITLE
feat: Cyberpunk Neon (Dark Mode Isometric Theme) (#6372)

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -1,6 +1,6 @@
 # CommitPulse Themes
 
-All 27 available themes for your CommitPulse badge. Use the `?theme=<slug>` query parameter to apply a theme.
+All 28 available themes for your CommitPulse badge. Use the `?theme=<slug>` query parameter to apply a theme.
 
 ```
 https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
@@ -35,6 +35,7 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 | tokyonight       | `#1a1b26`  | `#c0caf5` | `#f7768e` |
 | tokyo_night      | `#1a1b26`  | `#c0caf5` | `#7aa2f7` |
 | cyberpunk        | `#fce22a`  | `#111111` | `#ff003c` |
+| cyberpunk_neon   | `#0d0d14`  | `#00f3ff` | `#ff0055` |
 | glacier          | `#e0f2fe`  | `#0369a1` | `#06b6d4` |
 | lumos            | `#0a0a0a`  | `#a7f3d0` | `#fbbf24` |
 | monokai          | `#272822`  | `#f8f8f2` | `#a6e22e` |
@@ -318,6 +319,18 @@ https://commitpulse.vercel.app/api/streak?user=YOUR_USERNAME&theme=<slug>
 | `bg`      | fce22a |
 | `text`    | 111111 |
 | `accent`  | ff003c |
+
+---
+
+### Cyberpunk Neon
+
+![cyberpunk_neon](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=cyberpunk_neon)
+
+| Parameter | Value  |
+| --------- | ------ |
+| `bg`      | 0d0d14 |
+| `text`    | 00f3ff |
+| `accent`  | ff0055 |
 
 ---
 

--- a/lib/svg/themes.test.ts
+++ b/lib/svg/themes.test.ts
@@ -41,11 +41,11 @@ describe('themes object', () => {
 // ── Theme count ───────────────────────────────────────────────────────────────
 
 describe('theme count', () => {
-  it('contains exactly 28 preset themes matching THEMES.md documentation', () => {
+  it('contains exactly 29 preset themes matching THEMES.md documentation', () => {
     // If this fails, either a theme was added to themes.ts without updating
     // THEMES.md, or a theme was removed without updating the docs.
     // Update this count when intentionally adding/removing themes.
-    expect(themeNames).toHaveLength(29);
+    expect(themeNames).toHaveLength(30);
   });
 
   it('contains all expected theme keys', () => {
@@ -76,6 +76,7 @@ describe('theme count', () => {
       'lumos',
       'tokyonight',
       'cyberpunk',
+      'cyberpunk_neon',
       'tokyo_night',
       'monokai',
       'midnight_ocean',

--- a/lib/svg/themes.ts
+++ b/lib/svg/themes.ts
@@ -59,6 +59,7 @@ export const themes: Record<string, BadgeTheme> = {
   lumos: makeTheme('0a0a0a', 'a7f3d0', 'fbbf24', 'ef4444'),
   tokyonight: makeTheme('1a1b26', 'c0caf5', 'f7768e'),
   cyberpunk: makeTheme('fce22a', '111111', 'ff003c', '2d0000'),
+  cyberpunk_neon: makeTheme('0d0d14', '00f3ff', 'ff0055', 'b800ff'),
   tokyo_night: makeTheme('1a1b26', 'c0caf5', '7aa2f7'),
   monokai: makeTheme('272822', 'f8f8f2', 'a6e22e', 'f92672'),
   midnight_ocean: makeTheme('020c1b', 'ccd6f6', '0af5ff', 'ff4d6d'),


### PR DESCRIPTION
## 🎨 Theme Submission: Cyberpunk Neon
Fixes #6372

### Description
Introducing **Cyberpunk Neon**, a high-contrast, dark mode isometric theme for developers who prefer the "hacker" aesthetic on their GitHub READMEs.

*Note: Since the generator's theme architecture strictly expects 4 colors (`bg`, `text`, `accent`, `negative`), I mapped the primary neon pink as the accent and the deep purple as the depth shadow. This perfectly captures the cyberpunk vibe while remaining compatible with the existing generator engine.*

### Color Choices
| Color      | Value     | Why This Color?                               |
| ---------- | --------- | --------------------------------------------- |
| Background | `#0d0d14` | Deep space dark creates the perfect canvas    |
| Text       | `#00f3ff` | Cyan text pops brilliantly against the dark   |
| Accent     | `#ff0055` | Neon Pink serves as the vibrant primary block |
| Negative   | `#b800ff` | Purple provides a highly stylized deep shadow |

### Aesthetic Inspiration
Inspired by late-night city skylines, synthwave music, and cyberpunk aesthetics. It brings a bold, energetic, and highly saturated look to the standard isometric contribution graph.

### Preview
![cyberpunk_neon](https://commitpulse.vercel.app/api/streak?user=jhasourav07&theme=cyberpunk_neon)

### Testing Completed
- [x] Theme added to `lib/svg/themes.ts` following convention (`cyberpunk_neon`).
- [x] Documented the new theme in `THEMES.md` including the table and preview gallery.
- [x] **Updated unit tests** in `lib/svg/themes.test.ts` to expect 30 total themes and validate the `cyberpunk_neon` config. All tests passing!
