### PR TITLE
fix: add CSRF protection by requiring valid Origin header on state-changing POST endpoints

### DIFF
--- a/app/api/notify/route.ts
+++ b/app/api/notify/route.ts
@@ -19,6 +19,15 @@ import logger from '@/lib/logger';
 const notifyWriteCache = new DistributedCache<number>(5000, 60000);
 const NOTIFY_WRITE_COOLDOWN_MS = 5 * 60 * 1000;
 
+const ALLOWED_ORIGINS = [
+  process.env.NEXT_PUBLIC_APP_URL || 'https://commitpulse.vercel.app',
+  'https://commitpulse.vercel.app',
+];
+
+function isOriginAllowed(origin: string | null): boolean {
+  return !!origin && ALLOWED_ORIGINS.includes(origin);
+}
+
 /**
  * Masks an email address to prevent PII exposure in unauthenticated responses.
  * Example: "john.doe@gmail.com" → "jo***@gm***.com"
@@ -92,6 +101,12 @@ async function authorizeNotificationMutation(
 // ─── POST /api/notify ────────────────────────────────────────────────────────
 // Register or update email notification preferences for a user
 export async function POST(req: Request) {
+  // CSRF protection — require a valid Origin header for state-changing requests
+  const origin = req.headers.get('origin');
+  if (!isOriginAllowed(origin)) {
+    return NextResponse.json({ success: false, message: 'Origin not allowed.' }, { status: 403 });
+  }
+
   // Rate limiting
   const ip = getClientIp(req);
 
@@ -257,6 +272,12 @@ export async function POST(req: Request) {
 // ─── DELETE /api/notify ──────────────────────────────────────────────────────
 // Remove notification preferences for a user (unsubscribe / right to erasure)
 export async function DELETE(req: NextRequest) {
+  // CSRF protection — require a valid Origin header for state-changing requests
+  const origin = req.headers.get('origin');
+  if (!isOriginAllowed(origin)) {
+    return NextResponse.json({ success: false, message: 'Origin not allowed.' }, { status: 403 });
+  }
+
   // Rate limiting
   const ip = getClientIp(req);
 

--- a/app/api/track-user/route.ts
+++ b/app/api/track-user/route.ts
@@ -32,7 +32,7 @@ export async function POST(req: Request) {
   const origin = req.headers.get('origin');
   const corsHeaders = getCorsHeaders(origin);
 
-  if (req.method === 'POST' && origin && !ALLOWED_ORIGINS.includes(origin)) {
+  if (!origin || !ALLOWED_ORIGINS.includes(origin)) {
     return NextResponse.json(
       { success: false, error: 'Origin not allowed' },
       { status: 403, headers: corsHeaders }


### PR DESCRIPTION
## Summary

Adds CSRF protection to state-changing POST endpoints by requiring a valid `Origin` header. Requests without an `Origin` header or with an untrusted origin are now rejected with 403.

## Changes

- **`app/api/track-user/route.ts`**: Changed the origin check from `origin && !ALLOWED_ORIGINS.includes(origin)` to `!origin || !ALLOWED_ORIGINS.includes(origin)`. This rejects POST requests that are missing the `Origin` header entirely.
- **`app/api/notify/route.ts`**: Added `ALLOWED_ORIGINS` constant and `isOriginAllowed()` helper. Added origin verification at the top of both `POST` and `DELETE` handlers to prevent cross-site request forgery.

## Why this approach

- The `Origin` header is set by all modern browsers on cross-origin requests
- Requiring it prevents CSRF attacks from malicious websites
- Non-browser clients (curl, scripts) can still set the header manually
- GET requests are not affected (read-only, no state changes)

## Closes

Closes #6382