### PR TITLE
fix: detect and redact leaked credentials in commit messages

### DIFF
--- a/lib/secretScanner.test.ts
+++ b/lib/secretScanner.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { containsSecrets, detectSecrets, redactSecrets } from './secretScanner';
+
+describe('detectSecrets', () => {
+  it('detects classic GitHub personal access tokens', () => {
+    const text = `fix auth: use ghp_${'a1B2c3D4'.repeat(5)} for now`;
+    const findings = detectSecrets(text);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].type).toBe('github-token');
+  });
+
+  it('detects fine-grained GitHub tokens', () => {
+    const text = `temp: github_pat_11ABCDEFG0${'x'.repeat(60)}`;
+    expect(detectSecrets(text)[0]?.type).toBe('github-token');
+  });
+
+  it('detects AWS access key ids', () => {
+    expect(detectSecrets('creds AKIAIOSFODNN7EXAMPLE added')[0]?.type).toBe('aws-access-key-id');
+  });
+
+  it('detects Slack and Stripe tokens', () => {
+    expect(detectSecrets('xoxb-123456789012-abcdefghijkl')[0]?.type).toBe('slack-token');
+    expect(detectSecrets(`sk_live_${'4eC39HqLyjWDarjtT1zdp7dc'}`)[0]?.type).toBe('stripe-key');
+  });
+
+  it('detects JWTs', () => {
+    const jwt =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJVadQssw5c';
+    expect(detectSecrets(`token: ${jwt}`)[0]?.type).toBe('jwt');
+  });
+
+  it('detects private key blocks including truncated ones', () => {
+    const block = '-----BEGIN RSA PRIVATE KEY-----\nMIIEow...\n-----END RSA PRIVATE KEY-----';
+    expect(detectSecrets(block)[0]?.type).toBe('private-key-block');
+    expect(detectSecrets('-----BEGIN PRIVATE KEY-----\nMIIEow')[0]?.type).toBe('private-key-block');
+  });
+
+  it('detects credentials embedded in connection strings', () => {
+    const text = 'point to postgres://admin:hunter22secret@db.internal:5432/prod';
+    expect(detectSecrets(text)[0]?.type).toBe('connection-string-credentials');
+  });
+
+  it('detects password and api key assignments', () => {
+    expect(detectSecrets('set password=SuperSecret99!')[0]?.type).toBe('credential-assignment');
+    expect(detectSecrets('API_KEY: "abcd1234efgh5678"')[0]?.type).toBe('credential-assignment');
+  });
+
+  it('does not flag ordinary commit messages', () => {
+    const messages = [
+      'fix: handle empty contribution calendar',
+      'feat(auth): rotate tokens on schedule',
+      'docs: document the password reset flow',
+      'refactor: extract secret scanner into lib',
+      'chore: bump eslint to 9.20.1',
+      'password requirements updated in validation docs',
+    ];
+    for (const message of messages) {
+      expect(detectSecrets(message)).toHaveLength(0);
+    }
+  });
+
+  it('does not flag placeholders and env indirection', () => {
+    expect(detectSecrets('password=${DB_PASSWORD}')).toHaveLength(0);
+    expect(detectSecrets('api_key=<your-key-here>')).toHaveLength(0);
+  });
+});
+
+describe('redactSecrets', () => {
+  it('replaces the secret with a typed placeholder and keeps the rest', () => {
+    const redacted = redactSecrets('deploy with AKIAIOSFODNN7EXAMPLE today');
+    expect(redacted).toBe('deploy with [REDACTED:aws-access-key-id] today');
+  });
+
+  it('redacts multiple different secrets in one message', () => {
+    const text = 'creds: AKIAIOSFODNN7EXAMPLE and password=Sup3rSecret!';
+    const redacted = redactSecrets(text);
+    expect(redacted).toContain('[REDACTED:aws-access-key-id]');
+    expect(redacted).toContain('[REDACTED:credential-assignment]');
+    expect(redacted).not.toContain('AKIAIOSFODNN7EXAMPLE');
+    expect(redacted).not.toContain('Sup3rSecret!');
+  });
+
+  it('returns the identical reference when nothing matches', () => {
+    const text = 'fix: adjust badge colors';
+    expect(redactSecrets(text)).toBe(text);
+  });
+});
+
+describe('containsSecrets', () => {
+  it('reports presence without mutating', () => {
+    expect(containsSecrets('token ghp_' + 'A1b2C3d4'.repeat(5))).toBe(true);
+    expect(containsSecrets('perfectly normal message')).toBe(false);
+  });
+});

--- a/lib/secretScanner.ts
+++ b/lib/secretScanner.ts
@@ -1,0 +1,119 @@
+/**
+ * Secret detection and redaction for commit messages.
+ *
+ * Commit messages flow from webhook payloads into CI analytics views
+ * without any screening, so an accidentally pasted token or password
+ * becomes visible to everyone who can see the dashboard. This module
+ * detects high confidence secret formats and replaces them with a
+ * typed placeholder before the message is stored or rendered.
+ */
+
+export interface SecretFinding {
+  /** Which detector matched, e.g. "github-token". */
+  type: string;
+  /** Index of the match within the scanned text. */
+  index: number;
+  /** Length of the matched secret. */
+  length: number;
+}
+
+interface SecretPattern {
+  type: string;
+  pattern: RegExp;
+}
+
+// Ordered from most to least specific so overlapping matches redact
+// with the most precise label. Every regex uses the global flag; they
+// are re-instantiated per scan via lastIndex reset in scan().
+const SECRET_PATTERNS: SecretPattern[] = [
+  {
+    // Classic and fine-grained GitHub tokens.
+    type: 'github-token',
+    pattern: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,255}\b|\bgithub_pat_[A-Za-z0-9_]{22,255}\b/g,
+  },
+  {
+    type: 'aws-access-key-id',
+    pattern: /\b(?:AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}\b/g,
+  },
+  {
+    type: 'google-api-key',
+    pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g,
+  },
+  {
+    type: 'slack-token',
+    pattern: /\bxox[baprs]-[0-9A-Za-z-]{10,250}\b/g,
+  },
+  {
+    type: 'stripe-key',
+    pattern: /\b[rs]k_live_[0-9a-zA-Z]{24,247}\b/g,
+  },
+  {
+    type: 'openai-key',
+    pattern: /\bsk-[A-Za-z0-9_-]{20,}T3BlbkFJ[A-Za-z0-9_-]{20,}\b|\bsk-proj-[A-Za-z0-9_-]{40,}\b/g,
+  },
+  {
+    type: 'jwt',
+    pattern: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+  },
+  {
+    type: 'private-key-block',
+    pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z ]*PRIVATE KEY-----|$)/g,
+  },
+  {
+    type: 'connection-string-credentials',
+    // postgres://user:password@host, mongodb+srv://user:password@host, etc.
+    pattern: /\b[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s:/@]+:[^\s@]+@[^\s]+/g,
+  },
+  {
+    // password=..., api_key: "...", secret = '...' style assignments.
+    type: 'credential-assignment',
+    pattern:
+      /\b(?:password|passwd|pwd|api[_-]?key|apikey|secret|access[_-]?token|auth[_-]?token|client[_-]?secret)\b\s*[:=]\s*["']?(?!\s)(?!["'])(?!\$\{)(?!<[^>]+>)[^\s"']{8,}["']?/gi,
+  },
+];
+
+const REDACTION_LABEL = (type: string) => `[REDACTED:${type}]`;
+
+/** Return every secret found in the text, ordered by position. */
+export function detectSecrets(text: string): SecretFinding[] {
+  if (!text) return [];
+  const findings: SecretFinding[] = [];
+  const claimed: [number, number][] = [];
+
+  for (const { type, pattern } of SECRET_PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) {
+      const start = match.index ?? 0;
+      const end = start + match[0].length;
+      // Skip regions already claimed by a more specific detector.
+      if (claimed.some(([s, e]) => start < e && end > s)) continue;
+      claimed.push([start, end]);
+      findings.push({ type, index: start, length: match[0].length });
+    }
+  }
+
+  return findings.sort((a, b) => a.index - b.index);
+}
+
+export function containsSecrets(text: string): boolean {
+  return detectSecrets(text).length > 0;
+}
+
+/**
+ * Replace every detected secret with a typed placeholder. Text without
+ * findings is returned unchanged (same reference), so callers can use
+ * an identity check to decide whether to log a warning.
+ */
+export function redactSecrets(text: string): string {
+  const findings = detectSecrets(text);
+  if (findings.length === 0) return text;
+
+  let result = '';
+  let cursor = 0;
+  for (const finding of findings) {
+    result += text.slice(cursor, finding.index) + REDACTION_LABEL(finding.type);
+    cursor = finding.index + finding.length;
+  }
+  result += text.slice(cursor);
+  return result;
+}

--- a/services/github/webhook-handler.ts
+++ b/services/github/webhook-handler.ts
@@ -1,4 +1,5 @@
 import { DistributedCache } from '@/lib/cache';
+import { redactSecrets } from '@/lib/secretScanner';
 import type { CIWorkflowRun, CIInsights } from '@/types/ci-analytics';
 
 interface WebhookPayload {
@@ -92,7 +93,9 @@ function extractWorkflowEvent(payload: WebhookPayload): CIEvent | null {
       runNumber: run.run_number,
       branch: run.head_branch,
       commit: run.head_commit.id.substring(0, 7),
-      message: run.head_commit.message,
+      // Commit messages can carry accidentally pasted credentials; scrub
+      // them before they reach analytics storage and dashboards.
+      message: redactSecrets(run.head_commit.message),
       author: run.head_commit.author.name,
     },
   };


### PR DESCRIPTION
## What does this PR do?

Fixes #4988

Commit messages arrive through CI webhook payloads and are stored and displayed without any screening, so an accidentally pasted API key or password becomes visible to everyone who can see the analytics views. This PR adds secret detection and redaction at the point where commit messages enter the system.

## Implementation

**New module `lib/secretScanner.ts`** with three exports:

- `detectSecrets(text)` returns typed findings with positions, using detectors ordered from most to least specific with overlap suppression, so a GitHub token inside a larger assignment is labelled precisely
- `redactSecrets(text)` replaces each finding with a typed `[REDACTED:type]` placeholder and returns the identical reference when nothing matches, letting callers detect whether redaction occurred with a cheap identity check
- `containsSecrets(text)` for warn or block use cases

**Detectors** cover GitHub classic and fine grained tokens, AWS access key ids, Google API keys, Slack tokens, Stripe live keys, OpenAI keys, JWTs, private key blocks (including blocks truncated by commit message length limits), credentials embedded in connection strings such as `postgres://user:pass@host`, and generic `password=` or `api_key:` assignments. Placeholders like `${DB_PASSWORD}` and `<your-key-here>` are explicitly ignored to keep false positives out of ordinary messages.

**Wiring**: `services/github/webhook-handler.ts` now passes `head_commit.message` through `redactSecrets` before the event is stored, so dashboards, caches and logs only ever see the scrubbed message.

## Testing Done

- 14 new vitest cases: every detector class, multi secret redaction in one message, identity return for clean text, six ordinary commit message shapes that must not be flagged, and the placeholder exclusions
- Full `services/github` suite still passes (49 files, 247 tests), `npm run typecheck` clean