### PR TITLE
fix: handle single trusted proxy XFF chain

### DIFF
--- a/utils/getClientIp.test.ts
+++ b/utils/getClientIp.test.ts
@@ -161,4 +161,21 @@ describe('getClientIp', () => {
     });
     expect(getClientIp(reqMalformed)).toBe('127.0.0.1');
   });
+  it('does not return a trusted proxy as the client IP when it is the only hop in the chain', () => {
+    const req = new Request('http://localhost:3000/api/streak', {
+      headers: {
+        'x-forwarded-for': '203.0.113.5',
+      },
+    });
+
+    const ip = getClientIp(req, {
+      proxyConfig: {
+        trustedProxies: ['203.0.113.5'],
+        trustPrivateRanges: false,
+      },
+      directIp: '203.0.113.5',
+    });
+
+    expect(ip).toBe('127.0.0.1');
+  });
 });

--- a/utils/getClientIp.ts
+++ b/utils/getClientIp.ts
@@ -141,7 +141,7 @@ export function getClientIp(
 
       // Traverse from right to left (most recent to oldest proxy hop)
       // The rightmost IP is the one that connected directly to our server/balancer
-      let clientIp = directIp;
+      let clientIp = defaultIp;
 
       for (let i = ips.length - 1; i >= 0; i--) {
         const currentIp = ips[i];
@@ -149,8 +149,6 @@ export function getClientIp(
           // If the proxy is trusted, the client IP is the one preceding it (to the left)
           if (i > 0) {
             clientIp = ips[i - 1];
-          } else {
-            clientIp = currentIp;
           }
         } else {
           // Found the first untrusted IP in the chain - this is our true client


### PR DESCRIPTION
## Description

Fixes #6181 

This PR fixes an edge case in `getClientIp` where a single trusted proxy in the `X-Forwarded-For` chain could be incorrectly returned as the client IP.

### Changes

* Added a regression test covering a single-hop trusted proxy chain.
* Updated proxy chain traversal logic to avoid treating a trusted proxy as the originating client when no preceding client IP exists.
* Ensured the function falls back to the existing default value instead of returning the proxy's own IP.

### Example

Before:

```text
X-Forwarded-For: 203.0.113.5
trustedProxies: ['203.0.113.5']
directIp: 203.0.113.5

→ returns 203.0.113.5 (incorrect)
```

After:

```text
X-Forwarded-For: 203.0.113.5
trustedProxies: ['203.0.113.5']
directIp: 203.0.113.5

→ returns fallback IP (127.0.0.1 in test/dev, unknown in production)
```

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (backend utility bug fix)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and/or relevant tests locally.
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [ ] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
