### PR TITLE
fix(github): remove misleading fabricated LOC comment and undefined s…

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1031,7 +1031,6 @@ async function fetchContributionsUncached(
 
   calendar.lastSyncedAt = new Date().toISOString();
 
-  // 1. Fabricate the LOC additions and deletions fields with strict lint-compliant object mappings
   const processedWeeks = (calendar.weeks || []).map((week: unknown) => {
     const rawWeek = week as unknown as Record<string, unknown>;
     const contributionDays = Array.isArray(rawWeek.contributionDays)
@@ -1045,22 +1044,13 @@ async function fetchContributionsUncached(
         const count = typeof rawDay.contributionCount === 'number' ? rawDay.contributionCount : 0;
 
         if (count === 0) {
-          return {
-            ...rawDay,
-            locAdditions: 0,
-            locDeletions: 0,
-          };
+          return { ...rawDay, locAdditions: 0, locDeletions: 0 };
         }
-        return {
-          ...rawDay,
-          locAdditions: undefined,
-          locDeletions: undefined,
-        };
+        return rawDay;
       }),
     };
   }) as unknown as typeof calendar.weeks;
 
-  // 2. Return the extended structure with processed fields packed into the calendar
   return {
     calendar: {
       ...calendar,


### PR DESCRIPTION
## Description

Removes the misleading "Fabricate the LOC additions" comment and unnecessary `locAdditions: undefined` / `locDeletions: undefined` spreads from `getHistory` in `lib/github.ts`.

**Fixes #6001**

### Changes

| File | Change |
|------|--------|
| `lib/github.ts:getHistory` | Removed `// Fabricate the LOC additions` comment |
| `lib/github.ts:getHistory` | Removed `locAdditions: undefined` / `locDeletions: undefined` spreads — these fields are absent by default, so returning `rawDay` unchanged is cleaner and avoids implying fake data |

**Pillar:** 🛠️ Other (Bug fix, refactoring)

**Visual Preview:** N/A — no visual changes

please add gssoc26 and necessary labels 