### PR TITLE
test(track-user-protection): add cooldown expiration coverage

### DIFF
--- a/services/security/track-user-protection.test.ts
+++ b/services/security/track-user-protection.test.ts
@@ -135,6 +135,28 @@ describe('TrackUserProtection', () => {
     });
   });
 
+  describe('Cooldown expiration', () => {
+    it('allows writes again after the cooldown period expires', () => {
+      vi.useFakeTimers();
+
+      try {
+        trackUserProtection.recordWrite('octocat');
+
+        expect(trackUserProtection.isWriteAllowed('octocat')).toBe(false);
+
+        vi.advanceTimersByTime(5 * 60 * 1000 - 1);
+
+        expect(trackUserProtection.isWriteAllowed('octocat')).toBe(false);
+
+        vi.advanceTimersByTime(1);
+
+        expect(trackUserProtection.isWriteAllowed('octocat')).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe('Singleton instance', () => {
     it('returns the same instance across multiple getInstance() calls', () => {
       const instanceA = TrackUserProtection.getInstance();


### PR DESCRIPTION
## Description

Fixes #6600

Adds test coverage for the cooldown expiration behavior in `TrackUserProtection` using Vitest fake timers.

### Changes

* Added a dedicated test suite for cooldown expiration.
* Verified that a username enters the cooldown period immediately after `recordWrite()`.
* Verified that the username remains blocked until the cooldown duration has fully elapsed.
* Verified that writes are allowed again once the cooldown expires.
* Used `vi.useFakeTimers()` and `vi.advanceTimersByTime()` to simulate time deterministically without introducing real delays.

### Why

The existing test suite verified cooldown activation and manual reset but did not verify the automatic expiration of cooldowns. This test ensures future changes to the cooldown logic do not introduce regressions.

### Testing

* Ran the full test suite locally.
* All existing tests continue to pass.
* No production code changes were required.
* Added deterministic coverage using fake timers.

## Pillar

* [x] 🛠️ Other (Test Coverage)
* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if applicable.
* [x] I have made sure that I have only one commit to merge in this PR.
* [x] Existing functionality remains unchanged.
