### PR TITLE
feat(benchmark): report percentile latency (P50/P95/P99) in SVG benchmark

### DIFF
--- a/scripts/benchmark-svg.test.ts
+++ b/scripts/benchmark-svg.test.ts
@@ -90,13 +90,47 @@ describe('scripts/benchmark-svg', () => {
     const lines = logSpy.mock.calls
       .map((args) => String(args[0]))
       .filter(
-        (line) => line.startsWith('Average:') || line.startsWith('Min:') || line.startsWith('Max:')
+        (line) =>
+          line.startsWith('Average:') ||
+          line.startsWith('P50:') ||
+          line.startsWith('P95:') ||
+          line.startsWith('P99:') ||
+          line.startsWith('Min:') ||
+          line.startsWith('Max:')
       );
 
-    expect(lines.length).toBe(9);
+    expect(lines.length).toBe(18);
     for (const line of lines) {
       expect(line).toMatch(/:\s\d+\.\d{2}ms$/);
     }
+  });
+
+  it('correctly calculates and logs percentiles (P50/P95/P99)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { performance } = await import('perf_hooks');
+
+    let callIndex = 0;
+    const differences = Array.from({ length: 20 }, (_, i) => i + 1);
+
+    vi.mocked(performance.now).mockImplementation(() => {
+      const themeCallIndex = callIndex % 40;
+      callIndex += 1;
+
+      const iterIndex = Math.floor(themeCallIndex / 2);
+      const isEnd = themeCallIndex % 2 === 1;
+
+      if (!isEnd) {
+        return iterIndex * 100;
+      } else {
+        return iterIndex * 100 + differences[iterIndex];
+      }
+    });
+
+    await runBenchmarkScript();
+
+    expect(logSpy).toHaveBeenCalledWith('P50: 10.50ms');
+    expect(logSpy).toHaveBeenCalledWith('P95: 19.05ms');
+    expect(logSpy).toHaveBeenCalledWith('P99: 19.81ms');
   });
 
   it('prints separator line after each theme block', async () => {

--- a/scripts/benchmark-svg.ts
+++ b/scripts/benchmark-svg.ts
@@ -52,6 +52,16 @@ const themes = [
   },
 ];
 
+function getPercentile(times: number[], percentile: number): number {
+  if (times.length === 0) return 0;
+  const sorted = [...times].sort((a, b) => a - b);
+  const index = (percentile / 100) * (sorted.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  const weight = index - lower;
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight;
+}
+
 function benchmark(): void {
   console.log('\nSVG Benchmark Results\n');
 
@@ -90,12 +100,18 @@ function benchmark(): void {
     }
 
     const avg = times.reduce((a, b) => a + b, 0) / times.length;
+    const p50 = getPercentile(times, 50);
+    const p95 = getPercentile(times, 95);
+    const p99 = getPercentile(times, 99);
 
     const min = Math.min(...times);
     const max = Math.max(...times);
 
     console.log(`Theme: ${theme.name}`);
     console.log(`Average: ${avg.toFixed(2)}ms`);
+    console.log(`P50: ${p50.toFixed(2)}ms`);
+    console.log(`P95: ${p95.toFixed(2)}ms`);
+    console.log(`P99: ${p99.toFixed(2)}ms`);
     console.log(`Min: ${min.toFixed(2)}ms`);
     console.log(`Max: ${max.toFixed(2)}ms`);
     console.log('--------------------------');


### PR DESCRIPTION
Fixes #6644

### Description
This PR implements percentile latency reporting (P50, P95, and P99) in the SVG benchmark script (`scripts/benchmark-svg.ts`). Averages can hide latency spikes, and percentiles provide a more accurate evaluation of real-world performance.

### Changes
- Implemented `getPercentile()` helper in `scripts/benchmark-svg.ts` to compute arbitrary percentiles with linear interpolation.
- Added P50, P95, and P99 metrics to the console log outputs.
- Updated `scripts/benchmark-svg.test.ts` to verify:
  - Correct percentile calculations for a set of mock values.
  - Floating-point formatting constraints (2 decimal places) for the new metrics.

### Verification
- Verified by running the Vitest tests (`npm run test`) and manually running the benchmark using `npx tsx scripts/benchmark-svg.ts --iterations=10`.