### PR TITLE
test: add coverage for normalizeHexColor utility

### DIFF
--- a/lib/svg/sanitizer.test.ts
+++ b/lib/svg/sanitizer.test.ts
@@ -7,6 +7,7 @@ import {
   sanitizeRadius,
   sanitizeFont,
   sanitizeGoogleFontUrl,
+  normalizeHexColor,
   parseGradientStops,
   MAX_GRADIENT_STOPS,
 } from './sanitizer';
@@ -304,6 +305,42 @@ describe('SVG Sanitizer Utilities', () => {
       expect(hexColor('c9d1d9', '000000')).toBe('c9d1d9');
       expect(hexColor('58a6ff', '000000')).toBe('58a6ff');
     });
+  });
+});
+
+describe('normalizeHexColor', () => {
+  it('normalizes valid 6-digit hex colors', () => {
+    expect(normalizeHexColor('ffffff')).toBe('ffffff');
+    expect(normalizeHexColor('#ffffff')).toBe('ffffff');
+  });
+
+  it('normalizes valid 3-digit hex colors', () => {
+    expect(normalizeHexColor('abc')).toBe('abc');
+    expect(normalizeHexColor('#abc')).toBe('abc');
+  });
+
+  it('normalizes valid 4-digit hex colors', () => {
+    expect(normalizeHexColor('f0f0')).toBe('f0f0');
+    expect(normalizeHexColor('#f0f0')).toBe('f0f0');
+  });
+
+  it('normalizes valid 8-digit hex colors', () => {
+    expect(normalizeHexColor('ff00ff00')).toBe('ff00ff00');
+    expect(normalizeHexColor('#ff00ff00')).toBe('ff00ff00');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeHexColor('  #ffffff  ')).toBe('ffffff');
+  });
+
+  it('returns null for invalid values', () => {
+    expect(normalizeHexColor('invalid')).toBeNull();
+    expect(normalizeHexColor('zzzzzz')).toBeNull();
+    expect(normalizeHexColor('')).toBeNull();
+  });
+
+  it('returns null for hash-only input', () => {
+    expect(normalizeHexColor('#')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Description

Fixes #6512 

Adds dedicated unit tests for `normalizeHexColor()` to improve sanitizer utility test coverage.

### Changes

* Added tests for valid 3-digit hex colors
* Added tests for valid 4-digit hex colors
* Added tests for valid 6-digit hex colors
* Added tests for valid 8-digit hex colors
* Added tests for leading `#` normalization
* Added tests for whitespace trimming
* Added tests for invalid color rejection
* Added tests for empty string and hash-only inputs

### Why

`normalizeHexColor()` is exported by the sanitizer module but previously lacked direct unit test coverage. These tests help prevent regressions and ensure color normalization behavior remains consistent across future changes.

### Testing

* Ran test suite locally
* All tests passing
* No production code changes
* Coverage increased for sanitizer utilities

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)
* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse quality standard.
* [ ] (Recommended) I joined the CommitPulse Discord community.
