### PR TITLE
fix(generator): add id and name attributes to GitHub username input

### DIFF
--- a/app/generator/components/GitHubImportModal.tsx
+++ b/app/generator/components/GitHubImportModal.tsx
@@ -136,6 +136,8 @@ export function GitHubImportModal({ isOpen, onClose, onApply }: GitHubImportModa
                   <FaGithub className="w-4 h-4" />
                 </div>
                 <input
+                  id="username"
+                  name="username"
                   type="text"
                   value={username}
                   onChange={(e) => setUsername(e.target.value)}


### PR DESCRIPTION
## Description

Fixes #984

This PR adds the missing `id` and `name` attributes to the GitHub username input field in the GitHub Import modal.

### Changes
- Added `id="username"`
- Added `name="username"`

### Why
- Improves browser autofill support
- Improves accessibility
- Enhances HTML form semantics