### PR TITLE
feat(i18n): add development warnings for missing translation keys

### DIFF
--- a/context/TranslationContext.test.tsx
+++ b/context/TranslationContext.test.tsx
@@ -1,0 +1,55 @@
+import { render } from '@testing-library/react';
+import { useTranslation, TranslationProvider } from './TranslationContext';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+
+vi.unmock('./TranslationContext');
+
+describe('TranslationContext - Missing Translation Key Warnings', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let consoleWarnSpy: any;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it('should log a warning in development mode when translation key is missing', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    render(
+      <TranslationProvider>
+        <TestComponent missingKey="home.nonexistent" />
+      </TranslationProvider>
+    );
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '⚠ Missing translation key "home.nonexistent" in locale "en"'
+    );
+  });
+
+  it('should NOT log a warning in production mode when translation key is missing', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    render(
+      <TranslationProvider>
+        <TestComponent missingKey="home.nonexistent" />
+      </TranslationProvider>
+    );
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+});
+
+const TestComponent = ({ missingKey }: { missingKey?: string }) => {
+  const { language, t } = useTranslation();
+  return (
+    <div>
+      <span data-testid="lang">{language}</span>
+      <span data-testid="welcome">{t('home.welcome')}</span>
+      {missingKey && <span data-testid="missing">{t(missingKey)}</span>}
+    </div>
+  );
+};

--- a/context/TranslationContext.tsx
+++ b/context/TranslationContext.tsx
@@ -121,6 +121,9 @@ export function TranslationProvider({ children }: { children: ReactNode }) {
     }
 
     if (value === undefined) {
+      if (process.env.NODE_ENV === 'development') {
+        console.warn(`⚠ Missing translation key "${path}" in locale "${currentLang}"`);
+      }
       if (params && 'defaultValue' in params) {
         return params.defaultValue;
       }
@@ -154,6 +157,9 @@ export function useTranslation() {
       t: (path: string, params?: Record<string, string>): string => {
         const value = getNestedValue(en, path);
         if (value === undefined) {
+          if (process.env.NODE_ENV === 'development') {
+            console.warn(`⚠ Missing translation key "${path}" in locale "en"`);
+          }
           if (params && 'defaultValue' in params) {
             return params.defaultValue;
           }


### PR DESCRIPTION
## Summary
When a translation key cannot be found, the translation provider currently falls back to the English translation or returns the key itself. While this prevents runtime errors, missing translations can go unnoticed during development. This PR adds a development-only console warning whenever a translation key is missing after fallback resolution, helping contributors easily identify incomplete locale files.

## Changes Made
- `context/TranslationContext.tsx`:
  - Updated the lookup function `t` inside `TranslationProvider` to log a `console.warn` when the value is unresolved and `process.env.NODE_ENV === 'development'`.
  - Updated the fallback lookup function in the `useTranslation` hook to also log a warning in development mode.
- `context/TranslationContext.test.tsx`:
  - Added dedicated unit tests verifying that missing key lookups trigger `console.warn` in development mode, but remain silent in production mode.

## Verification
- Run `npm run test` (all unit tests pass).

Fixes #6653