### PR TITLE
test(sanitizer): expand parseGradientStops edge-case coverage

### DIFF
--- a/lib/svg/sanitizer.test.ts
+++ b/lib/svg/sanitizer.test.ts
@@ -360,4 +360,24 @@ describe('parseGradientStops', () => {
     const result = parseGradientStops(colors);
     expect(result.length).toBe(MAX_GRADIENT_STOPS);
   });
+
+  it('trims whitespace around color values', () => {
+    expect(parseGradientStops('  #ff6b35 ,  #7000ff  ')).toEqual(['ff6b35', '7000ff']);
+  });
+
+  it('handles whitespace with mixed valid and invalid colors', () => {
+    expect(parseGradientStops('  #ff6b35 , invalid , #7000ff ')).toEqual(['ff6b35', '7000ff']);
+  });
+
+  it('ignores empty tokens', () => {
+    expect(parseGradientStops('ff6b35,,7000ff,,,')).toEqual(['ff6b35', '7000ff']);
+  });
+
+  it('handles leading and trailing commas', () => {
+    expect(parseGradientStops(',ff6b35,7000ff,')).toEqual(['ff6b35', '7000ff']);
+  });
+
+  it('preserves uppercase hex colors', () => {
+    expect(parseGradientStops('FF6B35,7000FF')).toEqual(['FF6B35', '7000FF']);
+  });
 });


### PR DESCRIPTION
## Description

Fixes #6514 

Adds additional edge-case coverage for `parseGradientStops()`.

### Added Tests

* Whitespace around color values
* Mixed valid and invalid colors with whitespace
* Empty tokens between commas
* Leading and trailing commas
* Uppercase hex color handling

### Why

The existing test suite covered standard parsing behavior but did not explicitly verify several real-world input patterns commonly found in URL parameters.

These tests improve confidence in gradient parsing behavior and help prevent regressions without changing production code.

### Testing

* Ran test suite locally
* All tests passing
* No production code changes
* Improved coverage for gradient parsing utilities

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)
* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization

## Visual Preview

N/A (test-only change)
