### PR TITLE
test(api-compare): add error resilience test coverage

### DIFF
--- a/app/api/compare/route.error-resilience.test.ts
+++ b/app/api/compare/route.error-resilience.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted objects are created before vi.mock() factories run.
+const mocks = vi.hoisted(() => ({
+  limiter: {
+    check: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/github', () => ({
+  getFullDashboardData: vi.fn(),
+}));
+
+vi.mock('@/lib/githubtoken', () => ({
+  getUserGitHubToken: vi.fn(),
+}));
+
+vi.mock('@/utils/getClientIp', () => ({
+  getClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  RateLimiter: class {
+    check = mocks.limiter.check;
+
+    constructor(_limit?: number, _window?: number, _maxSize?: number) {}
+  },
+}));
+
+import { GET } from './route';
+import { getFullDashboardData } from '@/lib/github';
+import { getUserGitHubToken } from '@/lib/githubtoken';
+
+const mockedDashboard = vi.mocked(getFullDashboardData);
+const mockedToken = vi.mocked(getUserGitHubToken);
+
+describe('compare route - error resilience', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.limiter.check.mockResolvedValue(true);
+
+    mockedToken.mockResolvedValue(undefined);
+
+    mockedDashboard.mockResolvedValue({} as never);
+  });
+
+  it('returns 500 when token retrieval throws', async () => {
+    mockedToken.mockRejectedValue(new Error('Token service unavailable'));
+
+    const res = await GET(new Request('http://localhost/api/compare?user1=octocat&user2=torvalds'));
+
+    expect(res.status).toBe(500);
+
+    expect(await res.json()).toEqual({
+      error: 'Token service unavailable',
+    });
+  });
+
+  it('returns 502 when first dashboard request fails', async () => {
+    mockedDashboard
+      .mockRejectedValueOnce(new Error('database exploded'))
+      .mockResolvedValueOnce({} as never);
+
+    const res = await GET(new Request('http://localhost/api/compare?user1=octocat&user2=torvalds'));
+
+    expect(res.status).toBe(502);
+
+    const body = await res.json();
+
+    expect(body.error).toContain('Unable to fetch GitHub data for "octocat"');
+  });
+
+  it('returns 403 when GitHub rate limit error occurs', async () => {
+    mockedDashboard
+      .mockRejectedValueOnce(new Error('GitHub API rate limit reached'))
+      .mockResolvedValueOnce({} as never);
+
+    const res = await GET(new Request('http://localhost/api/compare?user1=octocat&user2=torvalds'));
+
+    expect(res.status).toBe(403);
+
+    expect(await res.json()).toEqual({
+      error: 'GitHub API rate limit reached. Please try again later.',
+    });
+  });
+
+  it('returns 429 when local rate limiter blocks', async () => {
+    mocks.limiter.check.mockResolvedValue(false);
+
+    const res = await GET(new Request('http://localhost/api/compare?user1=octocat&user2=torvalds'));
+
+    expect(res.status).toBe(429);
+
+    expect(await res.json()).toEqual({
+      error: 'Too many requests. Please try again later.',
+    });
+  });
+
+  it('returns 400 when validation fails', async () => {
+    const res = await GET(new Request('http://localhost/api/compare?user1=octocat&user2=octocat'));
+
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+
+    expect(body.error).toBe('Invalid parameters');
+    expect(body.details).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #6758

This PR adds comprehensive error resilience tests for `app/api/compare/route.ts` to improve coverage of failure scenarios and ensure the API responds gracefully instead of crashing.

### What was added

* Added a dedicated `route.error-resilience.test.ts` test suite.
* Tested GitHub token retrieval failures.
* Tested upstream GitHub data fetch failures.
* Tested GitHub API rate-limit error handling.
* Tested local rate-limiter rejection (429 responses).
* Tested invalid query parameter validation (400 responses).
* Mocked external dependencies to isolate the route logic and avoid network calls.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (API test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally.
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
* [x] My commits follow the Conventional Commits format.
* [ ] I have updated `README.md` if I added a new theme or URL parameter. (Not applicable)
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard. (Not applicable)
* [x] (Recommended) I joined the CommitPulse Discord community.
