### PR TITLE
fix: adjust landing page hero spacing

### DIFF
--- a/app/components/LandingPageClient.tsx
+++ b/app/components/LandingPageClient.tsx
@@ -621,8 +621,8 @@ export default function LandingPageClient() {
         <div className="absolute -right-[10%] top-[20%] h-[30%] w-[30%] rounded-full bg-cyan-500/5 blur-[120px]" />
       </div>
 
-      <main className="relative z-10 mx-auto max-w-6xl px-6 mt-32">
-        <div className="mb-16 text-center">
+      <main className="relative z-10 mx-auto max-w-6xl px-6 mt-16">
+        <div className="-mt-6 mb-16 text-center">
           <DiscordButton />
 
           <div ref={heroRef}>


### PR DESCRIPTION
## Description
Fixes #<7301>

### What changed?

- Reduced the top margin of the landing page container.
- Adjusted the hero section positioning to reduce unnecessary whitespace below the navigation bar.
- Improved the overall visual balance of the landing page without affecting functionality.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

### Before
<img width="960" height="540" alt="Screenshot 2026-07-05 132725" src="https://github.com/user-attachments/assets/38029aa8-2381-40cf-9b8a-b952bdbe341a" />


### After
<img width="960" height="540" alt="Screenshot 2026-07-05 132317" src="https://github.com/user-attachments/assets/291fc49a-7261-470e-9277-f4c6f9566d3e" />


## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that I have only one commit to merge in this PR.
- [x] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.