### PR TITLE
test(calculate): add DST boundary test coverage for streak calculations

### DIFF
--- a/lib/calculate.dst-boundary.test.ts
+++ b/lib/calculate.dst-boundary.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { calculateStreak, getLocalTodayStr, chunkDaysIntoWeeks } from './calculate';
+import type { ContributionCalendar, ContributionDay } from '../types';
+
+describe('calculate DST boundary behavior', () => {
+  it('preserves streak across US spring-forward transition', () => {
+    const days: ContributionDay[] = [
+      { date: '2024-03-08', contributionCount: 1 },
+      { date: '2024-03-09', contributionCount: 1 },
+      { date: '2024-03-10', contributionCount: 1 },
+      { date: '2024-03-11', contributionCount: 1 },
+      { date: '2024-03-12', contributionCount: 1 },
+    ];
+
+    const calendar: ContributionCalendar = {
+      totalContributions: 5,
+      weeks: chunkDaysIntoWeeks(days),
+    };
+
+    const result = calculateStreak(calendar, 'America/New_York', new Date('2024-03-12T12:00:00Z'));
+
+    expect(result.longestStreak).toBe(5);
+  });
+
+  it('preserves streak across US fall-back transition', () => {
+    const days: ContributionDay[] = [
+      { date: '2024-10-31', contributionCount: 1 },
+      { date: '2024-11-01', contributionCount: 1 },
+      { date: '2024-11-02', contributionCount: 1 },
+      { date: '2024-11-03', contributionCount: 1 },
+      { date: '2024-11-04', contributionCount: 1 },
+    ];
+
+    const calendar: ContributionCalendar = {
+      totalContributions: 5,
+      weeks: chunkDaysIntoWeeks(days),
+    };
+
+    const result = calculateStreak(calendar, 'America/New_York', new Date('2024-11-04T12:00:00Z'));
+
+    expect(result.longestStreak).toBe(5);
+  });
+
+  it('preserves streak across UK spring-forward transition', () => {
+    const days: ContributionDay[] = [
+      { date: '2024-03-29', contributionCount: 1 },
+      { date: '2024-03-30', contributionCount: 1 },
+      { date: '2024-03-31', contributionCount: 1 },
+      { date: '2024-04-01', contributionCount: 1 },
+      { date: '2024-04-02', contributionCount: 1 },
+    ];
+
+    const calendar: ContributionCalendar = {
+      totalContributions: 5,
+      weeks: chunkDaysIntoWeeks(days),
+    };
+
+    const result = calculateStreak(calendar, 'Europe/London', new Date('2024-04-02T12:00:00Z'));
+
+    expect(result.longestStreak).toBe(5);
+  });
+
+  it('preserves streak across UK fall-back transition', () => {
+    const days: ContributionDay[] = [
+      { date: '2024-10-24', contributionCount: 1 },
+      { date: '2024-10-25', contributionCount: 1 },
+      { date: '2024-10-26', contributionCount: 1 },
+      { date: '2024-10-27', contributionCount: 1 },
+      { date: '2024-10-28', contributionCount: 1 },
+    ];
+
+    const calendar: ContributionCalendar = {
+      totalContributions: 5,
+      weeks: chunkDaysIntoWeeks(days),
+    };
+
+    const result = calculateStreak(calendar, 'Europe/London', new Date('2024-10-28T12:00:00Z'));
+
+    expect(result.longestStreak).toBe(5);
+  });
+
+  it('returns the same local date across a DST clock change', () => {
+    const before = getLocalTodayStr(new Date('2024-03-10T06:59:59Z'), 'America/New_York');
+
+    const after = getLocalTodayStr(new Date('2024-03-10T07:00:01Z'), 'America/New_York');
+
+    expect(before).toBe('2024-03-10');
+    expect(after).toBe('2024-03-10');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #6573

Adds a dedicated DST boundary test suite (`lib/calculate.dst-boundary.test.ts`) to validate streak calculations and timezone handling during Daylight Saving Time transitions.

### Added Test Coverage

* US spring-forward transition (`America/New_York`)
* US fall-back transition (`America/New_York`)
* UK spring-forward transition (`Europe/London`)
* UK fall-back transition (`Europe/London`)
* Deterministic local date handling during DST clock changes

These tests help prevent regressions in streak calculations and ensure timezone logic remains accurate during DST boundary changes.

## Pillar

* [x] 🕐 Pillar 3 — Timezone Logic Optimization

## Visual Preview

N/A (test-only change)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
