### PR TITLE
fix: remove unsafe-inline and unsafe-eval from Content-Security-Policy

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,7 +5,7 @@ import { getClientIp } from './utils/getClientIp';
 
 const securityHeaders = {
   'Content-Security-Policy':
-    "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https:;",
+    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https:;",
   'X-Content-Type-Options': 'nosniff',
   'X-Frame-Options': 'DENY',
   'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',


### PR DESCRIPTION
## Summary

Removes `unsafe-inline` and `unsafe-eval` from the `script-src` directive in the Content-Security-Policy header applied by middleware. This significantly reduces the impact of any potential XSS vulnerability.

## Changes

- **`middleware.ts`**: Changed `script-src 'self' 'unsafe-inline' 'unsafe-eval'` to `script-src 'self'`

## Why this is safe

- The middleware CSP applies to API routes (`/api/streak`, `/api/stats`, etc.) which return JSON or SVG — they don't serve client-side JavaScript
- The SVG endpoints already have their own stricter CSP (`default-src 'none'`)
- `style-src 'unsafe-inline'` is retained for CSS styling compatibility
- If dashboard pages need client-side JS in the future, use nonce-based or hash-based CSP instead of `unsafe-inline`

## Security impact

- `unsafe-eval` allowed `eval()`, `Function()`, and similar dynamic code execution — a primary XSS attack vector
- `unsafe-inline` allowed inline `<script>` tags
- With this fix, any XSS vulnerability is limited to the page context without code execution capability

## Closes

Closes #6383