### PR TITLE
test: add responsive breakpoint tests for useRecentSearches

### DIFF
--- a/hooks/useRecentSearches.responsive-breakpoints.test.ts
+++ b/hooks/useRecentSearches.responsive-breakpoints.test.ts
@@ -1,0 +1,176 @@
+import React, { useEffect, useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { useRecentSearches, MAX_SEARCHES } from './useRecentSearches';
+
+const setViewport = (width: number) => {
+  Object.defineProperty(window, 'innerWidth', {
+    writable: true,
+    configurable: true,
+    value: width,
+  });
+
+  window.dispatchEvent(new Event('resize'));
+};
+
+function ResponsiveSearchPanel() {
+  const { searches, addSearch, clearSearches } = useRecentSearches();
+
+  const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
+
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  const children: React.ReactNode[] = [];
+
+  if (isMobile) {
+    children.push(
+      React.createElement(
+        'button',
+        {
+          key: 'toggle',
+          'data-testid': 'toggle',
+          onClick: () => setMenuOpen((p) => !p),
+        },
+        'Menu'
+      )
+    );
+
+    children.push(
+      React.createElement(
+        'span',
+        {
+          key: 'menu-state',
+          'data-testid': 'menu-state',
+        },
+        menuOpen ? 'open' : 'closed'
+      )
+    );
+  }
+
+  children.push(
+    React.createElement(
+      'nav',
+      {
+        key: 'nav',
+        'data-testid': 'navigation',
+        className: isMobile ? 'text-sm' : 'text-lg',
+      },
+      'Navigation'
+    )
+  );
+
+  children.push(
+    React.createElement(
+      'ul',
+      {
+        key: 'list',
+        'data-testid': 'search-list',
+      },
+      searches.map((search) => React.createElement('li', { key: search }, search))
+    )
+  );
+
+  children.push(
+    React.createElement(
+      'button',
+      {
+        key: 'add',
+        onClick: () => addSearch(`search-${searches.length + 1}`),
+      },
+      'Add'
+    )
+  );
+
+  children.push(
+    React.createElement(
+      'button',
+      {
+        key: 'clear',
+        onClick: clearSearches,
+      },
+      'Clear'
+    )
+  );
+
+  return React.createElement(
+    'div',
+    {
+      'data-testid': 'container',
+      className: isMobile ? 'flex-col' : 'flex-row',
+      style: {
+        width: isMobile ? '100%' : '800px',
+      },
+    },
+    ...children
+  );
+}
+
+describe('useRecentSearches responsive breakpoints', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setViewport(375);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders correctly at 375px', () => {
+    render(React.createElement(ResponsiveSearchPanel));
+
+    expect(window.innerWidth).toBe(375);
+  });
+
+  it('uses vertical layout', () => {
+    render(React.createElement(ResponsiveSearchPanel));
+
+    expect(screen.getByTestId('container').className).toContain('flex-col');
+  });
+
+  it('uses fluid width', () => {
+    render(React.createElement(ResponsiveSearchPanel));
+
+    expect(screen.getByTestId('container').style.width).toBe('100%');
+  });
+
+  it('scales navigation and preserves max searches', async () => {
+    const user = userEvent.setup();
+
+    render(React.createElement(ResponsiveSearchPanel));
+
+    expect(screen.getByTestId('navigation').className).toContain('text-sm');
+
+    for (let i = 0; i < MAX_SEARCHES + 2; i++) {
+      await user.click(screen.getByText('Add'));
+    }
+
+    expect(screen.getByTestId('search-list').children.length).toBe(MAX_SEARCHES);
+  });
+
+  it('handles mobile toggle state', async () => {
+    const user = userEvent.setup();
+
+    render(React.createElement(ResponsiveSearchPanel));
+
+    expect(screen.getByTestId('menu-state')).toHaveTextContent('closed');
+
+    await user.click(screen.getByTestId('toggle'));
+
+    expect(screen.getByTestId('menu-state')).toHaveTextContent('open');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #7136 

Adds responsive breakpoint tests for `useRecentSearches` by introducing a lightweight consumer component to validate mobile viewport behavior. The test suite covers:

* Mobile viewport rendering at 375px.
* Vertical layout reflow for small screens.
* Fluid widths to prevent horizontal scrolling.
* Responsive navigation scaling.
* Mobile toggle interactions.
* Preservation of recent search functionality and maximum search limits.

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (not applicable for test-only changes).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
