### PR TITLE
fix: correct timeout promise type annotation

### DIFF
--- a/app/api/track-user/route.ts
+++ b/app/api/track-user/route.ts
@@ -128,7 +128,7 @@ export async function POST(req: Request) {
     // Connect to database and perform upsert with 1.5s timeout
     try {
       let timer: NodeJS.Timeout | undefined;
-      const timeoutPromise = new Promise<{ success: boolean; error?: unknown }>((_, reject) => {
+      const timeoutPromise: Promise<never> = new Promise((_, reject) => {
         timer = setTimeout(() => reject(new Error('Database operation timed out')), 1500);
       });
 


### PR DESCRIPTION
## Description

Fixes #6200

Updated the `timeoutPromise` type annotation in `app/api/track-user/route.ts` from a misleading resolved type to `Promise<never>`, as the promise only rejects on timeout and never resolves. This improves type safety and code readability without changing runtime behavior.

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
