### PR TITLE
fix(achievements): add aria-labels to the search inputs

### DIFF
--- a/app/achievements/AchievementsClient.a11y.test.tsx
+++ b/app/achievements/AchievementsClient.a11y.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AchievementsClient from './AchievementsClient';
+
+describe('AchievementsClient search input accessibility', () => {
+  beforeEach(() => {
+    // No ?username -> the empty state renders, which contains both username search inputs.
+    window.history.replaceState({}, '', '/achievements');
+  });
+
+  it('gives both username search inputs an accessible name (not just a placeholder)', () => {
+    render(<AchievementsClient />);
+
+    // Found by accessible name; placeholders alone would not satisfy this query.
+    const inputs = screen.getAllByRole('textbox', { name: /search github username/i });
+    expect(inputs).toHaveLength(2);
+
+    const placeholders = inputs.map((input) => input.getAttribute('placeholder'));
+    expect(placeholders).toContain('e.g. jhasourav07');
+    expect(placeholders).toContain('Search user...');
+  });
+});

--- a/app/achievements/AchievementsClient.a11y.test.tsx
+++ b/app/achievements/AchievementsClient.a11y.test.tsx
@@ -1,11 +1,16 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import AchievementsClient from './AchievementsClient';
+import type { AchievementsResponse } from '@/types/achievements';
 
 describe('AchievementsClient search input accessibility', () => {
   beforeEach(() => {
     // No ?username -> the empty state renders, which contains both username search inputs.
     window.history.replaceState({}, '', '/achievements');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('gives both username search inputs an accessible name (not just a placeholder)', () => {
@@ -18,5 +23,43 @@ describe('AchievementsClient search input accessibility', () => {
     const placeholders = inputs.map((input) => input.getAttribute('placeholder'));
     expect(placeholders).toContain('e.g. jhasourav07');
     expect(placeholders).toContain('Search user...');
+  });
+
+  it('gives the achievement filter input an accessible name in the loaded view', async () => {
+    // The achievement filter only appears once a profile is loaded, so drive the
+    // auto-fetch via the URL and mock the API response.
+    window.history.replaceState({}, '', '/achievements?username=octocat');
+
+    const mockData: AchievementsResponse = {
+      username: 'octocat',
+      profile: {
+        avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+        name: 'The Octocat',
+        login: 'octocat',
+      },
+      overview: {
+        totalAchievements: 0,
+        unlockedCount: 0,
+        completionPercent: 0,
+        totalXp: 0,
+        developerLevel: 1,
+        xpForCurrentLevel: 0,
+        xpForNextLevel: 100,
+        levelProgress: 0,
+      },
+      categories: [],
+      recentUnlocks: [],
+      nextAchievement: null,
+    };
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => mockData }) as Response)
+    );
+
+    render(<AchievementsClient />);
+
+    const filter = await screen.findByRole('textbox', { name: /search achievements/i });
+    expect(filter).toHaveAttribute('placeholder', 'Search achievements by name or description...');
   });
 });

--- a/app/achievements/AchievementsClient.tsx
+++ b/app/achievements/AchievementsClient.tsx
@@ -465,6 +465,7 @@ export default function AchievementsClient() {
           <input
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
+            aria-label="Search GitHub username"
             placeholder="e.g. jhasourav07"
             className="w-full rounded-2xl border border-white/10 bg-white/5 py-4 pl-12 pr-4 text-white placeholder-white/30 backdrop-blur-xl transition-all duration-300 focus:border-emerald-500/50 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
           />
@@ -530,6 +531,7 @@ export default function AchievementsClient() {
             <input
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
+              aria-label="Search GitHub username"
               placeholder="Search user..."
               className="w-full rounded-xl border border-white/10 bg-white/5 py-2.5 pl-10 pr-3 text-sm text-white placeholder-white/20 backdrop-blur-xl transition-all focus:border-emerald-500/50 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
             />
@@ -650,6 +652,7 @@ export default function AchievementsClient() {
                   type="text"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
+                  aria-label="Search achievements"
                   placeholder="Search achievements by name or description..."
                   className="w-full rounded-xl border border-white/10 bg-white/5 py-2.5 pl-10 pr-4 text-sm text-white placeholder-white/40 backdrop-blur-xl transition-all duration-300 focus:border-emerald-500/50 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
                 />


### PR DESCRIPTION
## Description

Fixes #6468

The search inputs on the Achievements page had only a `placeholder` and no accessible name, so screen readers announced them as unlabeled edit fields (WCAG 4.1.2 / 3.3.2).

This adds an `aria-label` to all three search inputs in `app/achievements/AchievementsClient.tsx`:

- the empty-state username search (`placeholder="e.g. jhasourav07"`) -> `aria-label="Search GitHub username"`
- the loaded-view header username search (`placeholder="Search user..."`) -> `aria-label="Search GitHub username"`
- the achievement filter (`placeholder="Search achievements by name or description..."`) -> `aria-label="Search achievements"`

This matches the pattern already used in `app/contributors/ContributorsSearch.tsx`.

## Tests

Added `app/achievements/AchievementsClient.a11y.test.tsx`, which renders the page and asserts that both username search inputs (both visible in the default empty state) are found by their accessible name via `getByRole('textbox', { name: 'Search GitHub username' })`. This fails against the old, label-less inputs (a placeholder alone does not provide an accessible name).

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No visual change. The search inputs now expose an accessible name to assistive technology.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (new `AchievementsClient.a11y.test.tsx` passes; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). (Not an SVG change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
