### PR TITLE
feat: replace interactive preview placeholder with semantic button

### DIFF
--- a/app/customize/page.tsx
+++ b/app/customize/page.tsx
@@ -511,28 +511,7 @@ function CustomizePageInner(): ReactElement {
               </p>
 
               {/* ─── MOVING THE INTERACTION LISTENER DIRECTLY TO THE OUTER WRAPPER CONTAINER ROW ─── */}
-              <div
-                className="group relative"
-                onClick={(e) => {
-                  // Only trigger the focus highlight workflow if the placeholder box is actively rendering
-                  if (!hasUsername) {
-                    e.stopPropagation();
-                    const input = document.getElementById('username-input') as HTMLInputElement;
-                    if (input) {
-                      input.focus();
-                      input.style.outline = '4px solid #10b981';
-                      input.style.outlineOffset = '2px';
-                      input.style.transform = 'scale(1.02)';
-                      input.style.transition = 'all 0.3s ease';
-
-                      setTimeout(() => {
-                        input.style.outline = 'none';
-                        input.style.transform = 'scale(1)';
-                      }, 1000);
-                    }
-                  }
-                }}
-              >
+              <div className="group relative">
                 {/* Glow ring */}
                 <div className="absolute -inset-px bg-gradient-to-br from-emerald-500/20 to-purple-500/20 rounded-[1.5rem] opacity-0 group-hover:opacity-100 transition-opacity duration-700 blur-lg pointer-events-none" />
 
@@ -609,7 +588,29 @@ function CustomizePageInner(): ReactElement {
                       )}
                     </div>
                   ) : (
-                    <div className="relative z-10 flex w-full max-w-xl flex-col items-center justify-center rounded-[1.25rem] border border-dashed border-black/10 bg-gray-100/80 backdrop-blur-md dark:border-white/10 dark:bg-white/3 hover:border-black/30 dark:hover:border-white/30 transition-colors cursor-pointer px-6 py-12 text-center">
+                    <button
+                      type="button"
+                      aria-label="Enter GitHub username"
+                      onClick={() => {
+                        const input = document.getElementById(
+                          'username-input'
+                        ) as HTMLInputElement | null;
+
+                        if (input) {
+                          input.focus();
+                          input.style.outline = '4px solid #10b981';
+                          input.style.outlineOffset = '2px';
+                          input.style.transform = 'scale(1.02)';
+                          input.style.transition = 'all 0.3s ease';
+
+                          setTimeout(() => {
+                            input.style.outline = 'none';
+                            input.style.transform = 'scale(1)';
+                          }, 1000);
+                        }
+                      }}
+                      className="relative z-10 flex w-full max-w-xl flex-col items-center justify-center rounded-[1.25rem] border border-dashed border-black/10 bg-gray-100/80 backdrop-blur-md dark:border-white/10 dark:bg-white/3 hover:border-black/30 dark:hover:border-white/30 transition-colors cursor-pointer px-6 py-12 text-center"
+                    >
                       <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-black/10 bg-gray-100/80 dark:border-white/10 dark:bg-white/4 text-gray-500 dark:text-emerald-300/70">
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
@@ -632,7 +633,7 @@ function CustomizePageInner(): ReactElement {
                       <p className="mt-2 max-w-md text-sm leading-relaxed text-gray-500 dark:text-white/65">
                         {t('customize.empty_preview_desc')}
                       </p>
-                    </div>
+                    </button>
                   )}
                 </InteractiveViewer>
               </div>


### PR DESCRIPTION
## Description

Fixes #7294

This PR improves the accessibility of the Customize page by replacing the non-semantic interactive preview placeholder with a semantic `<button>` element.

### Changes Made

- Replaced the clickable preview placeholder `<div>` with a semantic `<button>`.
- Moved the focus behavior from the non-semantic wrapper to the button.
- Preserved the existing focus and highlight behavior for the GitHub username input.
- Added an accessible `aria-label` for improved screen reader support.
- Kept the existing UI, styling, and mouse interaction unchanged.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

### Before
- Interactive preview placeholder was implemented using a clickable `<div>`.

### After
- Interactive preview placeholder is implemented using a semantic `<button>`, preserving the same appearance while improving keyboard accessibility and semantic HTML.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`) where applicable.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (no new lint errors introduced).
- [x] My commits follow the Conventional Commits format.
- [x] I have updated `README.md` if I added a new theme or URL parameter. *(Not applicable.)*
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (unchanged).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.