### PR TITLE
fix: fail closed in DistributedCache.incr when Redis unavailable in production

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -511,6 +511,17 @@ export class DistributedCache<T> {
    */
   async incr(key: string, ttlMs: number): Promise<number> {
     if (!this.useRedis) {
+      // Fail closed — no shared state means no reliable distributed rate limiting.
+      // In serverless (Vercel, AWS Lambda, etc.) each cold start resets the in-memory
+      // counter, so an in-memory fallback would silently reset the limit and enable
+      // Denial-of-Wallet attacks on the shared GitHub token pool.
+      if (process.env.NODE_ENV === 'production') {
+        logger.error('Redis not configured in production — rate limiting disabled (fail-closed)', {
+          component: 'DistributedCache',
+          key,
+        });
+        return Number.MAX_SAFE_INTEGER;
+      }
       const current = (this.localCache.get(key) as unknown as number) || 0;
       const next = current + 1;
       if (current === 0) {


### PR DESCRIPTION
## Summary

Fixes the rate limiting bypass on serverless cold starts by failing closed in the local `incr()` fallback when Redis is not configured in production.

## Changes

- **`lib/cache.ts`**: In `DistributedCache.incr()`, when `useRedis` is false and `NODE_ENV === 'production'`, return `Number.MAX_SAFE_INTEGER` instead of using the in-memory counter. This prevents rate limiting from resetting on every serverless cold start.

## Why this approach

The Redis failure path (line 566) already uses `Number.MAX_SAFE_INTEGER` to fail closed. This fix applies the same logic to the "no Redis configured" path in production. In-memory fallback is still available for development/testing.

## Closes

Closes #6380