### PR TITLE
test(compare): fix flaky mouse-interactivity test by mirroring router/searchParams in the mock

### DIFF
--- a/app/compare/page.mouse-interactivity.test.tsx
+++ b/app/compare/page.mouse-interactivity.test.tsx
@@ -4,10 +4,26 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import CompareClient from './CompareClient';
 import React, { type ReactNode } from 'react';
 
-const { mockRouter, mockSearchParams } = vi.hoisted(() => ({
-  mockRouter: { replace: vi.fn() },
-  mockSearchParams: { get: vi.fn(() => null) },
-}));
+// Mirror Next.js: router.replace updates the URL, and useSearchParams reflects it.
+// Without this, the auto-compare effect (which calls setData(null) when the URL has
+// no user params) races with the manual compare's setData(json) and wipes the
+// just-rendered result, making the heatmap/habit assertions flaky.
+const { mockRouter, mockSearchParams, resetSearchParams } = vi.hoisted(() => {
+  const params = new Map<string, string>();
+  return {
+    mockRouter: {
+      replace: vi.fn((url: string) => {
+        params.clear();
+        const query = String(url).split('?')[1] ?? '';
+        for (const [key, value] of new URLSearchParams(query)) {
+          params.set(key, value);
+        }
+      }),
+    },
+    mockSearchParams: { get: vi.fn((key: string) => params.get(key) ?? null) },
+    resetSearchParams: () => params.clear(),
+  };
+});
 
 vi.mock('next/navigation', () => ({
   useRouter: () => mockRouter,
@@ -134,6 +150,7 @@ describe('CompareClient Mouse Interactivity & Touch Events', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetSearchParams();
     window.localStorage.clear();
 
     global.fetch = vi.fn(


### PR DESCRIPTION
## Description

Fixes #6554

`app/compare/page.mouse-interactivity.test.tsx` was flaky: intermittent CI failures (about 1 in 3 locally under load) with `AssertionError: expected 0 to be greater than 0` on the heatmap assertion, and sometimes a hover assertion on the coding-habits test.

Root cause: the test's `next/navigation` mock used a static `useSearchParams().get` that always returns `null` and a no-op `router.replace`. But `CompareClient.handleCompare` calls `router.replace('/compare?user1=...&user2=...')`, and an effect re-derives state from `useSearchParams()`, calling `setData(null)` when the URL has no user params. Because the mock never reflected the URL that `router.replace` set, that `setData(null)` raced the manual compare's `setData(json)` and wiped the rendered result; whether it landed before or after the assertions depended on timing, hence the flake. (Captured DOM at a failure: `activitySection=false, hasStatsShowdown=false` — the whole result block was gone.)

This makes the mock faithful to Next.js: `router.replace(url)` now updates the params that `useSearchParams().get` reads, so the auto-compare effect sees the users and is idempotent (it does not clear the result). Added `resetSearchParams()` in `beforeEach` so URL state does not leak between tests.

No production code is changed; this is a test-only fix.

## Tests

Verified locally: the previously-flaky test now passes 25/25 runs (was failing about 1 in 3), and the full `app/compare` suite passes 90/90 across repeated runs. `tsc --noEmit`, Prettier, and ESLint are clean.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No runtime or UI change. This removes a race in the compare test's `next/navigation` mock so CI is deterministic.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (25/25 stable runs of the previously-flaky test; full `app/compare` suite 90/90; `tsc --noEmit` clean).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter. (No new theme or URL parameter.)
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). (Not an SVG change.)
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
