### PR TITLE
fix(env): add startup validation for AUTH_SECRET and ENCRYPTION_KEY

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,19 @@
+/**
+ * instrumentation.ts — Next.js Server Startup Hook
+ *
+ * Next.js calls `register()` once when the server process boots, before it
+ * accepts any traffic. We use this to validate critical environment variables
+ * so that misconfigured deployments fail loudly at startup rather than
+ * silently mid-request.
+ *
+ * Docs: https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+ */
+export async function register() {
+  // Only run validation on the server side.
+  // The `edge` runtime does not have access to process.env in the same way,
+  // and client bundles should never import server-only validation logic.
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { assertCriticalEnv } = await import('@/lib/validate-env');
+    assertCriticalEnv();
+  }
+}

--- a/lib/validate-env.test.ts
+++ b/lib/validate-env.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import { validateCriticalEnv, assertCriticalEnv } from './validate-env';
+
+// Helper: build a minimal valid env object so tests are self-contained
+// and do not accidentally read the real process.env values set by vitest.setup.ts.
+function validEnv(overrides: Partial<NodeJS.ProcessEnv> = {}): NodeJS.ProcessEnv {
+  return {
+    AUTH_SECRET: 'a-super-secret-32-character-dummy!!',
+    ENCRYPTION_KEY: 'abcdefghijklmnopqrstuvwxyz012345',
+    ...overrides,
+  } as NodeJS.ProcessEnv;
+}
+
+// ─── validateCriticalEnv ────────────────────────────────────────────────────
+
+describe('validateCriticalEnv — happy path', () => {
+  it('returns valid:true and no errors when both keys are present and long enough', () => {
+    const result = validateCriticalEnv(validEnv());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('accepts keys that are exactly 32 characters', () => {
+    const result = validateCriticalEnv(
+      validEnv({
+        AUTH_SECRET: 'exactly-32-characters-long-here!', // 32 chars
+        ENCRYPTION_KEY: 'exactly-32-characters-long-here!', // 32 chars
+      })
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts keys longer than 32 characters', () => {
+    const result = validateCriticalEnv(
+      validEnv({
+        AUTH_SECRET: 'a'.repeat(64),
+        ENCRYPTION_KEY: 'b'.repeat(64),
+      })
+    );
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('validateCriticalEnv — AUTH_SECRET errors', () => {
+  it('returns an error when AUTH_SECRET is missing', () => {
+    const result = validateCriticalEnv(validEnv({ AUTH_SECRET: undefined }));
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/AUTH_SECRET/);
+    expect(result.errors[0]).toMatch(/openssl rand -base64 32/);
+  });
+
+  it('returns an error when AUTH_SECRET is an empty string', () => {
+    const result = validateCriticalEnv(validEnv({ AUTH_SECRET: '' }));
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/AUTH_SECRET/);
+  });
+
+  it('returns an error when AUTH_SECRET is too short (under 32 chars)', () => {
+    const result = validateCriticalEnv(validEnv({ AUTH_SECRET: 'short' }));
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/AUTH_SECRET/);
+    // Error message should include the actual length so the developer knows why it failed
+    expect(result.errors[0]).toMatch(/5 chars/);
+  });
+
+  it('returns an error when AUTH_SECRET is 31 characters (one under the minimum)', () => {
+    const result = validateCriticalEnv(validEnv({ AUTH_SECRET: 'a'.repeat(31) }));
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/31 chars/);
+  });
+});
+
+describe('validateCriticalEnv — ENCRYPTION_KEY errors', () => {
+  it('returns an error when ENCRYPTION_KEY is missing', () => {
+    const result = validateCriticalEnv(validEnv({ ENCRYPTION_KEY: undefined }));
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/ENCRYPTION_KEY/);
+    expect(result.errors[0]).toMatch(/openssl rand -hex 32/);
+  });
+
+  it('returns an error when ENCRYPTION_KEY is an empty string', () => {
+    const result = validateCriticalEnv(validEnv({ ENCRYPTION_KEY: '' }));
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/ENCRYPTION_KEY/);
+  });
+
+  it('returns an error when ENCRYPTION_KEY is too short (under 32 chars)', () => {
+    const result = validateCriticalEnv(validEnv({ ENCRYPTION_KEY: 'tiny' }));
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/ENCRYPTION_KEY/);
+    expect(result.errors[0]).toMatch(/4 chars/);
+  });
+
+  it('returns an error when ENCRYPTION_KEY is 31 characters (one under the minimum)', () => {
+    const result = validateCriticalEnv(validEnv({ ENCRYPTION_KEY: 'b'.repeat(31) }));
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/31 chars/);
+  });
+});
+
+describe('validateCriticalEnv — both keys invalid', () => {
+  it('collects errors from both keys independently when both are missing', () => {
+    const result = validateCriticalEnv(
+      validEnv({ AUTH_SECRET: undefined, ENCRYPTION_KEY: undefined })
+    );
+    expect(result.valid).toBe(false);
+    // Both errors must be reported together so the developer fixes everything in one pass
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors.some((e) => e.includes('AUTH_SECRET'))).toBe(true);
+    expect(result.errors.some((e) => e.includes('ENCRYPTION_KEY'))).toBe(true);
+  });
+
+  it('collects errors from both keys when both are too short', () => {
+    const result = validateCriticalEnv(
+      validEnv({ AUTH_SECRET: 'short', ENCRYPTION_KEY: 'alsoShort' })
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(2);
+  });
+
+  it('reports one error and not two when only AUTH_SECRET is missing', () => {
+    const result = validateCriticalEnv(validEnv({ AUTH_SECRET: undefined }));
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it('reports one error and not two when only ENCRYPTION_KEY is missing', () => {
+    const result = validateCriticalEnv(validEnv({ ENCRYPTION_KEY: undefined }));
+    expect(result.errors).toHaveLength(1);
+  });
+});
+
+// ─── assertCriticalEnv ──────────────────────────────────────────────────────
+
+describe('assertCriticalEnv — happy path', () => {
+  it('does not throw when the environment is fully configured', () => {
+    expect(() => assertCriticalEnv(validEnv())).not.toThrow();
+  });
+});
+
+describe('assertCriticalEnv — throws on bad config', () => {
+  it('throws when AUTH_SECRET is missing', () => {
+    expect(() => assertCriticalEnv(validEnv({ AUTH_SECRET: undefined }))).toThrow(/AUTH_SECRET/);
+  });
+
+  it('throws when ENCRYPTION_KEY is missing', () => {
+    expect(() => assertCriticalEnv(validEnv({ ENCRYPTION_KEY: undefined }))).toThrow(
+      /ENCRYPTION_KEY/
+    );
+  });
+
+  it('throws a single consolidated error listing all problems when both keys are missing', () => {
+    // A single throw surfaces all issues at once — no "fix one, redeploy, find next error" loop
+    expect(() =>
+      assertCriticalEnv(validEnv({ AUTH_SECRET: undefined, ENCRYPTION_KEY: undefined }))
+    ).toThrow(/AUTH_SECRET/);
+    expect(() =>
+      assertCriticalEnv(validEnv({ AUTH_SECRET: undefined, ENCRYPTION_KEY: undefined }))
+    ).toThrow(/ENCRYPTION_KEY/);
+  });
+
+  it('includes setup instructions and .env.local.example reference in the error message', () => {
+    let message = '';
+    try {
+      assertCriticalEnv(validEnv({ AUTH_SECRET: undefined }));
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toMatch(/\.env\.local\.example/);
+    expect(message).toMatch(/CommitPulse/);
+  });
+
+  it('throws an Error instance (not a string or other type)', () => {
+    let thrown: unknown;
+    try {
+      assertCriticalEnv(validEnv({ AUTH_SECRET: undefined }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+  });
+});

--- a/lib/validate-env.ts
+++ b/lib/validate-env.ts
@@ -1,0 +1,78 @@
+/**
+ * validate-env.ts
+ *
+ * Validates that critical server-side environment variables are present and
+ * meet minimum security requirements. Call this once at server startup so
+ * misconfigured deployments fail loudly at boot — not silently mid-request.
+ *
+ * Required variables:
+ *   AUTH_SECRET      — NextAuth.js JWT signing key (≥ 32 chars)
+ *   ENCRYPTION_KEY   — AES-256 token encryption key (≥ 32 chars)
+ */
+
+export interface EnvValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/**
+ * Validates the critical environment variables needed for authentication and
+ * encryption. Returns a result object rather than throwing so callers can
+ * decide how to surface errors (log, throw, render an error page, etc.).
+ */
+export function validateCriticalEnv(env: NodeJS.ProcessEnv = process.env): EnvValidationResult {
+  const errors: string[] = [];
+
+  // AUTH_SECRET: required by NextAuth.js to sign JWT session cookies.
+  // Without it, NextAuth falls back to an insecure default or throws at runtime,
+  // and every server restart invalidates all existing user sessions.
+  const authSecret = env.AUTH_SECRET;
+  if (!authSecret) {
+    errors.push(
+      'AUTH_SECRET is not set. ' +
+        'Generate one with: openssl rand -base64 32 ' +
+        'and add it to your .env.local and deployment environment.'
+    );
+  } else if (authSecret.length < 32) {
+    errors.push(
+      `AUTH_SECRET is too short (${authSecret.length} chars). ` +
+        'It must be at least 32 characters to provide sufficient entropy for JWT signing.'
+    );
+  }
+
+  // ENCRYPTION_KEY: required by lib/crypto.ts (AES-256-GCM) to encrypt and
+  // decrypt GitHub OAuth tokens stored in the database. Without it, token
+  // persistence fails and users see "not authenticated" despite valid sessions.
+  const encryptionKey = env.ENCRYPTION_KEY;
+  if (!encryptionKey) {
+    errors.push(
+      'ENCRYPTION_KEY is not set. ' +
+        'Generate one with: openssl rand -hex 32 ' +
+        'and add it to your .env.local and deployment environment.'
+    );
+  } else if (encryptionKey.length < 32) {
+    errors.push(
+      `ENCRYPTION_KEY is too short (${encryptionKey.length} chars). ` +
+        'It must be at least 32 characters to satisfy AES-256 key derivation requirements.'
+    );
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validates critical environment variables and throws a single consolidated
+ * Error if any are missing or invalid. Intended for use in server startup
+ * hooks (e.g. Next.js instrumentation.ts) where a thrown error will prevent
+ * the server from accepting traffic in a misconfigured state.
+ */
+export function assertCriticalEnv(env: NodeJS.ProcessEnv = process.env): void {
+  const result = validateCriticalEnv(env);
+  if (!result.valid) {
+    throw new Error(
+      '[CommitPulse] Server startup aborted — missing or invalid environment variables:\n' +
+        result.errors.map((e) => `  • ${e}`).join('\n') +
+        '\n\nSee .env.local.example for setup instructions.'
+    );
+  }
+}


### PR DESCRIPTION
## Description
Fixes #6190
Adds startup validation for AUTH_SECRET and ENCRYPTION_KEY so that
misconfigured deployments fail loudly at server boot rather than silently
mid-request.
Both variables were already documented in .env.local.example with generation
commands, but nothing prevented the server from starting with them missing or
too short.
**Changes:**
- lib/validate-env.ts — validateCriticalEnv() and assertCriticalEnv()
  functions. Validates presence and minimum 32-char length for both keys.
  Collects all errors before throwing so developers see every problem at once.
- lib/validate-env.test.ts — 21 Vitest tests covering all branches (happy
  path, each key missing, each key too short, both missing, error message
  content, Error instance type).
- instrumentation.ts — Next.js server startup hook that calls
  assertCriticalEnv() once on boot (Node.js runtime only). Server refuses to
  accept traffic if either key is absent or invalid.

## Visual Preview
<img width="1130" height="846" alt="image" src="https://github.com/user-attachments/assets/af2dca56-0a2a-47a5-b4f9-50770c6b9725" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
