### PR TITLE
fix(contributors): give the loading skeleton light-mode variants

### DIFF
--- a/app/contributors/loading.accessibility.test.tsx
+++ b/app/contributors/loading.accessibility.test.tsx
@@ -46,8 +46,10 @@ describe('Contributors loading accessibility', () => {
       'min-h-screen',
       'items-center',
       'justify-center',
-      'bg-[#050505]',
-      'text-white',
+      'bg-white',
+      'dark:bg-[#050505]',
+      'text-black',
+      'dark:text-white',
     ]);
 
     expect(status.classList.contains('sr-only')).toBe(false);

--- a/app/contributors/loading.accessibility.test.tsx
+++ b/app/contributors/loading.accessibility.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import Loading from './loading';
+import { LOADING_ROOT_CLASSES } from './loadingClasses';
 
 function hasClasses(element: Element | null, classes: string[]) {
   expect(element).not.toBeNull();
@@ -41,16 +42,7 @@ describe('Contributors loading accessibility', () => {
     const status = screen.getByRole('status');
     const page = status.parentElement;
 
-    hasClasses(page, [
-      'flex',
-      'min-h-screen',
-      'items-center',
-      'justify-center',
-      'bg-white',
-      'dark:bg-[#050505]',
-      'text-black',
-      'dark:text-white',
-    ]);
+    hasClasses(page, LOADING_ROOT_CLASSES);
 
     expect(status.classList.contains('sr-only')).toBe(false);
     expect(status.classList.contains('hidden')).toBe(false);

--- a/app/contributors/loading.empty-fallback.test.tsx
+++ b/app/contributors/loading.empty-fallback.test.tsx
@@ -44,8 +44,10 @@ describe('Contributors loading empty fallback', () => {
       'min-h-screen',
       'items-center',
       'justify-center',
-      'bg-[#050505]',
-      'text-white',
+      'bg-white',
+      'dark:bg-[#050505]',
+      'text-black',
+      'dark:text-white',
     ]);
 
     hasClasses(status, ['flex', 'flex-col', 'items-center', 'gap-6']);
@@ -67,7 +69,8 @@ describe('Contributors loading empty fallback', () => {
       'animate-spin',
       'rounded-full',
       'border-2',
-      'border-white/10',
+      'border-black/10',
+      'dark:border-white/10',
       'border-t-cyan-400',
     ]);
 

--- a/app/contributors/loading.empty-fallback.test.tsx
+++ b/app/contributors/loading.empty-fallback.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import Loading from './loading';
+import { LOADING_ROOT_CLASSES, LOADING_SPINNER_CLASSES } from './loadingClasses';
 
 function hasClasses(element: Element | null, classes: string[]) {
   expect(element).not.toBeNull();
@@ -39,16 +40,7 @@ describe('Contributors loading empty fallback', () => {
     const status = screen.getByRole('status');
     const page = status.parentElement;
 
-    hasClasses(page, [
-      'flex',
-      'min-h-screen',
-      'items-center',
-      'justify-center',
-      'bg-white',
-      'dark:bg-[#050505]',
-      'text-black',
-      'dark:text-white',
-    ]);
+    hasClasses(page, LOADING_ROOT_CLASSES);
 
     hasClasses(status, ['flex', 'flex-col', 'items-center', 'gap-6']);
   });
@@ -63,16 +55,7 @@ describe('Contributors loading empty fallback', () => {
 
     hasClasses(spinnerWrapper, ['relative']);
 
-    hasClasses(spinner, [
-      'h-16',
-      'w-16',
-      'animate-spin',
-      'rounded-full',
-      'border-2',
-      'border-black/10',
-      'dark:border-white/10',
-      'border-t-cyan-400',
-    ]);
+    hasClasses(spinner, LOADING_SPINNER_CLASSES);
 
     hasClasses(glowOverlay, [
       'absolute',

--- a/app/contributors/loading.mouse-interactivity.test.tsx
+++ b/app/contributors/loading.mouse-interactivity.test.tsx
@@ -149,7 +149,8 @@ describe('Contributors Loading — structure & accessibility', () => {
     const { container } = render(<Loading />);
     const root = container.firstChild as HTMLElement;
     expect(root).toHaveClass('min-h-screen');
-    expect(root).toHaveClass('bg-[#050505]');
+    expect(root).toHaveClass('bg-white');
+    expect(root).toHaveClass('dark:bg-[#050505]');
     expect(root).toHaveClass('flex');
     expect(root).toHaveClass('items-center');
     expect(root).toHaveClass('justify-center');

--- a/app/contributors/loading.mouse-interactivity.test.tsx
+++ b/app/contributors/loading.mouse-interactivity.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import Loading from './loading';
+import { LOADING_ROOT_CLASSES } from './loadingClasses';
 
 // Test wrapper that integrates the real Loading component within an interactive tracking layer
 const InteractiveLoadingHarness: React.FC = () => {
@@ -148,12 +149,7 @@ describe('Contributors Loading — structure & accessibility', () => {
   it('outermost wrapper uses full-viewport dark background layout', () => {
     const { container } = render(<Loading />);
     const root = container.firstChild as HTMLElement;
-    expect(root).toHaveClass('min-h-screen');
-    expect(root).toHaveClass('bg-white');
-    expect(root).toHaveClass('dark:bg-[#050505]');
-    expect(root).toHaveClass('flex');
-    expect(root).toHaveClass('items-center');
-    expect(root).toHaveClass('justify-center');
+    expect(root).toHaveClass(...LOADING_ROOT_CLASSES);
   });
 
   it('component contains no focusable interactive elements (purely informational)', () => {

--- a/app/contributors/loading.test.tsx
+++ b/app/contributors/loading.test.tsx
@@ -34,7 +34,8 @@ describe('Contributors Loading', () => {
     expect(wrapper).toHaveClass('min-h-screen');
     expect(wrapper).toHaveClass('items-center');
     expect(wrapper).toHaveClass('justify-center');
-    expect(wrapper).toHaveClass('bg-[#050505]');
+    expect(wrapper).toHaveClass('bg-white');
+    expect(wrapper).toHaveClass('dark:bg-[#050505]');
   });
 
   it('renders loader container with accessibility attributes', () => {

--- a/app/contributors/loading.test.tsx
+++ b/app/contributors/loading.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { describe, it, expect } from 'vitest';
 import Loading from './loading';
+import { LOADING_ROOT_CLASSES } from './loadingClasses';
 
 describe('Contributors Loading', () => {
   it('renders loading fallback component', () => {
@@ -30,12 +31,7 @@ describe('Contributors Loading', () => {
 
     const wrapper = container.firstChild as HTMLElement;
 
-    expect(wrapper).toHaveClass('flex');
-    expect(wrapper).toHaveClass('min-h-screen');
-    expect(wrapper).toHaveClass('items-center');
-    expect(wrapper).toHaveClass('justify-center');
-    expect(wrapper).toHaveClass('bg-white');
-    expect(wrapper).toHaveClass('dark:bg-[#050505]');
+    expect(wrapper).toHaveClass(...LOADING_ROOT_CLASSES);
   });
 
   it('renders loader container with accessibility attributes', () => {

--- a/app/contributors/loading.theme-contrast.test.tsx
+++ b/app/contributors/loading.theme-contrast.test.tsx
@@ -30,8 +30,10 @@ describe('Contributors loading theme contrast', () => {
       'min-h-screen',
       'items-center',
       'justify-center',
-      'bg-[#050505]',
-      'text-white',
+      'bg-white',
+      'dark:bg-[#050505]',
+      'text-black',
+      'dark:text-white',
     ]);
   });
 
@@ -57,7 +59,8 @@ describe('Contributors loading theme contrast', () => {
       'animate-spin',
       'rounded-full',
       'border-2',
-      'border-white/10',
+      'border-black/10',
+      'dark:border-white/10',
       'border-t-cyan-400',
     ]);
   });

--- a/app/contributors/loading.theme-contrast.test.tsx
+++ b/app/contributors/loading.theme-contrast.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import Loading from './loading';
+import { LOADING_ROOT_CLASSES, LOADING_SPINNER_CLASSES } from './loadingClasses';
 
 function hasClasses(element: Element | null, classes: string[]) {
   expect(element).not.toBeNull();
@@ -25,16 +26,7 @@ describe('Contributors loading theme contrast', () => {
 
     const page = screen.getByRole('status').parentElement;
 
-    hasClasses(page, [
-      'flex',
-      'min-h-screen',
-      'items-center',
-      'justify-center',
-      'bg-white',
-      'dark:bg-[#050505]',
-      'text-black',
-      'dark:text-white',
-    ]);
+    hasClasses(page, LOADING_ROOT_CLASSES);
   });
 
   it('does not render contributor loading text that can linger after data loads', () => {
@@ -53,16 +45,7 @@ describe('Contributors loading theme contrast', () => {
 
     hasClasses(status, ['flex', 'flex-col', 'items-center', 'gap-6']);
     hasClasses(spinnerWrapper, ['relative']);
-    hasClasses(spinner, [
-      'h-16',
-      'w-16',
-      'animate-spin',
-      'rounded-full',
-      'border-2',
-      'border-black/10',
-      'dark:border-white/10',
-      'border-t-cyan-400',
-    ]);
+    hasClasses(spinner, LOADING_SPINNER_CLASSES);
   });
 
   it('keeps glow overlay behind spinner without clipping foreground content', () => {

--- a/app/contributors/loading.timezone-boundaries.test.tsx
+++ b/app/contributors/loading.timezone-boundaries.test.tsx
@@ -86,6 +86,7 @@ describe('ContributorsLoading - Timezone Boundaries & Calendar Alignment', () =>
     const layoutWrapper = container.firstChild as HTMLElement;
     expect(layoutWrapper).toHaveClass('flex');
     expect(layoutWrapper).toHaveClass('min-h-screen');
-    expect(layoutWrapper).toHaveClass('bg-[#050505]');
+    expect(layoutWrapper).toHaveClass('bg-white');
+    expect(layoutWrapper).toHaveClass('dark:bg-[#050505]');
   });
 });

--- a/app/contributors/loading.timezone-boundaries.test.tsx
+++ b/app/contributors/loading.timezone-boundaries.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import Loading from './loading';
+import { LOADING_ROOT_CLASSES } from './loadingClasses';
 import '@testing-library/jest-dom';
 
 describe('ContributorsLoading - Timezone Boundaries & Calendar Alignment', () => {
@@ -84,9 +85,6 @@ describe('ContributorsLoading - Timezone Boundaries & Calendar Alignment', () =>
     const { container } = render(<Loading />);
 
     const layoutWrapper = container.firstChild as HTMLElement;
-    expect(layoutWrapper).toHaveClass('flex');
-    expect(layoutWrapper).toHaveClass('min-h-screen');
-    expect(layoutWrapper).toHaveClass('bg-white');
-    expect(layoutWrapper).toHaveClass('dark:bg-[#050505]');
+    expect(layoutWrapper).toHaveClass(...LOADING_ROOT_CLASSES);
   });
 });

--- a/app/contributors/loading.tsx
+++ b/app/contributors/loading.tsx
@@ -1,6 +1,6 @@
 export default function Loading() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-[#050505] text-white">
+    <div className="flex min-h-screen items-center justify-center bg-white dark:bg-[#050505] text-black dark:text-white">
       <div
         className="flex flex-col items-center gap-6"
         role="status"
@@ -9,7 +9,7 @@ export default function Loading() {
       >
         {/* Pulsing ring loader */}
         <div className="relative">
-          <div className="h-16 w-16 animate-spin rounded-full border-2 border-white/10 border-t-cyan-400" />
+          <div className="h-16 w-16 animate-spin rounded-full border-2 border-black/10 dark:border-white/10 border-t-cyan-400" />
           <div className="absolute inset-0 h-16 w-16 rounded-full bg-cyan-400/20 blur-xl animate-pulse" />
         </div>
       </div>

--- a/app/contributors/loadingClasses.ts
+++ b/app/contributors/loadingClasses.ts
@@ -1,0 +1,23 @@
+// Expected Tailwind classes on the /contributors loading skeleton, shared across
+// the loading.*.test.tsx suites so the light/dark expectations live in one place.
+export const LOADING_ROOT_CLASSES: string[] = [
+  'flex',
+  'min-h-screen',
+  'items-center',
+  'justify-center',
+  'bg-white',
+  'dark:bg-[#050505]',
+  'text-black',
+  'dark:text-white',
+];
+
+export const LOADING_SPINNER_CLASSES: string[] = [
+  'h-16',
+  'w-16',
+  'animate-spin',
+  'rounded-full',
+  'border-2',
+  'border-black/10',
+  'dark:border-white/10',
+  'border-t-cyan-400',
+];


### PR DESCRIPTION
## Description

Fixes #6464

The `/contributors` Suspense loading skeleton (`app/contributors/loading.tsx`) was hardcoded dark-only (`bg-[#050505] text-white`), so in light mode it flashed a full near-black screen before the white page painted. The spinner ring's `border-white/10` was also nearly invisible on a white background.

This mirrors the page's theming so the skeleton matches in both modes:

- root: `bg-white dark:bg-[#050505] text-black dark:text-white`
- spinner ring track: `border-black/10 dark:border-white/10` (the `border-t-cyan-400` accent works in both)

## Tests

Updated the existing `loading.*.test.tsx` suites that asserted the dark-only classes (theme-contrast, accessibility, empty-fallback, mouse-interactivity, the base test, and timezone-boundaries) to assert both the light and dark variants. These updated assertions fail against the old dark-only component (verified by reverting `loading.tsx`).

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

In light mode the `/contributors` loading state is now a white screen with a visible spinner instead of a near-black flash; dark mode is unchanged.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (the `app/contributors/loading` suites, 58 tests, pass; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). (Not an SVG change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
