### PR TITLE
test(Highlights): add error resilience coverage

### DIFF
--- a/components/dashboard/PRInsights/Highlights.error-resilience.test.tsx
+++ b/components/dashboard/PRInsights/Highlights.error-resilience.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Highlights from './Highlights';
+import type { PRInsightData } from '@/services/github/pr-insights';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    a: ({
+      children,
+      className,
+      href,
+      target,
+      rel,
+      ...props
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+      children?: React.ReactNode;
+    }) => {
+      const validProps = Object.keys(props).reduce(
+        (acc, key) => {
+          if (!['initial', 'animate', 'transition'].includes(key)) {
+            acc[key] = (props as Record<string, unknown>)[key];
+          }
+          return acc;
+        },
+        {} as Record<string, unknown>
+      );
+
+      return (
+        <a className={className} href={href} target={target} rel={rel} {...validProps}>
+          {children}
+        </a>
+      );
+    },
+  },
+}));
+
+vi.mock('lucide-react', () => ({
+  MessageSquare: () => <span data-testid="message-icon" />,
+  Zap: () => <span data-testid="zap-icon" />,
+  HardDrive: () => <span data-testid="drive-icon" />,
+  ArrowRight: () => <span data-testid="arrow-icon" />,
+}));
+
+const populatedHighlights: PRInsightData['highlights'] = {
+  fastestMerged: {
+    title: 'Fast merge',
+    url: 'https://example.com/1',
+    time: 1.5,
+  },
+  mostDiscussed: {
+    title: 'Discussion PR',
+    url: 'https://example.com/2',
+    comments: 18,
+  },
+  largest: {
+    title: 'Largest PR',
+    url: 'https://example.com/3',
+    additions: 250,
+    deletions: 75,
+  },
+};
+
+describe('Highlights error resilience', () => {
+  it('renders arrow icons only for populated highlight cards', () => {
+    render(<Highlights highlights={populatedHighlights} />);
+
+    expect(screen.getAllByTestId('arrow-icon')).toHaveLength(3);
+  });
+
+  it('does not render arrow icons when highlight data is unavailable', () => {
+    render(
+      <Highlights
+        highlights={{
+          fastestMerged: undefined,
+          mostDiscussed: undefined,
+          largest: undefined,
+        }}
+      />
+    );
+
+    expect(screen.queryByTestId('arrow-icon')).not.toBeInTheDocument();
+  });
+
+  it('applies disabled styling only to cards without highlight data', () => {
+    const { container } = render(
+      <Highlights
+        highlights={{
+          fastestMerged: populatedHighlights.fastestMerged,
+          mostDiscussed: undefined,
+          largest: undefined,
+        }}
+      />
+    );
+
+    const cards = container.querySelectorAll('a');
+
+    expect(cards).toHaveLength(3);
+
+    expect(cards[0]).not.toHaveClass('opacity-50');
+    expect(cards[0]).not.toHaveClass('cursor-not-allowed');
+
+    expect(cards[1]).toHaveClass('opacity-50');
+    expect(cards[1]).toHaveClass('cursor-not-allowed');
+
+    expect(cards[2]).toHaveClass('opacity-50');
+    expect(cards[2]).toHaveClass('cursor-not-allowed');
+  });
+
+  it('renders enabled and disabled cards together without affecting populated cards', () => {
+    render(
+      <Highlights
+        highlights={{
+          fastestMerged: populatedHighlights.fastestMerged,
+          mostDiscussed: undefined,
+          largest: populatedHighlights.largest,
+        }}
+      />
+    );
+
+    expect(screen.getAllByTestId('arrow-icon')).toHaveLength(2);
+
+    expect(screen.getByText('Fast merge')).toBeInTheDocument();
+    expect(screen.getByText('Largest PR')).toBeInTheDocument();
+
+    expect(screen.getAllByText('N/A')).toHaveLength(1);
+    expect(screen.getAllByText('No data available')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #7052 
Adds error resilience test coverage for `Highlights`.

## What changed

- Added tests to verify arrow icons only render for populated highlight cards
- Verified arrow icons are omitted when highlight data is unavailable
- Verified disabled styling is applied to cards without highlight data
- Verified enabled and disabled cards render correctly together without affecting one another

## Validation

- ✅ Component tests pass
- ✅ TypeScript typecheck passes
- ✅ ESLint passes (no new errors introduced)
- ✅ Formatting applied

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview

## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [x] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
