### PR TITLE
feat: add GitHub push webhook to auto-refresh contribution cache

### DIFF
--- a/app/api/webhooks/github/route.test.ts
+++ b/app/api/webhooks/github/route.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import crypto from 'crypto';
+
+const deleteMock = vi.fn(async () => true);
+vi.mock('@/lib/github', () => ({
+  contributionsCache: { delete: deleteMock },
+  cacheKey: (kind: string, username: string, year?: string) =>
+    year ? `${kind}:${username.toLowerCase()}:${year}` : `${kind}:${username.toLowerCase()}`,
+}));
+
+const rateLimitMock = vi.fn(async () => ({
+  success: true,
+  limit: 1,
+  remaining: 0,
+  reset: Date.now() + 60000,
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: rateLimitMock,
+}));
+
+const { POST } = await import('./route');
+
+const SECRET = 'push-webhook-secret';
+
+const sign = (body: string, secret = SECRET) =>
+  'sha256=' + crypto.createHmac('sha256', secret).update(body).digest('hex');
+
+const makeRequest = (body: string, headers: Record<string, string> = {}) =>
+  new NextRequest('http://localhost:3000/api/webhooks/github', {
+    method: 'POST',
+    headers: {
+      'x-github-event': 'push',
+      'x-hub-signature-256': sign(body),
+      ...headers,
+    },
+    body,
+  });
+
+const pushPayload = JSON.stringify({
+  pusher: { name: 'octocat' },
+  sender: { login: 'octocat' },
+});
+
+describe('POST /api/webhooks/github', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.GITHUB_WEBHOOK_SECRET = SECRET;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns 500 when the webhook secret is not configured', async () => {
+    delete process.env.GITHUB_WEBHOOK_SECRET;
+    const res = await POST(makeRequest(pushPayload));
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 401 when the signature header is missing', async () => {
+    const req = new NextRequest('http://localhost:3000/api/webhooks/github', {
+      method: 'POST',
+      headers: { 'x-github-event': 'push' },
+      body: pushPayload,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for a signature made with the wrong secret', async () => {
+    const res = await POST(
+      makeRequest(pushPayload, { 'x-hub-signature-256': sign(pushPayload, 'wrong') })
+    );
+    expect(res.status).toBe(401);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('responds to ping events without touching the cache', async () => {
+    const body = JSON.stringify({ zen: 'Keep it logically awesome.' });
+    const res = await POST(makeRequest(body, { 'x-github-event': 'ping' }));
+    expect(res.status).toBe(200);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('acknowledges but ignores non-push events', async () => {
+    const res = await POST(makeRequest(pushPayload, { 'x-github-event': 'issues' }));
+    expect(res.status).toBe(202);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('invalidates the default and current-year contribution cache on push', async () => {
+    const res = await POST(makeRequest(pushPayload));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.revalidated).toBe(true);
+    expect(data.username).toBe('octocat');
+
+    const year = String(new Date().getUTCFullYear());
+    expect(deleteMock).toHaveBeenCalledWith('contributions:octocat');
+    expect(deleteMock).toHaveBeenCalledWith(`contributions:octocat:${year}`);
+  });
+
+  it('rate limits repeated pushes to one revalidation per username per minute', async () => {
+    rateLimitMock.mockResolvedValueOnce({
+      success: false,
+      limit: 1,
+      remaining: 0,
+      reset: Date.now() + 60000,
+    });
+    const res = await POST(makeRequest(pushPayload));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.message).toContain('already performed');
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects payloads that do not identify a valid pusher', async () => {
+    const body = JSON.stringify({ pusher: { name: '../../etc/passwd' } });
+    const res = await POST(makeRequest(body));
+    expect(res.status).toBe(422);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid JSON that carries a valid signature', async () => {
+    const body = 'not-json';
+    const res = await POST(makeRequest(body));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/webhooks/github/route.ts
+++ b/app/api/webhooks/github/route.ts
@@ -1,0 +1,137 @@
+import { NextResponse } from 'next/server';
+import crypto from 'crypto';
+import { rateLimit } from '@/lib/rate-limit';
+import { logger } from '@/lib/logger';
+import { cacheKey, contributionsCache } from '@/lib/github';
+
+/**
+ * GitHub push webhook: invalidates the cached contribution data for the
+ * pushing user so their badge reflects the new commit immediately instead
+ * of waiting for the cache TTL to expire.
+ *
+ * Configure the webhook on GitHub with content type application/json,
+ * the push event, and the shared secret from GITHUB_WEBHOOK_SECRET.
+ */
+
+const MAX_PAYLOAD_SIZE = 1024 * 1024; // 1MB
+const SIGNATURE_PREFIX = 'sha256=';
+// One webhook-triggered revalidation per username per minute; a busy
+// repository can emit many push events in quick succession and each
+// revalidation costs a GitHub API round trip.
+const REVALIDATE_LIMIT = 1;
+const REVALIDATE_WINDOW_MS = 60_000;
+
+function getWebhookSecret(): string | null {
+  const secret = process.env.GITHUB_WEBHOOK_SECRET?.trim();
+  return secret || null;
+}
+
+function verifySignature(bodyText: string, signature: string, secret: string): boolean {
+  if (!signature.startsWith(SIGNATURE_PREFIX)) {
+    return false;
+  }
+  const signatureHex = signature.slice(SIGNATURE_PREFIX.length);
+  if (!/^[a-f0-9]{64}$/i.test(signatureHex)) {
+    return false;
+  }
+  const expected = Buffer.from(
+    crypto.createHmac('sha256', secret).update(bodyText).digest('hex'),
+    'hex'
+  );
+  const received = Buffer.from(signatureHex, 'hex');
+  return expected.length === received.length && crypto.timingSafeEqual(expected, received);
+}
+
+/** Usernames follow GitHub's rules: alphanumerics and inner hyphens, max 39 chars. */
+function isValidUsername(value: unknown): value is string {
+  return (
+    typeof value === 'string' && /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/.test(value)
+  );
+}
+
+export async function POST(req: Request) {
+  const webhookSecret = getWebhookSecret();
+  if (!webhookSecret) {
+    logger.error('Push webhook rejected: GITHUB_WEBHOOK_SECRET is not configured', {
+      route: '/api/webhooks/github',
+    });
+    return NextResponse.json({ error: 'Webhook secret is not configured' }, { status: 500 });
+  }
+
+  const contentLength = Number(req.headers.get('content-length') ?? 0);
+  if (contentLength > MAX_PAYLOAD_SIZE) {
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+  }
+
+  const bodyText = await req.text();
+  if (!bodyText || bodyText.length > MAX_PAYLOAD_SIZE) {
+    return NextResponse.json(
+      { error: bodyText ? 'Payload too large' : 'Empty request body' },
+      {
+        status: bodyText ? 413 : 400,
+      }
+    );
+  }
+
+  const signature = req.headers.get('x-hub-signature-256');
+  if (!signature) {
+    return NextResponse.json({ error: 'Missing signature' }, { status: 401 });
+  }
+  if (!verifySignature(bodyText, signature, webhookSecret)) {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+  }
+
+  const event = req.headers.get('x-github-event');
+  if (event === 'ping') {
+    return NextResponse.json({ success: true, message: 'pong' }, { status: 200 });
+  }
+  if (event !== 'push') {
+    // Signed but irrelevant events are acknowledged so GitHub does not retry.
+    return NextResponse.json(
+      { success: true, message: `Ignored event: ${event}` },
+      { status: 202 }
+    );
+  }
+
+  let payload: { pusher?: { name?: unknown }; sender?: { login?: unknown } };
+  try {
+    payload = JSON.parse(bodyText);
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const username = [payload.sender?.login, payload.pusher?.name].find(isValidUsername);
+  if (!username) {
+    return NextResponse.json({ error: 'Payload does not identify a pusher' }, { status: 422 });
+  }
+
+  const limit = await rateLimit(
+    username.toLowerCase(),
+    REVALIDATE_LIMIT,
+    REVALIDATE_WINDOW_MS,
+    'webhook:revalidate'
+  );
+  if (!limit.success) {
+    // Already refreshed within the window; report success so GitHub does not retry.
+    return NextResponse.json(
+      { success: true, message: 'Revalidation already performed recently', username },
+      { status: 200 }
+    );
+  }
+
+  // Drop the default and current-year cache entries; the next badge request
+  // refetches fresh contribution data from GitHub.
+  const currentYear = String(new Date().getUTCFullYear());
+  const invalidated = await Promise.all([
+    contributionsCache.delete(cacheKey('contributions', username)),
+    contributionsCache.delete(cacheKey('contributions', username, currentYear)),
+  ]);
+
+  logger.info('Push webhook invalidated contribution cache', {
+    route: '/api/webhooks/github',
+    username,
+    invalidatedKeys: invalidated.filter(Boolean).length,
+  });
+
+  return NextResponse.json({ success: true, username, revalidated: true }, { status: 200 });
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #7254

Badges currently refresh only when the cache TTL expires, so a user who just pushed has to wait out the TTL before the badge reflects the new commit. This adds a hardened push webhook receiver at `POST /api/webhooks/github` that invalidates the pusher's cached contribution data immediately.

## Implementation

- **Signature verification**: HMAC SHA-256 over the raw body with `crypto.timingSafeEqual`, matching the security posture of the existing `/api/webhook` route (prefix check, strict 64 char hex validation, buffer length equality before comparison)
- **Event handling**: answers `ping` with 200, acknowledges signed non push events with 202 so GitHub does not retry them, and processes only `push`
- **Username validation**: the pusher login is validated against GitHub's username rules before being used in a cache key, so a malicious payload cannot inject arbitrary key material
- **Rate limiting**: webhook triggered revalidation is capped at 1 per username per minute through the existing `rateLimit` helper under an isolated `webhook:revalidate` namespace, exactly as requested in the issue, protecting against high push frequency repositories
- **Cache invalidation**: drops the default and current year `contributions` entries from the exported `contributionsCache` (both the local L1 and the Redis layer through `DistributedCache.delete`), so the next badge request refetches fresh data
- **Payload limits**: 1MB cap enforced on both the declared content length and the actual body

## Setup

Point a repository or organization webhook at `/api/webhooks/github` with content type `application/json`, the push event, and the shared secret from `GITHUB_WEBHOOK_SECRET` (already used by the existing webhook route, no new configuration).

## Testing Done

- 9 new vitest cases covering missing secret, missing signature, wrong secret signature, ping handling, non push acknowledgement, successful cache invalidation of both keys, the per username rate limit path, rejection of invalid usernames, and invalid JSON with a valid signature
- `npm run typecheck` and `npx eslint` pass; the pre-commit hook (lint-staged with eslint and prettier) ran clean