### PR TITLE
test(TopRivalriesTicker): add type compiler coverage

### DIFF
--- a/components/TopRivalriesTicker.type-compiler.test.tsx
+++ b/components/TopRivalriesTicker.type-compiler.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { RivalryItem, TopRivalriesTickerProps } from './TopRivalriesTicker';
+
+function validateRivalryProps(props: TopRivalriesTickerProps) {
+  return {
+    valid:
+      props.rivalries === undefined || props.rivalries === null || Array.isArray(props.rivalries),
+  };
+}
+
+describe('TopRivalriesTicker type compiler validation', () => {
+  it('enforces the TopRivalriesTicker prop contract', () => {
+    expectTypeOf<TopRivalriesTickerProps>().toEqualTypeOf<{
+      rivalries?: RivalryItem[] | null;
+    }>();
+  });
+
+  it('enforces the RivalryItem contract', () => {
+    expectTypeOf<RivalryItem>().toEqualTypeOf<{
+      u1: string;
+      u2: string;
+      label: string;
+      icon: React.ComponentType<{ size?: number; className?: string }>;
+      color: string;
+    }>();
+  });
+
+  it('keeps rivalries optional and nullable', () => {
+    expectTypeOf<TopRivalriesTickerProps['rivalries']>().toEqualTypeOf<
+      RivalryItem[] | null | undefined
+    >();
+  });
+
+  it('keeps the icon type compatible with React components', () => {
+    expectTypeOf<RivalryItem['icon']>().toEqualTypeOf<
+      React.ComponentType<{ size?: number; className?: string }>
+    >();
+  });
+
+  it('rejects invalid rivalry structures at compile time', () => {
+    expectTypeOf<RivalryItem>().not.toEqualTypeOf<{
+      u1: number;
+      u2: number;
+      label: number;
+      icon: string;
+      color: number;
+    }>();
+  });
+
+  it('returns strict validation reports for rivalry props', () => {
+    const report = validateRivalryProps({
+      rivalries: [],
+    });
+
+    expect(report.valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Adds compile-time type coverage for `TopRivalriesTicker`.

## Changes

- Added type assertions for `TopRivalriesTickerProps`
- Added type assertions for `RivalryItem`
- Verified `rivalries` remains optional and nullable
- Verified `icon` maintains the expected React component type
- Added negative compile-time assertions for invalid structures
- Added a small runtime validation helper following existing repository conventions

## Verification

- [x] Tests pass
- [x] Typecheck passes
- [x] Lint passes (no new warnings/errors introduced)
Fixes #7032 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
