### PR TITLE
ci: cancel outdated workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [main, dev]
   merge_group: # Run CI on the merged commit before it lands on main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     name: Format · Lint · Typecheck · Test


### PR DESCRIPTION
## Description

Fixes #6528 

Adds GitHub Actions concurrency controls to automatically cancel outdated workflow runs when newer commits are pushed to the same branch or pull request.

### Changes

* Added a workflow-level `concurrency` configuration
* Enabled automatic cancellation of in-progress runs for the same workflow and branch

### Why

When multiple commits are pushed in quick succession, older CI runs continue executing even though their results are no longer relevant. This increases runner usage and slows feedback for contributors.

Using GitHub Actions concurrency ensures that only the latest workflow run remains active.

### Testing

* Verified workflow syntax
* No changes to existing CI checks
* Existing lint, typecheck, test, and build jobs remain unchanged

## Visual Preview

N/A (CI configuration change)
