### PR TITLE
fix(calculate): clarify normalizeCalendarToTimezone behavior

### DIFF
--- a/lib/calculate.ts
+++ b/lib/calculate.ts
@@ -577,7 +577,7 @@ export function calculateWrappedStats(calendar?: ContributionCalendar | null) {
  */
 export function normalizeCalendarToTimezone(
   calendar: ContributionCalendar,
-  _targetTimezone: string
+  _targetTimezone: string // retained for backward compatibility with existing callers
 ): ContributionCalendar {
   if (!calendar || !calendar.weeks || calendar.weeks.length === 0) {
     return calendar;

--- a/lib/calculate.ts
+++ b/lib/calculate.ts
@@ -560,19 +560,24 @@ export function calculateWrappedStats(calendar?: ContributionCalendar | null) {
 }
 
 /**
- * Normalizes a contribution calendar to a target timezone.
+ * Normalizes the structural layout of a contribution calendar.
  *
- * This function converts each contribution day's date to the target timezone
- * and re-groups the days by the target timezone's midnight boundaries.
- * This is essential for accurate comparisons between users in different timezones.
+ * This function aggregates duplicate calendar dates, sorts them
+ * chronologically, and re-groups them into Sunday-Saturday week buckets.
  *
- * @param calendar - The contribution calendar to normalize
- * @param targetTimezone - The target timezone to normalize to (e.g., 'UTC', 'America/New_York')
- * @returns A new calendar with dates normalized to the target timezone
+ * NOTE:
+ * ContributionDay entries only contain date strings (YYYY-MM-DD)
+ * and do not include timestamps or timezone information.
+ * Therefore, no actual timezone conversion is performed.
+ *
+ * @param calendar The contribution calendar to normalize
+ * @param _targetTimezone Reserved for future use. Currently unused because
+ * date-only contribution data cannot be shifted across timezone boundaries.
+ * @returns A calendar with normalized week structure
  */
 export function normalizeCalendarToTimezone(
   calendar: ContributionCalendar,
-  targetTimezone: string
+  _targetTimezone: string
 ): ContributionCalendar {
   if (!calendar || !calendar.weeks || calendar.weeks.length === 0) {
     return calendar;


### PR DESCRIPTION
## Description

Fixes #6170

The `normalizeCalendarToTimezone()` function was documented as performing timezone conversion, but it only aggregates duplicate dates, sorts them chronologically, and re-groups them into week buckets.

After reviewing the implementation and underlying data model, actual timezone conversion is not possible because `ContributionDay` only contains date strings (`YYYY-MM-DD`) and does not store timestamps or timezone metadata.

### Changes made

- Updated JSDoc to accurately describe the function's behavior.
- Clarified that no timezone conversion occurs.
- Documented why timezone normalization cannot be implemented with the current data structure.
- Renamed the unused parameter to `_targetTimezone` to make its current status explicit and avoid confusion.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (documentation-only change)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.