### PR TITLE
test(useRecentSearches): add mouse-interactivity tests for interactio…

### DIFF
--- a/hooks/useRecentSearches.mouse-interactivity.test.ts
+++ b/hooks/useRecentSearches.mouse-interactivity.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRecentSearches } from './useRecentSearches';
+
+const store: Record<string, string> = {};
+
+beforeEach(() => {
+  Object.keys(store).forEach((k) => delete store[k]);
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+      clear: () => {
+        Object.keys(store).forEach((k) => delete store[k]);
+      },
+    },
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe('useRecentSearches mouse-interactivity', () => {
+  it('addSearch updates the searches array on interaction', () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.addSearch('torvalds');
+    });
+    expect(result.current.searches).toEqual(['torvalds']);
+  });
+
+  it('multiple rapid addSearch calls (touch-like) all register', () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.addSearch('a');
+    });
+    act(() => {
+      result.current.addSearch('b');
+    });
+    act(() => {
+      result.current.addSearch('c');
+    });
+    expect(result.current.searches).toEqual(['c', 'b', 'a']);
+  });
+
+  it('clearSearches resets state after previous additions', () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.addSearch('torvalds');
+    });
+    act(() => {
+      result.current.clearSearches();
+    });
+    expect(result.current.searches).toEqual([]);
+  });
+
+  it('removeSearch propagates correctly after addSearch', () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.addSearch('torvalds');
+    });
+    act(() => {
+      result.current.addSearch('gaearon');
+    });
+    act(() => {
+      result.current.removeSearch('torvalds');
+    });
+    expect(result.current.searches).toEqual(['gaearon']);
+  });
+
+  it('deduplication on repeated addSearch with same value', () => {
+    const { result } = renderHook(() => useRecentSearches());
+    act(() => {
+      result.current.addSearch('torvalds');
+    });
+    act(() => {
+      result.current.addSearch('gaearon');
+    });
+    act(() => {
+      result.current.addSearch('torvalds');
+    });
+    expect(result.current.searches).toEqual(['torvalds', 'gaearon']);
+  });
+});


### PR DESCRIPTION
## Description
Adds mouse-interactivity tests for `useRecentSearches` hook, verifying interaction-driven state changes (add, remove, clear, deduplication).

## Changes
- `hooks/useRecentSearches.mouse-interactivity.test.ts` (new)

## Test Cases
1. **addSearch updates state** — verifies search is added on interaction
2. **Multiple rapid calls (touch-like)** — all rapid calls register correctly
3. **clearSearches resets state** — clears after previous additions
4. **removeSearch propagates** — removes correctly after adds
5. **Deduplication** — repeated adds move existing entry to front

## Verification
- `vitest run` — all 5 tests pass