### PR TITLE
test(useDebounce-mock-integrations): add coverage for #7120

### DIFF
--- a/hooks/useDebounce.mock-integrations.test.ts
+++ b/hooks/useDebounce.mock-integrations.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDebounce } from './useDebounce';
+
+// This suite targets #7120. The originally-specified scenarios (mocking
+// async service/database imports, pending-state overlay rendering, local
+// cache-layer query ordering, fallback on fake endpoint timeouts, cache
+// sync on success callbacks) describe a data-fetching/service layer that
+// does not exist in useDebounce.ts, which is a plain value-debouncing
+// hook built on setTimeout/clearTimeout. It makes no network or cache
+// calls of any kind.
+//
+// These tests instead cover the hook's real behavior, using fake timers
+// (the correct and standard way to test debounce timing), since the
+// hook's core job is deferring a value update by a fixed delay.
+
+describe('useDebounce - core timing behavior (#7120)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the initial value immediately, before the delay elapses', () => {
+    const { result } = renderHook(() => useDebounce('initial', 500));
+    expect(result.current).toBe('initial');
+  });
+
+  it('does not update the debounced value before the delay has elapsed', () => {
+    const { result, rerender } = renderHook(({ value, delay }) => useDebounce(value, delay), {
+      initialProps: { value: 'a', delay: 500 },
+    });
+
+    rerender({ value: 'b', delay: 500 });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe('a');
+  });
+
+  it('updates the debounced value once the delay has fully elapsed', () => {
+    const { result, rerender } = renderHook(({ value, delay }) => useDebounce(value, delay), {
+      initialProps: { value: 'a', delay: 500 },
+    });
+
+    rerender({ value: 'b', delay: 500 });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current).toBe('b');
+  });
+
+  it('resets the timer on rapid successive value changes, only committing the latest value', () => {
+    const { result, rerender } = renderHook(({ value, delay }) => useDebounce(value, delay), {
+      initialProps: { value: 'a', delay: 500 },
+    });
+
+    rerender({ value: 'b', delay: 500 });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    rerender({ value: 'c', delay: 500 });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    rerender({ value: 'd', delay: 500 });
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+    expect(result.current).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe('d');
+  });
+
+  it('clears the pending timer on unmount, so no update fires after the component is gone', () => {
+    const clearSpy = vi.spyOn(global, 'clearTimeout');
+    const { unmount } = renderHook(() => useDebounce('a', 500));
+    unmount();
+    expect(clearSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #7120

## Description
Adds `hooks/useDebounce.mock-integrations.test.ts` with 5 passing test cases (`vitest run` green).

### ⚠️ Note on the original spec
The issue's scenarios — mocking async service/database imports, pending-state overlay rendering, local cache-layer query ordering before database retrievals, fallback on fake endpoint timeouts, cache sync on success callbacks — describe a data-fetching/service layer. `hooks/useDebounce.ts` itself makes no network or cache calls at all; it's a plain value-debouncing hook built on `setTimeout`/`clearTimeout`. There's no service layer or cache to mock.

Rather than leave the issue unaddressed or write assertions that don't actually test anything, I wrote tests for what the hook **actually does**, using fake timers (the standard, correct approach for testing debounce timing):

- Returns the initial value immediately, before the delay elapses
- Does not update the debounced value before the delay has elapsed
- Updates the debounced value once the delay has fully elapsed
- Resets the timer on rapid successive value changes, only committing the latest value
- Clears the pending timer on unmount

If the intent was actually to test a different file with a real async/service layer, happy to redirect this PR — just let me know which file that should target. (Same note as on #7130, #7128, #7125, and #7124 — this looks like the same auto-generated-spec/target-file mismatch pattern.)

## Pillar
- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs) — test coverage addition

## Visual Preview
N/A — this PR adds unit tests only, no visual/SVG output changes.

## Test results
✓ hooks/useDebounce.mock-integrations.test.ts (5 tests) 65ms
Test Files  1 passed (1)
Tests  5 passed (5)
## Checklist before requesting a review:
- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`) — N/A, no streak/SVG output touched.
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format.
- [ ] I have updated `README.md` — N/A.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard — N/A, no SVG changes.
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.