### PR TITLE
test(useLocalStorage-mock-integrations): added async service layer mocking and local cache stub coverage

### DIFF
--- a/hooks/useLocalStorage.mock-integrations.test.ts
+++ b/hooks/useLocalStorage.mock-integrations.test.ts
@@ -1,0 +1,89 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLocalStorage } from './useLocalStorage';
+
+describe('useLocalStorage - Asynchronous Service Layer Mocking & Local Cache Stubs', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('reads from the localStorage cache before falling back to the initialValue on first render', () => {
+    // Pre-seed the cache as a stub of a prior successful write
+    localStorage.setItem('theme', JSON.stringify('dark'));
+
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem');
+
+    const { result } = renderHook(() => useLocalStorage('theme', 'light'));
+
+    // Cache must have been queried
+    expect(getItemSpy).toHaveBeenCalledWith('theme');
+    // Cached value must win over initialValue
+    expect(result.current[0]).toBe('dark');
+  });
+
+  it('returns the initialValue when the localStorage cache has no entry for the key', () => {
+    // Cache is empty — simulates a cold start with no prior data
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+
+    const { result } = renderHook(() => useLocalStorage('missing-key', 'fallback'));
+
+    expect(getItemSpy).toHaveBeenCalledWith('missing-key');
+    // Must return initialValue when cache miss occurs
+    expect(result.current[0]).toBe('fallback');
+  });
+
+  it('writes the new value to the localStorage cache on a successful setValue call', () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+    const { result } = renderHook(() => useLocalStorage('user', 'alice'));
+
+    act(() => {
+      result.current[1]('bob');
+    });
+
+    // Cache sync must have been written on the success path
+    expect(setItemSpy).toHaveBeenCalledWith('user', JSON.stringify('bob'));
+    // React state must also be updated
+    expect(result.current[0]).toBe('bob');
+  });
+
+  it('falls back gracefully without throwing when localStorage.setItem throws a quota exceeded error', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+
+    const { result } = renderHook(() => useLocalStorage('quota-key', 'original'));
+
+    // Must not throw even when the cache write fails
+    expect(() => {
+      act(() => {
+        result.current[1]('new-value');
+      });
+    }).not.toThrow();
+
+    // In-memory React state must still update despite the cache write failure
+    expect(result.current[0]).toBe('new-value');
+  });
+
+  it('re-syncs from the localStorage cache when the key changes', () => {
+    localStorage.setItem('key-a', JSON.stringify('value-a'));
+    localStorage.setItem('key-b', JSON.stringify('value-b'));
+
+    const { result, rerender } = renderHook(
+      ({ storageKey }: { storageKey: string }) => useLocalStorage(storageKey, 'default'),
+      { initialProps: { storageKey: 'key-a' } }
+    );
+
+    // Initial key must load from cache
+    expect(result.current[0]).toBe('value-a');
+
+    // Changing the key must trigger a re-sync from the new cache entry
+    rerender({ storageKey: 'key-b' });
+    expect(result.current[0]).toBe('value-b');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #7132 

## Summary
Adds `useLocalStorage.mock-integrations.test.ts` with 5 test cases targeting Asynchronous Service Layer Mocking & Local Cache Stubs for `useLocalStorage.ts`.

## Tests added
- Reads from the localStorage cache before falling back to initialValue on first render
- Returns initialValue when the localStorage cache has no entry for the key (cache miss)
- Writes the new value to the localStorage cache on a successful setValue call (cache sync)
- Falls back gracefully without throwing when localStorage.setItem throws a quota exceeded error
- Re-syncs from the localStorage cache when the key prop changes

## Files touched
- `hooks/useLocalStorage.mock-integrations.test.ts` (new)

## Pillar

- 🛠️ Other (Bug fix, refactoring, docs)

## Checklist before requesting a review:

- I have read the `CONTRIBUTING.md` file.
- I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- I have run `npm run format` and `npm run lint` locally and resolved all errors.
- My commits follow the Conventional Commits format.
- I have starred the repo.
- I have made sure that i have only one commit to merge in this PR.
