### PR TITLE
test(track-user-protection): add username normalization coverage

### DIFF
--- a/services/security/track-user-protection.test.ts
+++ b/services/security/track-user-protection.test.ts
@@ -143,3 +143,46 @@ describe('TrackUserProtection', () => {
     });
   });
 });
+describe('Username normalization', () => {
+  beforeEach(() => {
+    trackUserProtection.reset();
+    vi.clearAllMocks();
+    vi.mocked(gitHubUserValidator.validateUser).mockResolvedValue(true);
+  });
+
+  it('treats usernames with different casing as the same user', () => {
+    trackUserProtection.recordWrite('OctoCat');
+
+    expect(trackUserProtection.isWriteAllowed('octocat')).toBe(false);
+    expect(trackUserProtection.isWriteAllowed('OCTOCAT')).toBe(false);
+    expect(trackUserProtection.isWriteAllowed('OctoCat')).toBe(false);
+  });
+
+  it('ignores leading and trailing whitespace', () => {
+    trackUserProtection.recordWrite('  octocat  ');
+
+    expect(trackUserProtection.isWriteAllowed('octocat')).toBe(false);
+    expect(trackUserProtection.isWriteAllowed('  octocat')).toBe(false);
+    expect(trackUserProtection.isWriteAllowed('octocat   ')).toBe(false);
+  });
+
+  it('normalizes usernames consistently across public APIs', async () => {
+    trackUserProtection.recordWrite('  OctoCat  ');
+
+    expect(trackUserProtection.isWriteAllowed('octocat')).toBe(false);
+
+    const result = await trackUserProtection.verifyAndDeduplicate(' OCTOCAT ');
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('COOLDOWN_ACTIVE');
+  });
+
+  it('stores equivalent usernames as a single normalized entry', () => {
+    trackUserProtection.recordWrite('OctoCat');
+    trackUserProtection.recordWrite(' octocat ');
+    trackUserProtection.recordWrite('OCTOCAT');
+
+    expect(trackUserProtection.isWriteAllowed('octocat')).toBe(false);
+    expect(trackUserProtection.isWriteAllowed('OctoCat')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #6597 

Adds dedicated test coverage for username normalization behavior across the `TrackUserProtection` public APIs.

### Changes

* Added tests to verify usernames are treated case-insensitively.
* Added tests to verify leading and trailing whitespace is ignored.
* Added tests to ensure `recordWrite()`, `isWriteAllowed()`, and `verifyAndDeduplicate()` consistently normalize equivalent usernames.
* Added tests confirming equivalent username variants reference the same protected user state.

### Why

`TrackUserProtection` normalizes usernames before validation and deduplication, but this behavior was not explicitly verified by the existing test suite.

These tests help prevent regressions where different public APIs might normalize usernames inconsistently, ensuring predictable behavior regardless of casing or surrounding whitespace.

### Testing

* Ran the full test suite locally.
* All existing tests continue to pass.
* No production code changes were made.
* Improved coverage for username normalization across public APIs.

## Pillar

* [x] 🛠️ Other (Test Coverage)
* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if applicable.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] Existing functionality remains unchanged.
