### PR TITLE
test(security): add test coverage for username normalization across TrackUserProtection APIs

### DIFF
--- a/services/security/track-user-protection.test.ts
+++ b/services/security/track-user-protection.test.ts
@@ -142,4 +142,50 @@ describe('TrackUserProtection', () => {
       expect(instanceA).toBe(instanceB);
     });
   });
+
+  describe('Username normalization', () => {
+    it('ignores leading and trailing whitespace in validateFormat', () => {
+      expect(trackUserProtection.validateFormat('  octocat  ')).toBe(true);
+      expect(trackUserProtection.validateFormat('\toctocat\n')).toBe(true);
+    });
+
+    it('treats usernames case-insensitively and ignores whitespace in recordWrite and isWriteAllowed', () => {
+      trackUserProtection.recordWrite('  OctoCat  ');
+
+      expect(trackUserProtection.isWriteAllowed('  OctoCat  ')).toBe(false);
+      expect(trackUserProtection.isWriteAllowed('octocat')).toBe(false);
+      expect(trackUserProtection.isWriteAllowed('OCTOCAT')).toBe(false);
+      expect(trackUserProtection.isWriteAllowed('  octocat  ')).toBe(false);
+    });
+
+    it('behaves consistently across verifyAndDeduplicate for equivalent usernames', async () => {
+      vi.mocked(gitHubUserValidator.validateUser).mockResolvedValue(true);
+
+      const firstResult = await trackUserProtection.verifyAndDeduplicate('  OctoCat  ');
+      expect(firstResult.allowed).toBe(true);
+
+      // Record a write for the first user to activate cooldown
+      trackUserProtection.recordWrite('  OctoCat  ');
+
+      // Subsequent check for equivalent username should trigger cooldown
+      const secondResult = await trackUserProtection.verifyAndDeduplicate('OCTOCAT');
+      expect(secondResult.allowed).toBe(false);
+      expect(secondResult.reason).toBe('COOLDOWN_ACTIVE');
+
+      const thirdResult = await trackUserProtection.verifyAndDeduplicate('  octocat  ');
+      expect(thirdResult.allowed).toBe(false);
+      expect(thirdResult.reason).toBe('COOLDOWN_ACTIVE');
+    });
+
+    it('references the same internal entry for equivalent usernames', () => {
+      trackUserProtection.recordWrite('OctoCat');
+      expect(trackUserProtection.isWriteAllowed('octocat')).toBe(false);
+
+      trackUserProtection.reset();
+      expect(trackUserProtection.isWriteAllowed('octocat')).toBe(true);
+
+      trackUserProtection.recordWrite('  octocat  ');
+      expect(trackUserProtection.isWriteAllowed('OCTOCAT')).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #6648

### Description
This PR adds comprehensive unit test coverage to verify that username normalization (case-insensitivity, trim leading/trailing whitespace) is applied consistently across all public APIs of the `TrackUserProtection` service.

### Changes
- Added `describe('Username normalization')` block to `services/security/track-user-protection.test.ts` with test cases verifying:
  - leading/trailing whitespace ignoring in `validateFormat()`
  - case-insensitivity and whitespace ignoring in `recordWrite()` and `isWriteAllowed()`
  - consistency across `verifyAndDeduplicate()` for equivalent usernames
  - correct internal referencing (resetting, equivalent updates) for equivalent usernames

### Verification
- Ran Vitest unit tests: `npx vitest run services/security/track-user-protection.test.ts` (10 tests passed)