### PR TITLE
perf: cache parsed trusted proxy config

### DIFF
--- a/utils/trustedProxy.ts
+++ b/utils/trustedProxy.ts
@@ -88,6 +88,7 @@ export function isIPv4(ip: string): boolean {
  * Pre-processes a TrustedProxyConfig into a ParsedProxyConfig
  * separating wildcards, exact IPs, and CIDR ranges for faster lookup.
  */
+const parsedProxyConfigCache = new WeakMap<TrustedProxyConfig, ParsedProxyConfig>();
 export function buildProxyConfig(config: TrustedProxyConfig): ParsedProxyConfig {
   const exactSet = new Set<string>();
   const cidrList: ParsedCidr[] = [];
@@ -118,7 +119,12 @@ export function buildProxyConfig(config: TrustedProxyConfig): ParsedProxyConfig 
  */
 export function isTrustedProxy(ip: string, config: TrustedProxyConfig): boolean {
   const sanitizedIp = ip.trim();
-  const parsed = buildProxyConfig(config);
+  let parsed = parsedProxyConfigCache.get(config);
+
+  if (!parsed) {
+    parsed = buildProxyConfig(config);
+    parsedProxyConfigCache.set(config, parsed);
+  }
 
   if (parsed.wildcard) return true;
   if (parsed.exactSet.has(sanitizedIp)) return true;


### PR DESCRIPTION
## Description

Fixes #6180 

Optimized trusted proxy configuration handling by caching parsed proxy configurations using a `WeakMap`.

### Changes Made

* Added a module-level `WeakMap<TrustedProxyConfig, ParsedProxyConfig>` cache.
* Reused previously parsed proxy configurations in `isTrustedProxy()` instead of rebuilding them on every invocation.
* Avoided repeated allocation of:

  * `Set` instances for exact IP matches
  * Parsed CIDR range arrays
  * Parsed configuration objects
* Preserved existing functionality and behavior.

### Impact

Since `isTrustedProxy()` is called by `getClientIp()` on the request path, this change reduces unnecessary CPU work and garbage collection pressure by eliminating repeated parsing of identical proxy configurations.

### Testing

* Verified that `utils/trustedProxy.test.ts` passes successfully.
* Confirmed no functional changes to trusted proxy matching behavior.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (performance optimization, no UI changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [ ] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
