### PR TITLE
feat: sync Customization Studio settings to URL query parameters

### DIFF
--- a/app/customize/components/ExportPanel.tsx
+++ b/app/customize/components/ExportPanel.tsx
@@ -299,6 +299,40 @@ export function ExportPanel({
               : t('customize.export.download_png', { defaultValue: 'Download PNG' })}
           </button>
 
+          {/* Share Configuration Button */}
+          <button
+            type="button"
+            onClick={async () => {
+              try {
+                await navigator.clipboard.writeText(window.location.href);
+                toast.success('Configuration URL copied to clipboard!');
+              } catch (err) {
+                console.error('Failed to copy URL', err);
+                toast.error('Failed to copy configuration URL');
+              }
+            }}
+            className={`relative inline-flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-bold transition-all duration-200 bg-purple-500/10 border border-purple-500/30 text-purple-500 hover:bg-purple-500/20 hover:scale-[1.03] active:scale-[0.97]`}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="w-3.5 h-3.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="18" cy="5" r="3" />
+              <circle cx="6" cy="12" r="3" />
+              <circle cx="18" cy="19" r="3" />
+              <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+              <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+            </svg>
+            {t('customize.export.share_config', { defaultValue: 'Share Config' })}
+          </button>
+
           {/* Clipboard Copy Button */}
           <button
             id="copy-markdown-btn"

--- a/app/customize/page.tsx
+++ b/app/customize/page.tsx
@@ -207,12 +207,11 @@ function CustomizePageInner(): ReactElement {
   // On change sync state to URL
   useEffect(() => {
     if (!queryString) return;
-    // Guard: skip router.replace when the URL already matches the computed params.
-    // Without this, router.replace fires on every mount (including remounts caused by
-    // template.tsx), creating an infinite reload loop in production.
+    // Guard: skip if the URL already matches the computed params.
     if (window.location.search === `?${queryString}`) return;
-    router.replace(`/customize?${queryString}`, { scroll: false });
-  }, [queryString, router]);
+    const newUrl = `${window.location.pathname}?${queryString}`;
+    window.history.replaceState({ ...window.history.state, as: newUrl, url: newUrl }, '', newUrl);
+  }, [queryString]);
 
   useEffect(() => {
     // Safe: resets error state as the first synchronous step when any preview


### PR DESCRIPTION
## Description

This PR implements real-time URL query parameter synchronization for the Customization Studio, allowing users to easily bookmark and share their exact 3D monolith configurations.

**Key changes:**
- Replaced `router.replace` with `window.history.replaceState` inside the customization state sync hook. This completely prevents unnecessary Next.js re-renders and network request loops while flawlessly patching the browser's URL in real-time as users modify settings.
- Added a "Share Config" button to the `ExportPanel` component next to the image download buttons. It uses the `navigator.clipboard` API to copy the active URL (which contains all the synchronized state parameters) so users can instantly share their creations.

Fixes #7239 

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
*(You can drag and drop a screenshot of the new "Share Config" button here before submitting!)*

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
