### PR TITLE
refactor: strengthen input validation and safety guards in resume-parser #6043

### DIFF
--- a/lib/resume-parser.empty-fallback.test.ts
+++ b/lib/resume-parser.empty-fallback.test.ts
@@ -7,9 +7,9 @@ describe('resume-parser-empty-fallback', () => {
     const result = await parseResume(buffer, 'application/pdf');
 
     expect(result).toEqual({
-      name: '',
-      email: '',
-      phone: '',
+      name: 'N/A',
+      email: 'N/A',
+      phone: 'N/A',
       skills: [],
       education: [],
       experience: [],
@@ -21,9 +21,9 @@ describe('resume-parser-empty-fallback', () => {
     const result = await parseResume(buffer, 'application/pdf');
 
     expect(result).toEqual({
-      name: '',
-      email: '',
-      phone: '',
+      name: 'N/A',
+      email: 'N/A',
+      phone: 'N/A',
       skills: [],
       education: [],
       experience: [],
@@ -35,7 +35,7 @@ describe('resume-parser-empty-fallback', () => {
     const buffer = Buffer.from(text);
     const result = await parseResume(buffer, 'application/pdf');
 
-    expect(result.email).toBe('');
+    expect(result.email).toBe('N/A');
   });
 
   it('should return empty email if email is malformed', async () => {
@@ -43,7 +43,7 @@ describe('resume-parser-empty-fallback', () => {
     const buffer = Buffer.from(text);
     const result = await parseResume(buffer, 'application/pdf');
 
-    expect(result.email).toBe('');
+    expect(result.email).toBe('N/A');
   });
 
   it('should return empty name if first few lines do not match name regex', async () => {
@@ -51,7 +51,7 @@ describe('resume-parser-empty-fallback', () => {
     const buffer = Buffer.from(text);
     const result = await parseResume(buffer, 'application/pdf');
 
-    expect(result.name).toBe('');
+    expect(result.name).toBe('N/A');
   });
 
   it('should return empty name if first lines have lowercase initials only', async () => {
@@ -59,7 +59,7 @@ describe('resume-parser-empty-fallback', () => {
     const buffer = Buffer.from(text);
     const result = await parseResume(buffer, 'application/pdf');
 
-    expect(result.name).toBe('');
+    expect(result.name).toBe('N/A');
   });
 
   it('should return empty phone if phone is missing or contains invalid characters', async () => {
@@ -67,7 +67,7 @@ describe('resume-parser-empty-fallback', () => {
     const buffer = Buffer.from(text);
     const result = await parseResume(buffer, 'application/pdf');
 
-    expect(result.phone).toBe('');
+    expect(result.phone).toBe('N/A');
   });
 
   it('should return empty skills if no skills section header is present', async () => {
@@ -91,8 +91,8 @@ University of Toronto 2018 - 2022
     expect(result.education).toEqual([
       {
         institution: 'University of Toronto 2018 - 2022',
-        degree: '',
-        field: '',
+        degree: 'N/A',
+        field: 'N/A',
         startDate: '2018',
         endDate: '2022',
       },

--- a/lib/resume-parser.error-resilience.test.ts
+++ b/lib/resume-parser.error-resilience.test.ts
@@ -28,9 +28,9 @@ describe('resume-parser-error-resilience', () => {
     const result = await parseResume(binaryData, 'application/pdf');
 
     expect(result).toEqual({
-      name: '',
-      email: '',
-      phone: '',
+      name: 'N/A',
+      email: 'N/A',
+      phone: 'N/A',
       skills: [],
       education: [],
       experience: [],
@@ -62,8 +62,8 @@ MIT 2015 to 2019
     expect(result.education).toEqual([
       {
         institution: 'MIT 2015 to 2019',
-        degree: '',
-        field: '',
+        degree: 'N/A',
+        field: 'N/A',
         startDate: '2015',
         endDate: '2019',
       },
@@ -83,10 +83,10 @@ Senior Engineer at Meta 2018 - 2021
     expect(result.experience).toEqual([
       {
         company: 'Senior Engineer at Meta 2018 - 2021',
-        role: '',
+        role: 'N/A',
         startDate: '2018',
         endDate: '2021',
-        description: '',
+        description: 'N/A',
       },
     ]);
   });

--- a/lib/resume-parser.test.ts
+++ b/lib/resume-parser.test.ts
@@ -77,13 +77,25 @@ Frontend Developer at XYZ 2022-2024
     const result = await parseResume(Buffer.from(''), 'application/pdf');
 
     expect(result).toEqual({
-      name: '',
-      email: '',
-      phone: '',
+      name: 'N/A',
+      email: 'N/A',
+      phone: 'N/A',
       skills: [],
       education: [],
       experience: [],
     });
+  });
+
+  it('handles international phone and plus-addressed email formatting', async () => {
+    const resume = `
+John Doe
+john.doe+filter@example.co.uk
++91 98765 43210
+`;
+    const result = await parseResume(Buffer.from(resume), 'application/pdf');
+    expect(result.name).toBe('John Doe');
+    expect(result.email).toBe('john.doe+filter@example.co.uk');
+    expect(result.phone).toBe('+91 98765 43210');
   });
 
   it('returns sensible fallbacks when sections are missing', async () => {

--- a/lib/resume-parser.ts
+++ b/lib/resume-parser.ts
@@ -7,7 +7,7 @@ if (typeof globalThis !== 'undefined' && !('DOMMatrix' in globalThis)) {
   (globalThis as any).DOMMatrix = class DOMMatrix {};
 }
 
-const EMAIL_REGEX = /[\w.-]+@[\w.-]+\.\w+/;
+const EMAIL_REGEX = /[\w.+-]+@[\w.-]+\.[a-zA-Z]{2,}/i;
 const NAME_LINE_REGEX = /^([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)/;
 
 const SKILL_SECTION_HEADERS = /skills|technologies|proficiencies|tech stack|tools/i;
@@ -16,7 +16,7 @@ const EXPERIENCE_SECTION_HEADERS = /experience|work|employment|professional|care
 
 function extractEmail(text: string): string {
   const match = text.match(EMAIL_REGEX);
-  return match ? match[0] : '';
+  return match ? match[0] : 'N/A';
 }
 
 function extractName(text: string): string {
@@ -30,7 +30,7 @@ function extractName(text: string): string {
       return match[1];
     }
   }
-  return '';
+  return 'N/A';
 }
 
 function extractSection(text: string, headers: RegExp): string[] {
@@ -194,20 +194,46 @@ async function extractTextFromBuffer(buffer: Buffer, mimeType: string): Promise<
  * const phone = extractPhone(rawText);
  */
 function extractPhone(text: string): string {
-  const match = text.match(/(\+?\d{1,3}[\s.-]?)?(\(?\d{3}\)?[\s.-]?)(\d{3}[\s.-]?\d{4})/);
-  return match ? match[0].trim() : '';
+  const match = text.match(/(?:\+?\d{1,3}[\s.-]?)?\(?\d{2,4}\)?[\s.-]?\d{2,4}[\s.-]?\d{3,9}/);
+  return match ? match[0].trim() : 'N/A';
 }
 
 export async function parseResume(buffer: Buffer, mimeType: string): Promise<ParsedResume> {
+  if (!buffer) {
+    throw new TypeError('Buffer cannot be null or undefined');
+  }
   const rawText = await extractTextFromBuffer(buffer, mimeType);
 
+  const name = extractName(rawText);
+  const email = extractEmail(rawText);
+  const phone = extractPhone(rawText);
+  const skills = extractSkills(rawText);
+  const education = extractEducation(rawText);
+  const experience = extractExperience(rawText);
+
   return {
-    name: extractName(rawText),
-    email: extractEmail(rawText),
-    phone: extractPhone(rawText),
-    skills: extractSkills(rawText),
-    education: extractEducation(rawText),
-    experience: extractExperience(rawText),
+    name: name && name.trim() ? name.trim() : 'N/A',
+    email: email && email.trim() ? email.trim() : 'N/A',
+    phone: phone && phone.trim() ? phone.trim() : 'N/A',
+    skills: Array.isArray(skills) ? skills.filter(Boolean) : [],
+    education: Array.isArray(education)
+      ? education.map((edu) => ({
+          institution: edu.institution?.trim() || 'N/A',
+          degree: edu.degree?.trim() || 'N/A',
+          field: edu.field?.trim() || 'N/A',
+          startDate: edu.startDate?.trim() || 'N/A',
+          endDate: edu.endDate?.trim() || 'N/A',
+        }))
+      : [],
+    experience: Array.isArray(experience)
+      ? experience.map((exp) => ({
+          company: exp.company?.trim() || 'N/A',
+          role: exp.role?.trim() || 'N/A',
+          startDate: exp.startDate?.trim() || 'N/A',
+          endDate: exp.endDate?.trim() || 'N/A',
+          description: exp.description?.trim() || 'N/A',
+        }))
+      : [],
   };
 }
 


### PR DESCRIPTION
Fixes #6043

### Description
This PR refactors `lib/resume-parser.ts` to improve input validation rules and prevent UI layout defects on the frontend dashboard by returning sensible default fallbacks.

### Changes Made
- **Regex Enhancements**:
  - Improved `EMAIL_REGEX` to support plus addressing formats (`user+filter@domain.com`).
  - Refactored `PHONE_REGEX` to support international country prefixes, area codes in brackets, spaces, dashes, and dots.
- **Fallbacks & Safety Guards**:
  - Configured `name`, `email`, and `phone` to default to `"N/A"` instead of empty strings if no matches are found, preventing layout breaks.
  - Refactored `parseResume` to safely handle arrays (`skills`, `education`, `experience`) by validating they exist, filtering empty items, and mapping internal missing fields to `"N/A"`.
- **Unit Tests**:
  - Updated existing tests in `lib/resume-parser.test.ts`, `lib/resume-parser.empty-fallback.test.ts`, and `lib/resume-parser.error-resilience.test.ts` to expect `"N/A"` fallbacks.
  - Added new test cases verifying international phone number styles and plus-addressed emails.

### Verification Results
Ran Vitest:
`npx vitest run resume-parser`
- **Result**: All 66 tests successfully passed.
