### PR TITLE
fix: sanitize social URLs by stripping leading @ symbols and correctl…

### DIFF
--- a/app/compare/CompareClient.mouse-interactivity.test.tsx
+++ b/app/compare/CompareClient.mouse-interactivity.test.tsx
@@ -184,8 +184,12 @@ describe('CompareClient Interactive Tooltips, Cursor Hovers & Touch Event Propag
     });
 
     // Check StatBattle border elements transitions on mouseEnter / mouseLeave
-    const repositoryCard = screen.getByText('5,000').closest('div');
-    expect(repositoryCard).toBeInTheDocument();
+    let repositoryCard;
+    await waitFor(() => {
+      const repoVal = screen.getByText('5,000');
+      repositoryCard = repoVal.closest('div.rounded-xl') || repoVal.parentElement?.parentElement;
+      expect(repositoryCard).toBeInTheDocument();
+    });
 
     fireEvent.mouseEnter(repositoryCard!);
     fireEvent.mouseLeave(repositoryCard!);
@@ -203,16 +207,17 @@ describe('CompareClient Interactive Tooltips, Cursor Hovers & Touch Event Propag
 
     fireEvent.click(screen.getByRole('button', { name: /compare/i }));
 
-    await waitFor(() => {
-      expect(screen.getByText(/coding habits/i)).toBeInTheDocument();
-    });
-
-    const habitCards = screen.getAllByRole('heading', { level: 3 });
-    const userAHabit = habitCards.find((c) => c.textContent === 'Night Owl');
-    const userBHabit = habitCards.find((c) => c.textContent === 'Early Bird');
-
-    expect(userAHabit).toBeInTheDocument();
-    expect(userBHabit).toBeInTheDocument();
+    let userAHabit, userBHabit;
+    await waitFor(
+      () => {
+        const cards = screen.getAllByRole('heading', { level: 3 });
+        userAHabit = cards.find((c) => c.textContent && c.textContent.includes('Night Owl'));
+        userBHabit = cards.find((c) => c.textContent && c.textContent.includes('Early Bird'));
+        expect(userAHabit).toBeInTheDocument();
+        expect(userBHabit).toBeInTheDocument();
+      },
+      { timeout: 3000 }
+    );
 
     // Trigger hover events to verify standard scale and glow hover properties
     const containerA = userAHabit!.closest('div');

--- a/app/generator/components/sections/SocialsSection.empty-fallback.test.tsx
+++ b/app/generator/components/sections/SocialsSection.empty-fallback.test.tsx
@@ -23,6 +23,7 @@ vi.mock('../../data/socials', () => ({
     },
   ],
   SOCIAL_CATEGORIES: ['Development', 'Social'],
+  resolveSocialUrl: (social: unknown, url: string) => url,
 }));
 
 describe('SocialsSection Edge Cases & Empty/Missing Inputs Verification', () => {

--- a/app/generator/components/sections/SocialsSection.massive-scaling.test.tsx
+++ b/app/generator/components/sections/SocialsSection.massive-scaling.test.tsx
@@ -20,6 +20,7 @@ vi.mock('../../data/socials', () => {
   return {
     SOCIALS: MOCK_SOCIALS,
     SOCIAL_CATEGORIES: ['Dev', 'Design'],
+    resolveSocialUrl: (social: unknown, url: string) => url,
   };
 });
 

--- a/app/generator/components/sections/SocialsSection.theme-contrast.test.tsx
+++ b/app/generator/components/sections/SocialsSection.theme-contrast.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../../data/socials', () => ({
     },
   ],
   SOCIAL_CATEGORIES: ['Development', 'Social'],
+  resolveSocialUrl: (social: unknown, url: string) => url,
 }));
 
 describe('SocialsSection Theme Contrast & Visual Cohesion', () => {

--- a/app/generator/components/sections/SocialsSection.tsx
+++ b/app/generator/components/sections/SocialsSection.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import { Search, X, ExternalLink } from 'lucide-react';
-import { SOCIALS, SOCIAL_CATEGORIES } from '../../data/socials';
+import { SOCIALS, SOCIAL_CATEGORIES, resolveSocialUrl } from '../../data/socials';
 import { SectionCard, FieldLabel } from '../SectionCard';
 import type { Social } from '../../types';
 
@@ -311,9 +311,7 @@ export function SocialsSection({
                         </label>
                         {hasLink && (
                           <a
-                            href={
-                              social.id === 'email' ? `mailto:${val.replace(/^mailto:/, '')}` : val
-                            }
+                            href={resolveSocialUrl(social, val)}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="ml-auto text-emerald-500 hover:text-emerald-400"

--- a/app/generator/data/socials.accessibility.test.tsx
+++ b/app/generator/data/socials.accessibility.test.tsx
@@ -24,6 +24,7 @@ vi.mock('./socials', () => ({
     },
   ],
   SOCIAL_CATEGORIES: ['Development', 'Professional'],
+  resolveSocialUrl: (social: unknown, url: string) => url,
 }));
 
 describe('SocialsSection Accessibility Standards & Screen Reader Compliance', () => {

--- a/app/generator/data/socials.test.ts
+++ b/app/generator/data/socials.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSocialUrl } from './socials';
+import type { Social } from '../types';
+
+describe('resolveSocialUrl', () => {
+  const mockTiktok: Social = {
+    id: 'tiktok',
+    name: 'TikTok',
+    category: 'Social Media',
+    iconUrl: '...',
+    type: 'simpleicon',
+    siSlug: 'tiktok',
+    baseUrl: 'https://tiktok.com/@',
+    placeholder: 'e.g. https://tiktok.com/@username',
+  };
+
+  const mockGithub: Social = {
+    id: 'github',
+    name: 'GitHub',
+    category: 'Developer',
+    iconUrl: '...',
+    type: 'simpleicon',
+    siSlug: 'github',
+    baseUrl: 'https://github.com/',
+    placeholder: 'e.g. https://github.com/username',
+  };
+
+  const mockEmail: Social = {
+    id: 'email',
+    name: 'Email',
+    category: 'Contact',
+    iconUrl: '...',
+    type: 'simpleicon',
+    siSlug: 'maildotru',
+    baseUrl: 'mailto:',
+    placeholder: 'e.g. hello@example.com',
+  };
+
+  it('returns empty string for falsy input', () => {
+    expect(resolveSocialUrl(mockTiktok, '')).toBe('');
+    expect(resolveSocialUrl(mockTiktok, '   ')).toBe('');
+  });
+
+  it('handles email specifically by prepending mailto:', () => {
+    expect(resolveSocialUrl(mockEmail, 'test@example.com')).toBe('mailto:test@example.com');
+    expect(resolveSocialUrl(mockEmail, 'mailto:test@example.com')).toBe('mailto:test@example.com');
+  });
+
+  it('returns the input directly if it already contains http:// or https://', () => {
+    expect(resolveSocialUrl(mockTiktok, 'https://tiktok.com/@myhandle')).toBe(
+      'https://tiktok.com/@myhandle'
+    );
+    expect(resolveSocialUrl(mockGithub, 'http://github.com/johndoe')).toBe(
+      'http://github.com/johndoe'
+    );
+  });
+
+  it('strips leading @ symbol when baseUrl ends with @ to prevent duplication', () => {
+    expect(resolveSocialUrl(mockTiktok, '@myhandle')).toBe('https://tiktok.com/@myhandle');
+  });
+
+  it('concatenates correctly when input is just the username and baseUrl ends with @', () => {
+    expect(resolveSocialUrl(mockTiktok, 'myhandle')).toBe('https://tiktok.com/@myhandle');
+  });
+
+  it('concatenates correctly when input is just the username and baseUrl does NOT end with @', () => {
+    expect(resolveSocialUrl(mockGithub, 'johndoe')).toBe('https://github.com/johndoe');
+  });
+
+  it('does NOT strip leading @ if baseUrl does NOT end with @ (e.g. literal @ in username for some reason)', () => {
+    expect(resolveSocialUrl(mockGithub, '@johndoe')).toBe('https://github.com/@johndoe');
+  });
+});

--- a/app/generator/data/socials.ts
+++ b/app/generator/data/socials.ts
@@ -546,3 +546,26 @@ export const SOCIAL_CATEGORIES: SocialCategory[] = [
 ];
 
 export const getSocialById = (id: string): Social | undefined => SOCIALS.find((s) => s.id === id);
+
+export function resolveSocialUrl(social: Social, input: string): string {
+  if (!input) return '';
+  const val = input.trim();
+  if (!val) return '';
+
+  if (social.id === 'email') {
+    return `mailto:${val.replace(/^mailto:/i, '')}`;
+  }
+
+  // If user typed a full URL, return it directly
+  if (/^https?:\/\//i.test(val)) {
+    return val;
+  }
+
+  // Handle baseUrl concatenation and prevent double '@'
+  let handle = val;
+  if (social.baseUrl.endsWith('@') && handle.startsWith('@')) {
+    handle = handle.substring(1);
+  }
+
+  return social.baseUrl + handle;
+}

--- a/app/generator/utils/readmeGenerator.massive-scaling.test.ts
+++ b/app/generator/utils/readmeGenerator.massive-scaling.test.ts
@@ -18,6 +18,7 @@ vi.mock('../data/socials', () => ({
     iconUrl: `https://cdn.example.com/socials/${id}.svg`,
     type: 'devicon',
   }),
+  resolveSocialUrl: (social: unknown, url: string) => url,
 }));
 
 function buildState(overrides: Partial<GeneratorState> = {}): GeneratorState {

--- a/app/generator/utils/readmeGenerator.ts
+++ b/app/generator/utils/readmeGenerator.ts
@@ -1,5 +1,5 @@
 import { getTechById } from '../data/technologies';
-import { getSocialById } from '../data/socials';
+import { getSocialById, resolveSocialUrl } from '../data/socials';
 import type { GeneratorState } from '../types';
 
 const BADGE_BASE = 'https://commitpulse.vercel.app/api/streak';
@@ -133,7 +133,7 @@ export function generateReadme(state: GeneratorState): string {
         const social = getSocialById(id);
         if (!social) return null;
         const url = state.socialLinks[id];
-        const resolvedUrl = social.id === 'email' ? `mailto:${url.replace(/^mailto:/, '')}` : url;
+        const resolvedUrl = resolveSocialUrl(social, url);
 
         if (social.type === 'simpleicon' && social.siSlug) {
           return [


### PR DESCRIPTION
Fixes #6499

**Description**
This PR fixes a bug where social platforms with base URLs ending in `@` (such as TikTok, YouTube, Medium) generated invalid profile links with duplicated `@@` symbols if users manually included the `@` symbol in their handles. A `resolveSocialUrl` helper was introduced to safely normalize social link inputs before URL construction. The logic intelligently strips leading `@` symbols if the `baseUrl` already includes it and defaults to using the raw user input if they typed an absolute `http(s)://` URL. The helper was applied to both the README generator logic and the live frontend link preview component. Unit tests for `resolveSocialUrl` have been added to verify these behaviors.

**Checklist before requesting a review:**
- [x] I have read the CONTRIBUTING.md file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format.
