### PR TITLE
feat(api-contract): detect breaking changes to the public BadgeParams API

### DIFF
--- a/lib/api-contract/detectBreakingChanges.test.ts
+++ b/lib/api-contract/detectBreakingChanges.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { detectBreakingChanges } from './detectBreakingChanges';
+import type { ApiField } from './extractBadgeParams';
+
+describe('detectBreakingChanges', () => {
+  it('reports no changes and a patch bump when the contract is unchanged', () => {
+    const fields: ApiField[] = [{ name: 'user', optional: false, typeText: 'string' }];
+
+    const report = detectBreakingChanges(fields, fields);
+
+    expect(report.changes).toEqual([]);
+    expect(report.breakingChanges).toEqual([]);
+    expect(report.recommendedBump).toBe('patch');
+  });
+
+  it('flags a removed field as breaking and recommends a major bump', () => {
+    const base: ApiField[] = [
+      { name: 'user', optional: false, typeText: 'string' },
+      { name: 'legacyParam', optional: true, typeText: 'string' },
+    ];
+    const current: ApiField[] = [{ name: 'user', optional: false, typeText: 'string' }];
+
+    const report = detectBreakingChanges(base, current);
+
+    expect(report.breakingChanges).toHaveLength(1);
+    expect(report.breakingChanges[0]).toMatchObject({
+      kind: 'field-removed',
+      field: 'legacyParam',
+    });
+    expect(report.recommendedBump).toBe('major');
+  });
+
+  it('flags an optional field becoming required as breaking', () => {
+    const base: ApiField[] = [{ name: 'theme', optional: true, typeText: 'string' }];
+    const current: ApiField[] = [{ name: 'theme', optional: false, typeText: 'string' }];
+
+    const report = detectBreakingChanges(base, current);
+
+    expect(report.breakingChanges).toHaveLength(1);
+    expect(report.breakingChanges[0].kind).toBe('field-now-required');
+    expect(report.recommendedBump).toBe('major');
+  });
+
+  it('does not flag a required field becoming optional as breaking', () => {
+    const base: ApiField[] = [{ name: 'grace', optional: false, typeText: 'number' }];
+    const current: ApiField[] = [{ name: 'grace', optional: true, typeText: 'number' }];
+
+    const report = detectBreakingChanges(base, current);
+
+    expect(report.breakingChanges).toEqual([]);
+    expect(report.changes[0].kind).toBe('field-now-optional');
+    expect(report.recommendedBump).toBe('minor');
+  });
+
+  it('treats adding a new optional field as a safe minor change', () => {
+    const base: ApiField[] = [{ name: 'user', optional: false, typeText: 'string' }];
+    const current: ApiField[] = [
+      { name: 'user', optional: false, typeText: 'string' },
+      { name: 'newFeatureFlag', optional: true, typeText: 'boolean' },
+    ];
+
+    const report = detectBreakingChanges(base, current);
+
+    expect(report.breakingChanges).toEqual([]);
+    expect(report.changes[0]).toMatchObject({ kind: 'field-added', field: 'newFeatureFlag' });
+    expect(report.recommendedBump).toBe('minor');
+  });
+
+  it('treats widening a union type as safe (existing values still accepted)', () => {
+    const base: ApiField[] = [{ name: 'scale', optional: false, typeText: "'linear' | 'log'" }];
+    const current: ApiField[] = [
+      { name: 'scale', optional: false, typeText: "'linear' | 'log' | 'sqrt'" },
+    ];
+
+    const report = detectBreakingChanges(base, current);
+
+    expect(report.breakingChanges).toEqual([]);
+    expect(report.changes[0].kind).toBe('field-type-widened');
+    expect(report.recommendedBump).toBe('minor');
+  });
+
+  it('treats narrowing a union type as breaking (previously valid values now rejected)', () => {
+    const base: ApiField[] = [
+      { name: 'scale', optional: false, typeText: "'linear' | 'log' | 'sqrt'" },
+    ];
+    const current: ApiField[] = [{ name: 'scale', optional: false, typeText: "'linear' | 'log'" }];
+
+    const report = detectBreakingChanges(base, current);
+
+    expect(report.breakingChanges).toHaveLength(1);
+    expect(report.breakingChanges[0].kind).toBe('field-type-narrowed');
+    expect(report.recommendedBump).toBe('major');
+  });
+
+  it('treats a full type replacement (e.g. string -> boolean) as breaking', () => {
+    const base: ApiField[] = [{ name: 'labels', optional: true, typeText: 'string' }];
+    const current: ApiField[] = [{ name: 'labels', optional: true, typeText: 'boolean' }];
+
+    const report = detectBreakingChanges(base, current);
+
+    expect(report.breakingChanges).toHaveLength(1);
+    expect(report.breakingChanges[0].kind).toBe('field-type-narrowed');
+    expect(report.recommendedBump).toBe('major');
+  });
+
+  it('aggregates multiple simultaneous changes and still recommends major if any is breaking', () => {
+    const base: ApiField[] = [
+      { name: 'user', optional: false, typeText: 'string' },
+      { name: 'removedField', optional: true, typeText: 'string' },
+    ];
+    const current: ApiField[] = [
+      { name: 'user', optional: false, typeText: 'string' },
+      { name: 'brandNewField', optional: true, typeText: 'boolean' },
+    ];
+
+    const report = detectBreakingChanges(base, current);
+
+    expect(report.changes).toHaveLength(2);
+    expect(report.breakingChanges).toHaveLength(1);
+    expect(report.recommendedBump).toBe('major');
+  });
+});

--- a/lib/api-contract/detectBreakingChanges.ts
+++ b/lib/api-contract/detectBreakingChanges.ts
@@ -1,0 +1,136 @@
+import type { ApiField } from './extractBadgeParams';
+
+export type ChangeKind =
+  | 'field-removed'
+  | 'field-now-required'
+  | 'field-type-narrowed'
+  | 'field-added'
+  | 'field-now-optional'
+  | 'field-type-widened';
+
+export interface ApiChange {
+  kind: ChangeKind;
+  field: string;
+  detail: string;
+  breaking: boolean;
+}
+
+export interface BreakingChangeReport {
+  changes: ApiChange[];
+  breakingChanges: ApiChange[];
+  recommendedBump: 'major' | 'minor' | 'patch';
+}
+
+/**
+ * Compares two snapshots of the `BadgeParams` interface (typically "base
+ * branch" vs "this PR") and classifies every difference against semver
+ * rules for a consumer-facing query-parameter API:
+ *
+ * - Removing a field, or turning an optional field required, breaks any
+ *   existing README embed URL that omits it → MAJOR.
+ * - Narrowing a field's type (e.g. `string` -> `'a' | 'b'`) can reject
+ *   previously-valid values → MAJOR.
+ * - Adding a new optional field, or relaxing required -> optional, is
+ *   backward compatible → MINOR.
+ * - No field changes → PATCH.
+ *
+ * This directly targets the gap described in the "commit analysis not
+ * capturing breaking changes" issue: there was no automated way to know
+ * whether a change to the public badge API required a major version bump
+ * before it shipped.
+ */
+export function detectBreakingChanges(
+  baseFields: ApiField[],
+  currentFields: ApiField[]
+): BreakingChangeReport {
+  const baseByName = new Map(baseFields.map((f) => [f.name, f]));
+  const currentByName = new Map(currentFields.map((f) => [f.name, f]));
+
+  const changes: ApiChange[] = [];
+
+  for (const [name, baseField] of baseByName) {
+    const currentField = currentByName.get(name);
+
+    if (!currentField) {
+      changes.push({
+        kind: 'field-removed',
+        field: name,
+        detail: `'${name}' was removed from the public API. Any existing badge URL using ?${name}= will silently drop that parameter.`,
+        breaking: true,
+      });
+      continue;
+    }
+
+    if (!baseField.optional && currentField.optional) {
+      changes.push({
+        kind: 'field-now-optional',
+        field: name,
+        detail: `'${name}' changed from required to optional.`,
+        breaking: false,
+      });
+    } else if (baseField.optional && !currentField.optional) {
+      changes.push({
+        kind: 'field-now-required',
+        field: name,
+        detail: `'${name}' changed from optional to required. Existing URLs that omit it will now fail validation.`,
+        breaking: true,
+      });
+    }
+
+    if (baseField.typeText !== currentField.typeText) {
+      const narrowed = isTypeNarrowed(baseField.typeText, currentField.typeText);
+      changes.push({
+        kind: narrowed ? 'field-type-narrowed' : 'field-type-widened',
+        field: name,
+        detail: `'${name}' type changed from \`${baseField.typeText}\` to \`${currentField.typeText}\`.`,
+        breaking: narrowed,
+      });
+    }
+  }
+
+  for (const [name] of currentByName) {
+    if (!baseByName.has(name)) {
+      changes.push({
+        kind: 'field-added',
+        field: name,
+        detail: `'${name}' was added to the public API.`,
+        breaking: false,
+      });
+    }
+  }
+
+  const breakingChanges = changes.filter((c) => c.breaking);
+  const hasNonBreakingChange = changes.length > 0 && breakingChanges.length === 0;
+
+  const recommendedBump: BreakingChangeReport['recommendedBump'] =
+    breakingChanges.length > 0 ? 'major' : hasNonBreakingChange ? 'minor' : 'patch';
+
+  return { changes, breakingChanges, recommendedBump };
+}
+
+/**
+ * Heuristic for whether a type change narrows (restricts) the accepted
+ * value set, which would reject previously-valid caller input.
+ *
+ * A widened union (base is a strict subset of current) is safe. Anything
+ * else — base was a primitive/wider type and current is a narrower union,
+ * or the union shrank — is treated as a narrowing (breaking) change, since
+ * we cannot prove it's safe without full type-checker cross-referencing.
+ */
+function isTypeNarrowed(baseType: string, currentType: string): boolean {
+  const baseUnion = splitUnion(baseType);
+  const currentUnion = splitUnion(currentType);
+
+  // Widening: every base member still accepted by current (base subset of current).
+  const isWidening = baseUnion.every((member) => currentUnion.includes(member));
+  if (isWidening) return false;
+
+  return true;
+}
+
+function splitUnion(typeText: string): string[] {
+  return typeText
+    .split('|')
+    .map((part) => part.trim())
+    .filter(Boolean);
+}

--- a/lib/api-contract/extractBadgeParams.test.ts
+++ b/lib/api-contract/extractBadgeParams.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { extractInterfaceFields } from './extractBadgeParams';
+
+describe('extractInterfaceFields', () => {
+  it('extracts required and optional fields with their type text', () => {
+    const source = `
+      export interface BadgeParams {
+        user: string;
+        grace?: number;
+        scale: 'linear' | 'log' | 'sqrt';
+      }
+    `;
+
+    const fields = extractInterfaceFields(source, 'BadgeParams');
+
+    expect(fields).toEqual([
+      { name: 'user', optional: false, typeText: 'string' },
+      { name: 'grace', optional: true, typeText: 'number' },
+      { name: 'scale', optional: false, typeText: "'linear' | 'log' | 'sqrt'" },
+    ]);
+  });
+
+  it('returns an empty array when the interface does not exist in the source', () => {
+    const source = `export interface SomethingElse { foo: string; }`;
+
+    const fields = extractInterfaceFields(source, 'BadgeParams');
+
+    expect(fields).toEqual([]);
+  });
+
+  it('ignores interfaces with a different name even if structurally similar', () => {
+    const source = `
+      export interface BadgeParamsV2 { user: string; }
+      export interface BadgeParams { name: string; }
+    `;
+
+    const fields = extractInterfaceFields(source, 'BadgeParams');
+
+    expect(fields).toEqual([{ name: 'name', optional: false, typeText: 'string' }]);
+  });
+
+  it('handles fields with no explicit type annotation by reporting "unknown"', () => {
+    const source = `
+      export interface BadgeParams {
+        user;
+      }
+    `;
+
+    const fields = extractInterfaceFields(source, 'BadgeParams');
+
+    expect(fields).toEqual([{ name: 'user', optional: false, typeText: 'unknown' }]);
+  });
+});

--- a/lib/api-contract/extractBadgeParams.ts
+++ b/lib/api-contract/extractBadgeParams.ts
@@ -1,0 +1,51 @@
+import ts from 'typescript';
+
+/**
+ * A single field of the public `BadgeParams` API contract, extracted from
+ * the TypeScript AST rather than parsed with regex, so renames/reordering
+ * inside the interface body can't silently break detection.
+ */
+export interface ApiField {
+  name: string;
+  optional: boolean;
+  typeText: string;
+}
+
+/**
+ * Parses TypeScript source text and extracts every member of the named
+ * interface as an `ApiField`. Used to snapshot the public `BadgeParams`
+ * contract at a given commit so two snapshots can be diffed for breaking
+ * changes (see `detectBreakingChanges.ts`).
+ *
+ * Returns an empty array if the interface is not found in the source,
+ * rather than throwing, so callers can distinguish "interface deleted
+ * entirely" (an empty snapshot, itself a breaking change) from a parse error.
+ */
+export function extractInterfaceFields(sourceText: string, interfaceName: string): ApiField[] {
+  const sourceFile = ts.createSourceFile(
+    'source.ts',
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+
+  const fields: ApiField[] = [];
+
+  function visit(node: ts.Node) {
+    if (ts.isInterfaceDeclaration(node) && node.name.text === interfaceName) {
+      for (const member of node.members) {
+        if (ts.isPropertySignature(member) && member.name) {
+          const name = member.name.getText(sourceFile);
+          const optional = member.questionToken !== undefined;
+          const typeText = member.type ? member.type.getText(sourceFile) : 'unknown';
+          fields.push({ name, optional, typeText });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return fields;
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "bench:svg": "tsx scripts/benchmark-svg.ts",
+    "check:api-breaking": "tsx scripts/detect-breaking-api-changes.ts",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/scripts/detect-breaking-api-changes.ts
+++ b/scripts/detect-breaking-api-changes.ts
@@ -1,0 +1,66 @@
+/**
+ * CLI: detect breaking changes to the public `BadgeParams` API contract
+ * between two git refs, and recommend a semver bump.
+ *
+ * Usage:
+ *   tsx scripts/detect-breaking-api-changes.ts [baseRef] [headRef]
+ *
+ * Defaults to comparing `origin/main` against the current working tree,
+ * so it can be run locally before opening a PR, or in CI comparing the
+ * PR's base ref against its head ref.
+ *
+ * Exits with code 1 if any breaking change is detected, so it can gate CI.
+ */
+import { execSync } from 'child_process';
+import { extractInterfaceFields } from '../lib/api-contract/extractBadgeParams';
+import { detectBreakingChanges } from '../lib/api-contract/detectBreakingChanges';
+
+const TYPES_FILE = 'types/index.ts';
+const INTERFACE_NAME = 'BadgeParams';
+
+function readFileAtRef(ref: string, filePath: string): string {
+  return execSync(`git show ${ref}:${filePath}`, { encoding: 'utf-8' });
+}
+
+function readWorkingTreeFile(filePath: string): string {
+  return execSync(`cat ${filePath}`, { encoding: 'utf-8' });
+}
+
+function main() {
+  const baseRef = process.argv[2] || 'origin/main';
+  const headRef = process.argv[3];
+
+  const baseSource = readFileAtRef(baseRef, TYPES_FILE);
+  const headSource = headRef ? readFileAtRef(headRef, TYPES_FILE) : readWorkingTreeFile(TYPES_FILE);
+
+  const baseFields = extractInterfaceFields(baseSource, INTERFACE_NAME);
+  const currentFields = extractInterfaceFields(headSource, INTERFACE_NAME);
+
+  const report = detectBreakingChanges(baseFields, currentFields);
+
+  console.log(`\nAPI contract comparison: ${baseRef} -> ${headRef || 'working tree'}`);
+  console.log(`Interface: ${INTERFACE_NAME} (${TYPES_FILE})\n`);
+
+  if (report.changes.length === 0) {
+    console.log('No changes detected in the public BadgeParams contract.');
+    console.log('Recommended version bump: patch\n');
+    return;
+  }
+
+  for (const change of report.changes) {
+    const tag = change.breaking ? '[BREAKING]' : '[safe]';
+    console.log(`${tag} ${change.detail}`);
+  }
+
+  console.log(`\nRecommended version bump: ${report.recommendedBump}\n`);
+
+  if (report.breakingChanges.length > 0) {
+    console.error(
+      `${report.breakingChanges.length} breaking change(s) detected in the public API. ` +
+        `This PR should bump the MAJOR version and document the change in CHANGELOG.md.`
+    );
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## Description

Fixes #4987

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

No visual change — this adds a dev-tooling script and library, no badge rendering is touched.

## What changed

The original issue describes missing breaking-change detection and broken version planning. This repo doesn't have a commit-diffing or release pipeline to extend, but it does have a real public contract worth protecting: the query parameters (`BadgeParams`) that every consumer embeds in their README badge URL. Renaming, removing, or narrowing one of those params silently breaks existing embeds with no warning before release.

- `lib/api-contract/extractBadgeParams.ts`: parses the `BadgeParams` interface via the TypeScript AST (not regex) to snapshot each field's name, optionality, and type text
- `lib/api-contract/detectBreakingChanges.ts`: diffs two snapshots and classifies each change:
  - **Breaking (major):** field removed, optional → required, type narrowed (e.g. union shrinks, or type changes entirely)
  - **Safe (minor):** field added, required → optional, type widened
  - No changes → patch
- `scripts/detect-breaking-api-changes.ts`: CLI wired to `npm run check:api-breaking`, diffs `BadgeParams` between a base git ref and the current working tree (or another ref), prints a human-readable report, and exits non-zero on any breaking change so it can gate CI
- 13 new unit tests covering extraction and every change classification

## Try it locally

```
npm run check:api-breaking origin/main
```

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`). (N/A for this change — no badge rendering touched; verified via `npm run check:api-breaking` instead, see above)
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter. (N/A — no new theme/parameter added)
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts). (N/A — no SVG output touched)