### PR TITLE
fix(customize): prevent infinite reload loop on /customize page

### DIFF
--- a/app/customize/page.tsx
+++ b/app/customize/page.tsx
@@ -207,6 +207,10 @@ function CustomizePageInner(): ReactElement {
   // On change sync state to URL
   useEffect(() => {
     if (!queryString) return;
+    // Guard: skip router.replace when the URL already matches the computed params.
+    // Without this, router.replace fires on every mount (including remounts caused by
+    // template.tsx), creating an infinite reload loop in production.
+    if (window.location.search === `?${queryString}`) return;
     router.replace(`/customize?${queryString}`, { scroll: false });
   }, [queryString, router]);
 

--- a/app/customize/utils.test.ts
+++ b/app/customize/utils.test.ts
@@ -165,13 +165,14 @@ describe('Export Snippet utilities', () => {
 
     it('returns minimal params with default values', () => {
       const result = buildQueryParams(defaultOptions);
-      expect(result).toBe('user=testuser&theme=dark&font=Inter');
+      // font=Inter is the default and is omitted (consistent with scale, speed, radius, etc.)
+      expect(result).toBe('user=testuser&theme=dark');
     });
 
     it('applies custom theme values', () => {
       const options = { ...defaultOptions, theme: 'light' };
       const result = buildQueryParams(options);
-      expect(result).toBe('user=testuser&theme=light&font=Inter');
+      expect(result).toBe('user=testuser&theme=light');
     });
 
     it('applies custom color overrides and omits theme', () => {
@@ -183,7 +184,7 @@ describe('Export Snippet utilities', () => {
         textHex: '#000000',
       };
       const result = buildQueryParams(options);
-      expect(result).toBe('user=testuser&bg=ffffff&accent=ff0000&text=000000&font=Inter');
+      expect(result).toBe('user=testuser&bg=ffffff&accent=ff0000&text=000000');
     });
 
     it('omits partial or invalid hex colors and falls back to theme', () => {
@@ -191,7 +192,7 @@ describe('Export Snippet utilities', () => {
       for (const partial of ['f', 'ff', 'ffaab']) {
         const options = { ...defaultOptions, theme: 'dark', bgHex: partial };
         const result = buildQueryParams(options);
-        expect(result).toBe('user=testuser&theme=dark&font=Inter');
+        expect(result).toBe('user=testuser&theme=dark');
         expect(result).not.toContain('bg=');
       }
     });
@@ -205,7 +206,7 @@ describe('Export Snippet utilities', () => {
         textHex: '',
       };
       const result = buildQueryParams(options);
-      expect(result).toBe('user=testuser&bg=ffffff&font=Inter');
+      expect(result).toBe('user=testuser&bg=ffffff');
       expect(result).not.toContain('accent=');
       expect(result).not.toContain('theme=');
     });
@@ -217,7 +218,7 @@ describe('Export Snippet utilities', () => {
         bgHex: 'ffffff',
       };
       const resultAuto = buildQueryParams(optionsAuto);
-      expect(resultAuto).toBe('user=testuser&theme=auto&font=Inter');
+      expect(resultAuto).toBe('user=testuser&theme=auto');
 
       const optionsRandom = {
         ...defaultOptions,
@@ -225,13 +226,13 @@ describe('Export Snippet utilities', () => {
         accentHex: 'ff0000',
       };
       const resultRandom = buildQueryParams(optionsRandom);
-      expect(resultRandom).toBe('user=testuser&theme=random&font=Inter');
+      expect(resultRandom).toBe('user=testuser&theme=random');
     });
 
     it('handles empty username gracefully', () => {
       const options = { ...defaultOptions, username: '   ' };
       const result = buildQueryParams(options);
-      expect(result).toBe('theme=dark&font=Inter');
+      expect(result).toBe('theme=dark');
     });
 
     it('includes all customized options', () => {

--- a/app/customize/utils.ts
+++ b/app/customize/utils.ts
@@ -259,7 +259,7 @@ export function buildQueryParams(options: CustomizeOptions): string {
 
   if (options.scale !== 'linear') params.set('scale', options.scale);
   if (options.speed !== '8s') params.set('speed', options.speed);
-  if (options.font) params.set('font', options.font);
+  if (options.font && options.font !== 'Inter') params.set('font', options.font);
   if (options.year) params.set('year', options.year);
   if (options.radius !== 8) params.set('radius', options.radius.toString());
   if (options.size !== 'medium') params.set('size', options.size);


### PR DESCRIPTION
## Description
This PR fixes a production-only infinite reload loop affecting the `/customize` page after a GitHub username was entered and the page was refreshed.

The issue was caused by a feedback loop between URL synchronization logic and route remounting behavior in the Next.js App Router.

## Root Cause

Two cooperating issues created the reload loop:

### 1. State → URL synchronization triggered unnecessary navigations

`CustomizePageInner` synchronizes component state to the URL using `router.replace()`.

The effect executed whenever the computed query string changed, but it did not verify whether the current URL already matched the desired query string.

As a result, `router.replace()` was repeatedly called even when no actual URL update was required.

In production, Next.js App Router treats these calls as navigation events, causing `app/template.tsx` to remount route children.

This remount re-triggered the URL → state initialization effect, which restored the same state, rebuilt the same query string, and invoked `router.replace()` again, creating an infinite cycle.

### 2. Default font value was always emitted into the URL

`buildQueryParams()` used a truthy check for the font parameter:

```ts
if (options.font) params.set('font', options.font);
```

Because the default font is `"Inter"`, the parameter was always included in the generated query string.

This ensured that `queryString` was never empty, preventing the existing early-return guard from stopping unnecessary URL synchronization.

## Changes

### URL synchronization guard

Added a URL equality check before calling `router.replace()`:

```ts
if (window.location.search === `?${queryString}`) return;
```

This prevents navigation when the current URL already reflects the computed application state.

### Default font handling

Updated query parameter generation to omit the default font value:

```ts
if (options.font && options.font !== 'Inter') {
  params.set('font', options.font);
}
```

This aligns font behavior with all other defaulted customization options, which are excluded from the URL unless explicitly changed.

### Test updates

Updated unit tests in `utils.test.ts` to reflect the corrected query parameter behavior:

* Default font (`Inter`) is no longer included in generated query strings.
* Expectations now match the handling used for other default values throughout the customization system.

## Result

* Eliminates the infinite reload loop on `/customize`.
* Prevents unnecessary navigation events when URL and state are already synchronized.
* Produces cleaner URLs by excluding default font values.
* Keeps query parameter generation consistent across all customization options.
* Resolves the production-only refresh issue while preserving existing customization functionality.

Fixes #6256 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

before changes :-


https://github.com/user-attachments/assets/5f168798-0f30-402f-b740-7be991ccb160


after changes ( hosted with updated version to verify the result ):-


https://github.com/user-attachments/assets/545203c3-5624-4336-8212-00b1413cdf9d


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
