### PR TITLE
fix(validation): add length limits to custom_title and custom_subtitle params

### DIFF
--- a/lib/validations.test.ts
+++ b/lib/validations.test.ts
@@ -1674,4 +1674,56 @@ describe('githubUsernameSchema regression tests', () => {
       }
     }
   });
+  describe('streakParamsSchema — custom_title and custom_subtitle length validation', () => {
+    it('rejects custom_title longer than 60 characters', () => {
+      const result = streakParamsSchema.safeParse({
+        user: 'octocat',
+        custom_title: 'A'.repeat(61),
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const msg = result.error.flatten().fieldErrors.custom_title?.[0];
+        expect(msg).toBe('custom_title cannot exceed 60 characters');
+      }
+    });
+
+    it('accepts custom_title exactly at 60 characters', () => {
+      const result = streakParamsSchema.safeParse({
+        user: 'octocat',
+        custom_title: 'A'.repeat(60),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects custom_subtitle longer than 80 characters', () => {
+      const result = streakParamsSchema.safeParse({
+        user: 'octocat',
+        custom_subtitle: 'A'.repeat(81),
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const msg = result.error.flatten().fieldErrors.custom_subtitle?.[0];
+        expect(msg).toBe('custom_subtitle cannot exceed 80 characters');
+      }
+    });
+
+    it('accepts custom_subtitle exactly at 80 characters', () => {
+      const result = streakParamsSchema.safeParse({
+        user: 'octocat',
+        custom_subtitle: 'A'.repeat(80),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('trims whitespace-only custom_title to empty string', () => {
+      const result = streakParamsSchema.safeParse({
+        user: 'octocat',
+        custom_title: '   ',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.custom_title).toBe('');
+      }
+    });
+  });
 });

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -434,8 +434,16 @@ const baseStreakParamsSchema = z.object({
   refresh: z.string().optional().transform(toRefreshFlag),
   bypassCache: z.string().optional().transform(toRefreshFlag),
   hide_title: z.string().optional().transform(toBooleanFlag),
-  custom_title: z.string().optional(),
-  custom_subtitle: z.string().optional(),
+  custom_title: z
+    .string()
+    .trim()
+    .max(60, { message: 'custom_title cannot exceed 60 characters' })
+    .optional(),
+  custom_subtitle: z
+    .string()
+    .trim()
+    .max(80, { message: 'custom_subtitle cannot exceed 80 characters' })
+    .optional(),
   hide_background: z.string().optional().transform(toBooleanFlag),
   hide_stats: z.string().optional().transform(toBooleanFlag),
   lang: z.enum(supportedLanguages).catch('en').default('en'),


### PR DESCRIPTION


## Description

Fixes #6713 

Added `.trim().max()` validation to `custom_title` (max 60) and `custom_subtitle` 
(max 80) in `baseStreakParamsSchema`. Previously these fields had no length 
constraints, allowing arbitrarily long strings to be embedded directly into the 
SVG `<text>` element, causing layout overflow and bloated cached responses.
Also added 5 test cases in `lib/validations.test.ts` covering:
- Rejects `custom_title` longer than 60 characters
- Accepts `custom_title` exactly at 60 characters
- Rejects `custom_subtitle` longer than 80 characters
- Accepts `custom_subtitle` exactly at 80 characters
- Trims whitespace-only values to empty string
## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [X] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A

## Checklist before requesting a review:

- [X] I have read the `CONTRIBUTING.md` file.
- [X] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [X] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [X] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [X] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [X] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
