### PR TITLE
feat(i18n): synchronize language preference across browser tabs

### DIFF
--- a/context/TranslationContext.test.tsx
+++ b/context/TranslationContext.test.tsx
@@ -1,0 +1,101 @@
+import { render, act, screen } from '@testing-library/react';
+import { useTranslation, TranslationProvider } from './TranslationContext';
+import { vi, describe, it, expect } from 'vitest';
+import React from 'react';
+
+vi.unmock('./TranslationContext');
+
+describe('TranslationContext - Tab Synchronization', () => {
+  it('should auto-detect browser language or fall back to localStorage', () => {
+    localStorage.clear();
+    render(
+      <TranslationProvider>
+        <TestComponent />
+      </TranslationProvider>
+    );
+    expect(screen.getByTestId('lang').textContent).toBe('en');
+  });
+
+  it('should react to storage event and update language preference across tabs', () => {
+    localStorage.clear();
+    render(
+      <TranslationProvider>
+        <TestComponent />
+      </TranslationProvider>
+    );
+
+    expect(screen.getByTestId('lang').textContent).toBe('en');
+
+    // Simulate storage event from another tab
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'language',
+          newValue: 'es',
+        })
+      );
+    });
+
+    expect(screen.getByTestId('lang').textContent).toBe('es');
+    expect(document.documentElement.lang).toBe('es');
+  });
+
+  it('should ignore storage events for unrelated keys', () => {
+    localStorage.clear();
+    render(
+      <TranslationProvider>
+        <TestComponent />
+      </TranslationProvider>
+    );
+
+    expect(screen.getByTestId('lang').textContent).toBe('en');
+
+    // Simulate storage event for another key
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'theme',
+          newValue: 'dark',
+        })
+      );
+    });
+
+    expect(screen.getByTestId('lang').textContent).toBe('en');
+  });
+
+  it('should ignore storage events with invalid language values', () => {
+    localStorage.clear();
+    render(
+      <TranslationProvider>
+        <TestComponent />
+      </TranslationProvider>
+    );
+
+    expect(screen.getByTestId('lang').textContent).toBe('en');
+
+    // Simulate storage event with invalid lang
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'language',
+          newValue: 'invalid_lang',
+        })
+      );
+    });
+
+    expect(screen.getByTestId('lang').textContent).toBe('en');
+  });
+});
+
+const TestComponent = () => {
+  const { language, changeLanguage, t } = useTranslation();
+  return (
+    <div>
+      <span data-testid="lang">{language}</span>
+      <button data-testid="change-btn" onClick={() => changeLanguage('es')}>
+        Change
+      </button>
+      <span data-testid="welcome">{t('home.welcome')}</span>
+    </div>
+  );
+};

--- a/context/TranslationContext.tsx
+++ b/context/TranslationContext.tsx
@@ -101,6 +101,26 @@ export function TranslationProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
+  useEffect(() => {
+    const handleStorageChange = (event: StorageEvent) => {
+      const { key, newValue } = event;
+      if (key === 'language' && newValue) {
+        const supportedLangs = Object.keys(translations) as Language[];
+        if (supportedLangs.includes(newValue as Language)) {
+          startTransition(() => {
+            setLanguage(newValue as Language);
+            document.documentElement.lang = newValue;
+          });
+        }
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+    };
+  }, []);
+
   const changeLanguage = (lang: Language) => {
     startTransition(() => {
       setLanguage(lang);


### PR DESCRIPTION
## Summary
The translation provider stores the selected language in `localStorage`, but it does not react to `storage` events. As a result, changing the language in one browser tab does not update other open tabs until they are refreshed. This pull request adds a storage event listener to synchronize language preferences reactively across all open tabs.

## Changes Made
- `context/TranslationContext.tsx`:
  - Added a `useEffect` hook in `TranslationProvider` that registers a listener for the window `'storage'` event.
  - When the `'language'` key changes, it updates the language preference using `startTransition` and adjusts the `document.documentElement.lang` attribute.
  - Provided cleanups to remove the listener on unmount.
- `context/TranslationContext.test.tsx`:
  - Added a dedicated test suite verifying auto-detection, tab synchronization via the storage event, ignoring unrelated keys, and ignoring invalid language values.

## Verification
- Run `npm run test` (all tests pass successfully).

Fixes #6652