### PR TITLE
fix(achievements): use merged PR count for merge master

### DIFF
--- a/app/api/achievements/route.test.ts
+++ b/app/api/achievements/route.test.ts
@@ -3,6 +3,7 @@ import { GET } from './route';
 import { getFullDashboardData } from '@/lib/github';
 import { getUserGitHubToken } from '@/lib/githubtoken';
 import { RateLimiter } from '@/lib/rate-limit';
+import { fetchPRInsights } from '@/services/github/pr-insights';
 
 vi.mock('@/lib/github', () => ({
   getFullDashboardData: vi.fn(),
@@ -10,6 +11,10 @@ vi.mock('@/lib/github', () => ({
 
 vi.mock('@/lib/githubtoken', () => ({
   getUserGitHubToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/services/github/pr-insights', () => ({
+  fetchPRInsights: vi.fn(),
 }));
 
 function makeRequest(params: Record<string, string> = {}): Request {
@@ -74,6 +79,7 @@ describe('GET /api/achievements', () => {
     vi.spyOn(RateLimiter.prototype, 'check').mockResolvedValue(true);
     vi.mocked(getUserGitHubToken).mockResolvedValue('mock-token');
     vi.mocked(getFullDashboardData).mockResolvedValue(mockDashboardData as never);
+    vi.mocked(fetchPRInsights).mockResolvedValue({ mergedPRs: 7 } as never);
   });
 
   // ── Validation ────────────────────────────────────────────────────────────
@@ -155,6 +161,20 @@ describe('GET /api/achievements', () => {
     expect(commitChampion.state.currentTier).toBe('silver');
     expect(commitChampion.state.currentValue).toBe(500);
     expect(commitChampion.state.xpEarned).toBe(150);
+  });
+
+  it('computes merge-master progress using mergedPRs from fetchPRInsights instead of totalPRs', async () => {
+    vi.mocked(fetchPRInsights).mockResolvedValueOnce({ mergedPRs: 15 } as never);
+    const res = await GET(makeRequest({ username: 'octocat' }));
+    const data = await res.json();
+    const prCategory = data.categories.find(
+      (c: { category: string }) => c.category === 'pull-request'
+    );
+    const mergeMaster = prCategory.achievements.find(
+      (a: { def: { id: string } }) => a.def.id === 'merge-master'
+    );
+
+    expect(mergeMaster.state.currentValue).toBe(15);
   });
 
   it('groups achievements into all five categories', async () => {

--- a/app/api/achievements/route.ts
+++ b/app/api/achievements/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { validateGitHubUsername } from '@/lib/validations';
 import { getFullDashboardData } from '@/lib/github';
+import { fetchPRInsights } from '@/services/github/pr-insights';
 import type {
   AchievementDef,
   AchievementCategory,
@@ -570,9 +571,13 @@ export async function GET(request: Request) {
 
   try {
     const userToken = await getUserGitHubToken();
-    const dashboardData = await getFullDashboardData(username, { token: userToken });
+    const [dashboardData, prInsightsData] = await Promise.all([
+      getFullDashboardData(username, { token: userToken }),
+      fetchPRInsights(username, userToken).catch(() => null),
+    ]);
 
     const { profile, stats, languages } = dashboardData;
+
     const totalStars = profile.stats.stars;
     const totalForks =
       (dashboardData.popularRepos as Array<{ forkCount: number }> | undefined)?.reduce(
@@ -644,7 +649,7 @@ export async function GET(request: Request) {
       'weekend-warrior': weekendContributions,
       'pr-rookie': stats.totalPRs,
       'pr-master': stats.totalPRs,
-      'merge-master': stats.totalPRs,
+      'merge-master': prInsightsData?.mergedPRs ?? 0,
       'review-expert': stats.totalReviews,
       'pr-legend': stats.totalPRs,
       'star-collector': totalStars,


### PR DESCRIPTION
## Description

Fixes  #7415
This PR fixes the Merge Master achievement calculation.

Previously, the achievement progress was calculated using the total number of opened pull requests (`stats.totalPRs`), even though the achievement is intended to track merged pull requests.

This change now reuses the existing `fetchPRInsights` service to calculate progress using `mergedPRs`, ensuring the achievement matches its description and measure label.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
N/A (Backend API bug fix)
## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [ ] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [ ] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [ ] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
