### PR TITLE
test(notify): add TypeScript compiler validation tests

### DIFF
--- a/app/api/notify/route.type-compiler.test.ts
+++ b/app/api/notify/route.type-compiler.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, expectTypeOf } from 'vitest';
+import type { z } from 'zod';
+
+import { notifyPostSchema, notifyGetSchema, type NotifyPostParams } from '@/lib/validations';
+
+describe('app/api/notify/route.ts - Type Compiler Validation & Schema Constraints Stability', () => {
+  it('infers NotifyPostParams from notifyPostSchema', () => {
+    expectTypeOf<NotifyPostParams>().toEqualTypeOf<z.infer<typeof notifyPostSchema>>();
+  });
+
+  it('accepts a valid notification registration payload', () => {
+    const result = notifyPostSchema.safeParse({
+      username: 'octocat',
+      email: 'octocat@example.com',
+      frequency: 'daily',
+      preferences: {
+        notifyOnCommit: true,
+        notifyOnStreak: false,
+        notifyOnMilestone: true,
+      },
+      managementToken: 'cpn_abcdefghijklmnopqrstuvwxyz123456',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.username).toBe('octocat');
+      expect(result.data.email).toBe('octocat@example.com');
+      expect(result.data.frequency).toBe('daily');
+      expect(result.data.managementToken).toMatch(/^cpn_/);
+    }
+  });
+
+  it('rejects invalid username and email with field errors', () => {
+    const result = notifyPostSchema.safeParse({
+      username: 'invalid username!',
+      email: 'not-an-email',
+      frequency: 'daily',
+      preferences: {
+        notifyOnCommit: true,
+        notifyOnStreak: true,
+        notifyOnMilestone: true,
+      },
+    });
+
+    expect(result.success).toBe(false);
+
+    if (!result.success) {
+      const errors = result.error.flatten().fieldErrors;
+
+      expect(errors.username).toBeDefined();
+      expect(errors.email).toBeDefined();
+    }
+  });
+
+  it('accepts payload without optional managementToken', () => {
+    const result = notifyPostSchema.safeParse({
+      username: 'octocat',
+      email: 'octocat@example.com',
+      frequency: 'weekly',
+      preferences: {
+        notifyOnCommit: true,
+        notifyOnStreak: true,
+        notifyOnMilestone: false,
+      },
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.managementToken).toBeUndefined();
+
+      expectTypeOf(result.data.managementToken).toEqualTypeOf<string | undefined>();
+    }
+  });
+
+  it('validates notifyGetSchema usernames', () => {
+    const valid = notifyGetSchema.safeParse({
+      user: 'octocat',
+    });
+
+    expect(valid.success).toBe(true);
+
+    const invalid = notifyGetSchema.safeParse({
+      user: 'invalid username!',
+    });
+
+    expect(invalid.success).toBe(false);
+
+    if (!invalid.success) {
+      expect(invalid.error.flatten().fieldErrors.user).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
## Description

Adds TypeScript compiler validation and schema stability tests for the `/api/notify` route.

This PR introduces a dedicated test suite that verifies:

- Type inference for `NotifyPostParams`
- Valid notification registration payloads
- Schema validation failures for invalid username/email inputs
- Optional `managementToken` support
- `notifyGetSchema` validation for valid and invalid usernames

Fixes #6772

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
