### PR TITLE
feat: prevent UI freeze during export by forcing paint cycle

### DIFF
--- a/hooks/useShareActions.test.ts
+++ b/hooks/useShareActions.test.ts
@@ -125,7 +125,9 @@ describe('useShareActions', () => {
     const { result } = renderHook(() => useShareActions(mockUsername, mockExportData, mockClose));
 
     await act(async () => {
-      await result.current.handleCopyImage();
+      const promise = result.current.handleCopyImage();
+      await vi.advanceTimersByTimeAsync(150);
+      await promise;
     });
 
     expect(writeMock).toHaveBeenCalled();

--- a/hooks/useShareActions.ts
+++ b/hooks/useShareActions.ts
@@ -179,6 +179,10 @@ export function useShareActions(
 
   const handleDownloadPNG = async () => {
     setOptionState('png', 'loading');
+
+    // Defer the heavy DOM capture to let the UI paint the loading state
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
     try {
       const node =
         document.getElementById('dashboard-root') ??
@@ -210,6 +214,10 @@ export function useShareActions(
 
   const handleDownloadWEBP = async () => {
     setOptionState('webp', 'loading');
+
+    // Defer the heavy DOM capture to let the UI paint the loading state
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
     try {
       const node =
         document.getElementById('dashboard-root') ??
@@ -242,6 +250,9 @@ export function useShareActions(
 
   const handleCopyImage = async () => {
     setOptionState('copyImage', 'loading');
+
+    // Defer the heavy DOM capture to let the UI paint the loading state
+    await new Promise((resolve) => setTimeout(resolve, 100));
 
     try {
       if (!navigator.clipboard || typeof ClipboardItem === 'undefined') {

--- a/hooks/useShareActions.ts
+++ b/hooks/useShareActions.ts
@@ -181,7 +181,7 @@ export function useShareActions(
     setOptionState('png', 'loading');
 
     // Defer the heavy DOM capture to let the UI paint the loading state
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 
     try {
       const node =
@@ -216,7 +216,7 @@ export function useShareActions(
     setOptionState('webp', 'loading');
 
     // Defer the heavy DOM capture to let the UI paint the loading state
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 
     try {
       const node =
@@ -252,7 +252,7 @@ export function useShareActions(
     setOptionState('copyImage', 'loading');
 
     // Defer the heavy DOM capture to let the UI paint the loading state
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 
     try {
       if (!navigator.clipboard || typeof ClipboardItem === 'undefined') {


### PR DESCRIPTION
## Description
Resolves #6116

### The Problem
When a user clicked "Export" or "Download Image", the application utilized `html-to-image` (via `toPng` and `toCanvas`) to capture the DOM. Because this process is synchronous and heavy, the main thread was hijacked immediately. As a result, the browser did not have enough time to paint the `isLoading(true)` state, making the UI feel frozen and unresponsive.

### The Solution
This PR introduces a small deferral in `hooks/useShareActions.ts` by using a 100ms timeout (`await new Promise((resolve) => setTimeout(resolve, 100));`) immediately after setting the `loading` state. 

This guarantees that the React commit phase finishes and the browser gets a chance to paint the loading spinner (and update the button state) *before* the heavy DOM capture process locks the main thread.


## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
