### PR TITLE
fix(svg): mark decorative SVG elements as non-focusable for screen readers

### DIFF
--- a/lib/svg/generator.accessibility.test.ts
+++ b/lib/svg/generator.accessibility.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { generateSVG, generateHeatmapSVG, generateVersusSVG } from './generator';
+import type { BadgeParams, ContributionCalendar, StreakStats } from '../../types';
+import { hexColor } from './sanitizer';
+
+describe('SVG accessibility attributes (WCAG 1.1.1)', () => {
+  const mockStats: StreakStats = {
+    currentStreak: 5,
+    longestStreak: 10,
+    totalContributions: 100,
+    todayDate: '2024-06-12',
+  };
+  const mockCalendar = {
+    weeks: [
+      {
+        contributionDays: [
+          { contributionCount: 0, date: '2024-06-10' },
+          { contributionCount: 5, date: '2024-06-11' },
+          { contributionCount: 15, date: '2024-06-12' },
+        ],
+      },
+    ],
+  } as ContributionCalendar;
+
+  const baseParams: BadgeParams = {
+    user: 'avi',
+    bg: hexColor('0d1117'),
+    text: hexColor('c9d1d9'),
+    accent: hexColor('58a6ff'),
+    speed: '8s',
+    scale: 'linear',
+  } as BadgeParams;
+
+  it('root SVG exposes focusable="false" alongside role="img"', () => {
+    const svg = generateSVG(mockStats, baseParams, mockCalendar);
+
+    expect(svg).toMatch(/<svg[^>]*role="img"/);
+    expect(svg).toMatch(/<svg[^>]*focusable="false"/);
+  });
+
+  it('marks the decorative towers group as focusable="false" so it is not announced individually', () => {
+    const svg = generateSVG(mockStats, baseParams, mockCalendar);
+
+    expect(svg).toMatch(/<g id="cp-towers"[^>]*focusable="false"/);
+  });
+
+  it('marks decorative heat particles as focusable="false" and aria-hidden', () => {
+    const svg = generateSVG(mockStats, baseParams, mockCalendar);
+
+    if (svg.includes('heat-particles')) {
+      expect(svg).toMatch(/<g class="heat-particles"[^>]*focusable="false"[^>]*aria-hidden="true"/);
+    }
+  });
+
+  it('heatmap SVG root exposes focusable="false"', () => {
+    const svg = generateHeatmapSVG(mockStats, baseParams, mockCalendar);
+
+    expect(svg).toMatch(/<svg[^>]*role="img"/);
+    expect(svg).toMatch(/<svg[^>]*focusable="false"/);
+  });
+
+  it('versus SVG root exposes focusable="false"', () => {
+    const svg = generateVersusSVG(
+      mockStats,
+      { currentStreak: 2, longestStreak: 4, totalContributions: 40, todayDate: '2024-06-12' },
+      { ...baseParams, user: 'avi', versus: 'octocat' } as BadgeParams,
+      mockCalendar,
+      mockCalendar
+    );
+
+    expect(svg).toMatch(/<svg[^>]*focusable="false"/);
+  });
+});

--- a/lib/svg/generator.ts
+++ b/lib/svg/generator.ts
@@ -201,7 +201,7 @@ function generateParticles(
         </circle>
       `;
   }
-  return `<g class="heat-particles" pointer-events="none">${particles}</g>`;
+  return `<g class="heat-particles" pointer-events="none" focusable="false" aria-hidden="true">${particles}</g>`;
 }
 
 export function getInteractiveTowerCSS(accentColorExpr: string): string {
@@ -981,11 +981,11 @@ export function generateSVG(
 
   try {
     return `
-<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" role="img" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
+<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" role="img" focusable="false" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
   ${renderHeader(safeUser, stats, sf, params, safeId)}
   ${renderStyle(selectedFont, statsFont, googleFontsImport, text, mainAccentHex, sf, bg, params.entrance || 'rise')}
   ${renderBackgroundRect(params.hideBackground ? 'transparent' : bgFill, radius)}
-  <g id="cp-towers" style="transform-origin: center; transform-box: fill-box;" transform="translate(0, ${Math.round((20 + yOffset) * sf)})">${towers}</g>
+  <g id="cp-towers" style="transform-origin: center; transform-box: fill-box;" transform="translate(0, ${Math.round((20 + yOffset) * sf)})" focusable="false">${towers}</g>
   ${renderIsometricLabels(calendar, params, text, sf)}
   ${renderFooter(stats, params, labels, safeUser, mainAccentHex, sf)}
   ${renderMilestoneBadges(stats, params, sf)}
@@ -1046,7 +1046,7 @@ function generateCompactSVG(stats: StreakStats, params: BadgeParams): string {
 
   try {
     return `
-<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" fill="none" role="img" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" fill="none" role="img" focusable="false" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
   <title id="cp-title-${safeId}">CommitPulse Compact Streak for ${safeUser}</title>
   <desc id="cp-desc-${safeId}">${safeUser} has a current streak of ${stats.currentStreak} days.</desc>
   <style>
@@ -1170,7 +1170,7 @@ function generateAutoThemeSVG(
   </style>
 
   <rect width="${W}" height="${H}" rx="${radius}" ${params.hideBackground ? 'fill="transparent"' : 'class="cp-bg-fill"'} />
-  <g id="cp-towers" style="transform-origin: center; transform-box: fill-box;" transform="translate(0, ${s(20 + yOffset)})">
+  <g id="cp-towers" style="transform-origin: center; transform-box: fill-box;" transform="translate(0, ${s(20 + yOffset)})" focusable="false">
     ${towers}
   </g>
   ${renderIsometricLabels(calendar, params, 'var(--cp-text)', sf)}
@@ -1900,7 +1900,7 @@ export function generateHeatmapSVG(
       : '';
 
   return `
-<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" role="img" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
+<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" role="img" focusable="false" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
   <title id="cp-title-${safeId}">CommitPulse Heatmap for ${safeUser}</title>
   <desc id="cp-desc-${safeId}">${safeUser} has ${stats.totalContributions} ${unit} and a longest streak of ${stats.longestStreak} days.</desc>
 
@@ -2031,7 +2031,7 @@ function generateAutoThemeHeatmapSVG(
       : '';
 
   return `
-<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" role="img" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
+<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" role="img" focusable="false" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
   <title id="cp-title-${safeId}">CommitPulse Heatmap for ${safeUser}</title>
   <desc id="cp-desc-${safeId}">${safeUser} has ${stats.totalContributions} ${unit} and a longest streak of ${stats.longestStreak} days.</desc>
 
@@ -2380,7 +2380,7 @@ export function generateVersusSVG(
   const isWinner2 = stats2.totalContributions > stats1.totalContributions;
 
   return `
-<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" role="img" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
+<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" role="img" focusable="false" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
   <title id="cp-title-${safeId}">CommitPulse Versus Stats: ${safeUser1} vs ${safeUser2}</title>
   <desc id="cp-desc-${safeId}">${safeUser1} has ${stats1.totalContributions} ${unit}. ${safeUser2} has ${stats2.totalContributions} ${unit}.</desc>
   ${renderDefs(sf, params)}
@@ -2456,7 +2456,7 @@ function generateAutoThemeVersusSVG(
   const isWinner2 = stats2.totalContributions > stats1.totalContributions;
 
   return `
-<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" role="img" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
+<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" role="img" focusable="false" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
   <title id="cp-title-${safeId}">CommitPulse Versus Stats: ${safeUser1} vs ${safeUser2}</title>
   <desc id="cp-desc-${safeId}">${safeUser1} has ${stats1.totalContributions} ${unit}. ${safeUser2} has ${stats2.totalContributions} ${unit}.</desc>
   ${renderDefs(sf, params)}
@@ -3448,7 +3448,7 @@ export function generateLanguagesSVG(
 
   if (total === 0) {
     return `
-<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" role="img" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
+<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" role="img" focusable="false" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
   ${renderHeader(safeUser, stats, sf, params, safeId)}
   ${renderStyle(selectedFont, statsFont, googleFontsImport, text, accent, sf, bg, params.entrance || 'rise')}
   <rect width="${W}" height="${H}" rx="${radius}" fill="${params.hideBackground ? 'transparent' : bg}" ${borderAttr} />
@@ -3512,12 +3512,12 @@ export function generateLanguagesSVG(
   });
 
   return `
-<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" role="img" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
+<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" fill="none" role="img" focusable="false" aria-labelledby="cp-title-${safeId}" aria-describedby="cp-desc-${safeId}">
   ${renderHeader(safeUser, stats, sf, params, safeId)}
   ${renderStyle(selectedFont, statsFont, googleFontsImport, text, accent, sf, bg, params.entrance || 'rise')}
   <rect width="${W}" height="${H}" rx="${radius}" fill="${params.hideBackground ? 'transparent' : bg}" ${borderAttr} />
   
-  <g id="cp-towers" style="transform-origin: center; transform-box: fill-box;">
+  <g id="cp-towers" style="transform-origin: center; transform-box: fill-box;" focusable="false">
     ${towersHtml}
   </g>
   


### PR DESCRIPTION
## Description

Fixes #7253

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No visual change — this is an accessibility-only fix. The rendered SVG output is pixel-identical; only markup attributes change.

## What changed

The root `<svg>` elements already exposed `role="img"` with `<title>`/`<desc>` linked via `aria-labelledby`/`aria-describedby` (implemented previously). However, decorative sub-elements had no `focusable="false"` guard, meaning assistive technology could still tab into or announce purely decorative graphics individually, which is what the issue actually calls out per WCAG 1.1.1.

- Added `focusable="false"` to every root `<svg>` across all badge variants (standard, compact, heatmap, versus, auto-theme)
- Added `focusable="false"` to the `cp-towers` decorative group in every variant that renders it
- Added `focusable="false" aria-hidden="true"` to the heat-particles decorative group, since it carries no semantic meaning
- Added `lib/svg/generator.accessibility.test.ts` covering the standard, heatmap, and versus SVG generators

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter. (N/A — no new theme/parameter added)
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). (Unchanged — no visual difference.)