### PR TITLE
bug: Default streak badge validates width/height parameters but ignores them during SVG rendering  #5321

### DIFF
--- a/app/api/streak/tests/dimensions.test.ts
+++ b/app/api/streak/tests/dimensions.test.ts
@@ -51,11 +51,10 @@ describe('Integration Test: API Streak Dimensions Parameter Group', () => {
 
     const svgData = await res.text();
 
-    // BUG FOUND: The API correctly validates custom width/height parameters,
-    // but the current SVG template hardcodes the output to 600x420.
-    // Asserting the current fallback behavior so the pipeline passes.
-    expect(svgData).toContain('viewBox="0 0 600 420"');
-    expect(svgData).toContain('<rect width="600" height="420"');
+    // Fix verified: custom width/height are now honored in the default view.
+    // The SVG canvas must use the requested dimensions, not the hardcoded 600x420.
+    expect(svgData).toContain('viewBox="0 0 777 666"');
+    expect(svgData).toContain('<rect width="777" height="666"');
   });
 
   it('Test 3: should reject negative dimensions with a 400 Bad Request', async () => {

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -910,8 +910,13 @@ export function generateSVG(
   const radius = sanitizeRadius(params.radius, 8) * sf;
   const labels = getLabels(params.lang);
   const labelVisible = params.label !== false;
-  const W = Math.round(SVG_WIDTH * sf);
-  const H = Math.round((labelVisible ? SVG_HEIGHT : SVG_HEIGHT - 40) * sf);
+  // Honor custom dimensions when provided; fall back to the size-scaled defaults.
+  // params.width/height take precedence over the size preset so users get exactly
+  // the canvas dimensions they requested.
+  const W = params.width ? Math.round(params.width) : Math.round(SVG_WIDTH * sf);
+  const H = params.height
+    ? Math.round(params.height)
+    : Math.round((labelVisible ? SVG_HEIGHT : SVG_HEIGHT - 40) * sf);
   const yOffset = params.label === false ? -40 : 0;
   const towerData = scaleTowerData(
     computeTowers(calendar, params.scale, stats.todayDate, params.mode),
@@ -1018,9 +1023,14 @@ function generateAutoThemeSVG(
   const sf = getSizeScale(params.size);
   const radius = sanitizeRadius(params.radius, 8) * sf;
   const labels = getLabels(params.lang);
-  const W = Math.round(SVG_WIDTH * sf);
   const labelVisible = params.label !== false;
-  const H = Math.round((labelVisible ? SVG_HEIGHT : SVG_HEIGHT - 40) * sf);
+  // Honor custom dimensions when provided; fall back to the size-scaled defaults.
+  // params.width/height take precedence over the size preset so users get exactly
+  // the canvas dimensions they requested.
+  const W = params.width ? Math.round(params.width) : Math.round(SVG_WIDTH * sf);
+  const H = params.height
+    ? Math.round(params.height)
+    : Math.round((labelVisible ? SVG_HEIGHT : SVG_HEIGHT - 40) * sf);
   const yOffset = params.label === false ? -40 : 0;
   const towerData = scaleTowerData(
     computeTowers(calendar, params.scale, stats.todayDate, params.mode),


### PR DESCRIPTION
## Description

Fixes #5321 
closes #5321 
## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [x] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

*For example, requesting dimensions with `width=777&height=666` in the default view now correctly scales the canvas:*
- Before: `viewBox="0 0 600 420"`
- After: `viewBox="0 0 777 666"`

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.