### PR TITLE
fix(dashboard): clamp extreme repository text lengths to prevent card layout breakdown

### DIFF
--- a/components/dashboard/PopularPinnnedRepos.tsx
+++ b/components/dashboard/PopularPinnnedRepos.tsx
@@ -129,8 +129,11 @@ export function PopularRepos({ popularRepos = [], pinnedRepos = [] }: UniversalR
               >
                 <div className="flex-1 min-w-0 h-full flex flex-col justify-between">
                   <div className="min-w-0 space-y-0.5">
-                    <h4 className="font-semibold text-foreground text-sm group-hover:text-purple-600 dark:group-hover:text-purple-400 transition-colors truncate">
-                      {repo.name}
+                    <h4
+                      className="font-semibold text-foreground text-sm group-hover:text-purple-600 dark:group-hover:text-purple-400 transition-colors truncate"
+                      title={repo.name}
+                    >
+                      {repo.name.length > 20 ? `${repo.name.substring(0, 17)}...` : repo.name}
                     </h4>
                     <p className="text-xs text-muted-foreground line-clamp-2 leading-normal">
                       {repo.description || 'No description provided.'}


### PR DESCRIPTION
###  Purpose
This PR resolves the layout distortion issue on the user dashboard. When a profile contains exceptionally long repository titles, the text boundaries expand and break the surrounding layout grid. 

###  Changes Implemented
- Added programmatic string-slicing logic inside `components/dashboard/PopularPinnnedRepos.tsx` to safely truncate repository names exceeding 20 characters.
- Appended a fallback `title={repo.name}` attribute to the `<h4>` element to preserve web accessibility (a11y), allowing users to view the uncut, original repository name on hover via a native browser tooltip.

###  Issue Link
Closes #6441 

###  Verification
- Checked locally via `npm run dev` to confirm text clips cleanly into an ellipsis (`...`).
- Passed strict local validation checks (`npm run lint`) with 0 compilation errors.
