### PR TITLE
fix(shortcuts): use router.push for keyboard quick-nav instead of a full page reload

### DIFF
--- a/app/components/navbar.mouse-interactivity.test.tsx
+++ b/app/components/navbar.mouse-interactivity.test.tsx
@@ -3,6 +3,10 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import Navbar from './navbar';
 
+vi.mock('@/hooks/useKeyboardShortcuts', () => ({
+  useKeyboardShortcuts: vi.fn(),
+}));
+
 type MatchMediaChangeListener = (event: MediaQueryListEvent) => void;
 
 const animationFrames: FrameRequestCallback[] = [];

--- a/app/components/navbar.test.tsx
+++ b/app/components/navbar.test.tsx
@@ -3,6 +3,10 @@ import { act, render, screen, fireEvent } from '@testing-library/react';
 import Navbar from './navbar';
 import type { ReactNode } from 'react';
 
+vi.mock('@/hooks/useKeyboardShortcuts', () => ({
+  useKeyboardShortcuts: vi.fn(),
+}));
+
 const originalLocalStorage = window.localStorage;
 
 afterAll(() => {

--- a/app/components/navbar.theme-contrast.test.tsx
+++ b/app/components/navbar.theme-contrast.test.tsx
@@ -2,6 +2,10 @@ import { render, screen } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import Navbar from './navbar';
 
+vi.mock('@/hooks/useKeyboardShortcuts', () => ({
+  useKeyboardShortcuts: vi.fn(),
+}));
+
 vi.mock('./theme-switch', () => ({
   useThemeToggle: vi.fn(),
 }));

--- a/hooks/useKeyboardShortcuts.test.ts
+++ b/hooks/useKeyboardShortcuts.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useKeyboardShortcuts } from './useKeyboardShortcuts';
+
+const push = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}));
+
+function press(key: string) {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key }));
+}
+
+describe('useKeyboardShortcuts', () => {
+  beforeEach(() => {
+    push.mockClear();
+  });
+
+  it('navigates client-side via router.push on the g-then-key sequence', () => {
+    renderHook(() => useKeyboardShortcuts());
+
+    press('g');
+    press('c');
+
+    // Client navigation (no full document reload / window.location.assign).
+    expect(push).toHaveBeenCalledWith('/contributors');
+  });
+
+  it('maps each shortcut key to its route', () => {
+    renderHook(() => useKeyboardShortcuts());
+
+    for (const [key, route] of Object.entries({
+      d: '/',
+      c: '/contributors',
+      p: '/compare',
+      u: '/customize',
+    })) {
+      push.mockClear();
+      press('g');
+      press(key);
+      expect(push).toHaveBeenCalledWith(route);
+    }
+  });
+
+  it('does not navigate when the second key is not a shortcut', () => {
+    renderHook(() => useKeyboardShortcuts());
+
+    press('g');
+    press('x');
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('ignores the sequence while typing in an input field', () => {
+    renderHook(() => useKeyboardShortcuts());
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'g', bubbles: true }));
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', bubbles: true }));
+
+    expect(push).not.toHaveBeenCalled();
+    input.remove();
+  });
+});

--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -23,6 +23,8 @@ function isTypingTarget(target: EventTarget | null): boolean {
   );
 }
 
+// Global "g then key" quick-nav shortcuts. Navigates via the App Router, so it
+// must be mounted within a Next.js App Router context (useRouter throws otherwise).
 export function useKeyboardShortcuts() {
   const router = useRouter();
   const waitingForSecondKey = useRef(false);

--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
 
 const SHORTCUT_ROUTES: Record<string, string> = {
   d: '/',
@@ -23,6 +24,7 @@ function isTypingTarget(target: EventTarget | null): boolean {
 }
 
 export function useKeyboardShortcuts() {
+  const router = useRouter();
   const waitingForSecondKey = useRef(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -59,7 +61,7 @@ export function useKeyboardShortcuts() {
 
       if (route) {
         event.preventDefault();
-        window.location.assign(route);
+        router.push(route);
       }
 
       resetShortcut();
@@ -71,5 +73,5 @@ export function useKeyboardShortcuts() {
       resetShortcut();
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, []);
+  }, [router]);
 }


### PR DESCRIPTION
## Description

Fixes #6466

The keyboard quick-nav hook (`hooks/useKeyboardShortcuts.ts`) navigated with `window.location.assign(route)`, which forces a full document reload and rehydration in the App Router, discarding client state and the router cache. The shortcut was therefore slower than the equivalent in-app link.

This switches it to client-side navigation:

- `const router = useRouter()` (from `next/navigation`)
- `router.push(route)` instead of `window.location.assign(route)`
- `router` added to the effect's dependency array

## Tests

- Added `hooks/useKeyboardShortcuts.test.ts` (mocks `next/navigation`), asserting the `g`-then-key sequence calls `router.push` with the right route for every shortcut, that a non-shortcut second key does nothing, and that the sequence is ignored while typing in an input. These fail against the old `window.location.assign` implementation.
- The hook now calls `useRouter`, so the three navbar test suites that render the real navbar without mocking the hook (`navbar.test.tsx`, `navbar.mouse-interactivity.test.tsx`, `navbar.theme-contrast.test.tsx`) now mock `useKeyboardShortcuts`, matching the three navbar suites that already did.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No visual change. Pressing `g` then `d`/`c`/`p`/`u` now performs an instant client-side route change instead of a full page reload.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (new `useKeyboardShortcuts.test.ts` and the navbar suites pass; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). (Not an SVG change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
