### PR TITLE
fix(security): validate port in CSRF origin check (#7212)

### DIFF
--- a/lib/security/csrf.test.ts
+++ b/lib/security/csrf.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { validateCSRF } from './csrf';
+
+function makeRequest(headers: Record<string, string>): Request {
+  return new Request('https://commitpulse.vercel.app/api/test', {
+    method: 'POST',
+    headers,
+  });
+}
+
+describe('validateCSRF', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_SITE_URL;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://commitpulse.vercel.app';
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_SITE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_SITE_URL = originalEnv;
+    }
+  });
+
+  it('allows requests with no origin and no referer (server-to-server)', () => {
+    const req = new Request('https://commitpulse.vercel.app/api/test', { method: 'POST' });
+    expect(validateCSRF(req)).toBeNull();
+  });
+
+  it('allows requests from the exact same origin', () => {
+    const req = makeRequest({ origin: 'https://commitpulse.vercel.app' });
+    expect(validateCSRF(req)).toBeNull();
+  });
+
+  it('allows requests from the same origin with referer header', () => {
+    const req = makeRequest({ referer: 'https://commitpulse.vercel.app/dashboard' });
+    expect(validateCSRF(req)).toBeNull();
+  });
+
+  it('rejects requests from a different port on the same hostname', () => {
+    const req = makeRequest({ origin: 'https://commitpulse.vercel.app:9999' });
+    const res = validateCSRF(req);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(403);
+  });
+
+  it('rejects requests from a different hostname', () => {
+    const req = makeRequest({ origin: 'https://evil.example.com' });
+    const res = validateCSRF(req);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(403);
+  });
+
+  it('rejects requests from a different protocol', () => {
+    const req = makeRequest({ origin: 'http://commitpulse.vercel.app' });
+    const res = validateCSRF(req);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(403);
+  });
+
+  it('allows requests from the same origin with explicit default port in origin', () => {
+    const req = makeRequest({ origin: 'https://commitpulse.vercel.app:443' });
+    expect(validateCSRF(req)).toBeNull();
+  });
+
+  it('allows requests from the same origin with explicit port in allowed origin env', () => {
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://commitpulse.vercel.app:3000';
+    const req = makeRequest({ origin: 'https://commitpulse.vercel.app:3000' });
+    expect(validateCSRF(req)).toBeNull();
+  });
+
+  it('rejects requests from a non-default port when allowed origin uses default port', () => {
+    const req = makeRequest({ origin: 'https://commitpulse.vercel.app:3000' });
+    const res = validateCSRF(req);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(403);
+  });
+
+  it('returns 403 with JSON error body on CSRF failure', () => {
+    const req = makeRequest({ origin: 'https://evil.example.com:443' });
+    const res = validateCSRF(req);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(403);
+  });
+
+  it('rejects requests with malformed origin', () => {
+    const req = makeRequest({ origin: 'not-a-url' });
+    const res = validateCSRF(req);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(403);
+  });
+
+  it('falls back to referer when origin is absent', () => {
+    const req = makeRequest({ referer: 'https://commitpulse.vercel.app/page' });
+    expect(validateCSRF(req)).toBeNull();
+  });
+
+  it('rejects referer from a different port', () => {
+    const req = makeRequest({ referer: 'https://commitpulse.vercel.app:8080/page' });
+    const res = validateCSRF(req);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(403);
+  });
+
+  it('allows either origin OR referer to be valid', () => {
+    const req = makeRequest({
+      origin: 'https://commitpulse.vercel.app',
+      referer: 'https://evil.example.com:9999/page',
+    });
+    expect(validateCSRF(req)).toBeNull();
+  });
+
+  it('rejects when both origin and referer are invalid', () => {
+    const req = makeRequest({
+      origin: 'https://evil.example.com',
+      referer: 'https://evil.example.com:9999/page',
+    });
+    const res = validateCSRF(req);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(403);
+  });
+});

--- a/lib/security/csrf.ts
+++ b/lib/security/csrf.ts
@@ -1,3 +1,8 @@
+function normalizePort(url: URL): string {
+  if (url.port) return url.port;
+  return url.protocol === 'https:' ? '443' : '80';
+}
+
 export function validateCSRF(request: Request): Response | null {
   const origin = request.headers.get('origin');
   const referer = request.headers.get('referer');
@@ -14,7 +19,11 @@ export function validateCSRF(request: Request): Response | null {
       const url = new URL(value);
       const allowed = new URL(allowedOrigin);
 
-      return url.protocol === allowed.protocol && url.hostname === allowed.hostname;
+      return (
+        url.protocol === allowed.protocol &&
+        url.hostname === allowed.hostname &&
+        normalizePort(url) === normalizePort(allowed)
+      );
     } catch {
       return false;
     }


### PR DESCRIPTION
Fixes #7212

## Problem
The `isValidOrigin` function in `lib/security/csrf.ts` only checked `protocol` and `hostname` when validating the `Origin` header, ignoring the **port** entirely. This allowed CSRF bypass from any server sharing the same hostname on a different port (e.g. `Origin: https://commitpulse.vercel.app:9999`).

## Solution
1. Added `normalizePort()` helper that resolves empty `URL.port` to the protocol default (443 for https, 80 for http), since `URL.port` returns empty string for default ports
2. Updated `isValidOrigin` to compare normalized ports alongside protocol and hostname
3. Added 15 unit tests in `lib/security/csrf.test.ts` covering:
   - Port mismatch rejection (the core vulnerability)
   - Default port normalization (`:443` matches no-port for HTTPS)
   - Custom port via `NEXT_PUBLIC_SITE_URL` env var
   - Referer header fallback with port validation
   - Malformed origin rejection
   - Combined origin + referer scenarios

## Changes
- `lib/security/csrf.ts`: Added `normalizePort()`, updated `isValidOrigin()` port comparison
- `lib/security/csrf.test.ts`: New test file with 15 test cases
