### PR TITLE
feat: export streak SVGs as high-res PNG via backend Resvg-js 

### DIFF
--- a/app/customize/components/ExportPanel.tsx
+++ b/app/customize/components/ExportPanel.tsx
@@ -176,57 +176,30 @@ export function ExportPanel({
         targetUrl = targetUrl.replace('https://commitpulse.vercel.app', window.location.origin);
       }
 
+      if (targetUrl.includes('?')) {
+        targetUrl += '&format=png';
+      } else {
+        targetUrl += '?format=png';
+      }
+
       const response = await fetch(targetUrl);
 
       if (!response.ok) {
-        throw new Error('Failed to fetch SVG');
+        throw new Error('Failed to fetch PNG from backend');
       }
 
-      const svgText = await response.text();
+      const blob = await response.blob();
+      const pngUrl = URL.createObjectURL(blob);
 
-      const svgBlob = new Blob([svgText], {
-        type: 'image/svg+xml;charset=utf-8',
-      });
+      const link = document.createElement('a');
+      link.href = pngUrl;
+      link.download = `commitpulse-${username || 'badge'}.png`;
 
-      const svgUrl = URL.createObjectURL(svgBlob);
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
 
-      const img = new Image();
-
-      img.onload = () => {
-        const canvas = document.createElement('canvas');
-
-        canvas.width = img.width || 1200;
-        canvas.height = img.height || 630;
-
-        const ctx = canvas.getContext('2d');
-
-        if (!ctx) {
-          URL.revokeObjectURL(svgUrl);
-          return;
-        }
-
-        ctx.drawImage(img, 0, 0);
-
-        canvas.toBlob((blob) => {
-          if (!blob) return;
-
-          const pngUrl = URL.createObjectURL(blob);
-
-          const link = document.createElement('a');
-          link.href = pngUrl;
-          link.download = `commitpulse-${username || 'badge'}.png`;
-
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
-
-          URL.revokeObjectURL(pngUrl);
-        }, 'image/png');
-
-        URL.revokeObjectURL(svgUrl);
-      };
-
-      img.src = svgUrl;
+      URL.revokeObjectURL(pngUrl);
     } catch (error) {
       console.error(error);
       toast.error('Failed to download PNG badge.');


### PR DESCRIPTION
## Description

Fixes #6670

Replaces the flaky, client-side `<canvas>` image extraction logic for PNG downloads with robust, server-side SVG-to-PNG rasterization. The dashboard's `/customize` UI now directly appends the `&format=png` parameter to fetch the high-resolution image generated by `@resvg/resvg-js` on the backend, allowing users to export their streaks with perfect font rendering and styling for easy sharing on social media platforms like X and LinkedIn.

**Changes:**
- Refactored `handleDownloadPng` in `app/customize/components/ExportPanel.tsx` to utilize the backend's native `format=png` API instead of manipulating a DOM canvas.
- Stripped 30+ lines of unnecessary DOM Blob object rendering code, resulting in cleaner and faster asset retrieval.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

*(PNG downloads from the customize UI now look absolutely identical to the "premium quality" SVGs across all devices.)*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).