### PR TITLE
fix(compare): add per-IP rate limiting to /api/compare endpoint

### DIFF
--- a/app/api/compare/route.empty-fallback.test.ts
+++ b/app/api/compare/route.empty-fallback.test.ts
@@ -8,8 +8,8 @@ vi.mock('@/lib/githubtoken', () => ({
 }));
 
 vi.mock('@/lib/rate-limit', () => ({
-  rateLimit: vi.fn().mockResolvedValue({
-    success: true,
+  RateLimiter: vi.fn().mockImplementation(function () {
+    return { check: vi.fn().mockResolvedValue(true) };
   }),
 }));
 import { GET } from './route';

--- a/app/api/compare/route.mouse-interactivity.test.ts
+++ b/app/api/compare/route.mouse-interactivity.test.ts
@@ -7,8 +7,8 @@ vi.mock('@/lib/github', () => ({
 }));
 
 vi.mock('@/lib/rate-limit', () => ({
-  rateLimit: vi.fn().mockResolvedValue({
-    success: true,
+  RateLimiter: vi.fn().mockImplementation(function () {
+    return { check: vi.fn().mockResolvedValue(true) };
   }),
 }));
 

--- a/app/api/compare/route.test.ts
+++ b/app/api/compare/route.test.ts
@@ -9,8 +9,8 @@ vi.mock('@/lib/githubtoken', () => ({
 }));
 
 vi.mock('@/lib/rate-limit', () => ({
-  rateLimit: vi.fn().mockResolvedValue({
-    success: true,
+  RateLimiter: vi.fn().mockImplementation(function () {
+    return { check: vi.fn().mockResolvedValue(true) };
   }),
 }));
 

--- a/app/api/compare/route.theme-contrast.test.ts
+++ b/app/api/compare/route.theme-contrast.test.ts
@@ -6,8 +6,8 @@ vi.mock('@/lib/github', () => ({
   getFullDashboardData: vi.fn(),
 }));
 vi.mock('@/lib/rate-limit', () => ({
-  rateLimit: vi.fn().mockResolvedValue({
-    success: true,
+  RateLimiter: vi.fn().mockImplementation(function () {
+    return { check: vi.fn().mockResolvedValue(true) };
   }),
 }));
 vi.mock('@/lib/githubtoken', () => ({

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -3,8 +3,10 @@ import { getFullDashboardData } from '@/lib/github';
 import { getUserGitHubToken } from '@/lib/githubtoken';
 import { compareParamsSchema, coerceQueryParams } from '@/lib/validations';
 import crypto from 'crypto';
-import { rateLimit } from '@/lib/rate-limit';
 import { getClientIp } from '@/utils/getClientIp';
+import { RateLimiter } from '@/lib/rate-limit';
+
+const compareLimiter = new RateLimiter(5, 60_000, 1);
 
 export const revalidate = 3600;
 
@@ -54,11 +56,14 @@ function buildCompareFetchErrorResponse(user: string, reason: unknown): NextResp
 
 export async function GET(request: Request) {
   const ip = getClientIp(request);
+  const rateLimitKey =
+    ip && ip !== 'unknown' ? ip : `unknown:${request.headers.get('user-agent') ?? 'no-agent'}`;
 
-  const limit = await rateLimit(ip, 5, 30000);
-
-  if (!limit.success) {
-    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  if (!(await compareLimiter.check(rateLimitKey))) {
+    return NextResponse.json(
+      { error: 'Too many requests. Please try again later.' },
+      { status: 429 }
+    );
   }
 
   const { searchParams } = new URL(request.url);


### PR DESCRIPTION
## Description

Fixes #5955 

`/api/compare` had no rate limiting despite being the most expensive endpoint in the codebase, each request fires 14 parallel GitHub API calls (7 per user via `getFullDashboardData`). This made it the single most effective endpoint for exhausting the shared GitHub token pool and taking down all other routes for every user.

### Changes
- Replaced the non-functional `rateLimit()` call (which was already partially added to main) with a proper `RateLimiter` instance, consistent with the pattern used in `/api/og`, `/api/notify`, `/api/user-details`, `/api/ci-analytics`, and `/api/achievements`
- Set limit to **5 requests/min per IP** - the lowest of any route, reflecting the 14x GitHub API cost per request
- Falls back to `user-agent` keying when IP is unknown
- Fixed all 4 test files to mock `RateLimiter` correctly so the singleton doesn't exhaust across tests (was the root cause of 20 CI failures in #5957)


## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [X] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [X] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [X] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [X] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
