### PR TITLE
test(hooks): add dynamic delay change coverage for useDebounce

### DIFF
--- a/hooks/useDebounce.test.ts
+++ b/hooks/useDebounce.test.ts
@@ -133,4 +133,112 @@ describe('useDebounce', () => {
       vi.useRealTimers();
     }
   });
+
+  it('uses the new shorter delay when delay decreases during a pending debounce', () => {
+    vi.useFakeTimers();
+
+    try {
+      const { result, rerender } = renderHook(({ value, delay }) => useDebounce(value, delay), {
+        initialProps: {
+          value: 'a',
+          delay: 300,
+        },
+      });
+
+      rerender({
+        value: 'b',
+        delay: 300,
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      rerender({
+        value: 'b',
+        delay: 150,
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(149);
+      });
+
+      expect(result.current).toBe('a');
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+
+      expect(result.current).toBe('b');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('uses the new longer delay when delay increases during a pending debounce', () => {
+    vi.useFakeTimers();
+
+    try {
+      const { result, rerender } = renderHook(({ value, delay }) => useDebounce(value, delay), {
+        initialProps: {
+          value: 'a',
+          delay: 100,
+        },
+      });
+
+      rerender({
+        value: 'b',
+        delay: 100,
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(50);
+      });
+
+      rerender({
+        value: 'b',
+        delay: 300,
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(299);
+      });
+
+      expect(result.current).toBe('a');
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+
+      expect(result.current).toBe('b');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('restarts debounce when only delay changes', () => {
+    vi.useFakeTimers();
+
+    try {
+      const { result, rerender } = renderHook(({ value, delay }) => useDebounce(value, delay), {
+        initialProps: {
+          value: 'hello',
+          delay: 300,
+        },
+      });
+
+      rerender({
+        value: 'hello',
+        delay: 100,
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      expect(result.current).toBe('hello');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Description

Fixes #6524 

Adds dedicated test coverage for dynamic `delay` changes in the `useDebounce` hook.

### Changes

* Added tests for decreasing the debounce delay while a debounce is pending
* Added tests for increasing the debounce delay while a debounce is pending
* Added tests verifying behavior when only the `delay` prop changes
* Verified that previous timers are properly cancelled and replaced when delay updates occur

### Why

The current test suite covers value updates, timer resets, large payloads, accessibility scenarios, and rapid rerender sequences. However, it does not explicitly verify behavior when the `delay` parameter changes during an active debounce cycle.

Since the hook's effect depends on both `value` and `delay`, changes to the delay are part of the hook's public behavior and should be covered by tests to prevent regressions.

### Testing

* Ran test suite locally
* All tests passing
* No production code changes
* Improved coverage for delay-dependent debounce behavior

## Pillar

* [x] 🛠️ Other (Bug fix, refactoring, docs)
* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse quality standard.
* [ ] (Recommended) I joined the CommitPulse Discord community.
