### PR TITLE
test(Footer-timezone-boundaries): verify Timezone Normalization & Calendar Data Boundary Alignment

### DIFF
--- a/app/components/Footer.timezone-boundaries.test.tsx
+++ b/app/components/Footer.timezone-boundaries.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Footer } from './Footer';
+import { useTranslation } from '@/context/TranslationContext';
+import '@testing-library/jest-dom';
+
+vi.mock('@/context/TranslationContext', () => ({
+  useTranslation: vi.fn(),
+}));
+
+const mockT = vi.fn((path: string, params?: Record<string, string>) => {
+  if (path === 'footer.copyright') return `© ${params?.year} CommitPulse. All rights reserved.`;
+  return path === 'footer.made_with' ? 'Made with ❤️ for developers' : path;
+});
+
+const originalTZ = process.env.TZ;
+
+function setSystemTime(isoUtc: string, timezone: string) {
+  process.env.TZ = timezone;
+  vi.setSystemTime(new Date(isoUtc));
+}
+
+describe('Footer Timezone Boundaries (copyright year)', () => {
+  beforeEach(() => {
+    vi.mocked(useTranslation).mockReturnValue({
+      language: 'en',
+      changeLanguage: vi.fn(),
+      t: mockT,
+      isPending: false,
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    process.env.TZ = originalTZ;
+  });
+
+  it.each([
+    { label: 'UTC', tz: 'UTC', iso: '2026-06-15T12:00:00Z', expectedYear: 2026 },
+    {
+      label: 'EST year boundary',
+      tz: 'America/New_York',
+      iso: '2026-01-01T02:00:00Z',
+      expectedYear: 2025,
+    },
+    {
+      label: 'IST year boundary',
+      tz: 'Asia/Kolkata',
+      iso: '2025-12-31T20:00:00Z',
+      expectedYear: 2026,
+    },
+    {
+      label: 'JST year boundary',
+      tz: 'Asia/Tokyo',
+      iso: '2025-12-31T16:00:00Z',
+      expectedYear: 2026,
+    },
+  ])('computes the copyright year correctly in $label', ({ tz, iso, expectedYear }) => {
+    setSystemTime(iso, tz);
+    render(<Footer />);
+    expect(
+      screen.getByText(`© ${expectedYear} CommitPulse. All rights reserved.`)
+    ).toBeInTheDocument();
+  });
+
+  it('computes the copyright year correctly on a leap day and across a DST transition instant', () => {
+    setSystemTime('2028-02-29T12:00:00Z', 'UTC');
+    const { unmount: unmount1 } = render(<Footer />);
+    expect(screen.getByText('© 2028 CommitPulse. All rights reserved.')).toBeInTheDocument();
+    unmount1();
+
+    setSystemTime('2026-03-08T07:00:00Z', 'America/New_York');
+    render(<Footer />);
+    expect(screen.getByText('© 2026 CommitPulse. All rights reserved.')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Adds `Footer.timezone-boundaries.test.tsx` with tests for the copyright year calculation (new Date().getFullYear()) across different timezones (UTC, EST, IST, JST) and around leap year/DST boundaries. This is the only date-related logic in Footer.tsx.

Fixes #6835 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
