### PR TITLE
fix: add leap year support to calendar calculations (#5262)

### DIFF
--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -7,8 +7,11 @@ import {
   calculateStreak,
   calculateMonthlyStats,
   aggregateCalendars,
+  convertLocalToUtc,
   chunkDaysIntoWeeks,
   normalizeCalendarToTimezone,
+  isLeapYear,
+  daysInYear,
 } from '@/lib/calculate';
 import {
   generateNotFoundSVG,
@@ -478,15 +481,24 @@ export async function GET(request: Request) {
       clearTimeout(timeoutId);
     }
 
-    if (days && normalizedView !== 'monthly') {
-      const allDays = calendar.weeks.flatMap((w) => w.contributionDays);
+    if (normalizedView !== 'monthly') {
+      let effectiveDays = days;
 
-      const filteredDays = allDays.slice(-days);
+      if (!effectiveDays && year) {
+        const yearNum = parseInt(year, 10);
+        if (!isNaN(yearNum)) {
+          effectiveDays = daysInYear(yearNum);
+        }
+      }
 
-      calendar = {
-        totalContributions: filteredDays.reduce((sum, d) => sum + d.contributionCount, 0),
-        weeks: chunkDaysIntoWeeks(filteredDays),
-      };
+      if (effectiveDays) {
+        const allDays = calendar.weeks.flatMap((w) => w.contributionDays);
+        const filteredDays = allDays.slice(-effectiveDays);
+        calendar = {
+          totalContributions: filteredDays.reduce((sum, d) => sum + d.contributionCount, 0),
+          weeks: chunkDaysIntoWeeks(filteredDays),
+        };
+      }
     }
 
     // ─── JSON output mode ──────────────────────────────────────────────────

--- a/lib/calculate.test.ts
+++ b/lib/calculate.test.ts
@@ -8,6 +8,8 @@ import {
   isStreakAlive,
   chunkDaysIntoWeeks,
   normalizeCalendarToTimezone,
+  isLeapYear,
+  daysInYear,
 } from './calculate';
 import type { ContributionCalendar, ContributionDay } from '../types';
 
@@ -2965,5 +2967,31 @@ describe('calculateSafePercentage utility metric verification', () => {
   it('correctly rounds regular integer percentages', () => {
     expect(calculateSafePercentage(1, 3)).toBe(33); // 33.333... rounds to 33
     expect(calculateSafePercentage(2, 3)).toBe(67); // 66.666... rounds to 67
+  });
+});
+
+describe('isLeapYear and daysInYear utility', () => {
+  it('identifies 2024 as a leap year', () => {
+    expect(isLeapYear(2024)).toBe(true);
+  });
+
+  it('identifies 2023 as a non-leap year', () => {
+    expect(isLeapYear(2023)).toBe(false);
+  });
+
+  it('identifies 2000 as a leap year (divisible by 400)', () => {
+    expect(isLeapYear(2000)).toBe(true);
+  });
+
+  it('identifies 1900 as a non-leap year (divisible by 100 but not 400)', () => {
+    expect(isLeapYear(1900)).toBe(false);
+  });
+
+  it('returns 366 days for leap year 2024', () => {
+    expect(daysInYear(2024)).toBe(366);
+  });
+
+  it('returns 365 days for non-leap year 2023', () => {
+    expect(daysInYear(2023)).toBe(365);
   });
 });

--- a/lib/calculate.ts
+++ b/lib/calculate.ts
@@ -14,6 +14,21 @@ import type {
  * ========================================================================== */
 
 /**
+ * Determines whether a given year is a leap year.
+ * Returns true for years divisible by 4 (except centuries not divisible by 400).
+ */
+export function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+/**
+ * Returns the number of days in a given year (365 or 366).
+ */
+export function daysInYear(year: number): number {
+  return isLeapYear(year) ? 366 : 365;
+}
+
+/**
  * Safely calculates and rounds a percentage fraction to prevent NaN or
  * Infinity division values when the total denominator resolves to zero.
  */

--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -1675,3 +1675,38 @@ describe('githubUsernameSchema regression tests', () => {
     }
   });
 });
+
+describe('streakParamsSchema — days parameter validation', () => {
+  it('accepts days=365 (normal year)', () => {
+    const result = streakParamsSchema.safeParse({ user: 'octocat', days: '365' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.days).toBe(365);
+  });
+
+  it('accepts days=366 (leap year)', () => {
+    const result = streakParamsSchema.safeParse({ user: 'octocat', days: '366' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.days).toBe(366);
+  });
+
+  it('rejects days=367 (exceeds leap year max)', () => {
+    const result = streakParamsSchema.safeParse({ user: 'octocat', days: '367' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects days=0 (must be positive)', () => {
+    const result = streakParamsSchema.safeParse({ user: 'octocat', days: '0' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative days', () => {
+    const result = streakParamsSchema.safeParse({ user: 'octocat', days: '-1' });
+    expect(result.success).toBe(false);
+  });
+
+  it('leaves days undefined when omitted', () => {
+    const result = streakParamsSchema.safeParse({ user: 'octocat' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.days).toBeUndefined();
+  });
+});

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -370,7 +370,7 @@ const baseStreakParamsSchema = z.object({
   size: z.enum(['small', 'medium', 'large']).catch('medium').default('medium'),
 
   // to fetch N days contributions
-  days: z.coerce.number().int().positive().max(365).optional(),
+  days: z.coerce.number().int().positive().max(366).optional(),
 
   // Silently fall back to '8s' for invalid format (matches old behavior)
   speed: z


### PR DESCRIPTION
## Description
Fixes #5262 - Leap year support in contribution calendar calculations.

## Changes
1. **lib/calculate.ts** - Added \isLeapYear()\ and \daysInYear()\ utility functions as specified in the issue
2. **lib/validations.ts** - Changed \days\ parameter max from 365 to 366 to allow leap year queries
3. **app/api/streak/route.ts** - Auto-detects leap years when \year\ parameter is specified (without explicit \days\), automatically setting the grid to 366 days
4. **Tests added** - Leap year detection tests (2000/2024/1900/2023) + days validation boundary tests (365/366/367/0/negative)

## Testing
All 7708+ tests pass (321 relevant tests in calculate.test.ts and validations.test.ts)