### PR TITLE
test: add TypeScript compiler validation tests for useShareActions

### DIFF
--- a/hooks/useShareActions.type-compiler.test.ts
+++ b/hooks/useShareActions.type-compiler.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { useShareActions } from './useShareActions';
+import type { DashboardExportData, ActivityData, LanguageData, UserStats } from '@/types/dashboard';
+
+// Infer the hook's public API directly from its implementation so the tests
+// automatically fail if the return contract or parameter schema changes.
+type UseShareActionsReturn = ReturnType<typeof useShareActions>;
+type UseShareActionsArgs = Parameters<typeof useShareActions>;
+
+describe('useShareActions — TypeScript compiler validation & schema constraints', () => {
+  it('1. accepts exactly (username: string, exportData: DashboardExportData, onClose: () => void)', () => {
+    expectTypeOf(useShareActions).parameters.toEqualTypeOf<
+      [string, DashboardExportData, () => void]
+    >();
+
+    expect(useShareActions.length).toBe(3);
+  });
+
+  it('2. DashboardExportData accepts its optional activity field being omitted', () => {
+    const minimal: DashboardExportData = {
+      stats: {
+        currentStreak: 0,
+        peakStreak: 0,
+        totalContributions: 0,
+      },
+      languages: [],
+    };
+
+    expect(minimal.activity).toBeUndefined();
+
+    expectTypeOf<DashboardExportData['activity']>().toEqualTypeOf<ActivityData[] | undefined>();
+
+    expectTypeOf<DashboardExportData['stats']>().toEqualTypeOf<UserStats>();
+
+    expectTypeOf<DashboardExportData['languages']>().toEqualTypeOf<LanguageData[]>();
+  });
+
+  it('3. returns the expected public API shape and state schema', () => {
+    expectTypeOf<UseShareActionsReturn>().toHaveProperty('states');
+    expectTypeOf<UseShareActionsReturn>().toHaveProperty('handleCopyLink');
+    expectTypeOf<UseShareActionsReturn>().toHaveProperty('handleTwitter');
+    expectTypeOf<UseShareActionsReturn>().toHaveProperty('handleLinkedIn');
+    expectTypeOf<UseShareActionsReturn>().toHaveProperty('handleReddit');
+    expectTypeOf<UseShareActionsReturn>().toHaveProperty('handleDownloadPNG');
+    expectTypeOf<UseShareActionsReturn>().toHaveProperty('handleDownloadWEBP');
+    expectTypeOf<UseShareActionsReturn>().toHaveProperty('handleCopyImage');
+    expectTypeOf<UseShareActionsReturn>().toHaveProperty('handleDownloadSVG');
+    expectTypeOf<UseShareActionsReturn>().toHaveProperty('handleCopyMarkdown');
+    expectTypeOf<UseShareActionsReturn>().toHaveProperty('handleDownloadCSV');
+    expectTypeOf<UseShareActionsReturn>().toHaveProperty('handleDownloadJSON');
+    expectTypeOf<UseShareActionsReturn>().toHaveProperty('handleDownloadSTL');
+    expectTypeOf<UseShareActionsReturn>().toHaveProperty('handleNativeShare');
+
+    expectTypeOf<UseShareActionsReturn['states']>().toEqualTypeOf<
+      Record<string, 'idle' | 'loading' | 'success' | 'error'>
+    >();
+  });
+
+  it('4. handlers expose the expected async/sync signatures', () => {
+    // Async handlers
+    expectTypeOf<UseShareActionsReturn['handleCopyLink']>().returns.toEqualTypeOf<
+      Promise<boolean>
+    >();
+
+    expectTypeOf<UseShareActionsReturn['handleDownloadPNG']>().returns.toEqualTypeOf<
+      Promise<void>
+    >();
+
+    expectTypeOf<UseShareActionsReturn['handleDownloadWEBP']>().returns.toEqualTypeOf<
+      Promise<void>
+    >();
+
+    expectTypeOf<UseShareActionsReturn['handleCopyImage']>().returns.toEqualTypeOf<Promise<void>>();
+
+    expectTypeOf<UseShareActionsReturn['handleDownloadSVG']>().returns.toEqualTypeOf<
+      Promise<void>
+    >();
+
+    expectTypeOf<UseShareActionsReturn['handleCopyMarkdown']>().returns.toEqualTypeOf<
+      Promise<void>
+    >();
+
+    expectTypeOf<UseShareActionsReturn['handleNativeShare']>().returns.toEqualTypeOf<
+      Promise<void>
+    >();
+
+    // Sync handlers
+    expectTypeOf<UseShareActionsReturn['handleTwitter']>().returns.toBeVoid();
+
+    expectTypeOf<UseShareActionsReturn['handleLinkedIn']>().returns.toBeVoid();
+
+    expectTypeOf<UseShareActionsReturn['handleReddit']>().returns.toBeVoid();
+
+    expectTypeOf<UseShareActionsReturn['handleDownloadCSV']>().returns.toBeVoid();
+
+    expectTypeOf<UseShareActionsReturn['handleDownloadJSON']>().returns.toBeVoid();
+
+    expectTypeOf<UseShareActionsReturn['handleDownloadSTL']>().returns.toBeVoid();
+
+    // No handler should accept parameters.
+    expectTypeOf<UseShareActionsReturn['handleCopyLink']>().parameters.toEqualTypeOf<[]>();
+
+    expectTypeOf<UseShareActionsReturn['handleDownloadCSV']>().parameters.toEqualTypeOf<[]>();
+  });
+
+  it('5. rejects invalid hook arguments during static type checking', () => {
+    const validExportData: DashboardExportData = {
+      stats: {
+        currentStreak: 0,
+        peakStreak: 0,
+        totalContributions: 0,
+      },
+      languages: [],
+    };
+
+    // @ts-expect-error username must be a string
+    const invalidUsername: UseShareActionsArgs = [123, validExportData, () => {}];
+
+    // @ts-expect-error exportData must satisfy DashboardExportData
+    const invalidExportData: UseShareActionsArgs = ['pari', { activity: [] }, () => {}];
+
+    // @ts-expect-error onClose must be a callback
+    const invalidOnClose: UseShareActionsArgs = ['pari', validExportData, 'not-a-function'];
+
+    // @ts-expect-error missing required arguments
+    const missingArgs: UseShareActionsArgs = ['pari'];
+
+    void invalidUsername;
+    void invalidExportData;
+    void invalidOnClose;
+    void missingArgs;
+  });
+});


### PR DESCRIPTION
## Description

Adds a dedicated TypeScript compiler validation test suite for `hooks/useShareActions`.

This PR verifies the hook's public API contract using `expectTypeOf`, ensuring:

* The hook accepts the expected parameters.
* `DashboardExportData` correctly supports its optional `activity` field.
* The returned API shape remains stable.
* Share/export handlers expose the expected async and sync signatures.
* Invalid hook arguments are rejected during static type checking to help prevent future type regressions.

Fixes #7145 

## Pillar

* [ ] 🎨 Pillar 1 — New Theme Design
* [ ] 📐 Pillar 2 — Geometric SVG Improvement
* [ ] 🕐 Pillar 3 — Timezone Logic Optimization
* [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (TypeScript compiler validation tests only)

## Checklist before requesting a review:

* [x] I have read the `CONTRIBUTING.md` file.
* [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
* [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
* [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
* [ ] I have updated `README.md` if I added a new theme or URL parameter.
* [x] I have starred the repo.
* [x] I have made sure that I have only one commit to merge in this PR.
* [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
* [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.

