### PR TITLE
fix: resolve check_run parsing bug in webhook handler (#7423)

### DIFF
--- a/services/github/webhook-handler.test.ts
+++ b/services/github/webhook-handler.test.ts
@@ -83,6 +83,30 @@ describe('parseWebhookEvent', () => {
     expect(event?.status).toBe('pending');
   });
 
+  it('parses a check_run event with root-level repository', () => {
+    const payload = {
+      repository: {
+        name: 'commitpulse',
+        full_name: 'JhaSourav07/commitpulse',
+        owner: { login: 'JhaSourav07', type: 'User' },
+      },
+      check_run: {
+        id: 12345,
+        name: 'test-check',
+        status: 'completed',
+        conclusion: 'success',
+        started_at: recentIso,
+        completed_at: recentIso,
+      },
+    };
+    const event = parseWebhookEvent(payload);
+    expect(event).not.toBeNull();
+    expect(event?.type).toBe('check_run');
+    expect(event?.status).toBe('success');
+    expect(event?.repository).toBe('JhaSourav07/commitpulse');
+    expect(event?.details.name).toBe('test-check');
+  });
+
   it('returns null when no workflow_run or check_run in payload', () => {
     const event = parseWebhookEvent({});
     expect(event).toBeNull();

--- a/services/github/webhook-handler.ts
+++ b/services/github/webhook-handler.ts
@@ -4,6 +4,14 @@ import type { CIWorkflowRun, CIInsights } from '@/types/ci-analytics';
 
 interface WebhookPayload {
   action?: string;
+  repository?: {
+    name: string;
+    full_name: string;
+    owner: {
+      login: string;
+      type: string;
+    };
+  };
   workflow_run?: {
     id: number;
     name: string;
@@ -105,7 +113,7 @@ function extractCheckRunEvent(payload: WebhookPayload): CIEvent | null {
   if (!payload.check_run) return null;
 
   const checkRun = payload.check_run;
-  const repo = payload.workflow_run?.repository;
+  const repo = payload.repository || payload.workflow_run?.repository;
 
   if (!repo) return null;
 


### PR DESCRIPTION
## Description

This PR resolves the issue where check run events from webhooks were always discarded.

The issue occurred because the `extractCheckRunEvent` function tried to read the repository details using `payload.workflow_run?.repository`. In a standard `check_run` event from GitHub, the `workflow_run` wrapper object is absent, and the repository resides directly at the root level of the payload (`payload.repository`).

### Changes Made:
- Extended the `WebhookPayload` interface to support root-level `repository` definitions.
- Updated `extractCheckRunEvent` to check for `payload.repository` as the primary source before checking `payload.workflow_run?.repository`.
- Added a dedicated unit test `parses a check_run event with root-level repository` to `services/github/webhook-handler.test.ts` to ensure future regression prevention.

Fixes #7423

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

N/A (Backend logic & test suite verification)

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally.
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors.
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [x] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have starred the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
