### PR TITLE
test(sanitizer): consolidate duplicate isValidHex cases

### DIFF
--- a/lib/svg/sanitizer.test.ts
+++ b/lib/svg/sanitizer.test.ts
@@ -32,10 +32,11 @@ describe('SVG Sanitizer Utilities', () => {
       expect(isValidHex('ff00ff"')).toBe(false);
     });
 
-    it('returns false for invalid length', () => {
+    it('returns false for invalid lengths', () => {
       expect(isValidHex('f')).toBe(false);
       expect(isValidHex('ff')).toBe(false);
       expect(isValidHex('fffff')).toBe(false);
+      expect(isValidHex('fffffff')).toBe(false);
     });
 
     it('returns false for undefined, null, or empty string', () => {
@@ -44,20 +45,8 @@ describe('SVG Sanitizer Utilities', () => {
       expect(isValidHex('')).toBe(false);
     });
 
-    it('returns false for an empty string', () => {
-      expect(isValidHex('')).toBe(false);
-    });
-
     it('returns false for just a hash symbol', () => {
       expect(isValidHex('#')).toBe(false);
-    });
-
-    it('returns false for undefined input', () => {
-      expect(isValidHex(undefined)).toBe(false);
-    });
-
-    it('returns false for invalid length (7 characters)', () => {
-      expect(isValidHex('fffffff')).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Description

Fixes #6517 

Refactors the `isValidHex()` test suite by removing duplicate test cases and consolidating overlapping edge-case coverage.

### Changes

* Removed duplicate empty string validation test
* Removed duplicate undefined input validation test
* Merged 7-character invalid length validation into the existing invalid length test
* Preserved all existing behavior and assertions
* Improved test suite readability and maintainability

### Why

Several test cases were validating the same behavior multiple times. Consolidating these tests reduces redundancy while maintaining the same level of coverage.

### Before

Multiple tests independently verified:

* Empty string input
* Undefined input
* Invalid string lengths

### After

The same scenarios are covered through consolidated test cases, resulting in a cleaner and easier-to-maintain test suite.

### Testing

* Ran test suite locally
* All tests passing
* No production code changes
* No behavioral changes

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)
* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization

## Visual Preview

N/A (test-only refactor)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse quality standard.
* [ ] (Recommended) I joined the CommitPulse Discord community.
