### PR TITLE
test(calculate): add multi-year scaling streak coverage

### DIFF
--- a/lib/calculate.multiyear-scaling.test.ts
+++ b/lib/calculate.multiyear-scaling.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { calculateStreak, chunkDaysIntoWeeks } from './calculate';
+import type { ContributionCalendar, ContributionDay } from '../types';
+
+describe('calculate multiyear scaling behavior', () => {
+  it('maintains a continuous streak across multiple years', () => {
+    const start = new Date('2015-01-01');
+
+    const days: ContributionDay[] = Array.from({ length: 3650 }, (_, i) => ({
+      date: new Date(start.getTime() + i * 86400000).toISOString().split('T')[0],
+      contributionCount: 1,
+    }));
+
+    const calendar: ContributionCalendar = {
+      totalContributions: days.length,
+      weeks: chunkDaysIntoWeeks(days),
+    };
+
+    const result = calculateStreak(calendar, 'UTC', new Date(days[days.length - 1].date));
+
+    expect(result.longestStreak).toBe(3650);
+    expect(result.currentStreak).toBeGreaterThan(0);
+  });
+
+  it('correctly handles leap year continuity through February 29', () => {
+    const days: ContributionDay[] = [
+      { date: '2024-02-27', contributionCount: 1 },
+      { date: '2024-02-28', contributionCount: 1 },
+      { date: '2024-02-29', contributionCount: 1 },
+      { date: '2024-03-01', contributionCount: 1 },
+      { date: '2024-03-02', contributionCount: 1 },
+    ];
+
+    const calendar: ContributionCalendar = {
+      totalContributions: 5,
+      weeks: chunkDaysIntoWeeks(days),
+    };
+
+    const result = calculateStreak(calendar, 'UTC', new Date('2024-03-02'));
+
+    expect(result.longestStreak).toBe(5);
+  });
+
+  it('preserves streaks across December to January year boundaries', () => {
+    const days: ContributionDay[] = [
+      { date: '2024-12-29', contributionCount: 1 },
+      { date: '2024-12-30', contributionCount: 1 },
+      { date: '2024-12-31', contributionCount: 1 },
+      { date: '2025-01-01', contributionCount: 1 },
+      { date: '2025-01-02', contributionCount: 1 },
+    ];
+
+    const calendar: ContributionCalendar = {
+      totalContributions: 5,
+      weeks: chunkDaysIntoWeeks(days),
+    };
+
+    const result = calculateStreak(calendar, 'UTC', new Date('2025-01-02'));
+
+    expect(result.longestStreak).toBe(5);
+  });
+
+  it('remains accurate under timezone-sensitive date boundaries', () => {
+    const days: ContributionDay[] = [
+      { date: '2025-01-01', contributionCount: 1 },
+      { date: '2025-01-02', contributionCount: 1 },
+      { date: '2025-01-03', contributionCount: 1 },
+    ];
+
+    const calendar: ContributionCalendar = {
+      totalContributions: 3,
+      weeks: chunkDaysIntoWeeks(days),
+    };
+
+    const result = calculateStreak(calendar, 'Asia/Kolkata', new Date('2025-01-03T23:30:00Z'));
+
+    expect(result.longestStreak).toBe(3);
+  });
+
+  it('handles decade-scale histories with intermittent gaps', () => {
+    const start = new Date('2010-01-01');
+
+    const days: ContributionDay[] = Array.from({ length: 3650 }, (_, i) => ({
+      date: new Date(start.getTime() + i * 86400000).toISOString().split('T')[0],
+      contributionCount: i % 500 === 0 ? 0 : 1,
+    }));
+
+    const calendar: ContributionCalendar = {
+      totalContributions: days.reduce((sum, day) => sum + day.contributionCount, 0),
+      weeks: chunkDaysIntoWeeks(days),
+    };
+
+    const result = calculateStreak(calendar, 'UTC', new Date(days[days.length - 1].date));
+
+    expect(result.longestStreak).toBeGreaterThan(100);
+    expect(result.totalContributions).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #6453

This PR adds dedicated multi-year streak calculation test coverage to improve reliability and scalability of CommitPulse's core streak logic.

### Changes

* Added `lib/calculate.multiyear-scaling.test.ts`
* Added coverage for multi-year contribution histories (10+ years)
* Added leap year validation (February 29 handling)
* Added year-boundary transition tests (December → January)
* Added timezone-sensitive streak calculation tests
* Added large historical dataset validation with intermittent gaps

### Benefits

* Protects against regressions in streak calculations
* Improves confidence in timezone-aware date handling
* Verifies correctness across leap years and year transitions
* Ensures stability for users with long GitHub contribution histories
* Expands automated test coverage for a critical feature

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [x] 🕐 Pillar 3 — Timezone Logic Optimization
* [ ] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable – test-only changes).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
