### PR TITLE
test(ai-insights-skeleton): add mouse interactivity tests

### DIFF
--- a/components/dashboard/AIInsightsSkeleton.mouse-interactivity.test.tsx
+++ b/components/dashboard/AIInsightsSkeleton.mouse-interactivity.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import AIInsightsSkeleton from './AIInsightsSkeleton';
+
+describe('AIInsightsSkeleton - Interactive Tooltips, Cursor Hovers & Touch Event Propagation (Variation 5)', () => {
+  it('triggers simulated mouseenter/hover gestures on skeleton elements', () => {
+    const { container } = render(<AIInsightsSkeleton />);
+
+    const shimmerElements = container.querySelectorAll('.shimmer');
+    expect(shimmerElements.length).toBeGreaterThan(0);
+
+    shimmerElements.forEach((element) => {
+      expect(() => {
+        fireEvent.mouseEnter(element);
+        fireEvent.mouseOver(element);
+      }).not.toThrow();
+    });
+  });
+
+  it('does not render tooltips or overlays while hovering over the loading skeleton', () => {
+    const { container } = render(<AIInsightsSkeleton />);
+
+    const firstShimmer = container.querySelector('.shimmer');
+    expect(firstShimmer).not.toBeNull();
+    if (!firstShimmer) return;
+
+    fireEvent.mouseEnter(firstShimmer);
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(container.querySelector('[role="tooltip"]')).toBeNull();
+  });
+
+  it('allows click and touch events to propagate correctly', () => {
+    const clickSpy = vi.fn();
+    const touchSpy = vi.fn();
+
+    const { container } = render(
+      <div onClick={clickSpy} onTouchStart={touchSpy}>
+        <AIInsightsSkeleton />
+      </div>
+    );
+
+    const shimmerElements = container.querySelectorAll('.shimmer');
+    expect(shimmerElements.length).toBeGreaterThan(0);
+
+    fireEvent.click(shimmerElements[0]);
+    fireEvent.touchStart(shimmerElements[0]);
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(touchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not apply interactive cursor classes to shimmer elements', () => {
+    const { container } = render(<AIInsightsSkeleton />);
+
+    const shimmerElements = container.querySelectorAll('.shimmer');
+
+    shimmerElements.forEach((element) => {
+      expect(element.className).not.toContain('cursor-pointer');
+      expect(element.className).not.toContain('cursor-text');
+    });
+  });
+
+  it('removes temporary hover visuals after mouse leaves', () => {
+    const { container } = render(<AIInsightsSkeleton />);
+
+    const firstShimmer = container.querySelector('.shimmer');
+    expect(firstShimmer).not.toBeNull();
+    if (!firstShimmer) return;
+
+    fireEvent.mouseEnter(firstShimmer);
+    fireEvent.mouseLeave(firstShimmer);
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(container.querySelectorAll('.overlay, .tooltip')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #7033

### What this PR does

- Adds a dedicated mouse interactivity test suite for `AIInsightsSkeleton`.
- Verifies hover and mouse enter interactions on shimmer elements.
- Confirms that no tooltips or overlays are rendered while the skeleton is displayed.
- Ensures click and touch events propagate correctly.
- Verifies that interactive cursor styles are not applied to shimmer elements.
- Confirms temporary hover visuals are cleaned up after mouse leave.

The test suite contains **5 Vitest test cases**, satisfying the acceptance criteria for this issue.

---

## Pillar

- [ ]  Pillar 1 — New Theme Design
- [ ]  Pillar 2 — Geometric SVG Improvement
- [ ]  Pillar 3 — Timezone Logic Optimization
- [x]  Other (Tests)

---

## Visual Preview

N/A (Test-only changes)

---

## Checklist

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I tested the changes locally.
- [x] The new test suite passes successfully.
- [x] My commit follows the Conventional Commits format.
- [x] This PR contains a single commit.