### PR TITLE
test(useRecentSearches): add error-resilience tests for corrupted loc…

### DIFF
--- a/hooks/useRecentSearches.error-resilience.test.ts
+++ b/hooks/useRecentSearches.error-resilience.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRecentSearches, STORAGE_KEY } from './useRecentSearches';
+
+const store: Record<string, string> = {};
+
+beforeEach(() => {
+  Object.keys(store).forEach((k) => delete store[k]);
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+      clear: () => {
+        Object.keys(store).forEach((k) => delete store[k]);
+      },
+    },
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe('useRecentSearches error-resilience', () => {
+  it('handles corrupted JSON in localStorage gracefully', () => {
+    store[STORAGE_KEY] = 'not-valid-json{{{';
+    const { result } = renderHook(() => useRecentSearches());
+    expect(result.current.searches).toEqual([]);
+  });
+
+  it('handles JSON with wrong type (object instead of array)', () => {
+    store[STORAGE_KEY] = JSON.stringify({ user: 'torvalds' });
+    const { result } = renderHook(() => useRecentSearches());
+    expect(result.current.searches).toEqual([]);
+  });
+
+  it('handles JSON with null at root gracefully', () => {
+    store[STORAGE_KEY] = JSON.stringify(null);
+    const { result } = renderHook(() => useRecentSearches());
+    expect(result.current.searches).toEqual([]);
+  });
+
+  it('handles empty localStorage for the storage key', () => {
+    const { result } = renderHook(() => useRecentSearches());
+    expect(result.current.searches).toEqual([]);
+  });
+
+  it('continues to work after recovering from corrupted data', () => {
+    store[STORAGE_KEY] = 'bad-data';
+    const { result } = renderHook(() => useRecentSearches());
+    expect(result.current.searches).toEqual([]);
+    act(() => {
+      result.current.addSearch('torvalds');
+    });
+    expect(result.current.searches).toEqual(['torvalds']);
+  });
+});


### PR DESCRIPTION
## Description
Adds error-resilience tests for `useRecentSearches` hook, verifying graceful handling of corrupted localStorage data and recovery after bad state.

#7135

## Changes
- `hooks/useRecentSearches.error-resilience.test.ts` (new)

## Test Cases
1. **Corrupted JSON** — handles malformed JSON gracefully
2. **Wrong type** — object instead of array falls back to empty
3. **Null root** — `JSON.parse(null)` returns empty searches
4. **Empty storage** — no key returns empty searches
5. **Recovery after corruption** — continues working after corrupted data

## Verification
- `vitest run` — all 5 tests pass