### PR TITLE
fix(notify): add missing X-RateLimit headers to DELETE rate-limit res…

### DIFF
--- a/app/api/notify/route.delete.test.ts
+++ b/app/api/notify/route.delete.test.ts
@@ -15,8 +15,13 @@ vi.mock('@/models/Notification', () => ({
 
 vi.mock('@/lib/rate-limit', () => ({
   notifyRateLimiter: {
-    check: vi.fn(),
+    checkWithResult: vi.fn(),
   },
+  getRateLimitHeaders: vi.fn(() => ({
+    'X-RateLimit-Limit': '60',
+    'X-RateLimit-Remaining': '0',
+    'X-RateLimit-Reset': '123456789',
+  })),
 }));
 
 vi.mock('@/lib/github-owner-verification', () => ({
@@ -54,7 +59,12 @@ describe('DELETE /api/notify', () => {
       MONGODB_URI: 'mongodb://localhost/test',
     };
 
-    vi.mocked(notifyRateLimiter.check).mockResolvedValue(true);
+    vi.mocked(notifyRateLimiter.checkWithResult).mockResolvedValue({
+      success: true,
+      limit: 60,
+      remaining: 59,
+      reset: Date.now() + 60000,
+    });
 
     vi.mocked(verifyGitHubOwner).mockResolvedValue({
       verified: true,
@@ -79,7 +89,12 @@ describe('DELETE /api/notify', () => {
   });
 
   it('returns 429 when rate limited', async () => {
-    vi.mocked(notifyRateLimiter.check).mockResolvedValue(false);
+    vi.mocked(notifyRateLimiter.checkWithResult).mockResolvedValue({
+      success: false,
+      limit: 60,
+      remaining: 0,
+      reset: Date.now() + 60000,
+    });
 
     const res = await DELETE(makeRequest('user=testuser'));
 

--- a/app/api/notify/route.massive-scaling.test.ts
+++ b/app/api/notify/route.massive-scaling.test.ts
@@ -18,7 +18,6 @@ vi.mock('@/lib/rate-limit', () => ({
     'X-RateLimit-Reset': result.reset.toString(),
   })),
   notifyRateLimiter: {
-    check: vi.fn().mockResolvedValue(true),
     checkWithResult: vi.fn().mockResolvedValue({
       success: true,
       limit: 5,
@@ -58,7 +57,6 @@ describe('POST /api/notify massive scaling: Massive Data Sets and Extreme High B
   beforeEach(() => {
     vi.clearAllMocks();
     process.env = { ...originalEnv, MONGODB_URI: 'mongodb://localhost/test' };
-    vi.mocked(notifyRateLimiter.check).mockResolvedValue(true);
     vi.mocked(notifyRateLimiter.checkWithResult).mockResolvedValue({
       success: true,
       limit: 5,

--- a/app/api/notify/route.mouse-interactivity.test.ts
+++ b/app/api/notify/route.mouse-interactivity.test.ts
@@ -63,7 +63,6 @@ vi.mock('@/lib/rate-limit', () => ({
         reset: Date.now(),
       })
     ),
-    check: vi.fn(() => Promise.resolve(true)),
   },
   getRateLimitHeaders: () => ({
     'X-RateLimit-Limit': '100',

--- a/app/api/notify/route.test.ts
+++ b/app/api/notify/route.test.ts
@@ -20,7 +20,6 @@ vi.mock('@/lib/rate-limit', () => ({
     'X-RateLimit-Reset': result.reset.toString(),
   })),
   notifyRateLimiter: {
-    check: vi.fn().mockResolvedValue(true),
     checkWithResult: vi.fn().mockResolvedValue({
       success: true,
       limit: 5,
@@ -71,7 +70,12 @@ describe('POST /api/notify', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env = { ...originalEnv, MONGODB_URI: 'mongodb://localhost/test' };
-    vi.mocked(notifyRateLimiter.check).mockResolvedValue(true);
+    vi.mocked(notifyRateLimiter.checkWithResult).mockResolvedValue({
+      success: true,
+      limit: 60,
+      remaining: 59,
+      reset: Date.now() + 60000,
+    });
     vi.mocked(gitHubUserValidator.validateUser).mockResolvedValue(true);
     vi.mocked(verifyGitHubOwner).mockResolvedValue({ verified: true });
     vi.mocked(Notification.findOne).mockResolvedValue(null);
@@ -344,7 +348,12 @@ describe('DELETE /api/notify', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env = { ...originalEnv, MONGODB_URI: 'mongodb://localhost/test' };
-    vi.mocked(notifyRateLimiter.check).mockResolvedValue(true);
+    vi.mocked(notifyRateLimiter.checkWithResult).mockResolvedValue({
+      success: true,
+      limit: 60,
+      remaining: 59,
+      reset: Date.now() + 60000,
+    });
     vi.mocked(verifyGitHubOwner).mockResolvedValue({ verified: true });
   });
 
@@ -398,7 +407,12 @@ describe('GET /api/notify', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env = { ...originalEnv, MONGODB_URI: 'mongodb://localhost/test' };
-    vi.mocked(notifyRateLimiter.check).mockResolvedValue(true);
+    vi.mocked(notifyRateLimiter.checkWithResult).mockResolvedValue({
+      success: true,
+      limit: 60,
+      remaining: 59,
+      reset: Date.now() + 60000,
+    });
     vi.mocked(Notification.findOne).mockReset();
   });
 
@@ -553,7 +567,12 @@ describe('DELETE /api/notify', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env = { ...originalEnv, MONGODB_URI: 'mongodb://localhost/test' };
-    vi.mocked(notifyRateLimiter.check).mockResolvedValue(true);
+    vi.mocked(notifyRateLimiter.checkWithResult).mockResolvedValue({
+      success: true,
+      limit: 60,
+      remaining: 59,
+      reset: Date.now() + 60000,
+    });
     vi.mocked(verifyGitHubOwner).mockResolvedValue({ verified: true });
   });
 

--- a/app/api/notify/route.ts
+++ b/app/api/notify/route.ts
@@ -262,11 +262,12 @@ export async function DELETE(req: NextRequest) {
 
   const rateLimitKey =
     ip && ip !== 'unknown' ? ip : `unknown:${req.headers.get('user-agent') ?? 'no-agent'}`;
+  const rateLimitResult = await notifyRateLimiter.checkWithResult(rateLimitKey);
 
-  if (!(await notifyRateLimiter.check(rateLimitKey))) {
+  if (!rateLimitResult.success) {
     return NextResponse.json(
       { success: false, message: 'Too many requests, please try again later.' },
-      { status: 429 }
+      { status: 429, headers: getRateLimitHeaders(rateLimitResult) }
     );
   }
 


### PR DESCRIPTION
## Description

Fixes #6199

This PR resolves an API inconsistency where the `DELETE` handler in `app/api/notify/route.ts` was returning a `429 Rate Limit Exceeded` response *without* the standard `X-RateLimit-*` HTTP headers.

By migrating the DELETE handler from `notifyRateLimiter.check()` to `notifyRateLimiter.checkWithResult()`, we ensure that the `getRateLimitHeaders(rateLimitResult)` payload is successfully appended to the `NextResponse`. 

This brings the `DELETE` route into parity with the `POST` and `GET` handlers in the same file, allowing clients to correctly calculate exponential backoffs. The Vitest mocks in `route.delete.test.ts` have also been updated to support `checkWithResult`.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (API Standardization)

## Visual Preview

*N/A - This PR applies strict HTTP rate-limit headers to API responses; there are no visual changes.*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/notify`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] I have run `npm run test` and all tests pass locally.
- [x] I have run `npm run test:coverage` and branch coverage is at or above 70%.
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.
