### PR TITLE
fix: User Dashboard Skeleton Loader UI in Light Mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -133,6 +133,18 @@ html {
 }
 
 .shimmer {
+  background-color: #e5e7eb;
+  background-image: linear-gradient(
+    90deg,
+    rgb(255 255 255 / 0%) 0%,
+    rgb(255 255 255 / 60%) 50%,
+    rgb(255 255 255 / 0%) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+.dark .shimmer {
   background-color: #1e2433; /* visible dark blue-gray on black */
   background-image: linear-gradient(
     90deg,

--- a/components/dashboard/AIInsightsSkeleton.theme-contrast.test.tsx
+++ b/components/dashboard/AIInsightsSkeleton.theme-contrast.test.tsx
@@ -3,14 +3,16 @@ import { describe, expect, it } from 'vitest';
 import AIInsightsSkeleton from './AIInsightsSkeleton';
 
 describe('AIInsightsSkeleton theme contrast', () => {
-  it('renders the skeleton container in dark theme environment', () => {
+  it('renders the skeleton container with theme-aware styles', () => {
     document.documentElement.classList.add('dark');
 
     const { container } = render(<AIInsightsSkeleton />);
     const root = container.firstElementChild;
 
-    expect(root).toHaveClass('bg-[#0a0a0a]');
-    expect(root).toHaveClass('border-[rgba(255,255,255,0.08)]');
+    expect(root).toHaveClass('bg-white');
+    expect(root).toHaveClass('dark:bg-[#0a0a0a]');
+    expect(root).toHaveClass('border-black/10');
+    expect(root).toHaveClass('dark:border-[rgba(255,255,255,0.08)]');
     expect(document.documentElement).toHaveClass('dark');
   });
 
@@ -37,7 +39,7 @@ describe('AIInsightsSkeleton theme contrast', () => {
   it('renders all insight rows with contrast-safe surfaces', () => {
     const { container } = render(<AIInsightsSkeleton />);
     const rows = container.querySelectorAll(
-      '.bg-\\[\\#111\\].border-\\[rgba\\(255\\,255\\,255\\,0\\.05\\)\\]'
+      `[class*="bg-gray-300"][class*="dark:bg-[#111]"][class*="border-[rgba(255,255,255,0.05)]"]`
     );
 
     expect(rows).toHaveLength(3);

--- a/components/dashboard/AIInsightsSkeleton.tsx
+++ b/components/dashboard/AIInsightsSkeleton.tsx
@@ -2,7 +2,7 @@ export default function AIInsightsSkeleton() {
   return (
     <div
       aria-label="Loading AI Insights"
-      className="p-6 rounded-xl bg-[#0a0a0a] border border-[rgba(255,255,255,0.08)]"
+      className="p-6 rounded-xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)] overflow-hidden"
     >
       {/* Header */}
       <div className="flex items-center gap-2.5 mb-5">
@@ -15,7 +15,7 @@ export default function AIInsightsSkeleton() {
         {[...Array(3)].map((_, i) => (
           <div
             key={i}
-            className="flex items-start gap-3 p-3 rounded-lg bg-[#111] border border-[rgba(255,255,255,0.05)]"
+            className="flex items-start gap-3 p-3 rounded-lg bg-gray-300 dark:bg-[#111] border border-[rgba(255,255,255,0.05)]"
           >
             {/* Icon */}
             <div className="w-4 h-4 shimmer rounded-full mt-1 shrink-0 opacity-80" />

--- a/components/dashboard/DashboardSkeleton.tsx
+++ b/components/dashboard/DashboardSkeleton.tsx
@@ -11,7 +11,7 @@ export default function DashboardSkeleton() {
         <div className="h-64 rounded-2xl shimmer border border-white/10" />
 
         {/* Achievements */}
-        <div className="p-6 rounded-xl bg-[#0a0a0a] border border-[rgba(255,255,255,0.08)]">
+        <div className="p-6 rounded-xl bg-white dark:bg-[#0a0a0a] border border-black/10 dark:border-[rgba(255,255,255,0.08)] overflow-hidden">
           <div className="flex items-center gap-2.5 mb-5">
             <div className="w-4 h-4 shimmer rounded" />
             <div className="w-24 h-4 shimmer rounded" />

--- a/components/dashboard/StatsCardSkeleton.tsx
+++ b/components/dashboard/StatsCardSkeleton.tsx
@@ -16,7 +16,7 @@ export default function StatsCardSkeleton() {
       </div>
 
       {/* Micro chart skeleton with deterministic heights */}
-      <div className="w-full h-8 flex items-end justify-between gap-px opacity-30">
+      <div className="w-full h-8 flex items-end justify-between gap-px opacity-80">
         {heights.map((h, i) => (
           <div key={i} className="flex-1 shimmer rounded-t-[1px]" style={{ height: `${h}%` }} />
         ))}

--- a/components/dashboard/__snapshots__/StatsCardSkeleton.test.tsx.snap
+++ b/components/dashboard/__snapshots__/StatsCardSkeleton.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`StatsCardSkeleton > matches snapshot without random variation 1`] = `
     />
   </div>
   <div
-    class="w-full h-8 flex items-end justify-between gap-px opacity-30"
+    class="w-full h-8 flex items-end justify-between gap-px opacity-80"
   >
     <div
       class="flex-1 shimmer rounded-t-[1px]"


### PR DESCRIPTION
## Description

Fixed the skeleton loader styling to follow the active theme. Updated the shimmer and placeholder colors so they display correctly in both Light Mode and Dark Mode, providing a more consistent loading experience.

Fixes #6548 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

### Light Theme

<img width="700" height="380" alt="Screenshot 2026-06-24 235200" src="https://github.com/user-attachments/assets/13ff49c8-6218-4f6f-a0c1-129cd7071840" />


### Dark Theme

<img width="700" height="380" alt="Screenshot 2026-06-24 235038" src="https://github.com/user-attachments/assets/9252395c-0e44-42a4-b133-1b3f2d740d3d" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
