### PR TITLE
test(compare): add async service mocking integration tests

### DIFF
--- a/app/api/compare/route.mock-integrations.test.ts
+++ b/app/api/compare/route.mock-integrations.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/github', () => ({
+  getFullDashboardData: vi.fn(),
+}));
+
+vi.mock('@/lib/githubtoken', () => ({
+  getUserGitHubToken: vi.fn(),
+}));
+
+vi.mock('@/utils/getClientIp', () => ({
+  getClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  RateLimiter: class {
+    check = vi.fn().mockResolvedValue(true);
+  },
+}));
+
+import { GET } from './route';
+import { getFullDashboardData } from '@/lib/github';
+import { getUserGitHubToken } from '@/lib/githubtoken';
+
+const makeRequest = () => new Request('http://localhost:3000/api/compare?user1=alice&user2=bob');
+
+const dashboardData = {
+  profile: {
+    login: 'alice',
+  },
+  stats: {
+    totalContributions: 100,
+  },
+};
+
+describe('GET /api/compare mock integrations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(getUserGitHubToken).mockResolvedValue('github-token');
+
+    vi.mocked(getFullDashboardData).mockResolvedValue(dashboardData as never);
+  });
+
+  it('requests both users with the GitHub token', async () => {
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(200);
+
+    expect(getUserGitHubToken).toHaveBeenCalledTimes(1);
+
+    expect(getFullDashboardData).toHaveBeenCalledTimes(2);
+
+    expect(getFullDashboardData).toHaveBeenNthCalledWith(1, 'alice', { token: 'github-token' });
+
+    expect(getFullDashboardData).toHaveBeenNthCalledWith(2, 'bob', { token: 'github-token' });
+  });
+
+  it('waits for both async GitHub requests before responding', async () => {
+    let resolveFirst!: (value: unknown) => void;
+    let resolveSecond!: (value: unknown) => void;
+
+    const firstPromise = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    const secondPromise = new Promise((resolve) => {
+      resolveSecond = resolve;
+    });
+
+    vi.mocked(getFullDashboardData)
+      .mockReturnValueOnce(firstPromise as never)
+      .mockReturnValueOnce(secondPromise as never);
+
+    const responsePromise = GET(makeRequest());
+
+    let settled = false;
+
+    responsePromise.then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+
+    resolveFirst(dashboardData);
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+
+    resolveSecond(dashboardData);
+
+    const res = await responsePromise;
+
+    expect(res.status).toBe(200);
+  });
+
+  it('returns fallback response when one GitHub request rejects', async () => {
+    vi.mocked(getFullDashboardData)
+      .mockRejectedValueOnce(new Error('Not found'))
+      .mockResolvedValueOnce(dashboardData as never);
+
+    const res = await GET(makeRequest());
+
+    expect(getFullDashboardData).toHaveBeenCalledTimes(2);
+
+    expect(res.status).toBe(404);
+
+    const body = await res.json();
+
+    expect(body.error).toContain('alice');
+  });
+
+  it('uses the token returned by getUserGitHubToken for every service call', async () => {
+    vi.mocked(getUserGitHubToken).mockResolvedValue('special-token');
+
+    await GET(makeRequest());
+
+    expect(getUserGitHubToken).toHaveBeenCalledOnce();
+
+    expect(getFullDashboardData).toHaveBeenNthCalledWith(1, 'alice', { token: 'special-token' });
+
+    expect(getFullDashboardData).toHaveBeenNthCalledWith(2, 'bob', { token: 'special-token' });
+  });
+
+  it('returns successful JSON after both mocked services resolve', async () => {
+    vi.mocked(getFullDashboardData)
+      .mockResolvedValueOnce({
+        profile: { login: 'alice' },
+      } as never)
+      .mockResolvedValueOnce({
+        profile: { login: 'bob' },
+      } as never);
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(200);
+
+    expect(getFullDashboardData).toHaveBeenCalledTimes(2);
+
+    const body = await res.json();
+
+    expect(body.user1.profile.login).toBe('alice');
+    expect(body.user2.profile.login).toBe('bob');
+  });
+});


### PR DESCRIPTION

## Description

Fixes #6761

### Summary
- Added asynchronous service layer integration tests for the compare API route.
- Mocked GitHub service dependencies and authentication token retrieval.
- Verified successful integration flow when both service calls resolve.
- Verified error handling when one of the mocked GitHub service calls fails.
- Confirmed that the GitHub token is passed to every service request.
- Tested that the route waits for all asynchronous operations before returning a response.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (test-only changes)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

