### PR TITLE
fix: return HTTP 504 Gateway Timeout for AbortController timeouts

### DIFF
--- a/app/api/ci-analytics/route.ts
+++ b/app/api/ci-analytics/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { fetchCIAnalytics } from '@/services/github/ci-analytics';
+import { isAbortError } from '@/lib/github';
 import { getUserGitHubToken } from '@/lib/githubtoken';
 import { validateGitHubUsername } from '@/lib/validations';
 import { RateLimiter, getRateLimitHeaders } from '@/lib/rate-limit';
@@ -37,6 +38,12 @@ export async function GET(request: Request) {
     return NextResponse.json(data);
   } catch (error: unknown) {
     console.error('Error fetching CI analytics:', error);
+    if (isAbortError(error)) {
+      return NextResponse.json(
+        { error: 'Upstream request timed out after 10 seconds.' },
+        { status: 504 }
+      );
+    }
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Failed to fetch CI analytics' },
       { status: 500 }

--- a/app/api/compare/githubFetch.test.ts
+++ b/app/api/compare/githubFetch.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET } from './route';
 import { getFullDashboardData } from '../../../lib/github';
 
-vi.mock('../../../lib/github', () => ({
-  getFullDashboardData: vi.fn(),
-}));
+vi.mock('../../../lib/github', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/github')>();
+  return {
+    ...actual,
+    getFullDashboardData: vi.fn(),
+  };
+});
 vi.mock('@/lib/githubtoken', () => ({
   getUserGitHubToken: vi.fn().mockResolvedValue(undefined),
 }));
@@ -57,12 +61,12 @@ describe('compare API - githubFetch integration', () => {
     expect(data.error).toContain('GitHub API rate limit reached');
   });
 
-  it('Connection Timeout (500): safely catches unhandled timeouts', async () => {
+  it('Connection Timeout (504): safely catches unhandled timeouts', async () => {
     vi.mocked(getFullDashboardData).mockResolvedValueOnce({ totalContributions: 100 } as never);
     vi.mocked(getFullDashboardData).mockRejectedValueOnce(new Error('Connection timeout ETICK'));
 
     const response = await GET(makeRequest('userA', 'userB'));
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(504);
     const data = await response.json();
     expect(data.error).toContain('Connection timeout');
   });

--- a/app/api/compare/route.mouse-interactivity.test.ts
+++ b/app/api/compare/route.mouse-interactivity.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET } from './route';
 import { getFullDashboardData } from '@/lib/github';
 
-vi.mock('@/lib/github', () => ({
-  getFullDashboardData: vi.fn(),
-}));
+vi.mock('@/lib/github', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/github')>();
+  return {
+    ...actual,
+    getFullDashboardData: vi.fn(),
+  };
+});
 
 vi.mock('@/lib/rate-limit', () => ({
   RateLimiter: vi.fn().mockImplementation(function () {
@@ -94,7 +98,7 @@ describe('ApiCompareRoute Tests', () => {
     expect(json.error).toContain('rate limit reached');
   });
 
-  it('returns 500 Internal Server Error when upstream request times out', async () => {
+  it('returns 504 Gateway Timeout when upstream request times out', async () => {
     vi.mocked(getFullDashboardData).mockRejectedValueOnce(
       new Error('Request timed out', { cause: new Error('timeout') })
     );
@@ -102,7 +106,7 @@ describe('ApiCompareRoute Tests', () => {
     const request = makeRequest({ user1: 'octocat', user2: 'defunkt' });
     const response = await GET(request);
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(504);
     const json = await response.json();
     expect(json.error).toContain('Connection timeout');
   });

--- a/app/api/compare/route.test.ts
+++ b/app/api/compare/route.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('@/lib/github', () => ({
-  getFullDashboardData: vi.fn(),
-}));
+vi.mock('@/lib/github', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/github')>();
+  return {
+    ...actual,
+    getFullDashboardData: vi.fn(),
+  };
+});
 
 vi.mock('@/lib/githubtoken', () => ({
   getUserGitHubToken: vi.fn().mockResolvedValue(undefined),
@@ -159,7 +163,7 @@ describe('GET /api/compare', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 500 when a timeout error is wrapped in a cause chain', async () => {
+  it('returns 504 when a timeout error is wrapped in a cause chain', async () => {
     vi.mocked(getFullDashboardData).mockRejectedValueOnce(
       new Error('[GitHub API] Failed to fetch profile for user "octocat"', {
         cause: new Error('GitHub API request timed out after 8s'),
@@ -168,7 +172,7 @@ describe('GET /api/compare', () => {
 
     const res = await GET(makeRequest('user1=octocat&user2=torvalds'));
 
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(504);
   });
 
   // ── ETag & Caching ─────────────────────────────────────────────────────────

--- a/app/api/compare/route.theme-contrast.test.ts
+++ b/app/api/compare/route.theme-contrast.test.ts
@@ -2,9 +2,13 @@ import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { GET } from './route';
 import { getFullDashboardData } from '@/lib/github';
 
-vi.mock('@/lib/github', () => ({
-  getFullDashboardData: vi.fn(),
-}));
+vi.mock('@/lib/github', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/github')>();
+  return {
+    ...actual,
+    getFullDashboardData: vi.fn(),
+  };
+});
 vi.mock('@/lib/rate-limit', () => ({
   RateLimiter: vi.fn().mockImplementation(function () {
     return { check: vi.fn().mockResolvedValue(true) };
@@ -118,14 +122,14 @@ describe('ApiCompareRoute – Dark and Light Prefers-Color-Scheme Visual Cohesio
     expect(body403.error).not.toMatch(/style=/i);
     expect(body403.error).not.toContain('\u200b');
 
-    // 500
+    // 504
     vi.mocked(getFullDashboardData).mockRejectedValueOnce(new Error('Connection timeout'));
-    const res500 = await GET(new Request('http://localhost/api/compare?user1=alice&user2=bob'));
-    const body500 = await res500.json();
-    expect(res500.status).toBe(500);
-    expect(body500.error).not.toMatch(/\x1b\[/);
-    expect(body500.error).not.toMatch(/style=/i);
-    expect(body500.error).not.toContain('\u200b');
+    const res504 = await GET(new Request('http://localhost/api/compare?user1=alice&user2=bob'));
+    const body504 = await res504.json();
+    expect(res504.status).toBe(504);
+    expect(body504.error).not.toMatch(/\x1b\[/);
+    expect(body504.error).not.toMatch(/style=/i);
+    expect(body504.error).not.toContain('\u200b');
 
     // 502
     vi.mocked(getFullDashboardData).mockRejectedValueOnce(new Error('Unexpected upstream error'));

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -42,7 +42,7 @@ function buildCompareFetchErrorResponse(user: string, reason: unknown): NextResp
   if (lowerMessage.includes('timeout') || lowerMessage.includes('timed out')) {
     return NextResponse.json(
       { error: `Connection timeout. Unable to fetch GitHub data for "${user}".` },
-      { status: 500 }
+      { status: 504 }
     );
   }
 

--- a/app/api/github/route.error-resilience.test.ts
+++ b/app/api/github/route.error-resilience.test.ts
@@ -13,9 +13,13 @@ vi.mock('next/server', async () => {
   };
 });
 
-vi.mock('@/lib/github', () => ({
-  getFullDashboardData: vi.fn(),
-}));
+vi.mock('@/lib/github', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/github')>();
+  return {
+    ...actual,
+    getFullDashboardData: vi.fn(),
+  };
+});
 
 vi.mock('@/utils/getClientIp', () => ({
   getClientIp: vi.fn(() => '127.0.0.1'),

--- a/app/api/github/route.test.ts
+++ b/app/api/github/route.test.ts
@@ -3,9 +3,14 @@ import { GET } from './route';
 import { RateLimiter } from '@/lib/rate-limit';
 
 // Replace the real GitHub API with a fake function
-vi.mock('../../../lib/github', () => ({
-  getFullDashboardData: vi.fn(),
-}));
+vi.mock('../../../lib/github', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/github')>('../../../lib/github');
+
+  return {
+    ...actual,
+    getFullDashboardData: vi.fn(),
+  };
+});
 
 // Run after() callbacks synchronously in tests (outside a request scope it is otherwise a no-op).
 vi.mock('next/server', async (importOriginal) => {

--- a/app/api/github/route.theme-contrast.test.ts
+++ b/app/api/github/route.theme-contrast.test.ts
@@ -2,9 +2,13 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@/lib/github', () => ({
-  getFullDashboardData: vi.fn(),
-}));
+vi.mock('@/lib/github', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/github')>();
+  return {
+    ...actual,
+    getFullDashboardData: vi.fn(),
+  };
+});
 
 vi.mock('@/services/github/quota-monitor', () => ({
   quotaMonitor: {

--- a/app/api/github/route.ts
+++ b/app/api/github/route.ts
@@ -1,7 +1,7 @@
 // app/api/github/route.ts
 
 import { NextResponse, after } from 'next/server';
-import { getFullDashboardData } from '@/lib/github';
+import { getFullDashboardData, isAbortError } from '@/lib/github';
 import { githubParamsSchema, coerceQueryParams } from '@/lib/validations';
 import { getClientIp } from '@/utils/getClientIp';
 import { quotaMonitor } from '@/services/github/quota-monitor';
@@ -236,6 +236,14 @@ export async function GET(request: Request) {
       return NextResponse.json(
         { error: 'GitHub API rate limit reached. Please configure GITHUB_TOKEN.' },
         { status: 403 }
+      );
+    }
+
+    // 504 - Upstream request timeout or AbortController abort
+    if (isAbortError(rootCause || error)) {
+      return NextResponse.json(
+        { error: 'Upstream request timed out after 10 seconds.' },
+        { status: 504 }
       );
     }
 

--- a/app/api/pr-insights/route.ts
+++ b/app/api/pr-insights/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { fetchPRInsights } from '@/services/github/pr-insights';
+import { isAbortError } from '@/lib/github';
 import { validateGitHubUsername } from '@/lib/validations';
 import { getRateLimitHeaders, RateLimiter } from '@/lib/rate-limit';
 import { getUserGitHubToken } from '@/lib/githubtoken';
@@ -42,6 +43,12 @@ export async function GET(request: Request) {
     return NextResponse.json(data);
   } catch (error: unknown) {
     console.error('Error fetching PR insights:', error);
+    if (isAbortError(error)) {
+      return NextResponse.json(
+        { error: 'Upstream request timed out after 10 seconds.' },
+        { status: 504 }
+      );
+    }
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Failed to fetch PR insights' },
       { status: 500 }

--- a/app/api/streak/route.test.ts
+++ b/app/api/streak/route.test.ts
@@ -6,11 +6,16 @@ import { getValidationCacheForTests } from './validation-cache';
 // We only mock the two things that reach outside this process:
 // the GitHub API call and the wall-clock time helper.
 // calculateStreak and generateSVG run for real, giving us genuine end-to-end coverage.
-vi.mock('../../../lib/github', () => ({
-  fetchGitHubContributions: vi.fn(),
-  getOrgDashboardData: vi.fn(),
-  getCircuitTelemetry: vi.fn().mockReturnValue({ isOpen: false, resetInMs: 0 }),
-}));
+vi.mock('../../../lib/github', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/github')>('../../../lib/github');
+
+  return {
+    ...actual,
+    fetchGitHubContributions: vi.fn(),
+    getOrgDashboardData: vi.fn(),
+    getCircuitTelemetry: vi.fn().mockReturnValue({ isOpen: false, resetInMs: 0 }),
+  };
+});
 
 vi.mock('../../../utils/time', () => ({
   getSecondsUntilUTCMidnight: vi.fn(),

--- a/app/api/streak/route.ts
+++ b/app/api/streak/route.ts
@@ -7,6 +7,7 @@ import {
   getOrgDashboardData,
   getCircuitTelemetry,
   fetchCommitHourDistribution,
+  isAbortError,
 } from '@/lib/github';
 import {
   calculateStreak,
@@ -722,6 +723,7 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
   const message = sanitizeErrorMessage(rawMessage);
 
   if (parseResult.success && parseResult.data.format === 'json') {
+    const isTimeout = isAbortError(error);
     const isNotFound =
       rawMessage.toLowerCase().includes('not found') ||
       rawMessage.toLowerCase().includes('could not resolve');
@@ -731,6 +733,16 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
       rawMessage.toLowerCase().includes('invalid') ||
       rawMessage.toLowerCase().includes('validation') ||
       rawMessage.toLowerCase().includes('strictly for organizations');
+
+    if (isTimeout) {
+      return NextResponse.json(
+        { error: 'Upstream request timed out after 10 seconds.' },
+        {
+          status: 504,
+          headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+        }
+      );
+    }
 
     const status = isRateLimit ? 429 : isNotFound ? 404 : isValidationError ? 400 : 500;
     const jsonErrorHeaders: Record<string, string> = {
@@ -828,7 +840,20 @@ function buildErrorResponse(error: unknown, parseResult: ParseResult): NextRespo
     });
   }
 
-  // 4. Return a 500 Internal Server Error for real crashes
+  // 4. Return a 504 Gateway Timeout for aborted/timed out requests
+  if (isAbortError(error)) {
+    const timeoutSvg = buildInlineErrorSVG('Request timed out. Please try again later.');
+    return new NextResponse(timeoutSvg, {
+      status: 504,
+      headers: {
+        'Content-Type': 'image/svg+xml; charset=utf-8',
+        'Cache-Control': 'no-store',
+        'Content-Security-Policy': SVG_CSP_HEADER,
+      },
+    });
+  }
+
+  // 5. Return a 500 Internal Server Error for real crashes
   logger.error('Unhandled error', {
     source: 'streak',
     message,

--- a/app/api/streak/tests/refresh.test.ts
+++ b/app/api/streak/tests/refresh.test.ts
@@ -2,11 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createRequest } from 'node-mocks-http';
 import { GET } from '../route';
 
-vi.mock('../../../../lib/github', () => ({
-  fetchGitHubContributions: vi.fn(),
-  getOrgDashboardData: vi.fn(),
-  getCircuitTelemetry: vi.fn().mockReturnValue({ isOpen: false, resetInMs: 0 }),
-}));
+vi.mock('../../../../lib/github', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../lib/github')>();
+  return {
+    ...actual,
+    fetchGitHubContributions: vi.fn(),
+    getOrgDashboardData: vi.fn(),
+    getCircuitTelemetry: vi.fn().mockReturnValue({ isOpen: false, resetInMs: 0 }),
+  };
+});
 
 vi.mock('../../../../utils/time', () => ({
   getSecondsUntilUTCMidnight: vi.fn(),

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -164,12 +164,23 @@ export function getGitHubTokens(): string[] {
     .filter((token) => isValidGitHubTokenFormat(token));
 }
 
-function isAbortError(error: unknown): boolean {
-  return (
+export function isAbortError(error: unknown): boolean {
+  if (
     typeof error === 'object' &&
     error !== null &&
     'name' in error &&
-    (error as { name?: unknown }).name === 'AbortError'
+    ((error as { name?: unknown }).name === 'AbortError' ||
+      (error as { name?: unknown }).name === 'TimeoutError')
+  ) {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('timeout') ||
+    lower.includes('timed out') ||
+    lower.includes('aborted') ||
+    lower.includes('operation was aborted')
   );
 }
 


### PR DESCRIPTION
## Description

Fixes #7460 
   
PR #6429 introduced `AbortController` timeouts across multiple API routes to prevent long-running upstream requests from hanging. However, when an upstream request exceeded the configured timeout, the resulting `AbortError` fell through generic error handlers and returned **HTTP 500 Internal Server Error**.

This PR fixes the issue by:
1. Exporting and enhancing the `isAbortError` utility in `lib/github.ts` to reliably detect `AbortController` aborts and timeout errors across the codebase.
2. Updating error handlers in affected routes (`app/api/github`, `app/api/pr-insights`, `app/api/ci-analytics`, `app/api/streak`) to return **HTTP 504 Gateway Timeout** when an upstream timeout occurs.
3. Updating Vitest integration mocks (`importOriginal`) and test assertions across the test suite to ensure 100% test pass rate and consistent timeout expectations.

## Pillar

- [ ] 🎨 Pillar 1 — New Theme Design
- [ ] 📐 Pillar 2 — Geometric SVG Improvement
- [ ] 🕐 Pillar 3 — Timezone Logic Optimization
- [x] 🛠️ Other (Bug fix, refactoring, docs)

## Visual Preview
*N/A — Backend API error status code optimization (HTTP 500 → HTTP 504 Gateway Timeout).*
## Checklist before requesting a review:

- [x] I have read the `CONTRIBUTING.md` file.
- [x] I have tested these changes locally (`localhost:3000/api/streak?user=YOUR_USERNAME`).
- [x] I have run `npm run format` and `npm run lint` locally and resolved all errors (CI will fail otherwise).
- [x] My commits follow the Conventional Commits format (e.g., `feat(themes): ...`, `fix(calculate): ...`).
- [ ] I have updated `README.md` if I added a new theme or URL parameter.
- [x] I have started the repo.
- [x] I have made sure that i have only one commit to merge in this PR.
- [ ] The SVG output matches the CommitPulse "premium quality" aesthetic standard (no raw elements, smooth animations, correct fonts).
- [ ] (Recommended) I joined the CommitPulse Discord community for contributor discussions, mentorship, and faster PR support.
