### PR TITLE
fix: close TOCTOU race in refresh policy by atomically checking and recording

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -111,7 +111,7 @@ export async function GET(request: Request) {
 
   let shouldBypassCache = isRefreshRequested;
   if (isRefreshRequested) {
-    if (!refreshPolicy.isRefreshAllowed(user)) {
+    if (!refreshPolicy.tryAcquire(user)) {
       logSecurityEvent('STATS_REFRESH_COOLDOWN_VIOLATION', {
         user,
         ip,
@@ -131,9 +131,6 @@ export async function GET(request: Request) {
       bypassCache: shouldBypassCache,
       token: userToken,
     });
-    if (shouldBypassCache) {
-      refreshPolicy.recordRefresh(user);
-    }
 
     const calendar = userData.calendar;
     const stats = calculateStreak(calendar, timezone);

--- a/services/github/refresh-policy.ts
+++ b/services/github/refresh-policy.ts
@@ -72,6 +72,25 @@ export class RefreshPolicy {
   }
 
   /**
+   * Atomically checks whether a refresh is allowed and, if so, records it.
+   *
+   * This eliminates the TOCTOU race condition between `isRefreshAllowed()`
+   * and `recordRefresh()` where concurrent requests could all pass the
+   * cooldown check before any of them recorded the refresh.
+   *
+   * @returns `true` if the refresh was allowed and recorded; `false` if blocked.
+   */
+  public tryAcquire(username: string): boolean {
+    if (!this.isRefreshAllowed(username)) {
+      return false;
+    }
+
+    // Record immediately to close the race window
+    this.recordRefresh(username);
+    return true;
+  }
+
+  /**
    * Records a successful refresh event for the username.
    */
   public recordRefresh(username: string): void {


### PR DESCRIPTION
## Summary

Fixes a TOCTOU (Time-of-Check-to-Time-of-Use) race condition in the refresh policy that allowed concurrent requests to bypass the cache simultaneously, exhausting GitHub API quota.

## Changes

- **`services/github/refresh-policy.ts`**: Added `tryAcquire()` method that atomically checks whether a refresh is allowed and records it in a single operation, closing the race window.
- **`app/api/stats/route.ts`**: Replaced separate `isRefreshAllowed()` + `recordRefresh()` calls with the new atomic `tryAcquire()` method.

## How it fixes the race

**Before:** Concurrent requests could all pass `isRefreshAllowed()` before any called `recordRefresh()`, defeating the 30-second cooldown.

**After:** `tryAcquire()` checks and records in one step. Only the first concurrent request succeeds; subsequent requests within the cooldown window are rejected.

## Closes

Closes #6381