### PR TITLE
test(useLocalStorage): add type compiler coverage

### DIFF
--- a/hooks/useLocalStorage.type-compiler.test.ts
+++ b/hooks/useLocalStorage.type-compiler.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expectTypeOf } from 'vitest';
+import { useLocalStorage } from './useLocalStorage';
+
+describe('TypeScript Compiler Validation & Schema Constraints Stability', () => {
+  test('useLocalStorage should match the expected generic hook contract', () => {
+    type UseLocalStorageSignature = <T>(
+      key: string,
+      initialValue: T
+    ) => readonly [T, (value: T) => void];
+
+    expectTypeOf(useLocalStorage).toMatchTypeOf<UseLocalStorageSignature>();
+  });
+
+  test('useLocalStorage should support primitive value contracts', () => {
+    type PrimitiveReturn = ReturnType<typeof useLocalStorage<string>>;
+    expectTypeOf<PrimitiveReturn>().toEqualTypeOf<readonly [string, (value: string) => void]>();
+  });
+
+  test('useLocalStorage should preserve object field property configurations', () => {
+    type User = {
+      name: string;
+      score: number;
+      isPro: boolean;
+    };
+
+    type UserReturn = ReturnType<typeof useLocalStorage<User>>;
+
+    expectTypeOf<UserReturn>().toEqualTypeOf<readonly [User, (value: User) => void]>();
+  });
+
+  test('useLocalStorage should accept custom types with optional values', () => {
+    type Preferences = {
+      theme: string;
+      fontSize?: number;
+      compactMode?: boolean;
+    };
+
+    type PreferencesReturn = ReturnType<typeof useLocalStorage<Preferences>>;
+
+    expectTypeOf<PreferencesReturn>().toEqualTypeOf<
+      readonly [Preferences, (value: Preferences) => void]
+    >();
+  });
+
+  test('useLocalStorage setter contract should reject incompatible function shapes', () => {
+    type CountReturn = ReturnType<typeof useLocalStorage<number>>;
+    type CountSetter = CountReturn[1];
+    type InvalidSetter = (value: string) => void;
+
+    expectTypeOf<InvalidSetter>().not.toMatchTypeOf<CountSetter>();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #7133

This PR adds a dedicated type-compiler test suite for `hooks/useLocalStorage.ts` to validate the hook’s TypeScript contract and guard against regressions in generic inference and setter compatibility.

### Summary of Changes

Added `hooks/useLocalStorage.type-compiler.test.ts` with 5 type-compiler tests covering:

* generic hook signature validation
* primitive value return contract
* object value return contract
* optional custom type support
* incompatible setter signature rejection

### Testing & Verification

Verified locally with:

* `npx vitest run hooks/useLocalStorage.type-compiler.test.ts`
* `npm run format`
* `npm run lint`
* `npm run test:coverage`
* `npm run test`

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A — this PR only adds a type-compiler test file and does not change UI or SVG output.

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] I have run `npm run test` and all tests pass locally.
* [x] I have run `npm run test:coverage` and branch coverage is at or above 70%.
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that i have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord server for faster collaboration, mentorship, and PR support.
