### PR TITLE
test(top-rivalries-ticker): add mouse interactivity coverage

### DIFF
--- a/components/TopRivalriesTicker.mouse-interactivity.test.tsx
+++ b/components/TopRivalriesTicker.mouse-interactivity.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode, HTMLAttributes } from 'react';
+import TopRivalriesTicker from './TopRivalriesTicker';
+import '@testing-library/jest-dom';
+
+const mockPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: HTMLAttributes<HTMLDivElement> & { children?: ReactNode }) => (
+      <div {...props} data-testid="motion-div">
+        {children}
+      </div>
+    ),
+  },
+}));
+
+describe('TopRivalriesTicker Mouse Interactivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('applies pointer cursor styling to rivalry items', () => {
+    const { container } = render(<TopRivalriesTicker />);
+
+    const rivalryItems = container.querySelectorAll('.group');
+
+    expect(rivalryItems.length).toBeGreaterThan(0);
+
+    rivalryItems.forEach((item) => {
+      expect(item).toHaveClass('cursor-pointer');
+    });
+  });
+
+  it('preserves hover interaction classes for icons and labels', () => {
+    const { container } = render(<TopRivalriesTicker />);
+
+    const rivalryItem = container.querySelector('.group');
+    expect(rivalryItem).toBeInTheDocument();
+
+    expect(rivalryItem).toHaveClass('group');
+
+    const hoverOpacityElement = container.querySelector('.group-hover\\:opacity-100');
+    expect(hoverOpacityElement).toBeInTheDocument();
+
+    const hoverTextElements = container.querySelectorAll('.group-hover\\:text-black');
+
+    expect(hoverTextElements.length).toBeGreaterThan(0);
+  });
+
+  it('navigates correctly when the first rivalry item is clicked', () => {
+    render(<TopRivalriesTicker />);
+
+    const rivalryLabel = screen.getAllByText('Kernel vs React')[0];
+    const rivalryContainer = rivalryLabel.closest('div.group');
+
+    expect(rivalryContainer).toBeInTheDocument();
+
+    fireEvent.click(rivalryContainer!);
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith('/compare?user1=torvalds&user2=gaearon');
+  });
+
+  it('propagates multiple rivalry click interactions independently', () => {
+    render(<TopRivalriesTicker />);
+
+    const kernelVsReact = screen.getAllByText('Kernel vs React')[0];
+    const platformWars = screen.getAllByText('Platform Wars')[0];
+
+    const firstContainer = kernelVsReact.closest('div.group');
+    const secondContainer = platformWars.closest('div.group');
+
+    expect(firstContainer).toBeInTheDocument();
+    expect(secondContainer).toBeInTheDocument();
+
+    fireEvent.click(firstContainer!);
+    fireEvent.click(secondContainer!);
+
+    expect(mockPush).toHaveBeenCalledTimes(2);
+
+    expect(mockPush).toHaveBeenNthCalledWith(1, '/compare?user1=torvalds&user2=gaearon');
+
+    expect(mockPush).toHaveBeenNthCalledWith(2, '/compare?user1=vercel&user2=netlify');
+  });
+
+  it('renders empty state safely without triggering navigation actions', () => {
+    render(<TopRivalriesTicker rivalries={[]} />);
+
+    expect(screen.getByText('No active rivalries')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('No active rivalries'));
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #7027

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Test-only change)

## Changes Made

- Added `components/TopRivalriesTicker.mouse-interactivity.test.tsx`.
- Added coverage for interactive rivalry ticker user interactions.
- Verified rivalry items maintain pointer-based interactive behavior.
- Verified hover-related interactive styling remains available on rivalry entries.
- Verified rivalry clicks trigger the expected navigation flow.
- Verified multiple rivalry items can be interacted with independently.
- Verified empty-state rendering does not trigger navigation actions or runtime issues.

## Test Coverage

Added 5 interaction-focused test cases:

1. Verifies rivalry items apply pointer cursor styling.
2. Verifies hover interaction classes are present on icons and labels.
3. Verifies clicking a rivalry item navigates to the correct comparison route.
4. Verifies multiple rivalry interactions propagate independently.
5. Verifies empty-state rendering behaves safely without navigation calls.

## Validation

```bash
npm run test -- TopRivalriesTicker.mouse-interactivity.test.tsx
npm run lint
npm run build
````

### Result

* ✅ 5/5 tests passing
* ✅ ESLint completed without errors
* ✅ Production build completed successfully

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have started the repo.
* [x] I have made sure that I have only one commit to merge in this PR.