### PR TITLE
feat: author attribution and team contribution analysis

### DIFF
--- a/app/api/team-attribution/route.test.ts
+++ b/app/api/team-attribution/route.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/utils/getClientIp', () => ({
+  getClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+const rateLimitMock = vi.fn(async () => ({
+  success: true,
+  limit: 30,
+  remaining: 29,
+  reset: Date.now() + 60000,
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: rateLimitMock,
+  getRateLimitHeaders: () => ({}),
+}));
+
+const { POST } = await import('./route');
+
+const makeRequest = (body: unknown) =>
+  new NextRequest('http://localhost:3000/api/team-attribution', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+
+describe('POST /api/team-attribution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns attribution metrics for valid commits', async () => {
+    const res = await POST(
+      makeRequest({
+        commits: [
+          { author: 'alice', date: '2026-06-01T10:00:00Z', additions: 10 },
+          { author: 'alice', date: '2026-06-02T10:00:00Z' },
+          { author: 'bob', date: '2026-06-03T10:00:00Z' },
+        ],
+      })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.totalCommits).toBe(3);
+    expect(data.authors[0].author).toBe('alice');
+    expect(data.busFactor).toBe(1);
+  });
+
+  it('rejects invalid JSON', async () => {
+    const res = await POST(makeRequest('{nope'));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a missing commits array', async () => {
+    const res = await POST(makeRequest({ commits: 'not-an-array' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects commits with malformed entries', async () => {
+    const res = await POST(makeRequest({ commits: [{ author: 'x', date: 'not-a-date' }] }));
+    expect(res.status).toBe(422);
+  });
+
+  it('rejects oversized commit lists', async () => {
+    const commits = Array.from({ length: 10_001 }, () => ({
+      author: 'a',
+      date: '2026-06-01T00:00:00Z',
+    }));
+    const res = await POST(makeRequest({ commits }));
+    expect(res.status).toBe(413);
+  });
+
+  it('enforces the rate limit', async () => {
+    rateLimitMock.mockResolvedValueOnce({
+      success: false,
+      limit: 30,
+      remaining: 0,
+      reset: Date.now() + 60000,
+    });
+    const res = await POST(makeRequest({ commits: [] }));
+    expect(res.status).toBe(429);
+  });
+});

--- a/app/api/team-attribution/route.ts
+++ b/app/api/team-attribution/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+import { rateLimit, getRateLimitHeaders } from '@/lib/rate-limit';
+import { getClientIp } from '@/utils/getClientIp';
+import { analyzeTeamAttribution, type AttributedCommit } from '@/lib/analytics/authorAttribution';
+
+const MAX_COMMITS = 10_000;
+
+function isAttributedCommit(value: unknown): value is AttributedCommit {
+  if (typeof value !== 'object' || value === null) return false;
+  const c = value as Record<string, unknown>;
+  return (
+    typeof c.author === 'string' &&
+    typeof c.date === 'string' &&
+    !Number.isNaN(Date.parse(c.date)) &&
+    (c.additions === undefined || (typeof c.additions === 'number' && c.additions >= 0)) &&
+    (c.deletions === undefined || (typeof c.deletions === 'number' && c.deletions >= 0))
+  );
+}
+
+/**
+ * Analyze author attribution for a set of commits.
+ *
+ * Accepts { commits: [{ author, date, additions?, deletions? }] } and
+ * returns per-author metrics plus team level indicators (bus factor,
+ * contribution concentration, top contributors).
+ */
+export async function POST(req: Request) {
+  const ip = getClientIp(req);
+  const limit = await rateLimit(ip, 30, 60000, 'team-attribution');
+  if (!limit.success) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      { status: 429, headers: getRateLimitHeaders(limit) }
+    );
+  }
+
+  let body: { commits?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (!Array.isArray(body.commits)) {
+    return NextResponse.json({ error: 'commits must be an array' }, { status: 400 });
+  }
+  if (body.commits.length > MAX_COMMITS) {
+    return NextResponse.json(
+      { error: `commits exceeds the maximum of ${MAX_COMMITS} entries` },
+      { status: 413 }
+    );
+  }
+  if (!body.commits.every(isAttributedCommit)) {
+    return NextResponse.json(
+      { error: 'each commit needs an author string and a valid ISO date' },
+      { status: 422 }
+    );
+  }
+
+  return NextResponse.json(analyzeTeamAttribution(body.commits), {
+    headers: getRateLimitHeaders(limit),
+  });
+}

--- a/lib/analytics/authorAttribution.test.ts
+++ b/lib/analytics/authorAttribution.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import {
+  analyzeTeamAttribution,
+  busFactor,
+  giniCoefficient,
+  type AttributedCommit,
+} from './authorAttribution';
+
+const commit = (author: string, date: string, additions = 0, deletions = 0): AttributedCommit => ({
+  author,
+  date,
+  additions,
+  deletions,
+});
+
+describe('giniCoefficient', () => {
+  it('is 0 for perfectly even contribution', () => {
+    expect(giniCoefficient([10, 10, 10, 10])).toBeCloseTo(0);
+  });
+
+  it('approaches 1 when one author does everything', () => {
+    expect(giniCoefficient([100, 0, 0, 0])).toBeCloseTo(0.75);
+    expect(giniCoefficient([1000, 0, 0, 0, 0, 0, 0, 0, 0, 0])).toBeCloseTo(0.9);
+  });
+
+  it('handles degenerate inputs', () => {
+    expect(giniCoefficient([])).toBe(0);
+    expect(giniCoefficient([5])).toBe(0);
+    expect(giniCoefficient([0, 0, 0])).toBe(0);
+  });
+});
+
+describe('busFactor', () => {
+  it('is 1 when a single author covers half the commits', () => {
+    expect(busFactor([60, 20, 20])).toBe(1);
+  });
+
+  it('grows as work is spread more evenly', () => {
+    expect(busFactor([25, 25, 25, 25])).toBe(2);
+    expect(busFactor([10, 10, 10, 10, 10])).toBe(3);
+  });
+
+  it('is 0 for no commits', () => {
+    expect(busFactor([])).toBe(0);
+    expect(busFactor([0, 0])).toBe(0);
+  });
+});
+
+describe('analyzeTeamAttribution', () => {
+  const commits: AttributedCommit[] = [
+    commit('alice', '2026-06-01T10:00:00Z', 100, 20),
+    commit('alice', '2026-06-01T15:00:00Z', 50, 5),
+    commit('alice', '2026-06-03T09:00:00Z', 10, 1),
+    commit('bob', '2026-06-02T11:00:00Z', 30, 10),
+    commit('carol', '2026-06-04T12:00:00Z', 5, 0),
+    commit('bob', '2026-06-05T16:00:00Z', 20, 2),
+  ];
+
+  it('attributes commits, lines and activity per author', () => {
+    const result = analyzeTeamAttribution(commits);
+    expect(result.totalCommits).toBe(6);
+    expect(result.totalAuthors).toBe(3);
+
+    const alice = result.authors.find((a) => a.author === 'alice')!;
+    expect(alice.commits).toBe(3);
+    expect(alice.share).toBeCloseTo(0.5);
+    expect(alice.activeDays).toBe(2);
+    expect(alice.additions).toBe(160);
+    expect(alice.deletions).toBe(26);
+    expect(alice.firstCommit).toBe('2026-06-01T10:00:00Z');
+    expect(alice.lastCommit).toBe('2026-06-03T09:00:00Z');
+  });
+
+  it('orders authors by commit count with a stable name tiebreak', () => {
+    const result = analyzeTeamAttribution(commits);
+    expect(result.authors.map((a) => a.author)).toEqual(['alice', 'bob', 'carol']);
+    expect(result.topContributors).toEqual(['alice', 'bob', 'carol']);
+  });
+
+  it('computes bus factor and concentration for the team', () => {
+    const result = analyzeTeamAttribution(commits);
+    expect(result.busFactor).toBe(1); // alice alone covers half
+    expect(result.concentration).toBeGreaterThan(0);
+    expect(result.concentration).toBeLessThan(1);
+  });
+
+  it('ignores commits with blank authors', () => {
+    const result = analyzeTeamAttribution([
+      commit('  ', '2026-06-01T00:00:00Z'),
+      commit('dave', '2026-06-01T00:00:00Z'),
+    ]);
+    expect(result.totalAuthors).toBe(1);
+    expect(result.totalCommits).toBe(1);
+  });
+
+  it('handles an empty commit list', () => {
+    const result = analyzeTeamAttribution([]);
+    expect(result.totalCommits).toBe(0);
+    expect(result.totalAuthors).toBe(0);
+    expect(result.busFactor).toBe(0);
+    expect(result.concentration).toBe(0);
+    expect(result.topContributors).toEqual([]);
+  });
+
+  it('treats missing line counts as zero', () => {
+    const result = analyzeTeamAttribution([{ author: 'erin', date: '2026-06-01T00:00:00Z' }]);
+    expect(result.authors[0].additions).toBe(0);
+    expect(result.authors[0].deletions).toBe(0);
+  });
+});

--- a/lib/analytics/authorAttribution.ts
+++ b/lib/analytics/authorAttribution.ts
@@ -1,0 +1,138 @@
+/**
+ * Author attribution and team contribution analysis.
+ *
+ * The dashboard could show a team's combined activity but not who did
+ * what: no per-author share, no concentration measure, no way to spot
+ * that one person carries the project. This module turns a plain list
+ * of attributed commits into per-author metrics and team level
+ * indicators (bus factor, concentration index, top contributors).
+ */
+
+export interface AttributedCommit {
+  /** Author login or resolved identity. */
+  author: string;
+  /** ISO timestamp of the commit. */
+  date: string;
+  additions?: number;
+  deletions?: number;
+}
+
+export interface AuthorMetrics {
+  author: string;
+  commits: number;
+  /** Share of total commits, 0 to 1. */
+  share: number;
+  /** Distinct UTC days with at least one commit. */
+  activeDays: number;
+  additions: number;
+  deletions: number;
+  firstCommit: string;
+  lastCommit: string;
+}
+
+export interface TeamAttribution {
+  totalCommits: number;
+  totalAuthors: number;
+  authors: AuthorMetrics[];
+  /**
+   * Smallest number of authors that together account for at least half
+   * of all commits. A bus factor of 1 means the project stalls if a
+   * single person leaves.
+   */
+  busFactor: number;
+  /**
+   * Gini coefficient of commit counts, 0 (perfectly even) to 1 (one
+   * author does everything). Values above 0.6 indicate the workload is
+   * concentrated on few people.
+   */
+  concentration: number;
+  topContributors: string[];
+  generatedAt: string;
+}
+
+function utcDay(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+/** Gini coefficient over a list of non-negative counts. */
+export function giniCoefficient(counts: number[]): number {
+  const values = counts.filter((c) => c >= 0).sort((a, b) => a - b);
+  const n = values.length;
+  const total = values.reduce((a, b) => a + b, 0);
+  if (n < 2 || total === 0) return 0;
+
+  let weightedSum = 0;
+  for (let i = 0; i < n; i++) {
+    weightedSum += (i + 1) * values[i];
+  }
+  return (2 * weightedSum) / (n * total) - (n + 1) / n;
+}
+
+/** Smallest set of authors covering at least half of all commits. */
+export function busFactor(commitCounts: number[]): number {
+  const sorted = [...commitCounts].sort((a, b) => b - a);
+  const total = sorted.reduce((a, b) => a + b, 0);
+  if (total === 0) return 0;
+
+  let covered = 0;
+  for (let i = 0; i < sorted.length; i++) {
+    covered += sorted[i];
+    if (covered * 2 >= total) return i + 1;
+  }
+  return sorted.length;
+}
+
+export function analyzeTeamAttribution(commits: AttributedCommit[]): TeamAttribution {
+  const byAuthor = new Map<
+    string,
+    { commits: number; days: Set<string>; additions: number; deletions: number; dates: string[] }
+  >();
+
+  for (const commit of commits) {
+    const author = commit.author.trim();
+    if (!author) continue;
+    const entry = byAuthor.get(author) ?? {
+      commits: 0,
+      days: new Set<string>(),
+      additions: 0,
+      deletions: 0,
+      dates: [],
+    };
+    entry.commits += 1;
+    entry.days.add(utcDay(commit.date));
+    entry.additions += commit.additions ?? 0;
+    entry.deletions += commit.deletions ?? 0;
+    entry.dates.push(commit.date);
+    byAuthor.set(author, entry);
+  }
+
+  const totalCommits = Array.from(byAuthor.values()).reduce((sum, e) => sum + e.commits, 0);
+
+  const authors: AuthorMetrics[] = Array.from(byAuthor.entries())
+    .map(([author, entry]) => {
+      const sortedDates = entry.dates.sort();
+      return {
+        author,
+        commits: entry.commits,
+        share: totalCommits > 0 ? entry.commits / totalCommits : 0,
+        activeDays: entry.days.size,
+        additions: entry.additions,
+        deletions: entry.deletions,
+        firstCommit: sortedDates[0],
+        lastCommit: sortedDates[sortedDates.length - 1],
+      };
+    })
+    .sort((a, b) => b.commits - a.commits || a.author.localeCompare(b.author));
+
+  const counts = authors.map((a) => a.commits);
+
+  return {
+    totalCommits,
+    totalAuthors: authors.length,
+    authors,
+    busFactor: busFactor(counts),
+    concentration: Number(giniCoefficient(counts).toFixed(3)),
+    topContributors: authors.slice(0, 3).map((a) => a.author),
+    generatedAt: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #4989

The dashboard can show a team's combined activity but not who did what: no per author share, no concentration measure, no way to spot that one person quietly carries the project. This PR adds attribution analytics.

## Implementation

**New module `lib/analytics/authorAttribution.ts`** (alongside the existing `teamHealth.ts`):

- `analyzeTeamAttribution(commits)` aggregates attributed commits into per author metrics: commit count, share of total, distinct active UTC days, additions and deletions, first and last commit
- **Bus factor**: the smallest set of authors that together cover at least half of all commits; a value of 1 flags a project that stalls if a single person leaves
- **Concentration**: Gini coefficient over per author commit counts, 0 for perfectly even teams up to 1 when one author does everything, so trends can be tracked over time
- **Recognition**: authors are ranked with a stable tiebreak and the top 3 surfaced as `topContributors`
- Blank authors are ignored, missing line counts default to zero, and empty input produces a well formed zero report

**New endpoint `POST /api/team-attribution`**: accepts `{ commits: [{ author, date, additions?, deletions? }] }`, validates every entry (author string, parseable ISO date, non negative line counts), caps input at 10,000 commits, and rate limits per IP through the existing `rateLimit` helper in an isolated namespace.

## Testing Done

- 18 new vitest cases: Gini values for even, skewed and degenerate distributions, bus factor growth as work spreads, per author aggregation, ordering and tiebreak, blank author handling, empty input, plus route tests for the success path, invalid JSON, malformed entries, oversized payloads and the rate limit
- `npm run typecheck` clean; pre-commit eslint and prettier hooks passed