### PR TITLE
fix: profile optimizer modal ui

### DIFF
--- a/components/dashboard/DashboardClient.tsx
+++ b/components/dashboard/DashboardClient.tsx
@@ -1237,11 +1237,16 @@ export default function DashboardClient({
         )}
       </AnimatePresence>
 
-      <ProfileOptimizerModal
-        isOpen={isOptimizerOpen}
-        onClose={() => setIsOptimizerOpen(false)}
-        userData={initialData}
-      />
+      {isOptimizerOpen &&
+        typeof window !== 'undefined' &&
+        createPortal(
+          <ProfileOptimizerModal
+            isOpen={isOptimizerOpen}
+            onClose={() => setIsOptimizerOpen(false)}
+            userData={initialData}
+          />,
+          document.body
+        )}
 
       {typeof window !== 'undefined' &&
         createPortal(

--- a/components/dashboard/ProfileOptimizerModal.tsx
+++ b/components/dashboard/ProfileOptimizerModal.tsx
@@ -52,6 +52,15 @@ export default function ProfileOptimizerModal({
     }
   }, [isOpen, loadingSteps.length]);
 
+  //prevents background scrolling while the modal is open
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
   const handleCopy = async () => {
     const text = recommendations
       .map(
@@ -418,34 +427,25 @@ export default function ProfileOptimizerModal({
               {/* Score Card */}
               <div className="flex flex-col md:flex-row gap-6 p-6 rounded-xl bg-gray-50 dark:bg-white/5 border border-black/5 dark:border-white/5">
                 <div className="flex flex-col items-center justify-center shrink-0">
-                  <div className="relative w-32 h-32 flex items-center justify-center rounded-full border-4 border-emerald-500/20">
-                    <svg className="absolute inset-0 w-full h-full -rotate-90">
+                  <div className="relative w-30 h-30 flex items-center justify-center rounded-full border-4 border-emerald-500/50 dark:border-emerald-500/20">
+                    <svg className="flex items-center justify-center absolute inset-0 w-full h-full -rotate-90">
                       <circle
-                        cx="64"
-                        cy="64"
-                        r="60"
+                        cx="56"
+                        cy="56"
+                        r="52"
                         fill="none"
                         stroke="currentColor"
-                        strokeWidth="8"
-                        className="text-transparent"
-                      />
-                      <circle
-                        cx="64"
-                        cy="64"
-                        r="60"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="8"
+                        strokeWidth="6"
                         strokeDasharray="377"
                         strokeDashoffset={377 - (377 * overallScore) / 100}
                         className="text-emerald-500 transition-all duration-1000 ease-out"
                       />
                     </svg>
                     <div className="text-center">
-                      <span className="text-4xl font-bold text-gray-900 dark:text-white">
+                      <span className="text-2xl font-semibold text-gray-900 dark:text-white">
                         {overallScore}
                       </span>
-                      <span className="block text-xs text-gray-500 font-semibold mt-1">
+                      <span className="block text-xs text-gray-500 font-normal mt-1">
                         Grade: {grade}
                       </span>
                     </div>
@@ -516,24 +516,24 @@ export default function ProfileOptimizerModal({
                           {rec.issue}
                         </h4>
                         <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-                          <div className="p-3 bg-emerald-50 dark:bg-emerald-500/5 rounded-lg border border-emerald-100 dark:border-emerald-500/10">
-                            <span className="text-emerald-700 dark:text-emerald-400 font-semibold block mb-1">
+                          <div className="p-3 bg-gray-100 dark:bg-[#111] rounded-lg border border-black/10 dark:border-[rgba(255,255,255,0.05)]">
+                            <span className="text-gray-900 dark:text-white font-semibold block mb-1">
                               Recommendation
                             </span>
-                            <span className="text-gray-700 dark:text-gray-300">
+                            <span className="text-gray-500 dark:text-white/50">
                               {rec.recommendation}
                             </span>
                           </div>
-                          <div className="p-3 bg-blue-50 dark:bg-blue-500/5 rounded-lg border border-blue-100 dark:border-blue-500/10">
-                            <span className="text-blue-700 dark:text-blue-400 font-semibold block mb-1">
+                          <div className="p-3 bg-gray-100 dark:bg-[#111] rounded-lg border border-black/10 dark:border-[rgba(255,255,255,0.05)]">
+                            <span className="text-gray-900 dark:text-white font-semibold block mb-1">
                               Why it matters
                             </span>
-                            <span className="text-gray-700 dark:text-gray-300">{rec.impact}</span>
+                            <span className="text-gray-500 dark:text-white/50">{rec.impact}</span>
                           </div>
                         </div>
                         <div className="mt-4 p-3 bg-gray-50 dark:bg-white/5 rounded-lg flex items-center gap-3">
                           <CheckCircle className="w-5 h-5 text-gray-400 shrink-0" />
-                          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                          <span className="text-sm font-medium text-gray-500 dark:text-white/50">
                             <strong className="text-gray-900 dark:text-white">
                               Example Action:
                             </strong>{' '}


### PR DESCRIPTION
## Description

Fix Profile Optimizer modal layout issues by ensuring the modal appears fully above the navbar, the score circle is displayed without clipping, dark and light theme UI inconsistencies are resolved, and background scrolling is disabled while the modal is open

Fixes #6346 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

### Light theme
<img width="270" height="400" alt="fix_6346_02" src="https://github.com/user-attachments/assets/422a7deb-77a2-4da2-907e-7f7dd1554b07" />

<img width="270" height="400" alt="fix_6346_01" src="https://github.com/user-attachments/assets/97090d9b-4c6d-4647-aeba-db6264b79058" />

### Dark theme

<img width="270" height="400" alt="fix_6346_03" src="https://github.com/user-attachments/assets/8e837619-9e56-49ff-bb5e-978cecdcfee4" />

<img width="270" height="400" alt="fix_6346_04" src="https://github.com/user-attachments/assets/7d560f41-04ea-4f2b-bf9d-350b158cdb74" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
