### PR TITLE
fix(ci-analytics): forward userToken to fetchWithRetry

### DIFF
--- a/services/github/ci-analytics.test.ts
+++ b/services/github/ci-analytics.test.ts
@@ -18,6 +18,39 @@ function makeRun(overrides: Partial<CIWorkflowRun>): CIWorkflowRun {
     ...overrides,
   };
 }
+import { vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/github', () => ({
+  fetchWithRetry: vi.fn(),
+  getGitHubTokens: vi.fn(() => ['shared-pool-token']),
+}));
+
+import { fetchWithRetry } from '@/lib/github';
+import { fetchCIAnalytics } from './ci-analytics';
+
+describe('fetchCIAnalytics token forwarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards the per-user token to fetchWithRetry as its 5th argument', async () => {
+    vi.mocked(fetchWithRetry).mockImplementation(async (_url, _opts) => {
+      return {
+        ok: true,
+        json: async () => [],
+      } as unknown as Response;
+    });
+
+    const userToken = 'user-personal-oauth-token';
+    await fetchCIAnalytics('octocat', userToken);
+
+    expect(fetchWithRetry).toHaveBeenCalled();
+    for (const call of vi.mocked(fetchWithRetry).mock.calls) {
+      const forwardedToken = call[4];
+      expect(forwardedToken).toBe(userToken);
+    }
+  });
+});
 
 describe('processRuns', () => {
   it('returns a 0 success rate (never NaN) when no run has a success or failure conclusion', () => {

--- a/services/github/ci-analytics.ts
+++ b/services/github/ci-analytics.ts
@@ -42,10 +42,16 @@ async function fetchAllPages<T>(url: string, perPage = 100, userToken?: string):
 
   while (hasMore && page <= MAX_REPO_PAGES) {
     const paginatedUrl = `${url}${url.includes('?') ? '&' : '?'}per_page=${perPage}&page=${page}`;
-    const res = await fetchWithRetry(paginatedUrl, {
-      headers: getHeaders(userToken),
-      cache: 'no-store',
-    });
+    const res = await fetchWithRetry(
+      paginatedUrl,
+      {
+        headers: getHeaders(userToken),
+        cache: 'no-store',
+      },
+      0,
+      undefined,
+      userToken
+    );
     if (!res.ok) break;
     const data = await res.json();
     if (!Array.isArray(data) || data.length === 0) {
@@ -92,10 +98,16 @@ async function fetchActionsPages<T>(
 
   while (page <= MAX_ACTION_PAGES) {
     const paginatedUrl = `${url}${url.includes('?') ? '&' : '?'}per_page=${perPage}&page=${page}`;
-    const res = await fetchWithRetry(paginatedUrl, {
-      headers: getHeaders(userToken),
-      cache: 'no-store',
-    });
+    const res = await fetchWithRetry(
+      paginatedUrl,
+      {
+        headers: getHeaders(userToken),
+        cache: 'no-store',
+      },
+      0,
+      undefined,
+      userToken
+    );
     if (!res.ok) break;
     const body = await res.json();
     const items = body[dataField];


### PR DESCRIPTION
## Description

Fixes #6385 

`ci-analytics.ts` was building an Authorization header via `getHeaders(userToken)` but never passing `userToken` as `fetchWithRetry's` 5th argument. Since `fetchWithRetry` unconditionally overwrites the Authorization header with its own token selection, per-user `OAuth` tokens were silently discarded and the shared PAT pool was always used instead.
Fixed by passing `userToken` as the 5th argument in both `fetchAllPages` and `fetchActionsPages`, and added a test to verify the token is correctly forwarded on every call.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [X] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [X] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [X] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [X] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
