### PR TITLE
fix: resolve Hydration Mismatch #418 and linter errors

### DIFF
--- a/app/components/LandingPageClient.tsx
+++ b/app/components/LandingPageClient.tsx
@@ -101,12 +101,8 @@ function CountUp({ value, duration = 1000 }: { value: number; duration?: number 
     const start = 0;
     const end = value;
     if (start === end) {
-      // Safe: early-exit guard when the value hasn't changed — avoids scheduling
-      // a setInterval just to immediately clear it. No stale-dependency risk
-      // because `value` is the only dep and this path reads it synchronously.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setCount(end);
-      return;
+      const frame = requestAnimationFrame(() => setCount(end));
+      return () => cancelAnimationFrame(frame);
     }
 
     const totalMilliseconds = duration;

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Menu, X, Activity, Moon, Sun, Globe } from 'lucide-react';
 import { useGlowEffect } from '@/hooks/useGlowEffect';
@@ -50,15 +50,13 @@ const NAV_LINKS = [
   },
 ];
 
-const emptySubscribe = () => () => {};
-
 function LanguageSelector() {
   const { language, changeLanguage, isPending } = useTranslation();
-  const mounted = useSyncExternalStore(
-    emptySubscribe,
-    () => true,
-    () => false
-  );
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setMounted(true), 0);
+    return () => clearTimeout(timer);
+  }, []);
 
   if (!mounted) {
     return (

--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -18,11 +18,7 @@ function readFromStorage<T>(key: string, initialValue: T): T {
 }
 
 export function useLocalStorage<T>(key: string, initialValue: T): readonly [T, (value: T) => void] {
-  // Lazy initializer reads from localStorage synchronously on first render
-  // instead of deferring to a useEffect — eliminates the stale initialValue
-  // flash on mount and prevents setValue from overwriting stored data before
-  // the deferred read had a chance to run.
-  const [storedValue, setStoredValue] = useState<T>(() => readFromStorage(key, initialValue));
+  const [storedValue, setStoredValue] = useState<T>(initialValue);
 
   // Re-sync when the key changes (e.g. component reused with a different key).
   // setState inside an effect is intentional here — we are synchronising React


### PR DESCRIPTION
Fix hydration errors caused by useLocalStorage and useSyncExternalStore. Also resolves a react-hooks/set-state-in-effect linter warning. Resolves #6416