### PR TITLE
fix(color): support 3/4/8-digit hex in hexToRgb

### DIFF
--- a/utils/color.test.ts
+++ b/utils/color.test.ts
@@ -29,6 +29,31 @@ describe('hexToRgb', () => {
     expect(hexToRgb('#000000')).toEqual({ r: 0, g: 0, b: 0 });
     expect(hexToRgb('#ffffff')).toEqual({ r: 255, g: 255, b: 255 });
   });
+
+  it('expands 3-digit shorthand hex (with and without #)', () => {
+    // "#fff" is a valid CSS color and is accepted elsewhere in the app; it must
+    // expand to full white rather than returning null.
+    expect(hexToRgb('#fff')).toEqual({ r: 255, g: 255, b: 255 });
+    expect(hexToRgb('f00')).toEqual({ r: 255, g: 0, b: 0 });
+    expect(hexToRgb('#0a0')).toEqual({ r: 0, g: 170, b: 0 });
+  });
+
+  it('parses 4-digit shorthand hex and ignores the alpha nibble', () => {
+    // "#fff0" is white with 0 alpha — the RGB channels should still resolve.
+    expect(hexToRgb('#fff0')).toEqual({ r: 255, g: 255, b: 255 });
+    expect(hexToRgb('f008')).toEqual({ r: 255, g: 0, b: 0 });
+  });
+
+  it('parses 8-digit hex and ignores the alpha byte', () => {
+    expect(hexToRgb('#10b981ff')).toEqual({ r: 16, g: 185, b: 129 });
+    expect(hexToRgb('ff000080')).toEqual({ r: 255, g: 0, b: 0 });
+  });
+
+  it('still returns null for lengths that are not valid hex formats', () => {
+    expect(hexToRgb('#12')).toBeNull(); // 2 digits
+    expect(hexToRgb('#12345')).toBeNull(); // 5 digits
+    expect(hexToRgb('#123456789')).toBeNull(); // 9 digits
+  });
 });
 
 describe('rgbToHex', () => {

--- a/utils/color.ts
+++ b/utils/color.ts
@@ -1,10 +1,27 @@
 export function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
-  const match = hex.replace('#', '').match(/^([0-9a-fA-F]{6})$/);
-  if (!match) return null;
+  const cleaned = hex.replace('#', '');
+
+  // Accept the same hex formats the rest of the app allows (see HEX_COLOR_REGEX
+  // in lib/svg/themes.ts): 3/4-digit shorthand and 6/8-digit full hex. Shorthand
+  // digits are expanded (e.g. "abc" -> "aabbcc") and any trailing alpha channel
+  // is ignored so contrast/HSL helpers work on every accepted color, not just 6-digit.
+  let normalized: string;
+  if (/^[0-9a-fA-F]{3,4}$/.test(cleaned)) {
+    normalized = cleaned
+      .slice(0, 3)
+      .split('')
+      .map((c) => c + c)
+      .join('');
+  } else if (/^[0-9a-fA-F]{6,8}$/.test(cleaned)) {
+    normalized = cleaned.slice(0, 6);
+  } else {
+    return null;
+  }
+
   return {
-    r: parseInt(match[1].slice(0, 2), 16),
-    g: parseInt(match[1].slice(2, 4), 16),
-    b: parseInt(match[1].slice(4, 6), 16),
+    r: parseInt(normalized.slice(0, 2), 16),
+    g: parseInt(normalized.slice(2, 4), 16),
+    b: parseInt(normalized.slice(4, 6), 16),
   };
 }
 


### PR DESCRIPTION
## Description

`hexToRgb` in `utils/color.ts` matched only exactly 6 hex digits, so valid
shorthand (e.g. `#fff`) and 8-digit alpha hex (e.g. `#10b981ff`) returned `null`
- even though the rest of the app accepts those formats (`HEX_COLOR_REGEX` in
`lib/svg/themes.ts`, and the public API, e.g. `?bg=fff`). That made
`getContrastRatio` return `0` and `hexToHsl` fall back to `{h:0,s:0,l:50}`,
producing wrong contrast/HSL results in `AdvancedColorPicker`.

This expands `hexToRgb` to normalize 3/4-digit shorthand (`#fff` → `#ffffff`)
and drop any trailing alpha channel on 4/8-digit hex, so every accepted hex
format resolves. Added unit tests covering 3-, 4-, and 8-digit inputs plus the
still-invalid lengths.

Closes #7417

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix)

## Visual Preview

N/A - this fixes a color utility function; no visual/UI change.

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] Verified locally via the test suite (`npm run test -- utils/color.test.ts` → 36 pass). _(The `/api/streak` badge URL is N/A — this changes no badge output.)_
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (both clean).
- [x] My commits follow the Conventional Commits format.
- [x] N/A — no new theme or URL parameter, so no `README.md` update needed.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] N/A — no SVG output changed by this PR.
- [x] (Recommended) I joined the CommitPulse Discord community.
