### PR TITLE
refactor(logging): replace console.warn with structured logger for missing CICD_ALERTS_SECRET

### DIFF
--- a/app/api/cicd/alerts/route.ts
+++ b/app/api/cicd/alerts/route.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { timingSafeEqual } from 'crypto';
 import { setAlertConfig } from '@/services/github/webhook-handler';
@@ -21,7 +22,9 @@ function verifyAuthToken(request: NextRequest): boolean {
   const expectedToken = process.env.CICD_ALERTS_SECRET || '';
 
   if (!expectedToken) {
-    console.warn('CICD_ALERTS_SECRET not configured');
+    logger.warn('CICD alerts auth rejected: CICD_ALERTS_SECRET is not configured', {
+      route: '/api/cicd/alerts',
+    });
     return false;
   }
 


### PR DESCRIPTION
## Description
Fixes #6479

`app/api/cicd/alerts/route.ts` used a raw `console.warn()` call to log a security-relevant misconfiguration:

```ts
if (!expectedToken) {
  console.warn('CICD_ALERTS_SECRET not configured');
  return false;
}
```

**Problem with the old approach:**
- This is the same class of issue already fixed for `app/api/webhook/route.ts` in #6090, where a missing secret was logged via raw `console.error` instead of the project's structured logger (`lib/logger.ts`)
- Using `console.warn` here results in unstructured logs for a security-relevant misconfiguration (missing auth secret blocking all CI/CD alert requests), inconsistent with the rest of the codebase's logging approach — `app/api/track-user/route.ts` and `app/api/webhook/route.ts` already use the shared `logger`

**What this PR does:**
- Imports the shared `logger` utility from `lib/logger.ts`
- Replaces the raw `console.warn()` call with `logger.warn()`, passing route context as structured metadata
- No logic changes — runtime behaviour is identical, only the log output format changes

**After:**
```ts
import { logger } from '@/lib/logger';

if (!expectedToken) {
  logger.warn('CICD alerts auth rejected: CICD_ALERTS_SECRET is not configured', {
    route: '/api/cicd/alerts',
  });
  return false;
}
```

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
No visual changes — this is a logging consistency refactor.

## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.