### PR TITLE
test(security): add test coverage for cooldown expiration using fake timers

### DIFF
--- a/services/security/track-user-protection.test.ts
+++ b/services/security/track-user-protection.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TrackUserProtection, trackUserProtection } from './track-user-protection';
 import { gitHubUserValidator } from '../github/validate-user';
 
@@ -140,6 +140,31 @@ describe('TrackUserProtection', () => {
       const instanceA = TrackUserProtection.getInstance();
       const instanceB = TrackUserProtection.getInstance();
       expect(instanceA).toBe(instanceB);
+    });
+  });
+
+  describe('Cooldown expiration via fake timers', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('blocks writes initially but allows them after cooldown expires naturally', () => {
+      const username = 'octocat';
+      trackUserProtection.recordWrite(username);
+      expect(trackUserProtection.isWriteAllowed(username)).toBe(false);
+
+      // Cooldown is 5 minutes (300,000 ms).
+      // Advance by 4 minutes and 59 seconds (299,000 ms)
+      vi.advanceTimersByTime(5 * 60 * 1000 - 1000);
+      expect(trackUserProtection.isWriteAllowed(username)).toBe(false);
+
+      // Advance past the 5 minute mark
+      vi.advanceTimersByTime(2000);
+      expect(trackUserProtection.isWriteAllowed(username)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Fixes #6650

### Description
This PR adds test coverage using Vitest fake timers (`vi.useFakeTimers()`) to verify that the username cooldown in `TrackUserProtection` expires naturally after 5 minutes and successfully allows database writes again.

### Changes
- Added `afterEach` to Vitest imports in `services/security/track-user-protection.test.ts`.
- Added a new `describe('Cooldown expiration via fake timers')` block verifying:
  - Initial write blocks subsequent attempts.
  - Advancing time just before cooldown limit keeps the username blocked.
  - Advancing time past the cooldown limit (5 minutes) allows writes again.
  - Real timers are restored post-test using `vi.useRealTimers()` in `afterEach`.

### Verification
- Ran Vitest unit tests: `npx vitest run services/security/track-user-protection.test.ts` (7 tests passed)